### PR TITLE
metrics endpoint -- rpc data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -129,7 +129,7 @@ dependencies = [
  "futures",
  "futures-util",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -171,7 +171,7 @@ dependencies = [
  "alloy-rlp",
  "crc",
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -197,7 +197,7 @@ dependencies = [
  "borsh",
  "k256",
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -233,7 +233,7 @@ dependencies = [
  "serde",
  "serde_with",
  "sha2",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -274,7 +274,7 @@ dependencies = [
  "http",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -301,7 +301,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -328,7 +328,7 @@ dependencies = [
  "cfg-if",
  "const-hex",
  "derive_more",
- "foldhash",
+ "foldhash 0.2.0",
  "hashbrown 0.16.1",
  "indexmap 2.13.0",
  "itoa",
@@ -384,7 +384,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -548,7 +548,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -562,7 +562,7 @@ dependencies = [
  "alloy-serde",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -600,7 +600,7 @@ dependencies = [
  "either",
  "elliptic-curve",
  "k256",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -616,7 +616,7 @@ dependencies = [
  "async-trait",
  "k256",
  "rand 0.8.5",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -707,7 +707,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tower",
  "tracing",
@@ -1253,6 +1253,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1424,6 +1446,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6354c81bbfd62d9cfa9cb3c773c2b7b2a3a482d569de977fd0e961f6e7c00583"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -1449,6 +1473,15 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1529,6 +1562,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1557,6 +1600,15 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "crossbeam-utils"
@@ -1790,13 +1842,15 @@ dependencies = [
  "futures",
  "governor",
  "hex",
+ "metrics",
+ "metrics-exporter-prometheus",
  "nonzero_ext",
  "parquet",
  "postgres-types",
  "rand 0.9.2",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-postgres",
  "tracing",
@@ -1994,6 +2048,12 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -2006,6 +2066,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -2193,6 +2259,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.13.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2221,6 +2306,9 @@ name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
 
 [[package]]
 name = "hashbrown"
@@ -2230,7 +2318,7 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
  "serde",
  "serde_core",
 ]
@@ -2311,6 +2399,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2320,9 +2414,11 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -2341,6 +2437,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -2609,6 +2706,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2815,6 +2922,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "metrics"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
+dependencies = [
+ "base64",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "indexmap 2.13.0",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.15.5",
+ "metrics",
+ "quanta",
+ "rand 0.9.2",
+ "rand_xoshiro",
+ "sketches-ddsketch",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2970,6 +3124,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "ordered-float"
@@ -3331,7 +3491,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -3352,7 +3512,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3460,6 +3620,15 @@ name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
  "rand_core 0.9.5",
 ]
@@ -3701,12 +3870,25 @@ version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -3725,6 +3907,7 @@ version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3753,6 +3936,15 @@ name = "ryu"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+
+[[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "schemars"
@@ -3818,6 +4010,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -4036,6 +4251,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
+name = "sketches-ddsketch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4216,11 +4437,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4590,7 +4831,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -5172,7 +5413,7 @@ dependencies = [
  "pharos",
  "rustc_version 0.4.1",
  "send_wrapper",
- "thiserror",
+ "thiserror 2.0.18",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,7 @@ bytes = "1"
 deadpool-postgres = "0.14"
 tokio-postgres = { version = "0.7", features = ["with-serde_json-1"] }
 postgres-types = { version = "0.2", features = ["derive"] }
+
+# Metrics
+metrics = "0.24"
+metrics-exporter-prometheus = "0.16"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "bench")]
 mod bench;
 mod db;
+mod metrics;
 mod raw_data;
 mod rpc;
 mod decoding;
@@ -69,6 +70,16 @@ async fn main() -> anyhow::Result<()> {
         std::fs::create_dir_all("data")?;
         bench::init(Path::new("data/bench.csv"))?;
         tracing::info!("Benchmarking enabled, writing to data/bench.csv");
+    }
+
+    // Initialize metrics server if configured
+    if let Some(ref metrics_config) = config.metrics {
+        let addr = metrics_config
+            .addr
+            .parse()
+            .context("Invalid metrics.addr in config")?;
+        metrics::init_metrics_server(addr);
+        metrics::describe_rpc_metrics();
     }
 
     if decode_only {

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -1,0 +1,21 @@
+mod rpc;
+
+pub use rpc::{chain_label_from_url, describe_rpc_metrics, RpcMetricsGuard, RpcMethod};
+
+use std::net::SocketAddr;
+
+use metrics_exporter_prometheus::PrometheusBuilder;
+
+/// Initialize the metrics exporter and HTTP server.
+///
+/// Call this once at application startup before any metrics are recorded.
+/// The server exposes metrics at the `/metrics` endpoint.
+pub fn init_metrics_server(addr: SocketAddr) {
+    let builder = PrometheusBuilder::new().with_http_listener(addr);
+
+    builder
+        .install()
+        .expect("failed to install Prometheus exporter");
+
+    tracing::info!("Metrics server listening on http://{}/metrics", addr);
+}

--- a/src/metrics/rpc.rs
+++ b/src/metrics/rpc.rs
@@ -1,0 +1,243 @@
+use std::time::Instant;
+
+use metrics::{counter, describe_counter, describe_gauge, describe_histogram, gauge, histogram};
+use url::Url;
+
+use crate::rpc::RpcError;
+
+/// RPC method names for metric labels
+#[derive(Debug, Clone, Copy)]
+pub enum RpcMethod {
+    GetBlockNumber,
+    GetBlock,
+    GetTransaction,
+    GetTransactionReceipt,
+    GetBlockReceipts,
+    GetLogs,
+    GetBalance,
+    GetCode,
+    EthCall,
+    // Batch/concurrent variants
+    GetBlocksBatch,
+    GetTransactionReceiptsBatch,
+    GetLogsBatch,
+    EthCallBatch,
+    GetBlockReceiptsConcurrent,
+}
+
+impl RpcMethod {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::GetBlockNumber => "eth_blockNumber",
+            Self::GetBlock => "eth_getBlockByNumber",
+            Self::GetTransaction => "eth_getTransactionByHash",
+            Self::GetTransactionReceipt => "eth_getTransactionReceipt",
+            Self::GetBlockReceipts => "eth_getBlockReceipts",
+            Self::GetLogs => "eth_getLogs",
+            Self::GetBalance => "eth_getBalance",
+            Self::GetCode => "eth_getCode",
+            Self::EthCall => "eth_call",
+            Self::GetBlocksBatch => "eth_getBlockByNumber_batch",
+            Self::GetTransactionReceiptsBatch => "eth_getTransactionReceipt_batch",
+            Self::GetLogsBatch => "eth_getLogs_batch",
+            Self::EthCallBatch => "eth_call_batch",
+            Self::GetBlockReceiptsConcurrent => "eth_getBlockReceipts_concurrent",
+        }
+    }
+}
+
+/// Error categories for metric labels
+#[derive(Debug, Clone, Copy)]
+pub enum RpcErrorCategory {
+    Transport,
+    RateLimit,
+    InvalidUrl,
+    Batch,
+    Provider,
+}
+
+impl RpcErrorCategory {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Transport => "transport",
+            Self::RateLimit => "rate_limit",
+            Self::InvalidUrl => "invalid_url",
+            Self::Batch => "batch",
+            Self::Provider => "provider",
+        }
+    }
+
+    /// Categorize an RpcError into a metric label
+    pub fn from_error(err: &RpcError) -> Self {
+        match err {
+            RpcError::Transport(_) => Self::Transport,
+            RpcError::RateLimitExceeded => Self::RateLimit,
+            RpcError::InvalidUrl(_) => Self::InvalidUrl,
+            RpcError::BatchError(_) => Self::Batch,
+            RpcError::ProviderError(_) => Self::Provider,
+        }
+    }
+}
+
+/// Register metric descriptions (call once at startup)
+pub fn describe_rpc_metrics() {
+    describe_histogram!(
+        "rpc_request_duration_seconds",
+        "Duration of RPC requests in seconds"
+    );
+    describe_counter!("rpc_requests_total", "Total number of RPC requests");
+    describe_counter!("rpc_errors_total", "Total number of RPC errors");
+    describe_gauge!(
+        "rpc_requests_in_flight",
+        "Number of RPC requests currently in progress"
+    );
+}
+
+/// Extract a sanitized chain identifier from an RPC URL.
+///
+/// Converts URLs like "https://eth-mainnet.g.alchemy.com/v2/xxx" to "alchemy_eth_mainnet"
+/// or falls back to the host if parsing fails.
+pub fn chain_label_from_url(url: &Url) -> String {
+    let host = url.host_str().unwrap_or("unknown");
+
+    // For Alchemy URLs, extract the network from the subdomain
+    if host.contains("alchemy") {
+        if let Some(subdomain) = host.split('.').next() {
+            return format!("alchemy_{}", subdomain.replace('-', "_"));
+        }
+    }
+
+    // For Infura URLs
+    if host.contains("infura") {
+        if let Some(subdomain) = host.split('.').next() {
+            return format!("infura_{}", subdomain.replace('-', "_"));
+        }
+    }
+
+    // For QuickNode or other providers, sanitize the hostname
+    host.replace(['.', '-'], "_")
+}
+
+/// RAII guard for recording RPC request metrics.
+///
+/// Records duration and updates counters when dropped.
+/// Use `success()` or `failure()` to record the outcome before dropping.
+pub struct RpcMetricsGuard {
+    method: &'static str,
+    chain: String,
+    start: Instant,
+    completed: bool,
+}
+
+impl RpcMetricsGuard {
+    pub fn new(method: RpcMethod, chain: &str) -> Self {
+        let method_str = method.as_str();
+
+        // Increment in-flight gauge
+        gauge!(
+            "rpc_requests_in_flight",
+            "method" => method_str,
+            "chain" => chain.to_string()
+        )
+        .increment(1.0);
+
+        Self {
+            method: method_str,
+            chain: chain.to_string(),
+            start: Instant::now(),
+            completed: false,
+        }
+    }
+
+    /// Record successful completion
+    pub fn success(mut self) {
+        self.completed = true;
+        self.record_completion("success");
+    }
+
+    /// Record failure with error categorization
+    pub fn failure(mut self, error: &RpcError) {
+        self.completed = true;
+        let error_category = RpcErrorCategory::from_error(error);
+
+        counter!(
+            "rpc_errors_total",
+            "method" => self.method,
+            "chain" => self.chain.clone(),
+            "error_type" => error_category.as_str()
+        )
+        .increment(1);
+
+        self.record_completion("error");
+    }
+
+    fn record_completion(&self, status: &'static str) {
+        let duration = self.start.elapsed().as_secs_f64();
+
+        // Record histogram
+        histogram!(
+            "rpc_request_duration_seconds",
+            "method" => self.method,
+            "chain" => self.chain.clone(),
+            "status" => status
+        )
+        .record(duration);
+
+        // Increment total counter
+        counter!(
+            "rpc_requests_total",
+            "method" => self.method,
+            "chain" => self.chain.clone(),
+            "status" => status
+        )
+        .increment(1);
+
+        // Decrement in-flight gauge
+        gauge!(
+            "rpc_requests_in_flight",
+            "method" => self.method,
+            "chain" => self.chain.clone()
+        )
+        .decrement(1.0);
+    }
+}
+
+impl Drop for RpcMetricsGuard {
+    fn drop(&mut self) {
+        // If dropped without calling success/failure (e.g., panic), still decrement in-flight
+        if !self.completed {
+            gauge!(
+                "rpc_requests_in_flight",
+                "method" => self.method,
+                "chain" => self.chain.clone()
+            )
+            .decrement(1.0);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_chain_label_from_url_alchemy() {
+        let url = Url::parse("https://eth-mainnet.g.alchemy.com/v2/abc123").unwrap();
+        assert_eq!(chain_label_from_url(&url), "alchemy_eth_mainnet");
+
+        let url = Url::parse("https://base-mainnet.g.alchemy.com/v2/abc123").unwrap();
+        assert_eq!(chain_label_from_url(&url), "alchemy_base_mainnet");
+    }
+
+    #[test]
+    fn test_chain_label_from_url_infura() {
+        let url = Url::parse("https://mainnet.infura.io/v3/abc123").unwrap();
+        assert_eq!(chain_label_from_url(&url), "infura_mainnet");
+    }
+
+    #[test]
+    fn test_chain_label_from_url_other() {
+        let url = Url::parse("https://rpc.ankr.com/eth").unwrap();
+        assert_eq!(chain_label_from_url(&url), "rpc_ankr_com");
+    }
+}

--- a/src/rpc/alchemy.rs
+++ b/src/rpc/alchemy.rs
@@ -13,6 +13,7 @@ use async_trait::async_trait;
 use tokio::sync::{Mutex, Semaphore};
 use url::Url;
 
+use crate::metrics::{chain_label_from_url, RpcMetricsGuard, RpcMethod};
 use crate::rpc::rpc::{
     error_chain, with_retry, RetryConfig, RpcClient, RpcClientConfig, RpcError, RpcProvider,
 };
@@ -274,6 +275,11 @@ impl AlchemyClient {
         &self.config.retry
     }
 
+    /// Get the chain label for metrics, derived from the RPC URL.
+    fn chain_label(&self) -> String {
+        chain_label_from_url(&self.config.url)
+    }
+
     /// Consume compute units, waiting if necessary.
     /// Uses sliding window rate limiting to prevent burst accumulation.
     async fn consume_compute_units(&self, cost: ComputeUnitCost) {
@@ -432,16 +438,22 @@ impl AlchemyClient {
     }
 
     pub async fn get_block_number(&self) -> Result<BlockNumber, RpcError> {
+        let guard = RpcMetricsGuard::new(RpcMethod::GetBlockNumber, &self.chain_label());
         self.consume_compute_units(ComputeUnitCost::BLOCK_NUMBER)
             .await;
-        with_retry(&self.config.retry, "get_block_number", || async {
+        let result = with_retry(&self.config.retry, "get_block_number", || async {
             self.inner
                 .provider()
                 .get_block_number()
                 .await
                 .map_err(|e| RpcError::ProviderError(error_chain(&e)))
         })
-        .await
+        .await;
+        match &result {
+            Ok(_) => guard.success(),
+            Err(e) => guard.failure(e),
+        }
+        result
     }
 
     pub async fn get_block(
@@ -449,6 +461,7 @@ impl AlchemyClient {
         block_id: BlockId,
         full_transactions: bool,
     ) -> Result<Option<Block>, RpcError> {
+        let guard = RpcMetricsGuard::new(RpcMethod::GetBlock, &self.chain_label());
         let cost = match block_id {
             BlockId::Hash(_) => ComputeUnitCost::GET_BLOCK_BY_HASH,
             BlockId::Number(_) => ComputeUnitCost::GET_BLOCK_BY_NUMBER,
@@ -456,7 +469,7 @@ impl AlchemyClient {
         let op_name = format!("eth_getBlockByNumber({:?})", block_id);
 
         self.consume_compute_units(cost).await;
-        with_retry(&self.config.retry, &op_name, || async {
+        let result = with_retry(&self.config.retry, &op_name, || async {
             let builder = self.inner.provider().get_block(block_id);
             if full_transactions {
                 builder
@@ -469,7 +482,12 @@ impl AlchemyClient {
                     .map_err(|e| RpcError::ProviderError(error_chain(&e)))
             }
         })
-        .await
+        .await;
+        match &result {
+            Ok(_) => guard.success(),
+            Err(e) => guard.failure(e),
+        }
+        result
     }
 
     pub async fn get_block_by_number(
@@ -482,34 +500,46 @@ impl AlchemyClient {
     }
 
     pub async fn get_transaction(&self, hash: B256) -> Result<Option<Transaction>, RpcError> {
+        let guard = RpcMetricsGuard::new(RpcMethod::GetTransaction, &self.chain_label());
         let op_name = format!("eth_getTransactionByHash({:?})", hash);
         self.consume_compute_units(ComputeUnitCost::GET_TRANSACTION_BY_HASH)
             .await;
-        with_retry(&self.config.retry, &op_name, || async {
+        let result = with_retry(&self.config.retry, &op_name, || async {
             self.inner
                 .provider()
                 .get_transaction_by_hash(hash)
                 .await
                 .map_err(|e| RpcError::ProviderError(error_chain(&e)))
         })
-        .await
+        .await;
+        match &result {
+            Ok(_) => guard.success(),
+            Err(e) => guard.failure(e),
+        }
+        result
     }
 
     pub async fn get_transaction_receipt(
         &self,
         hash: B256,
     ) -> Result<Option<TransactionReceipt>, RpcError> {
+        let guard = RpcMetricsGuard::new(RpcMethod::GetTransactionReceipt, &self.chain_label());
         let op_name = format!("eth_getTransactionReceipt({:?})", hash);
         self.consume_compute_units(ComputeUnitCost::GET_TRANSACTION_RECEIPT)
             .await;
-        with_retry(&self.config.retry, &op_name, || async {
+        let result = with_retry(&self.config.retry, &op_name, || async {
             self.inner
                 .provider()
                 .get_transaction_receipt(hash)
                 .await
                 .map_err(|e| RpcError::ProviderError(error_chain(&e)))
         })
-        .await
+        .await;
+        match &result {
+            Ok(_) => guard.success(),
+            Err(e) => guard.failure(e),
+        }
+        result
     }
 
     pub async fn get_block_receipts(
@@ -517,10 +547,16 @@ impl AlchemyClient {
         method_name: &str,
         block_number: BlockNumberOrTag,
     ) -> Result<Vec<Option<TransactionReceipt>>, RpcError> {
+        let guard = RpcMetricsGuard::new(RpcMethod::GetBlockReceipts, &self.chain_label());
         // Note: inner.get_block_receipts already has retry logic
         self.consume_compute_units(ComputeUnitCost::GET_BLOCK_RECEIPTS)
             .await;
-        self.inner.get_block_receipts(method_name, block_number).await
+        let result = self.inner.get_block_receipts(method_name, block_number).await;
+        match &result {
+            Ok(_) => guard.success(),
+            Err(e) => guard.failure(e),
+        }
+        result
     }
 
     /// Get block receipts for multiple blocks concurrently.
@@ -536,7 +572,9 @@ impl AlchemyClient {
         block_numbers: Vec<BlockNumberOrTag>,
         #[allow(unused_variables)] _concurrency: usize,
     ) -> Result<Vec<Vec<Option<TransactionReceipt>>>, RpcError> {
+        let guard = RpcMetricsGuard::new(RpcMethod::GetBlockReceiptsConcurrent, &self.chain_label());
         if block_numbers.is_empty() {
+            guard.success();
             return Ok(vec![]);
         }
 
@@ -553,7 +591,15 @@ impl AlchemyClient {
                     inner.get_block_receipts(&method_name, block_number).await
                 }
             })
-            .await?;
+            .await;
+
+        let results = match results {
+            Ok(r) => r,
+            Err(e) => {
+                guard.failure(&e);
+                return Err(e);
+            }
+        };
 
         // Collect results, failing on first error
         let mut receipts = Vec::with_capacity(results.len());
@@ -562,14 +608,17 @@ impl AlchemyClient {
                 Ok(r) => receipts.push(r),
                 Err(e) => {
                     tracing::error!("get_block_receipts failed for block index {}: {}", i, e);
+                    guard.failure(&e);
                     return Err(e);
                 }
             }
         }
+        guard.success();
         Ok(receipts)
     }
 
     pub async fn get_logs(&self, filter: &Filter) -> Result<Vec<Log>, RpcError> {
+        let guard = RpcMetricsGuard::new(RpcMethod::GetLogs, &self.chain_label());
         let filter = filter.clone();
         let op_name = format!(
             "eth_getLogs(blocks {:?}-{:?})",
@@ -577,14 +626,19 @@ impl AlchemyClient {
             filter.get_to_block()
         );
         self.consume_compute_units(ComputeUnitCost::GET_LOGS).await;
-        with_retry(&self.config.retry, &op_name, || async {
+        let result = with_retry(&self.config.retry, &op_name, || async {
             self.inner
                 .provider()
                 .get_logs(&filter)
                 .await
                 .map_err(|e| RpcError::ProviderError(error_chain(&e)))
         })
-        .await
+        .await;
+        match &result {
+            Ok(_) => guard.success(),
+            Err(e) => guard.failure(e),
+        }
+        result
     }
 
     pub async fn get_balance(
@@ -592,10 +646,11 @@ impl AlchemyClient {
         address: Address,
         block: Option<BlockId>,
     ) -> Result<U256, RpcError> {
+        let guard = RpcMetricsGuard::new(RpcMethod::GetBalance, &self.chain_label());
         let op_name = format!("eth_getBalance({:?}, {:?})", address, block);
         self.consume_compute_units(ComputeUnitCost::GET_BALANCE)
             .await;
-        with_retry(&self.config.retry, &op_name, || async {
+        let result = with_retry(&self.config.retry, &op_name, || async {
             self.inner
                 .provider()
                 .get_balance(address)
@@ -603,7 +658,12 @@ impl AlchemyClient {
                 .await
                 .map_err(|e| RpcError::ProviderError(error_chain(&e)))
         })
-        .await
+        .await;
+        match &result {
+            Ok(_) => guard.success(),
+            Err(e) => guard.failure(e),
+        }
+        result
     }
 
     pub async fn get_code(
@@ -611,9 +671,10 @@ impl AlchemyClient {
         address: Address,
         block: Option<BlockId>,
     ) -> Result<Bytes, RpcError> {
+        let guard = RpcMetricsGuard::new(RpcMethod::GetCode, &self.chain_label());
         let op_name = format!("eth_getCode({:?}, {:?})", address, block);
         self.consume_compute_units(ComputeUnitCost::GET_CODE).await;
-        with_retry(&self.config.retry, &op_name, || async {
+        let result = with_retry(&self.config.retry, &op_name, || async {
             self.inner
                 .provider()
                 .get_code_at(address)
@@ -621,7 +682,12 @@ impl AlchemyClient {
                 .await
                 .map_err(|e| RpcError::ProviderError(error_chain(&e)))
         })
-        .await
+        .await;
+        match &result {
+            Ok(_) => guard.success(),
+            Err(e) => guard.failure(e),
+        }
+        result
     }
 
     pub async fn call(
@@ -629,10 +695,11 @@ impl AlchemyClient {
         tx: &alloy::rpc::types::TransactionRequest,
         block: Option<BlockId>,
     ) -> Result<Bytes, RpcError> {
+        let guard = RpcMetricsGuard::new(RpcMethod::EthCall, &self.chain_label());
         let tx = tx.clone();
         let op_name = format!("eth_call(to={:?}, block={:?})", tx.to, block);
         self.consume_compute_units(ComputeUnitCost::ETH_CALL).await;
-        with_retry(&self.config.retry, &op_name, || async {
+        let result = with_retry(&self.config.retry, &op_name, || async {
             self.inner
                 .provider()
                 .call(tx.clone())
@@ -640,7 +707,12 @@ impl AlchemyClient {
                 .await
                 .map_err(|e| RpcError::ProviderError(error_chain(&e)))
         })
-        .await
+        .await;
+        match &result {
+            Ok(_) => guard.success(),
+            Err(e) => guard.failure(e),
+        }
+        result
     }
 
     pub async fn get_blocks_batch(
@@ -648,15 +720,24 @@ impl AlchemyClient {
         block_numbers: Vec<BlockNumberOrTag>,
         full_transactions: bool,
     ) -> Result<Vec<Option<Block>>, RpcError> {
+        let guard = RpcMetricsGuard::new(RpcMethod::GetBlocksBatch, &self.chain_label());
         if !self.config.batching_enabled {
             let mut results = Vec::with_capacity(block_numbers.len());
             for number in block_numbers {
-                results.push(self.get_block_by_number(number, full_transactions).await?);
+                match self.get_block_by_number(number, full_transactions).await {
+                    Ok(block) => results.push(block),
+                    Err(e) => {
+                        guard.failure(&e);
+                        return Err(e);
+                    }
+                }
             }
+            guard.success();
             return Ok(results);
         }
 
         if block_numbers.is_empty() {
+            guard.success();
             return Ok(vec![]);
         }
 
@@ -686,13 +767,28 @@ impl AlchemyClient {
                     .await
                 }
             })
-            .await?;
+            .await;
+
+        let results = match results {
+            Ok(r) => r,
+            Err(e) => {
+                guard.failure(&e);
+                return Err(e);
+            }
+        };
 
         // Collect results, failing on first error
         let mut blocks = Vec::with_capacity(results.len());
         for result in results {
-            blocks.push(result?);
+            match result {
+                Ok(block) => blocks.push(block),
+                Err(e) => {
+                    guard.failure(&e);
+                    return Err(e);
+                }
+            }
         }
+        guard.success();
         Ok(blocks)
     }
 
@@ -742,6 +838,7 @@ impl AlchemyClient {
         &self,
         hashes: Vec<B256>,
     ) -> Result<Vec<Option<TransactionReceipt>>, RpcError> {
+        let guard = RpcMetricsGuard::new(RpcMethod::GetTransactionReceiptsBatch, &self.chain_label());
         if !self.config.batching_enabled {
             let mut results = Vec::with_capacity(hashes.len());
             for hash in hashes {
@@ -753,10 +850,12 @@ impl AlchemyClient {
                     }
                 }
             }
+            guard.success();
             return Ok(results);
         }
 
         if hashes.is_empty() {
+            guard.success();
             return Ok(vec![]);
         }
 
@@ -776,21 +875,39 @@ impl AlchemyClient {
                     }
                 }
             })
-            .await?;
+            .await;
 
-        Ok(results)
+        match results {
+            Ok(r) => {
+                guard.success();
+                Ok(r)
+            }
+            Err(e) => {
+                guard.failure(&e);
+                Err(e)
+            }
+        }
     }
 
     pub async fn get_logs_batch(&self, filters: Vec<Filter>) -> Result<Vec<Vec<Log>>, RpcError> {
+        let guard = RpcMetricsGuard::new(RpcMethod::GetLogsBatch, &self.chain_label());
         if !self.config.batching_enabled {
             let mut results = Vec::with_capacity(filters.len());
             for filter in filters {
-                results.push(self.get_logs(&filter).await?);
+                match self.get_logs(&filter).await {
+                    Ok(logs) => results.push(logs),
+                    Err(e) => {
+                        guard.failure(&e);
+                        return Err(e);
+                    }
+                }
             }
+            guard.success();
             return Ok(results);
         }
 
         if filters.is_empty() {
+            guard.success();
             return Ok(vec![]);
         }
 
@@ -817,13 +934,28 @@ impl AlchemyClient {
                     .await
                 }
             })
-            .await?;
+            .await;
+
+        let results = match results {
+            Ok(r) => r,
+            Err(e) => {
+                guard.failure(&e);
+                return Err(e);
+            }
+        };
 
         // Collect results, failing on first error
         let mut logs = Vec::with_capacity(results.len());
         for result in results {
-            logs.push(result?);
+            match result {
+                Ok(l) => logs.push(l),
+                Err(e) => {
+                    guard.failure(&e);
+                    return Err(e);
+                }
+            }
         }
+        guard.success();
         Ok(logs)
     }
 
@@ -831,15 +963,18 @@ impl AlchemyClient {
         &self,
         calls: Vec<(alloy::rpc::types::TransactionRequest, BlockId)>,
     ) -> Result<Vec<Result<Bytes, RpcError>>, RpcError> {
+        let guard = RpcMetricsGuard::new(RpcMethod::EthCallBatch, &self.chain_label());
         if !self.config.batching_enabled {
             let mut results = Vec::with_capacity(calls.len());
             for (tx, block) in calls {
                 results.push(self.call(&tx, Some(block)).await);
             }
+            guard.success();
             return Ok(results);
         }
 
         if calls.is_empty() {
+            guard.success();
             return Ok(vec![]);
         }
 
@@ -863,9 +998,18 @@ impl AlchemyClient {
                     .await
                 }
             })
-            .await?;
+            .await;
 
-        Ok(results)
+        match results {
+            Ok(r) => {
+                guard.success();
+                Ok(r)
+            }
+            Err(e) => {
+                guard.failure(&e);
+                Err(e)
+            }
+        }
     }
 }
 

--- a/src/types/config/indexer.rs
+++ b/src/types/config/indexer.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use serde::Deserialize;
 
 use crate::types::config::chain::{ChainConfig, ChainConfigRaw, resolve_chain_config};
+use crate::types::config::metrics::MetricsConfig;
 use crate::types::config::raw_data::RawDataCollectionConfig;
 use crate::types::config::transformations::TransformationConfig;
 
@@ -12,6 +13,8 @@ pub struct IndexerConfigRaw {
     pub raw_data_collection: RawDataCollectionConfig,
     #[serde(default)]
     pub transformations: Option<TransformationConfig>,
+    #[serde(default)]
+    pub metrics: Option<MetricsConfig>,
 }
 
 #[derive(Debug)]
@@ -19,6 +22,7 @@ pub struct IndexerConfig {
     pub chains: Vec<ChainConfig>,
     pub raw_data_collection: RawDataCollectionConfig,
     pub transformations: Option<TransformationConfig>,
+    pub metrics: Option<MetricsConfig>,
 }
 
 impl IndexerConfig {
@@ -45,6 +49,7 @@ impl IndexerConfig {
                             chains,
                             raw_data_collection: raw_config.raw_data_collection,
                             transformations: raw_config.transformations,
+                            metrics: raw_config.metrics,
                         })
                     }
                     Err(e) => {

--- a/src/types/config/metrics.rs
+++ b/src/types/config/metrics.rs
@@ -1,0 +1,7 @@
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct MetricsConfig {
+    /// Address to bind the metrics HTTP server (e.g., "0.0.0.0:9090")
+    pub addr: String,
+}

--- a/src/types/config/mod.rs
+++ b/src/types/config/mod.rs
@@ -2,6 +2,7 @@ pub mod chain;
 pub mod contract;
 pub mod eth_call;
 pub mod indexer;
+pub mod metrics;
 pub mod raw_data;
 pub mod tokens;
 pub mod transformations;


### PR DESCRIPTION
This adds a configurable /metrics endpoint that allows prometheus to pull metrics to send to grafana. Initially this only has metrics for rpc latencies, total requests, errored requests, and in flight requests