### PR TITLE
live mdoe cleanup

### DIFF
--- a/src/decoding/current/eth_calls.rs
+++ b/src/decoding/current/eth_calls.rs
@@ -120,6 +120,14 @@ pub async fn decode_eth_calls_live(
                                 );
                             }
                         }
+
+                        // Update block status to mark decoding complete
+                        if let Ok(mut status) = live_storage.read_status(range_start) {
+                            status.decoded = true;
+                            if let Err(e) = live_storage.write_status(range_start, &status) {
+                                tracing::warn!("Failed to update block status after eth_call decoding: {}", e);
+                            }
+                        }
                     } else {
                         // Historical mode: write to parquet
                         process_regular_calls(
@@ -196,6 +204,14 @@ pub async fn decode_eth_calls_live(
                                 );
                             }
                         }
+
+                        // Update block status to mark decoding complete
+                        if let Ok(mut status) = live_storage.read_status(range_start) {
+                            status.decoded = true;
+                            if let Err(e) = live_storage.write_status(range_start, &status) {
+                                tracing::warn!("Failed to update block status after once_call decoding: {}", e);
+                            }
+                        }
                     } else {
                         // Historical mode: write to parquet
                         process_once_calls(
@@ -260,6 +276,14 @@ pub async fn decode_eth_calls_live(
                                     "Failed to write decoded event_calls for {}/{} at block {}: {}",
                                     contract_name, function_name, range_start, e
                                 );
+                            }
+                        }
+
+                        // Update block status to mark decoding complete
+                        if let Ok(mut status) = live_storage.read_status(range_start) {
+                            status.decoded = true;
+                            if let Err(e) = live_storage.write_status(range_start, &status) {
+                                tracing::warn!("Failed to update block status after event_call decoding: {}", e);
                             }
                         }
                     } else {

--- a/src/live/compaction.rs
+++ b/src/live/compaction.rs
@@ -579,6 +579,7 @@ impl CompactionService {
             Field::new("block_timestamp", DataType::UInt64, false),
             Field::new("log_index", DataType::UInt32, false),
             Field::new("transaction_index", DataType::UInt32, false),
+            Field::new("transaction_hash", DataType::FixedSizeBinary(32), false),
             Field::new("address", DataType::Binary, false),
             Field::new("topic0", DataType::Binary, true),
             Field::new("topic1", DataType::Binary, true),
@@ -591,6 +592,7 @@ impl CompactionService {
         let mut timestamps = UInt64Builder::new();
         let mut log_indices = UInt32Builder::new();
         let mut tx_indices = UInt32Builder::new();
+        let mut tx_hashes = FixedSizeBinaryBuilder::new(32);
         let mut addresses = BinaryBuilder::new();
         let mut topic0s = BinaryBuilder::new();
         let mut topic1s = BinaryBuilder::new();
@@ -603,6 +605,7 @@ impl CompactionService {
             timestamps.append_value(*timestamp);
             log_indices.append_value(log.log_index);
             tx_indices.append_value(log.transaction_index);
+            tx_hashes.append_value(&log.transaction_hash)?;
             addresses.append_value(&log.address);
 
             // Handle topics (up to 4)
@@ -637,6 +640,7 @@ impl CompactionService {
                 Arc::new(timestamps.finish()) as ArrayRef,
                 Arc::new(log_indices.finish()) as ArrayRef,
                 Arc::new(tx_indices.finish()) as ArrayRef,
+                Arc::new(tx_hashes.finish()) as ArrayRef,
                 Arc::new(addresses.finish()) as ArrayRef,
                 Arc::new(topic0s.finish()) as ArrayRef,
                 Arc::new(topic1s.finish()) as ArrayRef,

--- a/src/live/progress.rs
+++ b/src/live/progress.rs
@@ -10,6 +10,7 @@ use thiserror::Error;
 use tokio_postgres::types::ToSql;
 
 use crate::db::DbPool;
+use super::storage::LiveStorage;
 
 #[derive(Debug, Error)]
 pub enum ProgressError {
@@ -20,6 +21,8 @@ pub enum ProgressError {
 /// Tracks per-block progress for all handlers.
 pub struct LiveProgressTracker {
     chain_id: i64,
+    /// Chain name for LiveStorage access.
+    chain_name: String,
     /// Set of (block_number, handler_key) pairs that are complete.
     completed: HashMap<u64, HashSet<String>>,
     /// All known handler keys.
@@ -30,9 +33,10 @@ pub struct LiveProgressTracker {
 
 impl LiveProgressTracker {
     /// Create a new progress tracker.
-    pub fn new(chain_id: i64, db_pool: Option<Arc<DbPool>>) -> Self {
+    pub fn new(chain_id: i64, db_pool: Option<Arc<DbPool>>, chain_name: String) -> Self {
         Self {
             chain_id,
+            chain_name,
             completed: HashMap::new(),
             handler_keys: HashSet::new(),
             db_pool,
@@ -79,6 +83,17 @@ impl LiveProgressTracker {
                 )
                 .await
                 .map_err(|e| ProgressError::Database(e.to_string()))?;
+        }
+
+        // Check if all handlers are now complete for this block
+        if self.is_block_complete(block_number) {
+            let storage = LiveStorage::new(&self.chain_name);
+            if let Ok(mut status) = storage.read_status(block_number) {
+                status.transformed = true;
+                if let Err(e) = storage.write_status(block_number, &status) {
+                    tracing::warn!("Failed to update block status after transformation: {}", e);
+                }
+            }
         }
 
         Ok(())
@@ -222,7 +237,7 @@ mod tests {
 
     #[test]
     fn test_progress_tracker_basic() {
-        let mut tracker = LiveProgressTracker::new(1, None);
+        let mut tracker = LiveProgressTracker::new(1, None, "test_chain".to_string());
         tracker.register_handler("handler_a");
         tracker.register_handler("handler_b");
 
@@ -240,7 +255,7 @@ mod tests {
 
     #[test]
     fn test_pending_handlers() {
-        let mut tracker = LiveProgressTracker::new(1, None);
+        let mut tracker = LiveProgressTracker::new(1, None, "test_chain".to_string());
         tracker.register_handler("a");
         tracker.register_handler("b");
         tracker.register_handler("c");
@@ -255,7 +270,7 @@ mod tests {
 
     #[test]
     fn test_clear_block() {
-        let mut tracker = LiveProgressTracker::new(1, None);
+        let mut tracker = LiveProgressTracker::new(1, None, "test_chain".to_string());
         tracker.register_handler("handler");
 
         tokio_test::block_on(tracker.mark_complete(200, "handler")).unwrap();
@@ -267,7 +282,7 @@ mod tests {
 
     #[test]
     fn test_empty_handlers() {
-        let tracker = LiveProgressTracker::new(1, None);
+        let tracker = LiveProgressTracker::new(1, None, "test_chain".to_string());
         // With no handlers, all blocks are "complete"
         assert!(tracker.is_block_complete(100));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -272,6 +272,32 @@ async fn process_chain_live_only(
         None
     };
 
+    // Build transformation registry and progress tracker if transformations enabled
+    let progress_tracker = if config.transformations.is_some() {
+        let registry = build_registry();
+        let tracker = Arc::new(Mutex::new(LiveProgressTracker::new(
+            chain.chain_id as i64,
+            db_pool.clone(),
+            chain.name.clone(),
+        )));
+
+        // Register all handlers
+        {
+            let mut t = tracker.lock().await;
+            for handler in registry.all_handlers() {
+                t.register_handler(&handler.handler_key());
+            }
+        }
+        tracing::info!(
+            "Registered {} handlers with live progress tracker",
+            registry.all_handlers().len()
+        );
+
+        Some(tracker)
+    } else {
+        None
+    };
+
     // Check if decoding is needed
     let has_events = chain.contracts.values().any(|c| {
         has_items(&c.events)
@@ -337,7 +363,7 @@ async fn process_chain_live_only(
         log_decoder_tx,
         eth_call_decoder_tx,
         None, // No transform_reorg_tx in live-only mode
-        None, // No progress tracker in live-only mode (no handlers)
+        progress_tracker,
         &mut tasks,
     )
     .await?;
@@ -786,6 +812,7 @@ async fn process_chain(config: &IndexerConfig, chain: &ChainConfig) -> anyhow::R
         Some(Arc::new(Mutex::new(LiveProgressTracker::new(
             chain.chain_id as i64,
             db_pool.clone(),
+            chain.name.clone(),
         ))))
     } else {
         None
@@ -997,6 +1024,7 @@ async fn spawn_live_mode(
         Arc::new(Mutex::new(LiveProgressTracker::new(
             chain.chain_id as i64,
             db_pool.clone(),
+            chain.name.clone(),
         )))
     });
 


### PR DESCRIPTION
cleanup fixes for live mode. write transaction hash to parquet files, update block status after decoding, and track progress