### PR TITLE
Refactor transformation engine into dedicated modules

### DIFF
--- a/src/transformations/engine.rs
+++ b/src/transformations/engine.rs
@@ -3,6 +3,12 @@
 //! The engine receives decoded events and calls, invokes registered handlers,
 //! and writes results to PostgreSQL. It tracks progress per handler and performs
 //! per-handler catchup from decoded parquet files on startup.
+//!
+//! Sub-components handle focused responsibilities:
+//! - [`executor`](super::executor): Handler spawn-loop, source/version injection, snapshot capture
+//! - [`finalizer`](super::finalizer): Range finalization, reorg cleanup, progress tracking
+//! - [`retry`](super::retry): Live retry processing from bincode storage
+//! - [`live_state`](super::live_state): Pending event buffering and completion tracking
 
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
@@ -16,22 +22,16 @@ use tokio::task::JoinSet;
 
 use super::context::{DecodedCall, DecodedEvent, TransactionAddresses, TransformationContext};
 use super::error::TransformationError;
+use super::executor::{inject_source_version, DbExecMode, HandlerExecutor, HandlerTask};
+use super::finalizer::RangeFinalizer;
 use super::historical::HistoricalDataReader;
+use super::live_state::{LiveProcessingState, PendingEventData};
 use super::registry::{extract_event_name, TransformationRegistry};
-use super::traits::EventHandler;
-use crate::db::{DbOperation, DbPool, DbValue, WhereClause};
-use crate::decoding::eth_calls::{
-    build_decode_configs, build_result_map, CallDecodeConfig, EventCallDecodeConfig,
-};
-use crate::decoding::event_parsing::ParsedEvent;
-use crate::decoding::logs::build_event_matchers;
-use crate::live::{
-    LiveDbValue, LiveProgressTracker, LiveStorage, LiveUpsertSnapshot,
-    StorageError, TransformRetryRequest,
-};
+use super::retry::{filter_calls_by_start_block, filter_events_by_start_block, RetryProcessor};
+use crate::db::DbPool;
+use crate::live::{LiveProgressTracker, TransformRetryRequest};
 use crate::rpc::UnifiedRpcClient;
 use crate::types::config::contract::{Contracts, FactoryCollections};
-use crate::types::config::eth_call::EvmType;
 
 /// Message containing decoded events for a block range.
 #[derive(Debug)]
@@ -93,127 +93,6 @@ impl Default for ExecutionMode {
     }
 }
 
-/// Buffered event data waiting for call dependencies.
-#[derive(Debug)]
-struct PendingEventData {
-    range_start: u64,
-    range_end: u64,
-    source_name: String,
-    event_name: String,
-    events: Vec<DecodedEvent>,
-    /// Call dependencies needed: (source, function_name)
-    required_calls: Vec<(String, String)>,
-}
-
-/// Default timeout for stuck pending events (5 minutes).
-const PENDING_EVENT_TIMEOUT_SECS: u64 = 300;
-
-/// Live processing state for buffering events with call dependencies.
-struct LiveProcessingState {
-    /// Track which (source, function) calls have arrived for which ranges.
-    /// Key: (source_name, function_name), Value: set of (range_start, range_end)
-    received_calls: HashMap<(String, String), HashSet<(u64, u64)>>,
-    /// Accumulated calls per range for event handlers with dependencies.
-    /// Key: (range_start, range_end), Value: accumulated calls
-    calls_buffer: HashMap<(u64, u64), Vec<DecodedCall>>,
-    /// Buffer events waiting for calls, keyed by handler_key.
-    pending_events: HashMap<String, Vec<PendingEventData>>,
-    /// Tracks which decode streams have completed for a range.
-    completion: HashMap<(u64, u64), RangeCompletionState>,
-    /// Track when events first become pending for timeout detection.
-    /// Key: (range_start, range_end, handler_key), Value: when first added
-    pending_event_timestamps: HashMap<(u64, u64, String), Instant>,
-    /// Ranges that have been finalized (to prevent double finalization).
-    finalized_ranges: HashSet<(u64, u64)>,
-}
-
-impl Default for LiveProcessingState {
-    fn default() -> Self {
-        Self {
-            received_calls: HashMap::new(),
-            calls_buffer: HashMap::new(),
-            pending_events: HashMap::new(),
-            completion: HashMap::new(),
-            pending_event_timestamps: HashMap::new(),
-            finalized_ranges: HashSet::new(),
-        }
-    }
-}
-
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-struct RangeCompletionState {
-    logs_complete: bool,
-    eth_calls_complete: bool,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum LiveRetryCallArtifactKind {
-    Regular,
-    EventTriggered { base_name: String },
-}
-
-impl RangeCompletionState {
-    fn mark(&mut self, kind: RangeCompleteKind) {
-        match kind {
-            RangeCompleteKind::Logs => self.logs_complete = true,
-            RangeCompleteKind::EthCalls => self.eth_calls_complete = true,
-        }
-    }
-
-    fn is_ready(self, expect_logs: bool, expect_eth_calls: bool) -> bool {
-        (!expect_logs || self.logs_complete) && (!expect_eth_calls || self.eth_calls_complete)
-    }
-}
-
-fn resolve_retry_missing_handlers(
-    request_missing: Option<HashSet<String>>,
-    tracker_missing: Option<HashSet<String>>,
-    all_handlers: HashSet<String>,
-) -> HashSet<String> {
-    tracker_missing.unwrap_or_else(|| request_missing.unwrap_or(all_handlers))
-}
-
-fn missing_retry_call_dependencies(
-    required_calls: &HashSet<(String, String)>,
-    calls: &[DecodedCall],
-) -> HashSet<(String, String)> {
-    let available_calls: HashSet<(String, String)> = calls
-        .iter()
-        .map(|call| (call.source_name.clone(), call.function_name.clone()))
-        .collect();
-
-    required_calls
-        .difference(&available_calls)
-        .cloned()
-        .collect()
-}
-
-fn classify_live_retry_call_artifact(
-    source_name: &str,
-    function_name: &str,
-    regular_keys: &HashSet<(String, String)>,
-    event_keys: &HashSet<(String, String)>,
-) -> Result<LiveRetryCallArtifactKind, TransformationError> {
-    let exact_key = (source_name.to_string(), function_name.to_string());
-    if regular_keys.contains(&exact_key) {
-        return Ok(LiveRetryCallArtifactKind::Regular);
-    }
-
-    if let Some(base_name) = function_name.strip_suffix("_event") {
-        let event_key = (source_name.to_string(), base_name.to_string());
-        if event_keys.contains(&event_key) {
-            return Ok(LiveRetryCallArtifactKind::EventTriggered {
-                base_name: base_name.to_string(),
-            });
-        }
-    }
-
-    Err(TransformationError::MissingData(format!(
-        "missing call schema for live retry {}/{}",
-        source_name, function_name
-    )))
-}
-
 /// The transformation engine processes decoded data and invokes handlers.
 ///
 /// Progress is tracked per handler (keyed by `handler_key()`) in the
@@ -221,7 +100,6 @@ fn classify_live_retry_call_artifact(
 pub struct TransformationEngine {
     registry: Arc<TransformationRegistry>,
     db_pool: Arc<DbPool>,
-    rpc_client: Arc<UnifiedRpcClient>,
     historical_reader: Arc<HistoricalDataReader>,
     chain_name: String,
     chain_id: u64,
@@ -230,17 +108,14 @@ pub struct TransformationEngine {
     decoded_calls_dir: PathBuf,
     raw_receipts_dir: PathBuf,
     contracts: Arc<Contracts>,
-    factory_collections: Arc<FactoryCollections>,
-    /// Maximum number of handlers to execute concurrently.
     handler_concurrency: usize,
-    /// Live processing state for buffering events with call dependencies.
+    // Sub-components
+    executor: Arc<HandlerExecutor>,
+    finalizer: Arc<RangeFinalizer>,
+    retry_processor: RetryProcessor,
     live_state: Mutex<LiveProcessingState>,
     /// Live mode progress tracker for marking block completion.
     progress_tracker: Option<Arc<Mutex<LiveProgressTracker>>>,
-    /// Whether live ranges require an eth_call completion signal before finalization.
-    expect_eth_call_completion: bool,
-    /// Whether ranges require a log completion signal before finalization.
-    expect_log_completion: bool,
 }
 
 impl TransformationEngine {
@@ -267,10 +142,45 @@ impl TransformationEngine {
         let raw_receipts_dir =
             PathBuf::from(format!("data/{}/historical/raw/receipts", chain_name));
 
+        let contracts = Arc::new(contracts);
+        let factory_collections = Arc::new(factory_collections);
+
+        let executor = Arc::new(HandlerExecutor {
+            db_pool: db_pool.clone(),
+            historical_reader: historical_reader.clone(),
+            rpc_client: rpc_client.clone(),
+            contracts: contracts.clone(),
+            chain_name: chain_name.clone(),
+            chain_id,
+            handler_concurrency,
+        });
+
+        let finalizer = Arc::new(RangeFinalizer {
+            registry: registry.clone(),
+            db_pool: db_pool.clone(),
+            chain_name: chain_name.clone(),
+            chain_id,
+            progress_tracker: progress_tracker.clone(),
+            expect_log_completion,
+            expect_eth_call_completion,
+        });
+
+        let retry_processor = RetryProcessor {
+            registry: registry.clone(),
+            db_pool: db_pool.clone(),
+            rpc_client: rpc_client.clone(),
+            historical_reader: historical_reader.clone(),
+            contracts: contracts.clone(),
+            factory_collections: factory_collections.clone(),
+            chain_name: chain_name.clone(),
+            chain_id,
+            handler_concurrency,
+            progress_tracker: progress_tracker.clone(),
+        };
+
         Ok(Self {
             registry,
             db_pool,
-            rpc_client,
             historical_reader,
             chain_name,
             chain_id,
@@ -278,13 +188,13 @@ impl TransformationEngine {
             decoded_logs_dir,
             decoded_calls_dir,
             raw_receipts_dir,
-            contracts: Arc::new(contracts),
-            factory_collections: Arc::new(factory_collections),
+            contracts,
             handler_concurrency,
+            executor,
+            finalizer,
+            retry_processor,
             live_state: Mutex::new(LiveProcessingState::default()),
             progress_tracker,
-            expect_eth_call_completion,
-            expect_log_completion,
         })
     }
 
@@ -311,10 +221,7 @@ impl TransformationEngine {
     // ─── Handler Migrations ──────────────────────────────────────────
 
     /// Run handler migration files from each handler's `migration_paths()`.
-    /// Each path can be a directory (all `.sql` files run in alphabetical order)
-    /// or a single `.sql` file. Tracked in the `_migrations` table with a `handlers/` prefix.
     async fn run_handler_migrations(&self) -> Result<(), TransformationError> {
-        // Collect migration paths from all handlers (deduplicate)
         let mut migration_paths: Vec<PathBuf> = Vec::new();
         let mut seen = HashSet::new();
 
@@ -331,7 +238,6 @@ impl TransformationEngine {
             return Ok(());
         }
 
-        // Check which migrations have already been applied
         let pool = self.db_pool.inner();
         let applied: HashSet<String> = {
             let client = pool.get().await?;
@@ -339,7 +245,6 @@ impl TransformationEngine {
             rows.iter().map(|r| r.get(0)).collect()
         };
 
-        // Resolve each path into (file_path, migration_name) pairs
         let mut sql_entries: Vec<(PathBuf, String)> = Vec::new();
 
         for path in &migration_paths {
@@ -349,11 +254,9 @@ impl TransformationEngine {
             }
 
             if path.is_file() {
-                // Single file: track as "handlers/{path}"
                 let migration_name = format!("{}", path.display());
                 sql_entries.push((path.clone(), migration_name));
             } else if path.is_dir() {
-                // Directory: collect and sort .sql files (flat scan)
                 let mut dir_files: Vec<_> = std::fs::read_dir(path)?
                     .filter_map(|e| e.ok())
                     .filter(|e| e.path().extension().map(|x| x == "sql").unwrap_or(false))
@@ -368,7 +271,6 @@ impl TransformationEngine {
             }
         }
 
-        // Apply each migration
         for (file_path, migration_name) in &sql_entries {
             if applied.contains(migration_name) {
                 continue;
@@ -402,9 +304,6 @@ impl TransformationEngine {
 
     // ─── Source Registration ────────────────────────────────────────
 
-    /// Register handler sources in the `active_versions` table.
-    /// For new sources, inserts with the handler's current version.
-    /// For existing sources with a different version, logs a warning.
     async fn register_handler_sources(&self) -> Result<(), TransformationError> {
         let pool = self.db_pool.inner();
         let client = pool.get().await?;
@@ -421,7 +320,6 @@ impl TransformationEngine {
                 .await?;
 
             if rows.is_empty() {
-                // New source — insert with current version
                 client
                     .execute(
                         "INSERT INTO active_versions (source, active_version) VALUES ($1, $2)",
@@ -453,174 +351,8 @@ impl TransformationEngine {
         Ok(())
     }
 
-    // ─── Source/Version Injection ────────────────────────────────────
-
-    /// Inject `source` and `source_version` into each DbOperation.
-    /// Called after handler.handle() returns ops, before execute_transaction().
-    fn inject_source_version(
-        ops: Vec<DbOperation>,
-        source: &str,
-        version: u32,
-    ) -> Vec<DbOperation> {
-        ops.into_iter()
-            .map(|op| match op {
-                DbOperation::Upsert {
-                    table,
-                    mut columns,
-                    mut values,
-                    mut conflict_columns,
-                    mut update_columns,
-                } => {
-                    columns.push("source".to_string());
-                    columns.push("source_version".to_string());
-                    values.push(DbValue::Text(source.to_string()));
-                    values.push(DbValue::Int32(version as i32));
-                    conflict_columns.push("source".to_string());
-                    conflict_columns.push("source_version".to_string());
-                    // Remove source/source_version from update_columns since they're part of conflict key
-                    update_columns.retain(|c| c != "source" && c != "source_version");
-                    DbOperation::Upsert {
-                        table,
-                        columns,
-                        values,
-                        conflict_columns,
-                        update_columns,
-                    }
-                }
-                DbOperation::Insert {
-                    table,
-                    mut columns,
-                    mut values,
-                } => {
-                    columns.push("source".to_string());
-                    columns.push("source_version".to_string());
-                    values.push(DbValue::Text(source.to_string()));
-                    values.push(DbValue::Int32(version as i32));
-                    DbOperation::Insert {
-                        table,
-                        columns,
-                        values,
-                    }
-                }
-                DbOperation::Update {
-                    table,
-                    set_columns,
-                    where_clause,
-                } => {
-                    let where_clause = Self::inject_where_clause(where_clause, source, version);
-                    DbOperation::Update {
-                        table,
-                        set_columns,
-                        where_clause,
-                    }
-                }
-                DbOperation::Delete {
-                    table,
-                    where_clause,
-                } => {
-                    let where_clause = Self::inject_where_clause(where_clause, source, version);
-                    DbOperation::Delete {
-                        table,
-                        where_clause,
-                    }
-                }
-                DbOperation::RawSql { query, params } => {
-                    tracing::warn!(
-                        "RawSql operation skipped for source/version injection — handler must manage source/source_version manually"
-                    );
-                    DbOperation::RawSql { query, params }
-                }
-            })
-            .collect()
-    }
-
-    /// Inject source/source_version conditions into a WhereClause.
-    fn inject_where_clause(clause: WhereClause, source: &str, version: u32) -> WhereClause {
-        let source_conditions = vec![
-            ("source".to_string(), DbValue::Text(source.to_string())),
-            ("source_version".to_string(), DbValue::Int32(version as i32)),
-        ];
-
-        match clause {
-            WhereClause::Eq(col, val) => {
-                let mut conditions = vec![(col, val)];
-                conditions.extend(source_conditions);
-                WhereClause::And(conditions)
-            }
-            WhereClause::And(mut conditions) => {
-                conditions.extend(source_conditions);
-                WhereClause::And(conditions)
-            }
-            WhereClause::Raw { condition, params } => {
-                tracing::warn!(
-                    "WhereClause::Raw skipped for source/version injection — handler must manage manually"
-                );
-                WhereClause::Raw { condition, params }
-            }
-        }
-    }
-
-    // ─── Per-Handler Progress Tracking ───────────────────────────────
-
-    /// Get completed ranges for a specific handler from the database.
-    async fn get_completed_ranges_for_handler(
-        &self,
-        handler_key: &str,
-    ) -> Result<HashSet<u64>, TransformationError> {
-        let rows = self
-            .db_pool
-            .query(
-                "SELECT range_start FROM _handler_progress WHERE chain_id = $1 AND handler_key = $2",
-                &[&(self.chain_id as i64), &handler_key.to_string()],
-            )
-            .await?;
-
-        let mut completed = HashSet::new();
-        for row in rows {
-            let range_start: i64 = row.get(0);
-            completed.insert(range_start as u64);
-        }
-
-        Ok(completed)
-    }
-
-    /// Record a completed range for a specific handler.
-    async fn record_completed_range_for_handler(
-        &self,
-        handler_key: &str,
-        range_start: u64,
-        range_end: u64,
-    ) -> Result<(), TransformationError> {
-        self.db_pool
-            .execute_transaction(vec![DbOperation::Upsert {
-                table: "_handler_progress".to_string(),
-                columns: vec![
-                    "chain_id".to_string(),
-                    "handler_key".to_string(),
-                    "range_start".to_string(),
-                    "range_end".to_string(),
-                ],
-                values: vec![
-                    DbValue::Int64(self.chain_id as i64),
-                    DbValue::Text(handler_key.to_string()),
-                    DbValue::Int64(range_start as i64),
-                    DbValue::Int64(range_end as i64),
-                ],
-                conflict_columns: vec![
-                    "chain_id".to_string(),
-                    "handler_key".to_string(),
-                    "range_start".to_string(),
-                ],
-                update_columns: vec!["range_end".to_string()],
-            }])
-            .await?;
-
-        Ok(())
-    }
-
     // ─── Range Scanning ──────────────────────────────────────────────
 
-    /// Scan decoded parquet files to find available ranges.
     fn scan_available_ranges(
         &self,
         base_dir: &PathBuf,
@@ -638,7 +370,6 @@ impl TransformationEngine {
                     if path.is_dir() {
                         scan_recursive(&path, ranges);
                     } else if path.extension().map(|e| e == "parquet").unwrap_or(false) {
-                        // Parse range from filename: 28990000-28999999.parquet
                         if let Some(file_name) = path.file_stem().and_then(|s| s.to_str()) {
                             let parts: Vec<&str> = file_name.split('-').collect();
                             if parts.len() == 2 {
@@ -665,19 +396,12 @@ impl TransformationEngine {
     // ─── Per-Handler Catchup ─────────────────────────────────────────
 
     /// Run catchup phase: process decoded parquet files per handler.
-    /// Each handler catches up independently based on its own progress.
     pub async fn run_catchup(&self) -> Result<(), TransformationError> {
-        // Catch up event handlers
         self.run_event_handler_catchup().await?;
-
-        // Catch up call handlers
         self.run_call_handler_catchup().await?;
-
         Ok(())
     }
 
-    /// Run catchup for all event handlers.
-    /// Processes `handler_concurrency` ranges concurrently per handler.
     async fn run_event_handler_catchup(&self) -> Result<(), TransformationError> {
         let available = self.scan_available_ranges(&self.decoded_logs_dir)?;
 
@@ -698,10 +422,8 @@ impl TransformationEngine {
                 .map(|t| (t.source.clone(), extract_event_name(&t.event_signature)))
                 .collect();
 
-            // Get call dependencies for this handler
             let call_deps = handler_info.handler.call_dependencies();
 
-            // Pre-compute available call ranges for each dependency
             let available_call_ranges: Vec<HashSet<(u64, u64)>> = call_deps
                 .iter()
                 .map(|(source, func)| {
@@ -713,7 +435,10 @@ impl TransformationEngine {
                 })
                 .collect();
 
-            let completed = self.get_completed_ranges_for_handler(&handler_key).await?;
+            let completed = self
+                .finalizer
+                .get_completed_ranges_for_handler(&handler_key)
+                .await?;
 
             let to_process: Vec<_> = available
                 .iter()
@@ -748,10 +473,8 @@ impl TransformationEngine {
                     .read_decoded_events_for_triggers(*range_start, *range_end, &event_triggers)
                     .await?;
 
-                // Filter events by contract start_block
-                let events = self.filter_events_by_start_block(events);
+                let events = filter_events_by_start_block(&self.contracts, events);
 
-                // Only check call dependencies when we have events that need them
                 if !events.is_empty() && !call_deps.is_empty() {
                     let calls_ready = available_call_ranges
                         .iter()
@@ -769,13 +492,11 @@ impl TransformationEngine {
                     }
                 }
 
-                // Read call dependencies for this range
                 let calls = if !events.is_empty() && !call_deps.is_empty() {
                     let calls = self
                         .read_decoded_calls_for_triggers(*range_start, *range_end, &call_deps)
                         .await?;
-                    // Filter calls by contract start_block
-                    self.filter_calls_by_start_block(calls)
+                    filter_calls_by_start_block(&self.contracts, calls)
                 } else {
                     Vec::new()
                 };
@@ -793,7 +514,7 @@ impl TransformationEngine {
                     let chain_name = self.chain_name.clone();
                     let chain_id = self.chain_id;
                     let historical = self.historical_reader.clone();
-                    let rpc = self.rpc_client.clone();
+                    let rpc = self.executor.rpc_client.clone();
                     let contracts = self.contracts.clone();
                     let rs = *range_start;
                     let re = *range_end;
@@ -816,7 +537,7 @@ impl TransformationEngine {
                         match handler.handle(&ctx).await {
                             Ok(ops) => {
                                 if !ops.is_empty() {
-                                    let ops = Self::inject_source_version(
+                                    let ops = inject_source_version(
                                         ops,
                                         handler_name,
                                         handler_version,
@@ -829,8 +550,8 @@ impl TransformationEngine {
                         }
                     });
                 } else {
-                    // No events — record progress directly
-                    self.record_completed_range_for_handler(&handler_key, *range_start, *range_end)
+                    self.finalizer
+                        .record_completed_range_for_handler(&handler_key, *range_start, *range_end)
                         .await?;
                 }
 
@@ -845,11 +566,12 @@ impl TransformationEngine {
                 }
             }
 
-            // Drain remaining tasks
             while let Some(result) = join_set.join_next().await {
                 match result {
                     Ok(Ok(Some((hk, rs, re)))) => {
-                        self.record_completed_range_for_handler(&hk, rs, re).await?;
+                        self.finalizer
+                            .record_completed_range_for_handler(&hk, rs, re)
+                            .await?;
                     }
                     Ok(Ok(None)) => {}
                     Ok(Err(e)) => {
@@ -888,8 +610,6 @@ impl TransformationEngine {
         Ok(())
     }
 
-    /// Run catchup for all call handlers.
-    /// Processes `handler_concurrency` ranges concurrently per handler.
     async fn run_call_handler_catchup(&self) -> Result<(), TransformationError> {
         let available = self.scan_available_ranges(&self.decoded_calls_dir)?;
 
@@ -910,7 +630,10 @@ impl TransformationEngine {
                 .map(|t| (t.source.clone(), t.function_name.clone()))
                 .collect();
 
-            let completed = self.get_completed_ranges_for_handler(&handler_key).await?;
+            let completed = self
+                .finalizer
+                .get_completed_ranges_for_handler(&handler_key)
+                .await?;
 
             let to_process: Vec<_> = available
                 .iter()
@@ -943,8 +666,7 @@ impl TransformationEngine {
                     .read_decoded_calls_for_triggers(*range_start, *range_end, &call_triggers)
                     .await?;
 
-                // Filter calls by contract start_block
-                let calls = self.filter_calls_by_start_block(calls);
+                let calls = filter_calls_by_start_block(&self.contracts, calls);
 
                 processed += 1;
 
@@ -958,7 +680,7 @@ impl TransformationEngine {
                     let chain_name = self.chain_name.clone();
                     let chain_id = self.chain_id;
                     let historical = self.historical_reader.clone();
-                    let rpc = self.rpc_client.clone();
+                    let rpc = self.executor.rpc_client.clone();
                     let contracts = self.contracts.clone();
                     let rs = *range_start;
                     let re = *range_end;
@@ -981,7 +703,7 @@ impl TransformationEngine {
                         match handler.handle(&ctx).await {
                             Ok(ops) => {
                                 if !ops.is_empty() {
-                                    let ops = Self::inject_source_version(
+                                    let ops = inject_source_version(
                                         ops,
                                         handler_name,
                                         handler_version,
@@ -994,8 +716,8 @@ impl TransformationEngine {
                         }
                     });
                 } else {
-                    // No calls — record progress directly
-                    self.record_completed_range_for_handler(&handler_key, *range_start, *range_end)
+                    self.finalizer
+                        .record_completed_range_for_handler(&handler_key, *range_start, *range_end)
                         .await?;
                 }
 
@@ -1009,11 +731,12 @@ impl TransformationEngine {
                 }
             }
 
-            // Drain remaining tasks
             while let Some(result) = join_set.join_next().await {
                 match result {
                     Ok(Ok(Some((hk, rs, re)))) => {
-                        self.record_completed_range_for_handler(&hk, rs, re).await?;
+                        self.finalizer
+                            .record_completed_range_for_handler(&hk, rs, re)
+                            .await?;
                     }
                     Ok(Ok(None)) => {}
                     Ok(Err(e)) => {
@@ -1046,7 +769,6 @@ impl TransformationEngine {
 
     // ─── Receipt Address Reading ────────────────────────────────────
 
-    /// Read transaction from/to addresses from receipt parquet files for a block range.
     fn read_receipt_addresses(
         &self,
         range_start: u64,
@@ -1120,7 +842,6 @@ impl TransformationEngine {
                 continue;
             }
 
-            // Extract transaction_hash column
             let tx_hash_col = match batch.column_by_name("transaction_hash") {
                 Some(col) => match col.as_any().downcast_ref::<FixedSizeBinaryArray>() {
                     Some(arr) => arr.clone(),
@@ -1129,7 +850,6 @@ impl TransformationEngine {
                 None => continue,
             };
 
-            // Extract from_address column
             let from_col = match batch.column_by_name("from_address") {
                 Some(col) => match col.as_any().downcast_ref::<FixedSizeBinaryArray>() {
                     Some(arr) => arr.clone(),
@@ -1138,7 +858,6 @@ impl TransformationEngine {
                 None => continue,
             };
 
-            // Extract to_address column (nullable)
             let to_col = batch
                 .column_by_name("to_address")
                 .and_then(|col| col.as_any().downcast_ref::<FixedSizeBinaryArray>().cloned());
@@ -1183,9 +902,6 @@ impl TransformationEngine {
 
     // ─── Parquet Reading ─────────────────────────────────────────────
 
-    /// Read decoded events from parquet files for specific triggers,
-    /// using `spawn_blocking` to avoid blocking the async runtime.
-    /// Multiple trigger files are read concurrently.
     async fn read_decoded_events_for_triggers(
         &self,
         range_start: u64,
@@ -1249,9 +965,6 @@ impl TransformationEngine {
         Ok(all_events)
     }
 
-    /// Read decoded calls from parquet files for specific triggers,
-    /// using `spawn_blocking` to avoid blocking the async runtime.
-    /// Multiple trigger files are read concurrently.
     async fn read_decoded_calls_for_triggers(
         &self,
         range_start: u64,
@@ -1314,14 +1027,6 @@ impl TransformationEngine {
     // ─── Live Processing ─────────────────────────────────────────────
 
     /// Run the transformation engine, processing messages from channels.
-    ///
-    /// This is spawned as a task similar to decode_logs and decode_eth_calls.
-    /// Events and calls are processed immediately as they arrive.
-    /// For event handlers with call dependencies, events are buffered until
-    /// their required calls arrive.
-    ///
-    /// The optional `reorg_rx` channel receives reorg notifications from live mode
-    /// to clean up pending events for orphaned blocks.
     pub async fn run(
         &self,
         mut events_rx: Receiver<DecodedEventsMessage>,
@@ -1331,7 +1036,6 @@ impl TransformationEngine {
         mut retry_rx: Option<Receiver<TransformRetryRequest>>,
         decode_catchup_done_rx: Option<oneshot::Receiver<()>>,
     ) -> Result<(), TransformationError> {
-        // Wait for decode catchup to finish so all decoded parquet files exist
         if let Some(rx) = decode_catchup_done_rx {
             tracing::info!(
                 "Waiting for eth_call decode catchup to complete before transformation catchup..."
@@ -1342,7 +1046,6 @@ impl TransformationEngine {
             );
         }
 
-        // Run catchup first
         self.run_catchup().await?;
 
         tracing::info!(
@@ -1359,8 +1062,6 @@ impl TransformationEngine {
                     if msg.events.is_empty() {
                         continue;
                     }
-
-                    // Process events, handling call dependencies
                     self.process_events_message(msg).await?;
                 }
 
@@ -1368,13 +1069,17 @@ impl TransformationEngine {
                     if msg.calls.is_empty() {
                         continue;
                     }
-
-                    // Process calls and check if any pending events can now be processed
                     self.process_calls_message(msg).await?;
                 }
 
                 Some(msg) = complete_rx.recv() => {
-                    self.process_range_complete(msg).await?;
+                    self.finalizer
+                        .process_range_complete(
+                            (msg.range_start, msg.range_end),
+                            msg.kind,
+                            &self.live_state,
+                        )
+                        .await?;
                 }
 
                 Some(msg) = async {
@@ -1383,7 +1088,9 @@ impl TransformationEngine {
                         None => std::future::pending().await,
                     }
                 } => {
-                    self.process_reorg(msg).await?;
+                    self.finalizer
+                        .process_reorg(msg.common_ancestor, &msg.orphaned, &self.live_state)
+                        .await?;
                 }
 
                 Some(msg) = async {
@@ -1392,11 +1099,12 @@ impl TransformationEngine {
                         None => std::future::pending().await,
                     }
                 } => {
-                    self.process_transform_retry(msg).await?;
+                    self.retry_processor
+                        .process_transform_retry(msg, &self.live_state, self)
+                        .await?;
                 }
 
                 else => {
-                    // All channels closed
                     tracing::info!("All channels closed, transformation engine shutting down");
                     break;
                 }
@@ -1411,7 +1119,6 @@ impl TransformationEngine {
     }
 
     /// Process an events message, buffering events with unmet call dependencies.
-    /// Ready handlers run concurrently bounded by `handler_concurrency`.
     async fn process_events_message(
         &self,
         msg: DecodedEventsMessage,
@@ -1436,13 +1143,13 @@ impl TransformationEngine {
             );
         }
 
-        // Filter events by contract start_block
-        let filtered_events = self.filter_events_by_start_block(msg.events.clone());
+        let filtered_events =
+            filter_events_by_start_block(&self.contracts, msg.events.clone());
         let events = Arc::new(filtered_events.clone());
 
         // Categorize handlers: ready to run vs needs buffering
         let range_key = (msg.range_start, msg.range_end);
-        let mut ready_handlers: Vec<(Arc<dyn EventHandler>, Arc<Vec<DecodedCall>>)> = Vec::new();
+        let mut ready_handlers: Vec<(Arc<dyn super::traits::TransformationHandler>, Arc<Vec<DecodedCall>>)> = Vec::new();
         {
             let mut state = self.live_state.lock().await;
             for handler in &handlers {
@@ -1461,12 +1168,7 @@ impl TransformationEngine {
                     });
 
                     if deps_ready {
-                        let calls = state
-                            .calls_buffer
-                            .get(&range_key)
-                            .cloned()
-                            .unwrap_or_default();
-                        // Filter calls by contract start_block (inline to avoid borrowing self inside lock)
+                        let calls = state.get_buffered_calls(range_key);
                         let calls: Vec<_> = calls
                             .into_iter()
                             .filter(|c| {
@@ -1499,7 +1201,6 @@ impl TransformationEngine {
                             events: filtered_events.clone(),
                             required_calls: call_deps.clone(),
                         };
-                        // Track when this pending event was first added for timeout detection
                         let timestamp_key = (msg.range_start, msg.range_end, handler_key.clone());
                         state
                             .pending_event_timestamps
@@ -1519,107 +1220,46 @@ impl TransformationEngine {
             return Ok(());
         }
 
-        // Run ready handlers concurrently
-        let semaphore = Arc::new(Semaphore::new(self.handler_concurrency));
-        let mut join_set: JoinSet<Result<Option<(String, u64, u64)>, TransformationError>> =
-            JoinSet::new();
+        // Build HandlerTasks and use executor
         let tx_addresses = self.read_receipt_addresses(msg.range_start, msg.range_end);
-        let tx_addresses = Arc::new(tx_addresses);
+        let tasks: Vec<HandlerTask> = ready_handlers
+            .into_iter()
+            .map(|(handler, calls)| HandlerTask {
+                handler,
+                events: events.clone(),
+                calls,
+                tx_addresses: tx_addresses.clone(),
+            })
+            .collect();
 
-        for (handler, calls) in ready_handlers {
-            let permit = semaphore.clone().acquire_owned().await.unwrap();
-            let events = events.clone();
-            let db_pool = self.db_pool.clone();
-            let chain_name = self.chain_name.clone();
-            let chain_id = self.chain_id;
-            let historical = self.historical_reader.clone();
-            let rpc = self.rpc_client.clone();
-            let contracts = self.contracts.clone();
-            let handler_name = handler.name();
-            let handler_version = handler.version();
-            let handler_key = handler.handler_key();
-            let range_start = msg.range_start;
-            let range_end = msg.range_end;
-            let source_name = msg.source_name.clone();
-            let event_name = msg.event_name.clone();
-            let tx_addrs = tx_addresses.clone();
+        let outcomes = self
+            .executor
+            .execute_handlers(tasks, msg.range_start, msg.range_end, &DbExecMode::Direct)
+            .await;
 
-            join_set.spawn(async move {
-                let _permit = permit;
-                // Each handler gets its own context (shared events, handler-specific calls)
-                let ctx = TransformationContext::new(
-                    chain_name,
-                    chain_id,
-                    range_start,
-                    range_end,
-                    events,
-                    calls,
-                    Arc::try_unwrap(tx_addrs).unwrap_or_else(|arc| (*arc).clone()),
-                    historical,
-                    rpc,
-                    contracts,
-                );
+        for outcome in outcomes {
+            self.finalizer
+                .record_completed_range_for_handler(
+                    &outcome.handler_key,
+                    outcome.range_start,
+                    outcome.range_end,
+                )
+                .await?;
 
-                match handler.handle(&ctx).await {
-                    Ok(ops) => {
-                        if !ops.is_empty() {
-                            let ops =
-                                Self::inject_source_version(ops, handler_name, handler_version);
-                            if let Err(e) = db_pool.execute_transaction(ops).await {
-                                tracing::error!(
-                                    "Handler {} transaction failed for range {}-{}: {:?}",
-                                    handler_key,
-                                    range_start,
-                                    range_end,
-                                    e
-                                );
-                                return Ok(None);
-                            }
-                        }
-                        Ok(Some((handler_key, range_start, range_end)))
-                    }
-                    Err(e) => {
-                        tracing::error!(
-                            "Handler {} failed for event {}/{}: {}",
-                            handler_key,
-                            source_name,
-                            event_name,
+            if outcome.range_end - outcome.range_start == 1 {
+                if let Some(ref tracker) = self.progress_tracker {
+                    let mut t = tracker.lock().await;
+                    if let Err(e) = t
+                        .mark_complete(outcome.range_start, &outcome.handler_key)
+                        .await
+                    {
+                        tracing::warn!(
+                            "Failed to mark live progress for block {} handler {}: {}",
+                            outcome.range_start,
+                            outcome.handler_key,
                             e
                         );
-                        Ok(None)
                     }
-                }
-            });
-        }
-
-        // Collect results and record progress
-        while let Some(result) = join_set.join_next().await {
-            match result {
-                Ok(Ok(Some((handler_key, rs, re)))) => {
-                    self.record_completed_range_for_handler(&handler_key, rs, re)
-                        .await?;
-
-                    // Mark live progress for single-block ranges (live mode)
-                    if re - rs == 1 {
-                        if let Some(ref tracker) = self.progress_tracker {
-                            let mut t = tracker.lock().await;
-                            if let Err(e) = t.mark_complete(rs, &handler_key).await {
-                                tracing::warn!(
-                                    "Failed to mark live progress for block {} handler {}: {}",
-                                    rs,
-                                    handler_key,
-                                    e
-                                );
-                            }
-                        }
-                    }
-                }
-                Ok(Ok(None)) => {}
-                Ok(Err(e)) => {
-                    tracing::error!("Handler task returned error: {}", e);
-                }
-                Err(e) => {
-                    tracing::error!("Handler task panicked: {}", e);
                 }
             }
         }
@@ -1643,7 +1283,6 @@ impl TransformationEngine {
             msg.range_start
         );
 
-        // Mark this call type as received for this range and buffer the calls
         {
             let mut state = self.live_state.lock().await;
             state
@@ -1658,14 +1297,14 @@ impl TransformationEngine {
                 .extend(msg.calls.clone());
         }
 
-        // Process call handlers (existing behavior) - filter calls by start_block
-        let filtered_calls = self.filter_calls_by_start_block(msg.calls);
+        let filtered_calls = filter_calls_by_start_block(&self.contracts, msg.calls);
         self.process_range(msg.range_start, msg.range_end, Vec::new(), filtered_calls)
             .await?;
 
-        // Check if any pending events can now be processed
         self.try_process_pending_events(range_key).await?;
-        self.maybe_finalize_range(range_key).await?;
+        self.finalizer
+            .maybe_finalize_range(range_key, &self.live_state)
+            .await?;
 
         Ok(())
     }
@@ -1675,15 +1314,13 @@ impl TransformationEngine {
         &self,
         range_key: (u64, u64),
     ) -> Result<(), TransformationError> {
-        // Collect ready events under lock, then process outside lock
-        let ready_events: Vec<(String, PendingEventData, Arc<dyn EventHandler>)> = {
+        let ready_events: Vec<(String, PendingEventData, Arc<dyn super::traits::TransformationHandler>)> = {
             let mut state = self.live_state.lock().await;
             let mut ready = Vec::new();
 
             let handler_keys: Vec<_> = state.pending_events.keys().cloned().collect();
 
             for handler_key in handler_keys {
-                // First pass: identify ready indices without holding mutable borrow
                 let ready_indices: Vec<usize> = {
                     let pending = state.pending_events.get(&handler_key).unwrap();
 
@@ -1706,7 +1343,6 @@ impl TransformationEngine {
                         .collect()
                 };
 
-                // Second pass: extract ready events
                 if !ready_indices.is_empty() {
                     tracing::info!(
                         "Handler {} unblocked for block {}: call deps now available",
@@ -1714,10 +1350,8 @@ impl TransformationEngine {
                         range_key.0
                     );
                     let pending = state.pending_events.get_mut(&handler_key).unwrap();
-                    // Extract in reverse order to preserve indices
                     for i in ready_indices.into_iter().rev() {
                         let event_data = pending.remove(i);
-                        // Find the handler
                         let handlers = self
                             .registry
                             .handlers_for_event(&event_data.source_name, &event_data.event_name);
@@ -1725,12 +1359,12 @@ impl TransformationEngine {
                             .into_iter()
                             .find(|h| h.handler_key() == handler_key)
                         {
+                            let handler: Arc<dyn super::traits::TransformationHandler> = handler;
                             ready.push((handler_key.clone(), event_data, handler));
                         }
                     }
                 }
 
-                // Clean up empty entries
                 if state
                     .pending_events
                     .get(&handler_key)
@@ -1748,1197 +1382,61 @@ impl TransformationEngine {
             return Ok(());
         }
 
-        // Fetch calls once for this range and filter by start_block
         let calls = {
             let state = self.live_state.lock().await;
-            let calls = state
-                .calls_buffer
-                .get(&range_key)
-                .cloned()
-                .unwrap_or_default();
-            Arc::new(self.filter_calls_by_start_block(calls))
+            let calls = state.get_buffered_calls(range_key);
+            Arc::new(filter_calls_by_start_block(&self.contracts, calls))
         };
 
-        // Process ready events concurrently
-        let semaphore = Arc::new(Semaphore::new(self.handler_concurrency));
-        let mut join_set: JoinSet<Result<Option<(String, u64, u64)>, TransformationError>> =
-            JoinSet::new();
-
-        for (handler_key, event_data, handler) in ready_events {
-            let permit = semaphore.clone().acquire_owned().await.unwrap();
-            let calls = calls.clone();
-            let db_pool = self.db_pool.clone();
-            let chain_name = self.chain_name.clone();
-            let chain_id = self.chain_id;
-            let historical = self.historical_reader.clone();
-            let rpc = self.rpc_client.clone();
-            let contracts = self.contracts.clone();
-            let handler_name = handler.name();
-            let handler_version = handler.version();
+        // Build HandlerTasks and use executor
+        let mut tasks = Vec::new();
+        for (_handler_key, event_data, handler) in ready_events {
             let tx_addresses =
                 self.read_receipt_addresses(event_data.range_start, event_data.range_end);
-
-            join_set.spawn(async move {
-                let _permit = permit;
-                tracing::debug!(
-                    "Handler {} processing previously buffered events for range {}-{}",
-                    handler_key,
-                    event_data.range_start,
-                    event_data.range_end
-                );
-
-                let source_name = event_data.source_name.clone();
-                let event_name = event_data.event_name.clone();
-                let rs = event_data.range_start;
-                let re = event_data.range_end;
-
-                let ctx = TransformationContext::new(
-                    chain_name,
-                    chain_id,
-                    rs,
-                    re,
-                    Arc::new(event_data.events),
-                    Arc::try_unwrap(calls)
-                        .unwrap_or_else(|arc| (*arc).clone())
-                        .into(),
-                    tx_addresses,
-                    historical,
-                    rpc,
-                    contracts,
-                );
-
-                match handler.handle(&ctx).await {
-                    Ok(ops) => {
-                        if !ops.is_empty() {
-                            let ops =
-                                Self::inject_source_version(ops, handler_name, handler_version);
-                            if let Err(e) = db_pool.execute_transaction(ops).await {
-                                tracing::error!(
-                                    "Handler {} transaction failed for range {}-{}: {:?}",
-                                    handler_key,
-                                    rs,
-                                    re,
-                                    e
-                                );
-                                return Ok(None);
-                            }
-                        }
-                        Ok(Some((handler_key, rs, re)))
-                    }
-                    Err(e) => {
-                        tracing::error!(
-                            "Handler {} failed for buffered event {}/{}: {}",
-                            handler_key,
-                            source_name,
-                            event_name,
-                            e
-                        );
-                        Ok(None)
-                    }
-                }
+            tasks.push(HandlerTask {
+                handler,
+                events: Arc::new(event_data.events),
+                calls: calls.clone(),
+                tx_addresses,
             });
         }
 
-        // Collect results and record progress
-        while let Some(result) = join_set.join_next().await {
-            match result {
-                Ok(Ok(Some((handler_key, rs, re)))) => {
-                    self.record_completed_range_for_handler(&handler_key, rs, re)
-                        .await?;
+        let outcomes = self
+            .executor
+            .execute_handlers(tasks, range_key.0, range_key.1, &DbExecMode::Direct)
+            .await;
 
-                    // Mark live progress for single-block ranges (live mode)
-                    if re - rs == 1 {
-                        if let Some(ref tracker) = self.progress_tracker {
-                            let mut t = tracker.lock().await;
-                            if let Err(e) = t.mark_complete(rs, &handler_key).await {
-                                tracing::warn!(
-                                    "Failed to mark live progress for block {} handler {}: {}",
-                                    rs,
-                                    handler_key,
-                                    e
-                                );
-                            }
-                        }
-                    }
-                }
-                Ok(Ok(None)) => {}
-                Ok(Err(e)) => {
-                    tracing::error!("Handler task returned error: {}", e);
-                }
-                Err(e) => {
-                    tracing::error!("Handler task panicked: {}", e);
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Process range completion signal.
-    /// Records progress for ALL handlers (event + call) even when no events/calls matched their triggers.
-    /// This ensures handlers don't unnecessarily re-process empty ranges on restart.
-    async fn process_range_complete(
-        &self,
-        msg: RangeCompleteMessage,
-    ) -> Result<(), TransformationError> {
-        let range_key = (msg.range_start, msg.range_end);
-        {
-            let mut state = self.live_state.lock().await;
-            state
-                .completion
-                .entry(range_key)
-                .or_default()
-                .mark(msg.kind);
-        }
-
-        self.maybe_finalize_range(range_key).await?;
-        Ok(())
-    }
-
-    /// Process a reorg notification by:
-    /// 1. Cleaning up pending events for orphaned blocks (memory)
-    /// 2. Deleting committed rows from database tables
-    /// 3. Cleaning up _live_progress entries
-    ///
-    /// When a reorg occurs, any events buffered for orphaned blocks should be discarded
-    /// since those blocks are no longer part of the canonical chain. Additionally,
-    /// data already committed to the database for orphaned blocks must be rolled back.
-    async fn process_reorg(&self, msg: ReorgMessage) -> Result<(), TransformationError> {
-        tracing::info!(
-            "Processing reorg: common_ancestor={}, orphaned={:?}",
-            msg.common_ancestor,
-            msg.orphaned
-        );
-
-        if msg.orphaned.is_empty() {
-            return Ok(());
-        }
-
-        // Phase 1: Clean up in-memory state
-        let total_removed = self.cleanup_pending_state(&msg.orphaned).await;
-        if total_removed > 0 {
-            tracing::info!(
-                "Reorg cleanup: removed {} pending events for {} orphaned blocks",
-                total_removed,
-                msg.orphaned.len()
-            );
-        }
-
-        // Phase 2: Delete committed rows from database tables
-        self.cleanup_reorg_tables(&msg.orphaned).await?;
-
-        // Phase 3: Clean up _live_progress entries
-        self.cleanup_live_progress(&msg.orphaned).await?;
-
-        Ok(())
-    }
-
-    /// Clean up in-memory pending state for orphaned blocks.
-    /// Returns the number of pending events removed.
-    async fn cleanup_pending_state(&self, orphaned: &[u64]) -> usize {
-        let mut state = self.live_state.lock().await;
-        let mut total_removed = 0;
-
-        for &orphaned_block in orphaned {
-            // In live mode, each block is its own range: (block, block+1)
-            let range_key = (orphaned_block, orphaned_block + 1);
-
-            // Remove from calls_buffer
-            if state.calls_buffer.remove(&range_key).is_some() {
-                tracing::debug!("Removed calls buffer for orphaned range {:?}", range_key);
-            }
-            state.completion.remove(&range_key);
-
-            // Remove from finalized_ranges to allow re-finalization if block is re-processed
-            state.finalized_ranges.remove(&range_key);
-
-            // Remove from received_calls
-            for ranges in state.received_calls.values_mut() {
-                ranges.remove(&range_key);
-            }
-
-            // Remove pending event timestamps for this range
-            state
-                .pending_event_timestamps
-                .retain(|(rs, re, _), _| (*rs, *re) != range_key);
-
-            // Remove pending events for this range from all handlers
-            for (handler_key, pending_list) in state.pending_events.iter_mut() {
-                let initial_len = pending_list.len();
-                pending_list.retain(|pending| {
-                    let matches = (pending.range_start, pending.range_end) == range_key;
-                    if matches {
-                        tracing::debug!(
-                            "Removing pending event for handler {} at orphaned range {:?}",
-                            handler_key,
-                            range_key
-                        );
-                    }
-                    !matches
-                });
-                total_removed += initial_len - pending_list.len();
-            }
-        }
-
-        // Clean up empty entries
-        state.pending_events.retain(|_, v| !v.is_empty());
-
-        total_removed
-    }
-
-    /// Rollback committed rows for orphaned blocks using snapshots.
-    ///
-    /// Phase 2a: Read snapshots from storage and restore previous state:
-    /// - Rows with previous_row = Some are restored via upsert
-    /// - Rows with previous_row = None are deleted by key
-    ///
-    /// Phase 2b: Delete remaining rows without snapshots (fallback for rows
-    /// that were INSERTed without update_columns, where we have no prior state).
-    async fn cleanup_reorg_tables(&self, orphaned: &[u64]) -> Result<(), TransformationError> {
-        // Collect all unique reorg tables from all handlers
-        let mut tables_to_clean: HashSet<&str> = HashSet::new();
-        for handler in self.registry.all_handlers() {
-            tables_to_clean.extend(handler.reorg_tables());
-        }
-
-        if tables_to_clean.is_empty() {
-            tracing::debug!("No reorg tables declared by handlers, skipping database cleanup");
-            return Ok(());
-        }
-
-        let storage = LiveStorage::new(&self.chain_name);
-        let mut restore_ops = Vec::new();
-        let mut tables_with_snapshots: HashSet<String> = HashSet::new();
-
-        // Phase 2a: Read snapshots and generate restore operations
-        for &block_number in orphaned {
-            match storage.read_snapshots(block_number) {
-                Ok(snapshots) => {
-                    for snapshot in snapshots {
-                        tables_with_snapshots.insert(snapshot.table.clone());
-
-                        match snapshot.previous_row {
-                            Some(previous) => {
-                                // Row existed before - restore via upsert
-                                let columns: Vec<String> =
-                                    previous.iter().map(|(k, _)| k.clone()).collect();
-                                let values: Vec<DbValue> =
-                                    previous.iter().map(|(_, v)| v.to_db_value()).collect();
-                                let conflict_cols: Vec<String> = snapshot
-                                    .key_columns
-                                    .iter()
-                                    .map(|(k, _)| k.clone())
-                                    .collect();
-
-                                // Update all non-key columns
-                                let update_cols: Vec<String> = columns
-                                    .iter()
-                                    .filter(|c| !conflict_cols.contains(c))
-                                    .cloned()
-                                    .collect();
-
-                                restore_ops.push(DbOperation::Upsert {
-                                    table: snapshot.table,
-                                    columns,
-                                    values,
-                                    conflict_columns: conflict_cols,
-                                    update_columns: update_cols,
-                                });
-                            }
-                            None => {
-                                // Row didn't exist before - delete by key
-                                let key_conditions: Vec<(String, DbValue)> = snapshot
-                                    .key_columns
-                                    .into_iter()
-                                    .map(|(k, v)| (k, v.to_db_value()))
-                                    .collect();
-
-                                restore_ops.push(DbOperation::Delete {
-                                    table: snapshot.table,
-                                    where_clause: WhereClause::And(key_conditions),
-                                });
-                            }
-                        }
-                    }
-                }
-                Err(StorageError::NotFound(_)) => {
-                    // No snapshots for this block - will use fallback DELETE
-                    tracing::debug!(
-                        "No snapshots found for block {}, will use fallback delete",
-                        block_number
-                    );
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        "Failed to read snapshots for block {}: {}, using fallback delete",
-                        block_number,
-                        e
-                    );
-                }
-            }
-        }
-
-        // Execute restore operations if any
-        if !restore_ops.is_empty() {
-            tracing::info!(
-                "Reorg rollback: executing {} restore operations from snapshots",
-                restore_ops.len()
-            );
-            self.db_pool.execute_transaction(restore_ops).await?;
-        }
-
-        // Phase 2b: Delete remaining rows without snapshots
-        // Only delete from tables that didn't have snapshots (pure INSERTs)
-        let block_list = orphaned
-            .iter()
-            .map(|b| b.to_string())
-            .collect::<Vec<_>>()
-            .join(",");
-
-        let mut fallback_ops = Vec::new();
-        for table in &tables_to_clean {
-            // Skip tables that had snapshot-based restoration
-            if tables_with_snapshots.contains(*table) {
-                continue;
-            }
-
-            fallback_ops.push(DbOperation::Delete {
-                table: table.to_string(),
-                where_clause: WhereClause::Raw {
-                    condition: format!(
-                        "chain_id = {} AND block_number IN ({})",
-                        self.chain_id, block_list
-                    ),
-                    params: vec![],
-                },
-            });
-        }
-
-        if !fallback_ops.is_empty() {
-            tracing::info!(
-                "Reorg cleanup: fallback deleting from {} tables for {} orphaned blocks",
-                fallback_ops.len(),
-                orphaned.len()
-            );
-            self.db_pool.execute_transaction(fallback_ops).await?;
-        }
-
-        // Delete snapshot files for orphaned blocks
-        for &block_number in orphaned {
-            if let Err(e) = storage.delete_snapshots(block_number) {
-                tracing::warn!(
-                    "Failed to delete snapshots for block {}: {}",
-                    block_number,
-                    e
-                );
-            }
-        }
-
-        Ok(())
-    }
-
-    async fn maybe_finalize_range(&self, range_key: (u64, u64)) -> Result<(), TransformationError> {
-        let (should_finalize, timed_out_handlers) = {
-            let mut state = self.live_state.lock().await;
-            let completion = state
-                .completion
-                .get(&range_key)
-                .copied()
-                .unwrap_or_default();
-
-            // Check for timed-out pending events
-            let timeout = std::time::Duration::from_secs(PENDING_EVENT_TIMEOUT_SECS);
-            let now = Instant::now();
-            let mut timed_out: Vec<String> = Vec::new();
-
-            for (handler_key, pending_list) in &state.pending_events {
-                for pending in pending_list {
-                    if (pending.range_start, pending.range_end) == range_key {
-                        let timestamp_key = (range_key.0, range_key.1, handler_key.clone());
-                        if let Some(&first_seen) =
-                            state.pending_event_timestamps.get(&timestamp_key)
-                        {
-                            if now.duration_since(first_seen) >= timeout {
-                                tracing::error!(
-                                    "Pending event TIMED OUT after {:?}: handler={} range={}-{} event={}/{} waiting_for={:?}. \
-                                     Force-finalizing range to unblock progress.",
-                                    now.duration_since(first_seen),
-                                    handler_key,
-                                    pending.range_start,
-                                    pending.range_end,
-                                    pending.source_name,
-                                    pending.event_name,
-                                    pending.required_calls
-                                );
-                                timed_out.push(handler_key.clone());
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Remove timed-out pending events
-            for handler_key in &timed_out {
-                if let Some(pending_list) = state.pending_events.get_mut(handler_key) {
-                    pending_list
-                        .retain(|pending| (pending.range_start, pending.range_end) != range_key);
-                }
-                let timestamp_key = (range_key.0, range_key.1, handler_key.clone());
-                state.pending_event_timestamps.remove(&timestamp_key);
-            }
-            state.pending_events.retain(|_, v| !v.is_empty());
-
-            let has_pending = state.pending_events.values().any(|pending_list| {
-                pending_list
-                    .iter()
-                    .any(|pending| (pending.range_start, pending.range_end) == range_key)
-            });
-
-            if has_pending && completion.logs_complete && completion.eth_calls_complete {
-                for (handler_key, pending_list) in &state.pending_events {
-                    for pending in pending_list {
-                        if (pending.range_start, pending.range_end) == range_key {
-                            tracing::warn!(
-                                "Stuck pending event detected: handler={} range={}-{} event={}/{} waiting_for={:?}. \
-                                 This may indicate missing eth_call configuration or RPC failure.",
-                                handler_key,
-                                pending.range_start,
-                                pending.range_end,
-                                pending.source_name,
-                                pending.event_name,
-                                pending.required_calls
-                            );
-                        }
-                    }
-                }
-            }
-
-            let ready = !has_pending
-                && completion.is_ready(
-                    self.expect_log_completion,
-                    self.range_requires_eth_call_completion(range_key),
-                );
-            (ready, timed_out)
-        };
-
-        if !timed_out_handlers.is_empty() {
-            tracing::warn!(
-                "Removed {} timed-out pending event handlers for range {:?}: {:?}",
-                timed_out_handlers.len(),
-                range_key,
-                timed_out_handlers
-            );
-        }
-
-        if !should_finalize {
-            return Ok(());
-        }
-
-        self.finalize_range(range_key.0, range_key.1).await
-    }
-
-    async fn finalize_range(
-        &self,
-        range_start: u64,
-        range_end: u64,
-    ) -> Result<(), TransformationError> {
-        let range_key = (range_start, range_end);
-
-        // Prevent double finalization by checking and marking atomically
-        {
-            let mut state = self.live_state.lock().await;
-            if state.finalized_ranges.contains(&range_key) {
-                tracing::debug!(
-                    "Range {}-{} already finalized, skipping duplicate finalization",
-                    range_start,
-                    range_end
-                );
-                return Ok(());
-            }
-            state.finalized_ranges.insert(range_key);
-        }
-
-        // Mark ALL handlers as complete for this range (event + call handlers)
-        for handler in self.registry.all_handlers() {
-            let handler_key = handler.handler_key();
-            self.record_completed_range_for_handler(&handler_key, range_start, range_end)
+        for outcome in outcomes {
+            self.finalizer
+                .record_completed_range_for_handler(
+                    &outcome.handler_key,
+                    outcome.range_start,
+                    outcome.range_end,
+                )
                 .await?;
 
-            if range_end - range_start == 1 {
+            if outcome.range_end - outcome.range_start == 1 {
                 if let Some(ref tracker) = self.progress_tracker {
                     let mut t = tracker.lock().await;
-                    if let Err(e) = t.mark_complete(range_start, &handler_key).await {
-                        tracing::warn!(
-                            "Failed to mark live progress for block {} handler {}: {}",
-                            range_start,
-                            handler_key,
-                            e
-                        );
-                    }
-                }
-            }
-        }
-
-        {
-            let mut state = self.live_state.lock().await;
-            state.calls_buffer.remove(&range_key);
-            state.completion.remove(&range_key);
-            for ranges in state.received_calls.values_mut() {
-                ranges.remove(&range_key);
-            }
-            // Clean up pending event timestamps for this range
-            state
-                .pending_event_timestamps
-                .retain(|(rs, re, _), _| (*rs, *re) != range_key);
-        }
-
-        tracing::debug!(
-            "Recorded progress for {} handlers on range {}-{}",
-            self.registry.all_handlers().len(),
-            range_start,
-            range_end
-        );
-
-        if range_end - range_start == 1 {
-            let storage = LiveStorage::new(&self.chain_name);
-            match storage.read_status(range_start) {
-                Ok(mut status) => {
-                    status.transformed = true;
-                    if let Err(e) = storage.write_status(range_start, &status) {
-                        tracing::warn!(
-                            "Failed to set transformed=true for block {}: {}",
-                            range_start,
-                            e
-                        );
-                    }
-                }
-                Err(StorageError::NotFound(_)) => {
-                    tracing::debug!(
-                        "Status file not found for block {}, skipping transformed=true",
-                        range_start
-                    );
-                }
-                Err(e) => {
-                    tracing::warn!("Failed to read status for block {}: {}", range_start, e);
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Check if this range requires eth_call completion signal before finalization.
-    ///
-    /// Only single-block ranges (live mode) require waiting for eth_call completion.
-    /// Historical batch ranges don't require this because:
-    /// 1. Historical data is processed in larger batches where calls are pre-fetched
-    /// 2. The batch processing handles call dependencies internally before finalization
-    /// 3. Live mode needs block-by-block coordination since data arrives incrementally
-    fn range_requires_eth_call_completion(&self, range_key: (u64, u64)) -> bool {
-        self.expect_eth_call_completion && range_key.1.saturating_sub(range_key.0) == 1
-    }
-
-    /// Clean up _live_progress entries for orphaned blocks.
-    async fn cleanup_live_progress(&self, orphaned: &[u64]) -> Result<(), TransformationError> {
-        if orphaned.is_empty() {
-            return Ok(());
-        }
-
-        let block_list = orphaned
-            .iter()
-            .map(|b| b.to_string())
-            .collect::<Vec<_>>()
-            .join(",");
-
-        let ops = vec![DbOperation::Delete {
-            table: "_live_progress".to_string(),
-            where_clause: WhereClause::Raw {
-                condition: format!(
-                    "chain_id = {} AND block_number IN ({})",
-                    self.chain_id, block_list
-                ),
-                params: vec![],
-            },
-        }];
-
-        tracing::debug!(
-            "Reorg cleanup: deleting _live_progress for {} orphaned blocks",
-            orphaned.len()
-        );
-        self.db_pool.execute_transaction(ops).await?;
-
-        Ok(())
-    }
-
-    async fn process_transform_retry(
-        &self,
-        request: TransformRetryRequest,
-    ) -> Result<(), TransformationError> {
-        let block_number = request.block_number;
-        let range_key = (block_number, block_number + 1);
-
-        tracing::info!(
-            "Processing direct transform retry for block {}",
-            block_number
-        );
-
-        {
-            let mut state = self.live_state.lock().await;
-            state.calls_buffer.remove(&range_key);
-            state.completion.remove(&range_key);
-            state.finalized_ranges.remove(&range_key);
-            state
-                .pending_event_timestamps
-                .retain(|(rs, re, _), _| (*rs, *re) != range_key);
-            for ranges in state.received_calls.values_mut() {
-                ranges.remove(&range_key);
-            }
-            for pending in state.pending_events.values_mut() {
-                pending.retain(|entry| (entry.range_start, entry.range_end) != range_key);
-            }
-            state
-                .pending_events
-                .retain(|_, entries| !entries.is_empty());
-        }
-
-        let tracker_missing = if let Some(ref tracker) = self.progress_tracker {
-            Some(tracker.lock().await.get_pending_handlers(block_number))
-        } else {
-            None
-        };
-        let all_handlers: HashSet<String> = self
-            .registry
-            .all_handlers()
-            .iter()
-            .map(|handler| handler.handler_key())
-            .collect();
-        let missing_handlers =
-            resolve_retry_missing_handlers(request.missing_handlers, tracker_missing, all_handlers);
-
-        if missing_handlers.is_empty() {
-            return self.finalize_range(block_number, block_number + 1).await;
-        }
-
-        let (events, calls) = self.read_live_retry_data(block_number).await?;
-        let events = self.filter_events_by_start_block(events);
-        let calls = self.filter_calls_by_start_block(calls);
-
-        let blocked_handlers = self
-            .execute_live_retry_handlers(block_number, events, calls, &missing_handlers)
-            .await?;
-
-        if !blocked_handlers.is_empty() {
-            tracing::warn!(
-                "Live retry for block {} is still waiting on call dependencies for handlers {:?}",
-                block_number,
-                blocked_handlers
-            );
-            return Ok(());
-        }
-
-        self.finalize_range(block_number, block_number + 1).await
-    }
-
-    async fn read_live_retry_data(
-        &self,
-        block_number: u64,
-    ) -> Result<(Vec<DecodedEvent>, Vec<DecodedCall>), TransformationError> {
-        let storage = LiveStorage::new(&self.chain_name);
-        let mut events = Vec::new();
-        let mut calls = Vec::new();
-
-        let (regular_matchers, factory_matchers) =
-            build_event_matchers(&self.contracts, &self.factory_collections).map_err(|e| {
-                TransformationError::DecodeError(format!(
-                    "failed to build live retry event matchers: {}",
-                    e
-                ))
-            })?;
-
-        let mut event_schemas: HashMap<(String, String), ParsedEvent> = HashMap::new();
-        for matcher in regular_matchers {
-            event_schemas.insert(
-                (matcher.name.clone(), matcher.event_name.clone()),
-                matcher.event,
-            );
-        }
-        for matchers in factory_matchers.values() {
-            for matcher in matchers {
-                event_schemas.insert(
-                    (matcher.name.clone(), matcher.event_name.clone()),
-                    matcher.event.clone(),
-                );
-            }
-        }
-
-        for (source_name, event_name) in storage.list_decoded_log_types(block_number)? {
-            let parsed_event = event_schemas
-                .get(&(source_name.clone(), event_name.clone()))
-                .ok_or_else(|| {
-                    TransformationError::MissingData(format!(
-                        "missing event schema for live retry {}/{}",
-                        source_name, event_name
-                    ))
-                })?;
-
-            for log in storage.read_decoded_logs(block_number, &source_name, &event_name)? {
-                events.push(Self::live_log_to_decoded_event(
-                    &log,
-                    parsed_event,
-                    &source_name,
-                    &event_name,
-                ));
-            }
-        }
-
-        let (regular_configs, once_configs, event_configs) = build_decode_configs(&self.contracts);
-        let regular_map: HashMap<(String, String), CallDecodeConfig> = regular_configs
-            .into_iter()
-            .map(|config| {
-                (
-                    (config.contract_name.clone(), config.function_name.clone()),
-                    config,
-                )
-            })
-            .collect();
-        let once_map: HashMap<(String, String), CallDecodeConfig> = once_configs
-            .into_iter()
-            .map(|config| {
-                (
-                    (config.contract_name.clone(), config.function_name.clone()),
-                    config,
-                )
-            })
-            .collect();
-        let event_map: HashMap<(String, String), EventCallDecodeConfig> = event_configs
-            .into_iter()
-            .map(|config| {
-                (
-                    (config.contract_name.clone(), config.function_name.clone()),
-                    config,
-                )
-            })
-            .collect();
-        let regular_keys: HashSet<(String, String)> = regular_map.keys().cloned().collect();
-        let event_keys: HashSet<(String, String)> = event_map.keys().cloned().collect();
-
-        for (source_name, function_name) in storage.list_decoded_call_types(block_number)? {
-            match classify_live_retry_call_artifact(
-                &source_name,
-                &function_name,
-                &regular_keys,
-                &event_keys,
-            )? {
-                LiveRetryCallArtifactKind::Regular => {
-                    let config = regular_map
-                        .get(&(source_name.clone(), function_name.clone()))
-                        .ok_or_else(|| {
-                            TransformationError::MissingData(format!(
-                                "missing regular call schema for live retry {}/{}",
-                                source_name, function_name
-                            ))
-                        })?;
-
-                    for call in
-                        storage.read_decoded_calls(block_number, &source_name, &function_name)?
-                    {
-                        calls.push(Self::live_call_to_decoded_call(
-                            &call,
-                            &source_name,
-                            &function_name,
-                            &config.output_type,
-                        ));
-                    }
-                }
-                LiveRetryCallArtifactKind::EventTriggered { base_name } => {
-                    let config = event_map
-                        .get(&(source_name.clone(), base_name.clone()))
-                        .ok_or_else(|| {
-                            TransformationError::MissingData(format!(
-                                "missing event call schema for live retry {}/{}",
-                                source_name, base_name
-                            ))
-                        })?;
-
-                    for call in
-                        storage.read_decoded_event_calls(block_number, &source_name, &base_name)?
-                    {
-                        calls.push(Self::live_event_call_to_decoded_call(
-                            &call,
-                            &source_name,
-                            &base_name,
-                            &config.output_type,
-                        ));
-                    }
-                }
-            }
-        }
-
-        let mut once_sources: HashSet<String> = self.contracts.keys().cloned().collect();
-        for contract in self.contracts.values() {
-            if let Some(factories) = &contract.factories {
-                once_sources.extend(factories.iter().map(|factory| factory.collection.clone()));
-            }
-        }
-
-        for source_name in once_sources {
-            let Ok(once_calls) = storage.read_decoded_once_calls(block_number, &source_name) else {
-                continue;
-            };
-
-            // Consolidate all function results per address into a single DecodedCall
-            // with function_name = "once" and merged result map.
-            // This mirrors the historical pipeline (src/decoding/eth_calls.rs:632-658)
-            // and matches how handlers declare call_dependencies (e.g., ("DERC20", "once")).
-            for call in once_calls {
-                let mut merged_result = HashMap::new();
-                for (function_name, value) in &call.decoded_values {
-                    if let Some(config) =
-                        once_map.get(&(source_name.clone(), function_name.clone()))
-                    {
-                        let partial_result =
-                            build_result_map(value, &config.output_type, function_name);
-                        merged_result.extend(partial_result);
-                    }
-                }
-                if !merged_result.is_empty() {
-                    calls.push(DecodedCall {
-                        block_number: call.block_number,
-                        block_timestamp: call.block_timestamp,
-                        contract_address: call.contract_address,
-                        source_name: source_name.clone(),
-                        function_name: "once".to_string(),
-                        trigger_log_index: None,
-                        result: merged_result,
-                    });
-                }
-            }
-        }
-
-        Ok((events, calls))
-    }
-
-    async fn execute_live_retry_handlers(
-        &self,
-        block_number: u64,
-        events: Vec<DecodedEvent>,
-        calls: Vec<DecodedCall>,
-        missing_handlers: &HashSet<String>,
-    ) -> Result<HashSet<String>, TransformationError> {
-        let range_start = block_number;
-        let range_end = block_number + 1;
-        let tx_addresses = Arc::new(self.read_live_receipt_addresses(block_number)?);
-        let semaphore = Arc::new(Semaphore::new(self.handler_concurrency));
-        let mut join_set: JoinSet<Result<Option<String>, TransformationError>> = JoinSet::new();
-        let mut blocked_handlers = HashSet::new();
-
-        for handler_info in self.registry.unique_event_handlers() {
-            let handler = handler_info.handler;
-            let handler_key = handler.handler_key();
-            if !missing_handlers.contains(&handler_key) {
-                continue;
-            }
-
-            let triggers: HashSet<(String, String)> = handler_info
-                .triggers
-                .iter()
-                .map(|trigger| {
-                    (
-                        trigger.source.clone(),
-                        extract_event_name(&trigger.event_signature),
-                    )
-                })
-                .collect();
-            let handler_events: Vec<DecodedEvent> = events
-                .iter()
-                .filter(|event| {
-                    triggers.contains(&(event.source_name.clone(), event.event_name.clone()))
-                })
-                .cloned()
-                .collect();
-
-            if handler_events.is_empty() {
-                continue;
-            }
-
-            let call_deps: HashSet<(String, String)> =
-                handler.call_dependencies().into_iter().collect();
-            let missing_deps = missing_retry_call_dependencies(&call_deps, &calls);
-            if !missing_deps.is_empty() {
-                tracing::warn!(
-                    "Skipping live retry for handler {} on block {}: missing call dependencies {:?}",
-                    handler_key,
-                    block_number,
-                    missing_deps
-                );
-                blocked_handlers.insert(handler_key);
-                continue;
-            }
-            let handler_calls: Vec<DecodedCall> = calls
-                .iter()
-                .filter(|call| {
-                    call_deps.contains(&(call.source_name.clone(), call.function_name.clone()))
-                })
-                .cloned()
-                .collect();
-
-            let permit = semaphore.clone().acquire_owned().await.unwrap();
-            let db_pool = self.db_pool.clone();
-            let chain_name = self.chain_name.clone();
-            let chain_id = self.chain_id;
-            let historical = self.historical_reader.clone();
-            let rpc = self.rpc_client.clone();
-            let contracts = self.contracts.clone();
-            let tx_addresses = tx_addresses.clone();
-            let handler_name = handler.name();
-            let handler_version = handler.version();
-
-            join_set.spawn(async move {
-                let _permit = permit;
-                let live_storage = LiveStorage::new(&chain_name);
-                let ctx = TransformationContext::new(
-                    chain_name.clone(),
-                    chain_id,
-                    range_start,
-                    range_end,
-                    Arc::new(handler_events),
-                    Arc::new(handler_calls),
-                    (*tx_addresses).clone(),
-                    historical,
-                    rpc,
-                    contracts,
-                );
-
-                match handler.handle(&ctx).await {
-                    Ok(ops) => {
-                        if !ops.is_empty() {
-                            let ops =
-                                Self::inject_source_version(ops, handler_name, handler_version);
-                            execute_with_snapshot_capture(
-                                ops,
-                                &db_pool,
-                                Some(&live_storage),
-                                range_start,
-                                handler_name,
-                                handler_version,
-                            )
-                            .await?;
-                        }
-                        Ok(Some(handler_key))
-                    }
-                    Err(e) => Err(e),
-                }
-            });
-        }
-
-        for handler_info in self.registry.unique_call_handlers() {
-            let handler = handler_info.handler;
-            let handler_key = handler.handler_key();
-            if !missing_handlers.contains(&handler_key) {
-                continue;
-            }
-
-            let triggers: HashSet<(String, String)> = handler_info
-                .triggers
-                .iter()
-                .map(|trigger| (trigger.source.clone(), trigger.function_name.clone()))
-                .collect();
-            let handler_calls: Vec<DecodedCall> = calls
-                .iter()
-                .filter(|call| {
-                    triggers.contains(&(call.source_name.clone(), call.function_name.clone()))
-                })
-                .cloned()
-                .collect();
-
-            if handler_calls.is_empty() {
-                continue;
-            }
-
-            let permit = semaphore.clone().acquire_owned().await.unwrap();
-            let db_pool = self.db_pool.clone();
-            let chain_name = self.chain_name.clone();
-            let chain_id = self.chain_id;
-            let historical = self.historical_reader.clone();
-            let rpc = self.rpc_client.clone();
-            let contracts = self.contracts.clone();
-            let handler_name = handler.name();
-            let handler_version = handler.version();
-
-            join_set.spawn(async move {
-                let _permit = permit;
-                let live_storage = LiveStorage::new(&chain_name);
-                let ctx = TransformationContext::new(
-                    chain_name.clone(),
-                    chain_id,
-                    range_start,
-                    range_end,
-                    Arc::new(Vec::new()),
-                    Arc::new(handler_calls),
-                    HashMap::new(),
-                    historical,
-                    rpc,
-                    contracts,
-                );
-
-                match handler.handle(&ctx).await {
-                    Ok(ops) => {
-                        if !ops.is_empty() {
-                            let ops =
-                                Self::inject_source_version(ops, handler_name, handler_version);
-                            execute_with_snapshot_capture(
-                                ops,
-                                &db_pool,
-                                Some(&live_storage),
-                                range_start,
-                                handler_name,
-                                handler_version,
-                            )
-                            .await?;
-                        }
-                        Ok(Some(handler_key))
-                    }
-                    Err(e) => Err(e),
-                }
-            });
-        }
-
-        while let Some(result) = join_set.join_next().await {
-            match result {
-                Ok(Ok(Some(handler_key))) => {
-                    if let Err(e) = self
-                        .record_completed_range_for_handler(&handler_key, range_start, range_end)
+                    if let Err(e) = t
+                        .mark_complete(outcome.range_start, &outcome.handler_key)
                         .await
                     {
                         tracing::warn!(
-                            "Failed to record completed range for handler {} on block {}: {}",
-                            handler_key,
-                            block_number,
+                            "Failed to mark live progress for block {} handler {}: {}",
+                            outcome.range_start,
+                            outcome.handler_key,
                             e
                         );
                     }
-
-                    if let Some(ref tracker) = self.progress_tracker {
-                        let mut tracker = tracker.lock().await;
-                        if let Err(e) = tracker.mark_complete(block_number, &handler_key).await {
-                            tracing::warn!(
-                                "Failed to mark retry progress for block {} handler {}: {}",
-                                block_number,
-                                handler_key,
-                                e
-                            );
-                        }
-                    }
-                }
-                Ok(Ok(None)) => {}
-                Ok(Err(e)) => {
-                    // Match normal pipeline: log and skip, don't tear down the engine
-                    tracing::error!(
-                        "Handler failed during live retry for block {}: {}",
-                        block_number,
-                        e
-                    );
-                }
-                Err(e) => {
-                    // Match normal pipeline: log and skip, don't tear down the engine
-                    tracing::error!(
-                        "Handler task panicked during live retry for block {}: {}",
-                        block_number,
-                        e
-                    );
                 }
             }
         }
 
-        Ok(blocked_handlers)
-    }
-
-    fn read_live_receipt_addresses(
-        &self,
-        block_number: u64,
-    ) -> Result<HashMap<[u8; 32], TransactionAddresses>, TransformationError> {
-        let storage = LiveStorage::new(&self.chain_name);
-        let mut tx_addresses = HashMap::new();
-
-        for receipt in storage.read_receipts(block_number)? {
-            tx_addresses.insert(
-                receipt.transaction_hash,
-                TransactionAddresses {
-                    from_address: receipt.from,
-                    to_address: receipt.to,
-                },
-            );
-        }
-
-        Ok(tx_addresses)
-    }
-
-    fn live_log_to_decoded_event(
-        log: &crate::live::LiveDecodedLog,
-        parsed_event: &ParsedEvent,
-        source_name: &str,
-        event_name: &str,
-    ) -> DecodedEvent {
-        let mut params = HashMap::new();
-        for (flattened, value) in parsed_event
-            .flattened_fields
-            .iter()
-            .zip(log.decoded_values.iter())
-        {
-            params.insert(flattened.full_name.clone(), value.clone());
-        }
-
-        DecodedEvent {
-            block_number: log.block_number,
-            block_timestamp: log.block_timestamp,
-            transaction_hash: log.transaction_hash,
-            log_index: log.log_index,
-            contract_address: log.contract_address,
-            source_name: source_name.to_string(),
-            event_name: event_name.to_string(),
-            event_signature: parsed_event.signature.clone(),
-            params,
-        }
-    }
-
-    fn live_call_to_decoded_call(
-        call: &crate::live::LiveDecodedCall,
-        source_name: &str,
-        function_name: &str,
-        output_type: &EvmType,
-    ) -> DecodedCall {
-        DecodedCall {
-            block_number: call.block_number,
-            block_timestamp: call.block_timestamp,
-            contract_address: call.contract_address,
-            source_name: source_name.to_string(),
-            function_name: function_name.to_string(),
-            trigger_log_index: None,
-            result: build_result_map(&call.decoded_value, output_type, function_name),
-        }
-    }
-
-    fn live_event_call_to_decoded_call(
-        call: &crate::live::LiveDecodedEventCall,
-        source_name: &str,
-        function_name: &str,
-        output_type: &EvmType,
-    ) -> DecodedCall {
-        DecodedCall {
-            block_number: call.block_number,
-            block_timestamp: call.block_timestamp,
-            contract_address: call.target_address,
-            source_name: source_name.to_string(),
-            function_name: function_name.to_string(),
-            trigger_log_index: Some(call.log_index),
-            result: build_result_map(&call.decoded_value, output_type, function_name),
-        }
+        Ok(())
     }
 
     /// Process a block range with per-handler transactions.
-    /// Each handler's operations execute in their own transaction and
-    /// progress is recorded independently. Handlers run concurrently
-    /// bounded by `handler_concurrency`.
     async fn process_range(
         &self,
         range_start: u64,
@@ -2954,7 +1452,6 @@ impl TransformationEngine {
             calls.len()
         );
 
-        // Get unique triggers before moving data into Arc
         let event_triggers: HashSet<_> = events
             .iter()
             .map(|e| (e.source_name.clone(), e.event_name.clone()))
@@ -2964,452 +1461,92 @@ impl TransformationEngine {
             .map(|c| (c.source_name.clone(), c.function_name.clone()))
             .collect();
 
-        // Create shared context for handlers
         let tx_addresses = self.read_receipt_addresses(range_start, range_end);
-        let ctx = Arc::new(TransformationContext::new(
-            self.chain_name.clone(),
-            self.chain_id,
-            range_start,
-            range_end,
-            Arc::new(events),
-            Arc::new(calls),
-            tx_addresses,
-            self.historical_reader.clone(),
-            self.rpc_client.clone(),
-            self.contracts.clone(),
-        ));
+        let events = Arc::new(events);
+        let calls = Arc::new(calls);
 
-        let semaphore = Arc::new(Semaphore::new(self.handler_concurrency));
-        let mut join_set: JoinSet<Result<Option<(String, u64, u64)>, TransformationError>> =
-            JoinSet::new();
-
-        // Spawn event handlers concurrently
-        // For live mode (single-block ranges), we capture snapshots for rollback
         let is_live_mode = range_end - range_start == 1;
-        let chain_name_for_storage = self.chain_name.clone();
+        let db_exec_mode = if is_live_mode {
+            DbExecMode::WithSnapshotCapture {
+                chain_name: self.chain_name.clone(),
+            }
+        } else {
+            DbExecMode::Direct
+        };
+
+        let mut tasks = Vec::new();
 
         for (source, event_name) in &event_triggers {
             for handler in self.registry.handlers_for_event(source, event_name) {
-                let permit = semaphore.clone().acquire_owned().await.unwrap();
-                let ctx = ctx.clone();
-                let db_pool = self.db_pool.clone();
-                let handler_name = handler.name();
-                let handler_version = handler.version();
-                let handler_key = handler.handler_key();
-                let source = source.clone();
-                let event_name = event_name.clone();
-                let chain_name = chain_name_for_storage.clone();
-
-                join_set.spawn(async move {
-                    let _permit = permit;
-                    tracing::debug!(
-                        "Invoking handler {} for event {}/{}",
-                        handler_key,
-                        source,
-                        event_name
-                    );
-
-                    match handler.handle(&ctx).await {
-                        Ok(ops) => {
-                            if !ops.is_empty() {
-                                tracing::debug!(
-                                    "Handler {} produced {} operations",
-                                    handler_key,
-                                    ops.len()
-                                );
-                                let ops =
-                                    Self::inject_source_version(ops, handler_name, handler_version);
-
-                                // Use snapshot-capturing execution for live mode
-                                let storage = if is_live_mode {
-                                    Some(LiveStorage::new(&chain_name))
-                                } else {
-                                    None
-                                };
-
-                                let result = execute_with_snapshot_capture(
-                                    ops,
-                                    &db_pool,
-                                    storage.as_ref(),
-                                    range_start,
-                                    handler_name,
-                                    handler_version,
-                                )
-                                .await;
-
-                                if let Err(e) = result {
-                                    tracing::error!(
-                                        "Handler {} transaction failed for range {}-{}: {:?}",
-                                        handler_key,
-                                        range_start,
-                                        range_end,
-                                        e
-                                    );
-                                    return Ok(None);
-                                }
-                            }
-                            Ok(Some((handler_key, range_start, range_end)))
-                        }
-                        Err(e) => {
-                            tracing::error!(
-                                "Handler {} failed for event {}/{}: {}",
-                                handler_key,
-                                source,
-                                event_name,
-                                e
-                            );
-                            Ok(None)
-                        }
-                    }
+                let handler: Arc<dyn super::traits::TransformationHandler> = handler;
+                tasks.push(HandlerTask {
+                    handler,
+                    events: events.clone(),
+                    calls: calls.clone(),
+                    tx_addresses: tx_addresses.clone(),
                 });
             }
         }
 
-        // Spawn call handlers concurrently
         for (source, function_name) in &call_triggers {
             for handler in self.registry.handlers_for_call(source, function_name) {
-                let permit = semaphore.clone().acquire_owned().await.unwrap();
-                let ctx = ctx.clone();
-                let db_pool = self.db_pool.clone();
-                let handler_name = handler.name();
-                let handler_version = handler.version();
-                let handler_key = handler.handler_key();
-                let source = source.clone();
-                let function_name = function_name.clone();
-                let chain_name = chain_name_for_storage.clone();
-
-                join_set.spawn(async move {
-                    let _permit = permit;
-                    tracing::trace!(
-                        "Invoking handler {} for call {}/{}",
-                        handler_key,
-                        source,
-                        function_name
-                    );
-
-                    match handler.handle(&ctx).await {
-                        Ok(ops) => {
-                            if !ops.is_empty() {
-                                tracing::trace!(
-                                    "Handler {} produced {} operations",
-                                    handler_key,
-                                    ops.len()
-                                );
-                                let ops =
-                                    Self::inject_source_version(ops, handler_name, handler_version);
-
-                                // Use snapshot-capturing execution for live mode
-                                let storage = if is_live_mode {
-                                    Some(LiveStorage::new(&chain_name))
-                                } else {
-                                    None
-                                };
-
-                                let result = execute_with_snapshot_capture(
-                                    ops,
-                                    &db_pool,
-                                    storage.as_ref(),
-                                    range_start,
-                                    handler_name,
-                                    handler_version,
-                                )
-                                .await;
-
-                                if let Err(e) = result {
-                                    tracing::error!(
-                                        "Handler {} transaction failed for range {}-{}: {:?}",
-                                        handler_key,
-                                        range_start,
-                                        range_end,
-                                        e
-                                    );
-                                    return Ok(None);
-                                }
-                            }
-                            Ok(Some((handler_key, range_start, range_end)))
-                        }
-                        Err(e) => {
-                            tracing::error!(
-                                "Handler {} failed for call {}/{}: {}",
-                                handler_key,
-                                source,
-                                function_name,
-                                e
-                            );
-                            Ok(None)
-                        }
-                    }
+                let handler: Arc<dyn super::traits::TransformationHandler> = handler;
+                tasks.push(HandlerTask {
+                    handler,
+                    events: events.clone(),
+                    calls: calls.clone(),
+                    tx_addresses: tx_addresses.clone(),
                 });
             }
         }
 
-        // Collect results and record progress
-        while let Some(result) = join_set.join_next().await {
-            match result {
-                Ok(Ok(Some((handler_key, rs, re)))) => {
-                    self.record_completed_range_for_handler(&handler_key, rs, re)
-                        .await?;
+        let outcomes = self
+            .executor
+            .execute_handlers(tasks, range_start, range_end, &db_exec_mode)
+            .await;
 
-                    // Mark live progress for single-block ranges (live mode)
-                    if re - rs == 1 {
-                        if let Some(ref tracker) = self.progress_tracker {
-                            let mut t = tracker.lock().await;
-                            if let Err(e) = t.mark_complete(rs, &handler_key).await {
-                                tracing::warn!(
-                                    "Failed to mark live progress for block {} handler {}: {}",
-                                    rs,
-                                    handler_key,
-                                    e
-                                );
-                            }
-                        }
+        for outcome in outcomes {
+            self.finalizer
+                .record_completed_range_for_handler(
+                    &outcome.handler_key,
+                    outcome.range_start,
+                    outcome.range_end,
+                )
+                .await?;
+
+            if outcome.range_end - outcome.range_start == 1 {
+                if let Some(ref tracker) = self.progress_tracker {
+                    let mut t = tracker.lock().await;
+                    if let Err(e) = t
+                        .mark_complete(outcome.range_start, &outcome.handler_key)
+                        .await
+                    {
+                        tracing::warn!(
+                            "Failed to mark live progress for block {} handler {}: {}",
+                            outcome.range_start,
+                            outcome.handler_key,
+                            e
+                        );
                     }
-                }
-                Ok(Ok(None)) => {
-                    // Handler failed or had no ops — already logged
-                }
-                Ok(Err(e)) => {
-                    tracing::error!("Handler task returned error: {}", e);
-                }
-                Err(e) => {
-                    tracing::error!("Handler task panicked: {}", e);
                 }
             }
         }
 
         Ok(())
     }
-
-    // ─── Start Block Filtering ──────────────────────────────────────────
-
-    /// Filter events by contract start_block.
-    /// Events from contracts with a start_block are excluded if the event's
-    /// block_number is before that start_block.
-    fn filter_events_by_start_block(&self, events: Vec<DecodedEvent>) -> Vec<DecodedEvent> {
-        events
-            .into_iter()
-            .filter(|e| {
-                let start_block = self
-                    .contracts
-                    .get(&e.source_name)
-                    .and_then(|c| c.start_block.map(|u| u.to::<u64>()));
-                start_block.map_or(true, |sb| e.block_number >= sb)
-            })
-            .collect()
-    }
-
-    /// Filter calls by contract start_block.
-    /// Calls from contracts with a start_block are excluded if the call's
-    /// block_number is before that start_block.
-    fn filter_calls_by_start_block(&self, calls: Vec<DecodedCall>) -> Vec<DecodedCall> {
-        calls
-            .into_iter()
-            .filter(|c| {
-                let start_block = self
-                    .contracts
-                    .get(&c.source_name)
-                    .and_then(|ct| ct.start_block.map(|u| u.to::<u64>()));
-                start_block.map_or(true, |sb| c.block_number >= sb)
-            })
-            .collect()
-    }
 }
 
-#[cfg(test)]
-mod tests {
-    use std::collections::{HashMap, HashSet};
+// ─── RecordAndFinalize implementation ──────────────────────────────
 
-    use super::{
-        classify_live_retry_call_artifact, missing_retry_call_dependencies,
-        resolve_retry_missing_handlers, LiveRetryCallArtifactKind, RangeCompleteKind,
-        RangeCompletionState,
-    };
-    use crate::transformations::context::{DecodedCall, DecodedValue};
-
-    #[test]
-    fn range_completion_requires_both_streams_when_calls_expected() {
-        let mut state = RangeCompletionState::default();
-        state.mark(RangeCompleteKind::Logs);
-        assert!(!state.is_ready(true, true));
-        state.mark(RangeCompleteKind::EthCalls);
-        assert!(state.is_ready(true, true));
+#[async_trait::async_trait]
+impl super::retry::RecordAndFinalize for TransformationEngine {
+    async fn finalize_range(
+        &self,
+        range_start: u64,
+        range_end: u64,
+    ) -> Result<(), TransformationError> {
+        self.finalizer
+            .finalize_range(range_start, range_end, &self.live_state)
+            .await
     }
-
-    #[test]
-    fn range_completion_only_requires_logs_without_calls() {
-        let mut state = RangeCompletionState::default();
-        state.mark(RangeCompleteKind::Logs);
-        assert!(state.is_ready(true, false));
-    }
-
-    #[test]
-    fn range_completion_can_finalize_call_only_ranges() {
-        let mut state = RangeCompletionState::default();
-        state.mark(RangeCompleteKind::EthCalls);
-        assert!(state.is_ready(false, true));
-    }
-
-    #[test]
-    fn retry_missing_handlers_prefers_current_tracker_state() {
-        let requested = Some(HashSet::from([
-            "handler_a_v1".to_string(),
-            "handler_b_v1".to_string(),
-        ]));
-        let tracker = Some(HashSet::from(["handler_b_v1".to_string()]));
-        let all_handlers = HashSet::from([
-            "handler_a_v1".to_string(),
-            "handler_b_v1".to_string(),
-            "handler_c_v1".to_string(),
-        ]);
-
-        let resolved = resolve_retry_missing_handlers(requested, tracker, all_handlers);
-        assert_eq!(resolved, HashSet::from(["handler_b_v1".to_string()]));
-    }
-
-    #[test]
-    fn retry_dependency_check_detects_missing_calls() {
-        let required = HashSet::from([
-            ("Pool".to_string(), "slot0".to_string()),
-            ("Pool".to_string(), "liquidity".to_string()),
-        ]);
-        let calls = vec![DecodedCall {
-            block_number: 100,
-            block_timestamp: 1200,
-            contract_address: [0; 20],
-            source_name: "Pool".to_string(),
-            function_name: "slot0".to_string(),
-            trigger_log_index: None,
-            result: HashMap::from([("result".to_string(), DecodedValue::Uint64(1))]),
-        }];
-
-        let missing = missing_retry_call_dependencies(&required, &calls);
-        assert_eq!(
-            missing,
-            HashSet::from([("Pool".to_string(), "liquidity".to_string())])
-        );
-    }
-
-    #[test]
-    fn live_retry_call_artifact_prefers_regular_name_over_event_suffix() {
-        let regular = HashSet::from([("Pool".to_string(), "foo_event".to_string())]);
-        let event = HashSet::from([("Pool".to_string(), "foo".to_string())]);
-
-        let kind =
-            classify_live_retry_call_artifact("Pool", "foo_event", &regular, &event).unwrap();
-
-        assert_eq!(kind, LiveRetryCallArtifactKind::Regular);
-    }
-
-    #[test]
-    fn live_retry_call_artifact_still_recognizes_event_triggered_suffix() {
-        let regular = HashSet::new();
-        let event = HashSet::from([("Pool".to_string(), "foo".to_string())]);
-
-        let kind =
-            classify_live_retry_call_artifact("Pool", "foo_event", &regular, &event).unwrap();
-
-        assert_eq!(
-            kind,
-            LiveRetryCallArtifactKind::EventTriggered {
-                base_name: "foo".to_string()
-            }
-        );
-    }
-}
-
-/// Execute a transaction with optional snapshot capture for reorg rollback.
-///
-/// For live mode (single-block ranges), this function:
-/// 1. Queries current row state for upserts with update_columns
-/// 2. Writes snapshots to storage (before transaction, for crash safety)
-/// 3. Executes the transaction
-///
-/// Writing snapshots before the transaction ensures that if a crash occurs after
-/// the transaction commits, the snapshot is already persisted. Orphan snapshots
-/// from failed transactions are harmless and cleaned up during compaction.
-async fn execute_with_snapshot_capture(
-    ops: Vec<DbOperation>,
-    db_pool: &DbPool,
-    storage: Option<&LiveStorage>,
-    block_number: u64,
-    handler_source: &str,
-    handler_version: u32,
-) -> Result<(), crate::db::DbError> {
-    // If no storage provided, just execute directly (historical mode)
-    let storage = match storage {
-        Some(s) => s,
-        None => return db_pool.execute_transaction(ops).await,
-    };
-
-    // Collect snapshots for upserts with update_columns (these modify existing rows)
-    let mut snapshots = Vec::new();
-
-    for op in &ops {
-        if let DbOperation::Upsert {
-            table,
-            columns,
-            values,
-            conflict_columns,
-            update_columns,
-        } = op
-        {
-            // Only capture snapshots for upserts that update existing rows
-            if update_columns.is_empty() {
-                continue;
-            }
-
-            // Build key columns from conflict_columns
-            let mut key_columns: Vec<(String, DbValue)> = Vec::new();
-            for conflict_col in conflict_columns {
-                // Find the value for this conflict column
-                if let Some(idx) = columns.iter().position(|c| c == conflict_col) {
-                    key_columns.push((conflict_col.clone(), values[idx].clone()));
-                }
-            }
-
-            // Query current row state
-            let previous_row = db_pool.query_row(table, &key_columns).await?;
-
-            // Convert to LiveDbValue
-            let live_key_columns: Vec<(String, LiveDbValue)> = key_columns
-                .into_iter()
-                .map(|(k, v)| (k, LiveDbValue::from_db_value(&v)))
-                .collect();
-
-            let live_previous_row = previous_row.map(|row| {
-                row.into_iter()
-                    .map(|(k, v)| (k, LiveDbValue::from_db_value(&v)))
-                    .collect()
-            });
-
-            snapshots.push(LiveUpsertSnapshot {
-                table: table.clone(),
-                source: handler_source.to_string(),
-                source_version: handler_version,
-                key_columns: live_key_columns,
-                previous_row: live_previous_row,
-            });
-        }
-    }
-
-    // Write snapshots to storage BEFORE transaction (for crash safety)
-    // If we crash after transaction but before snapshot write, we'd lose rollback ability.
-    // Orphan snapshots from failed transactions are cleaned up during compaction.
-    if !snapshots.is_empty() {
-        // Read existing snapshots and append new ones
-        let mut all_snapshots = storage.read_snapshots(block_number).unwrap_or_default();
-        all_snapshots.extend(snapshots);
-
-        if let Err(e) = storage.write_snapshots(block_number, &all_snapshots) {
-            tracing::warn!(
-                "Failed to write upsert snapshots for block {}: {}",
-                block_number,
-                e
-            );
-            // Continue with transaction even if snapshot write fails - fallback DELETE still works
-        }
-    }
-
-    // Execute the transaction
-    db_pool.execute_transaction(ops).await
 }

--- a/src/transformations/executor.rs
+++ b/src/transformations/executor.rs
@@ -1,0 +1,389 @@
+//! Handler execution engine.
+//!
+//! Provides the unified handler spawn-loop pattern used by live processing,
+//! catchup, and retry paths. Handles context construction, source/version
+//! injection, database execution, and optional snapshot capture.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::sync::Semaphore;
+use tokio::task::JoinSet;
+
+use super::context::{DecodedCall, DecodedEvent, TransactionAddresses, TransformationContext};
+use super::error::TransformationError;
+use super::historical::HistoricalDataReader;
+use super::traits::TransformationHandler;
+use crate::db::{DbOperation, DbPool, DbValue, WhereClause};
+use crate::live::{LiveDbValue, LiveStorage, LiveUpsertSnapshot};
+use crate::rpc::UnifiedRpcClient;
+use crate::types::config::contract::Contracts;
+
+/// Outcome of a successful handler execution.
+pub(crate) struct HandlerOutcome {
+    pub handler_key: String,
+    pub range_start: u64,
+    pub range_end: u64,
+}
+
+/// How to execute database operations.
+pub(crate) enum DbExecMode {
+    /// Execute directly via transaction (historical catchup, live events without snapshots).
+    Direct,
+    /// Capture snapshots before executing (live mode for reorg rollback).
+    WithSnapshotCapture { chain_name: String },
+}
+
+/// A single handler task to execute.
+pub(crate) struct HandlerTask {
+    pub handler: Arc<dyn TransformationHandler>,
+    pub events: Arc<Vec<DecodedEvent>>,
+    pub calls: Arc<Vec<DecodedCall>>,
+    pub tx_addresses: HashMap<[u8; 32], TransactionAddresses>,
+}
+
+/// Executes transformation handlers concurrently with bounded parallelism.
+pub(crate) struct HandlerExecutor {
+    pub db_pool: Arc<DbPool>,
+    pub historical_reader: Arc<HistoricalDataReader>,
+    pub rpc_client: Arc<UnifiedRpcClient>,
+    pub contracts: Arc<Contracts>,
+    pub chain_name: String,
+    pub chain_id: u64,
+    pub handler_concurrency: usize,
+}
+
+impl HandlerExecutor {
+    /// Execute a set of handler tasks concurrently, returning outcomes for successful handlers.
+    /// Failed handlers are logged and excluded from the result.
+    pub async fn execute_handlers(
+        &self,
+        tasks: Vec<HandlerTask>,
+        range_start: u64,
+        range_end: u64,
+        db_exec_mode: &DbExecMode,
+    ) -> Vec<HandlerOutcome> {
+        if tasks.is_empty() {
+            return Vec::new();
+        }
+
+        let semaphore = Arc::new(Semaphore::new(self.handler_concurrency));
+        let mut join_set: JoinSet<Result<Option<HandlerOutcome>, TransformationError>> =
+            JoinSet::new();
+
+        for task in tasks {
+            let permit = semaphore.clone().acquire_owned().await.unwrap();
+            let db_pool = self.db_pool.clone();
+            let chain_name = self.chain_name.clone();
+            let chain_id = self.chain_id;
+            let historical = self.historical_reader.clone();
+            let rpc = self.rpc_client.clone();
+            let contracts = self.contracts.clone();
+            let handler = task.handler;
+            let events = task.events;
+            let calls = task.calls;
+            let tx_addresses = task.tx_addresses;
+            let handler_name = handler.name();
+            let handler_version = handler.version();
+            let handler_key = handler.handler_key();
+            let snapshot_chain = match db_exec_mode {
+                DbExecMode::Direct => None,
+                DbExecMode::WithSnapshotCapture { chain_name } => Some(chain_name.clone()),
+            };
+
+            join_set.spawn(async move {
+                let _permit = permit;
+                let ctx = TransformationContext::new(
+                    chain_name,
+                    chain_id,
+                    range_start,
+                    range_end,
+                    events,
+                    calls,
+                    tx_addresses,
+                    historical,
+                    rpc,
+                    contracts,
+                );
+
+                match handler.handle(&ctx).await {
+                    Ok(ops) => {
+                        if !ops.is_empty() {
+                            let ops = inject_source_version(ops, handler_name, handler_version);
+
+                            let result = if let Some(ref cn) = snapshot_chain {
+                                let storage = LiveStorage::new(cn);
+                                execute_with_snapshot_capture(
+                                    ops,
+                                    &db_pool,
+                                    Some(&storage),
+                                    range_start,
+                                    handler_name,
+                                    handler_version,
+                                )
+                                .await
+                            } else {
+                                db_pool
+                                    .execute_transaction(ops)
+                                    .await
+                                    .map_err(TransformationError::DatabaseError)
+                            };
+
+                            if let Err(e) = result {
+                                tracing::error!(
+                                    "Handler {} transaction failed for range {}-{}: {:?}",
+                                    handler_key,
+                                    range_start,
+                                    range_end,
+                                    e
+                                );
+                                return Ok(None);
+                            }
+                        }
+                        Ok(Some(HandlerOutcome {
+                            handler_key,
+                            range_start,
+                            range_end,
+                        }))
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            "Handler {} failed for range {}-{}: {}",
+                            handler_key,
+                            range_start,
+                            range_end,
+                            e
+                        );
+                        Ok(None)
+                    }
+                }
+            });
+        }
+
+        let mut outcomes = Vec::new();
+        while let Some(result) = join_set.join_next().await {
+            match result {
+                Ok(Ok(Some(outcome))) => outcomes.push(outcome),
+                Ok(Ok(None)) => {}
+                Ok(Err(e)) => {
+                    tracing::error!("Handler task returned error: {}", e);
+                }
+                Err(e) => {
+                    tracing::error!("Handler task panicked: {}", e);
+                }
+            }
+        }
+
+        outcomes
+    }
+}
+
+// ─── Source/Version Injection (free functions) ───────────────────────
+
+/// Inject `source` and `source_version` into each DbOperation.
+/// Called after handler.handle() returns ops, before execute_transaction().
+pub(crate) fn inject_source_version(
+    ops: Vec<DbOperation>,
+    source: &str,
+    version: u32,
+) -> Vec<DbOperation> {
+    ops.into_iter()
+        .map(|op| match op {
+            DbOperation::Upsert {
+                table,
+                mut columns,
+                mut values,
+                mut conflict_columns,
+                mut update_columns,
+            } => {
+                columns.push("source".to_string());
+                columns.push("source_version".to_string());
+                values.push(DbValue::Text(source.to_string()));
+                values.push(DbValue::Int32(version as i32));
+                conflict_columns.push("source".to_string());
+                conflict_columns.push("source_version".to_string());
+                // Remove source/source_version from update_columns since they're part of conflict key
+                update_columns.retain(|c| c != "source" && c != "source_version");
+                DbOperation::Upsert {
+                    table,
+                    columns,
+                    values,
+                    conflict_columns,
+                    update_columns,
+                }
+            }
+            DbOperation::Insert {
+                table,
+                mut columns,
+                mut values,
+            } => {
+                columns.push("source".to_string());
+                columns.push("source_version".to_string());
+                values.push(DbValue::Text(source.to_string()));
+                values.push(DbValue::Int32(version as i32));
+                DbOperation::Insert {
+                    table,
+                    columns,
+                    values,
+                }
+            }
+            DbOperation::Update {
+                table,
+                set_columns,
+                where_clause,
+            } => {
+                let where_clause = inject_where_clause(where_clause, source, version);
+                DbOperation::Update {
+                    table,
+                    set_columns,
+                    where_clause,
+                }
+            }
+            DbOperation::Delete {
+                table,
+                where_clause,
+            } => {
+                let where_clause = inject_where_clause(where_clause, source, version);
+                DbOperation::Delete {
+                    table,
+                    where_clause,
+                }
+            }
+            DbOperation::RawSql { query, params } => {
+                tracing::warn!(
+                    "RawSql operation skipped for source/version injection — handler must manage source/source_version manually"
+                );
+                DbOperation::RawSql { query, params }
+            }
+        })
+        .collect()
+}
+
+/// Inject source/source_version conditions into a WhereClause.
+fn inject_where_clause(clause: WhereClause, source: &str, version: u32) -> WhereClause {
+    let source_conditions = vec![
+        ("source".to_string(), DbValue::Text(source.to_string())),
+        ("source_version".to_string(), DbValue::Int32(version as i32)),
+    ];
+
+    match clause {
+        WhereClause::Eq(col, val) => {
+            let mut conditions = vec![(col, val)];
+            conditions.extend(source_conditions);
+            WhereClause::And(conditions)
+        }
+        WhereClause::And(mut conditions) => {
+            conditions.extend(source_conditions);
+            WhereClause::And(conditions)
+        }
+        WhereClause::Raw { condition, params } => {
+            tracing::warn!(
+                "WhereClause::Raw skipped for source/version injection — handler must manage manually"
+            );
+            WhereClause::Raw { condition, params }
+        }
+    }
+}
+
+// ─── Snapshot-Capturing Execution ─────────────────────────────────────
+
+/// Execute a transaction with optional snapshot capture for reorg rollback.
+///
+/// For live mode (single-block ranges), this function:
+/// 1. Queries current row state for upserts with update_columns
+/// 2. Writes snapshots to storage (before transaction, for crash safety)
+/// 3. Executes the transaction
+///
+/// Writing snapshots before the transaction ensures that if a crash occurs after
+/// the transaction commits, the snapshot is already persisted. Orphan snapshots
+/// from failed transactions are harmless and cleaned up during compaction.
+pub(crate) async fn execute_with_snapshot_capture(
+    ops: Vec<DbOperation>,
+    db_pool: &DbPool,
+    storage: Option<&LiveStorage>,
+    block_number: u64,
+    handler_source: &str,
+    handler_version: u32,
+) -> Result<(), TransformationError> {
+    // If no storage provided, just execute directly (historical mode)
+    let storage = match storage {
+        Some(s) => s,
+        None => {
+            return db_pool
+                .execute_transaction(ops)
+                .await
+                .map_err(TransformationError::DatabaseError)
+        }
+    };
+
+    // Collect snapshots for upserts with update_columns (these modify existing rows)
+    let mut snapshots = Vec::new();
+
+    for op in &ops {
+        if let DbOperation::Upsert {
+            table,
+            columns,
+            values,
+            conflict_columns,
+            update_columns,
+        } = op
+        {
+            // Only capture snapshots for upserts that update existing rows
+            if update_columns.is_empty() {
+                continue;
+            }
+
+            // Build key columns from conflict_columns
+            let mut key_columns: Vec<(String, DbValue)> = Vec::new();
+            for conflict_col in conflict_columns {
+                // Find the value for this conflict column
+                if let Some(idx) = columns.iter().position(|c| c == conflict_col) {
+                    key_columns.push((conflict_col.clone(), values[idx].clone()));
+                }
+            }
+
+            // Query current row state
+            let previous_row = db_pool.query_row(table, &key_columns).await?;
+
+            // Convert to LiveDbValue
+            let live_key_columns: Vec<(String, LiveDbValue)> = key_columns
+                .into_iter()
+                .map(|(k, v)| (k, LiveDbValue::from_db_value(&v)))
+                .collect();
+
+            let live_previous_row = previous_row.map(|row| {
+                row.into_iter()
+                    .map(|(k, v)| (k, LiveDbValue::from_db_value(&v)))
+                    .collect()
+            });
+
+            snapshots.push(LiveUpsertSnapshot {
+                table: table.clone(),
+                source: handler_source.to_string(),
+                source_version: handler_version,
+                key_columns: live_key_columns,
+                previous_row: live_previous_row,
+            });
+        }
+    }
+
+    // Write snapshots to storage BEFORE transaction (for crash safety)
+    if !snapshots.is_empty() {
+        let mut all_snapshots = storage.read_snapshots(block_number).unwrap_or_default();
+        all_snapshots.extend(snapshots);
+
+        if let Err(e) = storage.write_snapshots(block_number, &all_snapshots) {
+            tracing::warn!(
+                "Failed to write upsert snapshots for block {}: {}",
+                block_number,
+                e
+            );
+        }
+    }
+
+    // Execute the transaction
+    db_pool
+        .execute_transaction(ops)
+        .await
+        .map_err(TransformationError::DatabaseError)
+}

--- a/src/transformations/finalizer.rs
+++ b/src/transformations/finalizer.rs
@@ -1,0 +1,433 @@
+//! Range finalization, reorg cleanup, and progress tracking.
+//!
+//! Manages the lifecycle of processed ranges: recording handler progress,
+//! detecting finalization readiness, executing finalization, and cleaning up
+//! after reorgs.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+
+use super::error::TransformationError;
+use super::live_state::LiveProcessingState;
+use super::registry::TransformationRegistry;
+use crate::db::{DbOperation, DbPool, DbValue, WhereClause};
+use crate::live::{LiveProgressTracker, LiveStorage, StorageError};
+
+/// Handles range finalization, reorg cleanup, and progress tracking.
+pub(crate) struct RangeFinalizer {
+    pub registry: Arc<TransformationRegistry>,
+    pub db_pool: Arc<DbPool>,
+    pub chain_name: String,
+    pub chain_id: u64,
+    pub progress_tracker: Option<Arc<Mutex<LiveProgressTracker>>>,
+    pub expect_log_completion: bool,
+    pub expect_eth_call_completion: bool,
+}
+
+impl RangeFinalizer {
+    // ─── Per-Handler Progress Tracking ───────────────────────────────
+
+    /// Get completed ranges for a specific handler from the database.
+    pub async fn get_completed_ranges_for_handler(
+        &self,
+        handler_key: &str,
+    ) -> Result<HashSet<u64>, TransformationError> {
+        let rows = self
+            .db_pool
+            .query(
+                "SELECT range_start FROM _handler_progress WHERE chain_id = $1 AND handler_key = $2",
+                &[&(self.chain_id as i64), &handler_key.to_string()],
+            )
+            .await?;
+
+        let mut completed = HashSet::new();
+        for row in rows {
+            let range_start: i64 = row.get(0);
+            completed.insert(range_start as u64);
+        }
+
+        Ok(completed)
+    }
+
+    /// Record a completed range for a specific handler.
+    pub async fn record_completed_range_for_handler(
+        &self,
+        handler_key: &str,
+        range_start: u64,
+        range_end: u64,
+    ) -> Result<(), TransformationError> {
+        self.db_pool
+            .execute_transaction(vec![DbOperation::Upsert {
+                table: "_handler_progress".to_string(),
+                columns: vec![
+                    "chain_id".to_string(),
+                    "handler_key".to_string(),
+                    "range_start".to_string(),
+                    "range_end".to_string(),
+                ],
+                values: vec![
+                    DbValue::Int64(self.chain_id as i64),
+                    DbValue::Text(handler_key.to_string()),
+                    DbValue::Int64(range_start as i64),
+                    DbValue::Int64(range_end as i64),
+                ],
+                conflict_columns: vec![
+                    "chain_id".to_string(),
+                    "handler_key".to_string(),
+                    "range_start".to_string(),
+                ],
+                update_columns: vec!["range_end".to_string()],
+            }])
+            .await?;
+
+        Ok(())
+    }
+
+    // ─── Range Completion ─────────────────────────────────────────────
+
+    /// Process range completion signal.
+    pub async fn process_range_complete(
+        &self,
+        range_key: (u64, u64),
+        kind: super::engine::RangeCompleteKind,
+        live_state: &Mutex<LiveProcessingState>,
+    ) -> Result<(), TransformationError> {
+        {
+            let mut state = live_state.lock().await;
+            state
+                .completion
+                .entry(range_key)
+                .or_default()
+                .mark(kind);
+        }
+
+        self.maybe_finalize_range(range_key, live_state).await?;
+        Ok(())
+    }
+
+    /// Check if a range is ready for finalization and finalize if so.
+    pub async fn maybe_finalize_range(
+        &self,
+        range_key: (u64, u64),
+        live_state: &Mutex<LiveProcessingState>,
+    ) -> Result<(), TransformationError> {
+        let (should_finalize, timed_out_handlers) = {
+            let mut state = live_state.lock().await;
+            state.check_finalization_readiness(
+                range_key,
+                self.expect_log_completion,
+                self.range_requires_eth_call_completion(range_key),
+            )
+        };
+
+        if !timed_out_handlers.is_empty() {
+            tracing::warn!(
+                "Removed {} timed-out pending event handlers for range {:?}: {:?}",
+                timed_out_handlers.len(),
+                range_key,
+                timed_out_handlers
+            );
+        }
+
+        if !should_finalize {
+            return Ok(());
+        }
+
+        self.finalize_range(range_key.0, range_key.1, live_state)
+            .await
+    }
+
+    /// Finalize a range: record progress for all handlers and clean up state.
+    pub async fn finalize_range(
+        &self,
+        range_start: u64,
+        range_end: u64,
+        live_state: &Mutex<LiveProcessingState>,
+    ) -> Result<(), TransformationError> {
+        let range_key = (range_start, range_end);
+
+        // Prevent double finalization
+        {
+            let mut state = live_state.lock().await;
+            if !state.mark_finalized(range_key) {
+                return Ok(());
+            }
+        }
+
+        // Mark ALL handlers as complete for this range (event + call handlers)
+        for handler in self.registry.all_handlers() {
+            let handler_key = handler.handler_key();
+            self.record_completed_range_for_handler(&handler_key, range_start, range_end)
+                .await?;
+
+            if range_end - range_start == 1 {
+                if let Some(ref tracker) = self.progress_tracker {
+                    let mut t = tracker.lock().await;
+                    if let Err(e) = t.mark_complete(range_start, &handler_key).await {
+                        tracing::warn!(
+                            "Failed to mark live progress for block {} handler {}: {}",
+                            range_start,
+                            handler_key,
+                            e
+                        );
+                    }
+                }
+            }
+        }
+
+        {
+            let mut state = live_state.lock().await;
+            state.cleanup_after_finalize(range_key);
+        }
+
+        tracing::debug!(
+            "Recorded progress for {} handlers on range {}-{}",
+            self.registry.all_handlers().len(),
+            range_start,
+            range_end
+        );
+
+        if range_end - range_start == 1 {
+            let storage = LiveStorage::new(&self.chain_name);
+            match storage.read_status(range_start) {
+                Ok(mut status) => {
+                    status.transformed = true;
+                    if let Err(e) = storage.write_status(range_start, &status) {
+                        tracing::warn!(
+                            "Failed to set transformed=true for block {}: {}",
+                            range_start,
+                            e
+                        );
+                    }
+                }
+                Err(StorageError::NotFound(_)) => {
+                    tracing::debug!(
+                        "Status file not found for block {}, skipping transformed=true",
+                        range_start
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to read status for block {}: {}", range_start, e);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Check if this range requires eth_call completion signal before finalization.
+    fn range_requires_eth_call_completion(&self, range_key: (u64, u64)) -> bool {
+        self.expect_eth_call_completion && range_key.1.saturating_sub(range_key.0) == 1
+    }
+
+    // ─── Reorg Cleanup ─────────────────────────────────────────────────
+
+    /// Process a reorg notification.
+    pub async fn process_reorg(
+        &self,
+        common_ancestor: u64,
+        orphaned: &[u64],
+        live_state: &Mutex<LiveProcessingState>,
+    ) -> Result<(), TransformationError> {
+        tracing::info!(
+            "Processing reorg: common_ancestor={}, orphaned={:?}",
+            common_ancestor,
+            orphaned
+        );
+
+        if orphaned.is_empty() {
+            return Ok(());
+        }
+
+        // Phase 1: Clean up in-memory state
+        let total_removed = {
+            let mut state = live_state.lock().await;
+            state.cleanup_for_orphaned_blocks(orphaned)
+        };
+        if total_removed > 0 {
+            tracing::info!(
+                "Reorg cleanup: removed {} pending events for {} orphaned blocks",
+                total_removed,
+                orphaned.len()
+            );
+        }
+
+        // Phase 2: Delete committed rows from database tables
+        self.cleanup_reorg_tables(orphaned).await?;
+
+        // Phase 3: Clean up _live_progress entries
+        self.cleanup_live_progress(orphaned).await?;
+
+        Ok(())
+    }
+
+    /// Rollback committed rows for orphaned blocks using snapshots.
+    async fn cleanup_reorg_tables(&self, orphaned: &[u64]) -> Result<(), TransformationError> {
+        let mut tables_to_clean: HashSet<&str> = HashSet::new();
+        for handler in self.registry.all_handlers() {
+            tables_to_clean.extend(handler.reorg_tables());
+        }
+
+        if tables_to_clean.is_empty() {
+            tracing::debug!("No reorg tables declared by handlers, skipping database cleanup");
+            return Ok(());
+        }
+
+        let storage = LiveStorage::new(&self.chain_name);
+        let mut restore_ops = Vec::new();
+        let mut tables_with_snapshots: HashSet<String> = HashSet::new();
+
+        // Phase 2a: Read snapshots and generate restore operations
+        for &block_number in orphaned {
+            match storage.read_snapshots(block_number) {
+                Ok(snapshots) => {
+                    for snapshot in snapshots {
+                        tables_with_snapshots.insert(snapshot.table.clone());
+
+                        match snapshot.previous_row {
+                            Some(previous) => {
+                                let columns: Vec<String> =
+                                    previous.iter().map(|(k, _)| k.clone()).collect();
+                                let values: Vec<DbValue> =
+                                    previous.iter().map(|(_, v)| v.to_db_value()).collect();
+                                let conflict_cols: Vec<String> = snapshot
+                                    .key_columns
+                                    .iter()
+                                    .map(|(k, _)| k.clone())
+                                    .collect();
+
+                                let update_cols: Vec<String> = columns
+                                    .iter()
+                                    .filter(|c| !conflict_cols.contains(c))
+                                    .cloned()
+                                    .collect();
+
+                                restore_ops.push(DbOperation::Upsert {
+                                    table: snapshot.table,
+                                    columns,
+                                    values,
+                                    conflict_columns: conflict_cols,
+                                    update_columns: update_cols,
+                                });
+                            }
+                            None => {
+                                let key_conditions: Vec<(String, DbValue)> = snapshot
+                                    .key_columns
+                                    .into_iter()
+                                    .map(|(k, v)| (k, v.to_db_value()))
+                                    .collect();
+
+                                restore_ops.push(DbOperation::Delete {
+                                    table: snapshot.table,
+                                    where_clause: WhereClause::And(key_conditions),
+                                });
+                            }
+                        }
+                    }
+                }
+                Err(StorageError::NotFound(_)) => {
+                    tracing::debug!(
+                        "No snapshots found for block {}, will use fallback delete",
+                        block_number
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to read snapshots for block {}: {}, using fallback delete",
+                        block_number,
+                        e
+                    );
+                }
+            }
+        }
+
+        if !restore_ops.is_empty() {
+            tracing::info!(
+                "Reorg rollback: executing {} restore operations from snapshots",
+                restore_ops.len()
+            );
+            self.db_pool.execute_transaction(restore_ops).await?;
+        }
+
+        // Phase 2b: Delete remaining rows without snapshots
+        let block_list = orphaned
+            .iter()
+            .map(|b| b.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+
+        let mut fallback_ops = Vec::new();
+        for table in &tables_to_clean {
+            if tables_with_snapshots.contains(*table) {
+                continue;
+            }
+
+            fallback_ops.push(DbOperation::Delete {
+                table: table.to_string(),
+                where_clause: WhereClause::Raw {
+                    condition: format!(
+                        "chain_id = {} AND block_number IN ({})",
+                        self.chain_id, block_list
+                    ),
+                    params: vec![],
+                },
+            });
+        }
+
+        if !fallback_ops.is_empty() {
+            tracing::info!(
+                "Reorg cleanup: fallback deleting from {} tables for {} orphaned blocks",
+                fallback_ops.len(),
+                orphaned.len()
+            );
+            self.db_pool.execute_transaction(fallback_ops).await?;
+        }
+
+        // Delete snapshot files for orphaned blocks
+        for &block_number in orphaned {
+            if let Err(e) = storage.delete_snapshots(block_number) {
+                tracing::warn!(
+                    "Failed to delete snapshots for block {}: {}",
+                    block_number,
+                    e
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Clean up _live_progress entries for orphaned blocks.
+    async fn cleanup_live_progress(&self, orphaned: &[u64]) -> Result<(), TransformationError> {
+        if orphaned.is_empty() {
+            return Ok(());
+        }
+
+        let block_list = orphaned
+            .iter()
+            .map(|b| b.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+
+        let ops = vec![DbOperation::Delete {
+            table: "_live_progress".to_string(),
+            where_clause: WhereClause::Raw {
+                condition: format!(
+                    "chain_id = {} AND block_number IN ({})",
+                    self.chain_id, block_list
+                ),
+                params: vec![],
+            },
+        }];
+
+        tracing::debug!(
+            "Reorg cleanup: deleting _live_progress for {} orphaned blocks",
+            orphaned.len()
+        );
+        self.db_pool.execute_transaction(ops).await?;
+
+        Ok(())
+    }
+}

--- a/src/transformations/live_state.rs
+++ b/src/transformations/live_state.rs
@@ -1,0 +1,292 @@
+//! Live processing state for buffering events with call dependencies.
+//!
+//! Manages pending events, call buffers, range completion tracking,
+//! and finalization state for the transformation engine's live mode.
+
+use std::collections::{HashMap, HashSet};
+use std::time::{Duration, Instant};
+
+use super::context::{DecodedCall, DecodedEvent};
+use super::engine::RangeCompleteKind;
+
+/// Buffered event data waiting for call dependencies.
+#[derive(Debug)]
+pub(crate) struct PendingEventData {
+    pub range_start: u64,
+    pub range_end: u64,
+    pub source_name: String,
+    pub event_name: String,
+    pub events: Vec<DecodedEvent>,
+    /// Call dependencies needed: (source, function_name)
+    pub required_calls: Vec<(String, String)>,
+}
+
+/// Default timeout for stuck pending events (5 minutes).
+pub(crate) const PENDING_EVENT_TIMEOUT_SECS: u64 = 300;
+
+/// Live processing state for buffering events with call dependencies.
+pub(crate) struct LiveProcessingState {
+    /// Track which (source, function) calls have arrived for which ranges.
+    /// Key: (source_name, function_name), Value: set of (range_start, range_end)
+    pub received_calls: HashMap<(String, String), HashSet<(u64, u64)>>,
+    /// Accumulated calls per range for event handlers with dependencies.
+    /// Key: (range_start, range_end), Value: accumulated calls
+    pub calls_buffer: HashMap<(u64, u64), Vec<DecodedCall>>,
+    /// Buffer events waiting for calls, keyed by handler_key.
+    pub pending_events: HashMap<String, Vec<PendingEventData>>,
+    /// Tracks which decode streams have completed for a range.
+    pub completion: HashMap<(u64, u64), RangeCompletionState>,
+    /// Track when events first become pending for timeout detection.
+    /// Key: (range_start, range_end, handler_key), Value: when first added
+    pub pending_event_timestamps: HashMap<(u64, u64, String), Instant>,
+    /// Ranges that have been finalized (to prevent double finalization).
+    pub finalized_ranges: HashSet<(u64, u64)>,
+}
+
+impl Default for LiveProcessingState {
+    fn default() -> Self {
+        Self {
+            received_calls: HashMap::new(),
+            calls_buffer: HashMap::new(),
+            pending_events: HashMap::new(),
+            completion: HashMap::new(),
+            pending_event_timestamps: HashMap::new(),
+            finalized_ranges: HashSet::new(),
+        }
+    }
+}
+
+impl LiveProcessingState {
+    /// Clean up in-memory state for orphaned blocks.
+    /// Returns the number of pending events removed.
+    pub fn cleanup_for_orphaned_blocks(&mut self, orphaned: &[u64]) -> usize {
+        let mut total_removed = 0;
+
+        for &orphaned_block in orphaned {
+            let range_key = (orphaned_block, orphaned_block + 1);
+
+            // Remove from calls_buffer
+            if self.calls_buffer.remove(&range_key).is_some() {
+                tracing::debug!("Removed calls buffer for orphaned range {:?}", range_key);
+            }
+            self.completion.remove(&range_key);
+
+            // Remove from finalized_ranges to allow re-finalization if block is re-processed
+            self.finalized_ranges.remove(&range_key);
+
+            // Remove from received_calls
+            for ranges in self.received_calls.values_mut() {
+                ranges.remove(&range_key);
+            }
+
+            // Remove pending event timestamps for this range
+            self
+                .pending_event_timestamps
+                .retain(|(rs, re, _), _| (*rs, *re) != range_key);
+
+            // Remove pending events for this range from all handlers
+            for (handler_key, pending_list) in self.pending_events.iter_mut() {
+                let initial_len = pending_list.len();
+                pending_list.retain(|pending| {
+                    let matches = (pending.range_start, pending.range_end) == range_key;
+                    if matches {
+                        tracing::debug!(
+                            "Removing pending event for handler {} at orphaned range {:?}",
+                            handler_key,
+                            range_key
+                        );
+                    }
+                    !matches
+                });
+                total_removed += initial_len - pending_list.len();
+            }
+        }
+
+        // Clean up empty entries
+        self.pending_events.retain(|_, v| !v.is_empty());
+
+        total_removed
+    }
+
+    /// Clean up state for a retry request on a given range.
+    pub fn cleanup_for_retry(&mut self, range_key: (u64, u64)) {
+        self.calls_buffer.remove(&range_key);
+        self.completion.remove(&range_key);
+        self.finalized_ranges.remove(&range_key);
+        self.pending_event_timestamps
+            .retain(|(rs, re, _), _| (*rs, *re) != range_key);
+        for ranges in self.received_calls.values_mut() {
+            ranges.remove(&range_key);
+        }
+        for pending in self.pending_events.values_mut() {
+            pending.retain(|entry| (entry.range_start, entry.range_end) != range_key);
+        }
+        self.pending_events
+            .retain(|_, entries| !entries.is_empty());
+    }
+
+    /// Check if a range is ready for finalization.
+    /// Returns (should_finalize, timed_out_handler_keys).
+    pub fn check_finalization_readiness(
+        &mut self,
+        range_key: (u64, u64),
+        expect_logs: bool,
+        expect_eth_calls: bool,
+    ) -> (bool, Vec<String>) {
+        let completion = self
+            .completion
+            .get(&range_key)
+            .copied()
+            .unwrap_or_default();
+
+        // Check for timed-out pending events
+        let timeout = Duration::from_secs(PENDING_EVENT_TIMEOUT_SECS);
+        let now = Instant::now();
+        let mut timed_out: Vec<String> = Vec::new();
+
+        for (handler_key, pending_list) in &self.pending_events {
+            for pending in pending_list {
+                if (pending.range_start, pending.range_end) == range_key {
+                    let timestamp_key = (range_key.0, range_key.1, handler_key.clone());
+                    if let Some(&first_seen) =
+                        self.pending_event_timestamps.get(&timestamp_key)
+                    {
+                        if now.duration_since(first_seen) >= timeout {
+                            tracing::error!(
+                                "Pending event TIMED OUT after {:?}: handler={} range={}-{} event={}/{} waiting_for={:?}. \
+                                 Force-finalizing range to unblock progress.",
+                                now.duration_since(first_seen),
+                                handler_key,
+                                pending.range_start,
+                                pending.range_end,
+                                pending.source_name,
+                                pending.event_name,
+                                pending.required_calls
+                            );
+                            timed_out.push(handler_key.clone());
+                        }
+                    }
+                }
+            }
+        }
+
+        // Remove timed-out pending events
+        for handler_key in &timed_out {
+            if let Some(pending_list) = self.pending_events.get_mut(handler_key) {
+                pending_list
+                    .retain(|pending| (pending.range_start, pending.range_end) != range_key);
+            }
+            let timestamp_key = (range_key.0, range_key.1, handler_key.clone());
+            self.pending_event_timestamps.remove(&timestamp_key);
+        }
+        self.pending_events.retain(|_, v| !v.is_empty());
+
+        let has_pending = self.pending_events.values().any(|pending_list| {
+            pending_list
+                .iter()
+                .any(|pending| (pending.range_start, pending.range_end) == range_key)
+        });
+
+        if has_pending && completion.logs_complete && completion.eth_calls_complete {
+            for (handler_key, pending_list) in &self.pending_events {
+                for pending in pending_list {
+                    if (pending.range_start, pending.range_end) == range_key {
+                        tracing::warn!(
+                            "Stuck pending event detected: handler={} range={}-{} event={}/{} waiting_for={:?}. \
+                             This may indicate missing eth_call configuration or RPC failure.",
+                            handler_key,
+                            pending.range_start,
+                            pending.range_end,
+                            pending.source_name,
+                            pending.event_name,
+                            pending.required_calls
+                        );
+                    }
+                }
+            }
+        }
+
+        let ready = !has_pending && completion.is_ready(expect_logs, expect_eth_calls);
+        (ready, timed_out)
+    }
+
+    /// Mark a range as finalized. Returns false if already finalized.
+    pub fn mark_finalized(&mut self, range_key: (u64, u64)) -> bool {
+        if self.finalized_ranges.contains(&range_key) {
+            tracing::debug!(
+                "Range {}-{} already finalized, skipping duplicate finalization",
+                range_key.0,
+                range_key.1
+            );
+            return false;
+        }
+        self.finalized_ranges.insert(range_key);
+        true
+    }
+
+    /// Clean up state after finalizing a range.
+    pub fn cleanup_after_finalize(&mut self, range_key: (u64, u64)) {
+        self.calls_buffer.remove(&range_key);
+        self.completion.remove(&range_key);
+        for ranges in self.received_calls.values_mut() {
+            ranges.remove(&range_key);
+        }
+        self.pending_event_timestamps
+            .retain(|(rs, re, _), _| (*rs, *re) != range_key);
+    }
+
+    /// Get buffered calls for a range.
+    pub fn get_buffered_calls(&self, range_key: (u64, u64)) -> Vec<DecodedCall> {
+        self.calls_buffer
+            .get(&range_key)
+            .cloned()
+            .unwrap_or_default()
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RangeCompletionState {
+    pub logs_complete: bool,
+    pub eth_calls_complete: bool,
+}
+
+impl RangeCompletionState {
+    pub fn mark(&mut self, kind: RangeCompleteKind) {
+        match kind {
+            RangeCompleteKind::Logs => self.logs_complete = true,
+            RangeCompleteKind::EthCalls => self.eth_calls_complete = true,
+        }
+    }
+
+    pub fn is_ready(self, expect_logs: bool, expect_eth_calls: bool) -> bool {
+        (!expect_logs || self.logs_complete) && (!expect_eth_calls || self.eth_calls_complete)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn range_completion_requires_both_streams_when_calls_expected() {
+        let mut state = RangeCompletionState::default();
+        state.mark(RangeCompleteKind::Logs);
+        assert!(!state.is_ready(true, true));
+        state.mark(RangeCompleteKind::EthCalls);
+        assert!(state.is_ready(true, true));
+    }
+
+    #[test]
+    fn range_completion_only_requires_logs_without_calls() {
+        let mut state = RangeCompletionState::default();
+        state.mark(RangeCompleteKind::Logs);
+        assert!(state.is_ready(true, false));
+    }
+
+    #[test]
+    fn range_completion_can_finalize_call_only_ranges() {
+        let mut state = RangeCompletionState::default();
+        state.mark(RangeCompleteKind::EthCalls);
+        assert!(state.is_ready(false, true));
+    }
+}

--- a/src/transformations/mod.rs
+++ b/src/transformations/mod.rs
@@ -58,8 +58,12 @@ pub mod engine;
 pub mod error;
 pub mod eth_call;
 pub mod event;
+mod executor;
+mod finalizer;
 pub mod historical;
+mod live_state;
 pub mod registry;
+mod retry;
 pub mod traits;
 pub mod util;
 

--- a/src/transformations/retry.rs
+++ b/src/transformations/retry.rs
@@ -1,0 +1,796 @@
+//! Live retry processing for blocks that need re-transformation.
+//!
+//! Handles reading stored live data (decoded logs, calls) from bincode storage,
+//! converting them to the unified decoded types, and re-executing handlers
+//! for blocks that had missing or failed transformations.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use tokio::sync::{Mutex, Semaphore};
+use tokio::task::JoinSet;
+
+use super::context::{DecodedCall, DecodedEvent, TransactionAddresses, TransformationContext};
+use super::error::TransformationError;
+use super::executor::{execute_with_snapshot_capture, inject_source_version};
+use super::historical::HistoricalDataReader;
+use super::live_state::LiveProcessingState;
+use super::registry::{extract_event_name, TransformationRegistry};
+use crate::decoding::eth_calls::{
+    build_decode_configs, build_result_map, CallDecodeConfig, EventCallDecodeConfig,
+};
+use crate::decoding::event_parsing::ParsedEvent;
+use crate::decoding::logs::build_event_matchers;
+use crate::live::{LiveProgressTracker, LiveStorage, TransformRetryRequest};
+use crate::rpc::UnifiedRpcClient;
+use crate::types::config::contract::{Contracts, FactoryCollections};
+use crate::types::config::eth_call::EvmType;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum LiveRetryCallArtifactKind {
+    Regular,
+    EventTriggered { base_name: String },
+}
+
+pub(crate) fn resolve_retry_missing_handlers(
+    request_missing: Option<HashSet<String>>,
+    tracker_missing: Option<HashSet<String>>,
+    all_handlers: HashSet<String>,
+) -> HashSet<String> {
+    tracker_missing.unwrap_or_else(|| request_missing.unwrap_or(all_handlers))
+}
+
+pub(crate) fn missing_retry_call_dependencies(
+    required_calls: &HashSet<(String, String)>,
+    calls: &[DecodedCall],
+) -> HashSet<(String, String)> {
+    let available_calls: HashSet<(String, String)> = calls
+        .iter()
+        .map(|call| (call.source_name.clone(), call.function_name.clone()))
+        .collect();
+
+    required_calls
+        .difference(&available_calls)
+        .cloned()
+        .collect()
+}
+
+pub(crate) fn classify_live_retry_call_artifact(
+    source_name: &str,
+    function_name: &str,
+    regular_keys: &HashSet<(String, String)>,
+    event_keys: &HashSet<(String, String)>,
+) -> Result<LiveRetryCallArtifactKind, TransformationError> {
+    let exact_key = (source_name.to_string(), function_name.to_string());
+    if regular_keys.contains(&exact_key) {
+        return Ok(LiveRetryCallArtifactKind::Regular);
+    }
+
+    if let Some(base_name) = function_name.strip_suffix("_event") {
+        let event_key = (source_name.to_string(), base_name.to_string());
+        if event_keys.contains(&event_key) {
+            return Ok(LiveRetryCallArtifactKind::EventTriggered {
+                base_name: base_name.to_string(),
+            });
+        }
+    }
+
+    Err(TransformationError::MissingData(format!(
+        "missing call schema for live retry {}/{}",
+        source_name, function_name
+    )))
+}
+
+/// Processes transform retries for blocks that need re-transformation.
+pub(crate) struct RetryProcessor {
+    pub registry: Arc<TransformationRegistry>,
+    pub db_pool: Arc<DbPool>,
+    pub rpc_client: Arc<UnifiedRpcClient>,
+    pub historical_reader: Arc<HistoricalDataReader>,
+    pub contracts: Arc<Contracts>,
+    pub factory_collections: Arc<FactoryCollections>,
+    pub chain_name: String,
+    pub chain_id: u64,
+    pub handler_concurrency: usize,
+    pub progress_tracker: Option<Arc<Mutex<LiveProgressTracker>>>,
+}
+
+use crate::db::DbPool;
+
+impl RetryProcessor {
+    pub async fn process_transform_retry(
+        &self,
+        request: TransformRetryRequest,
+        live_state: &Mutex<LiveProcessingState>,
+        record_and_finalize: &dyn RecordAndFinalize,
+    ) -> Result<(), TransformationError> {
+        let block_number = request.block_number;
+        let range_key = (block_number, block_number + 1);
+
+        tracing::info!(
+            "Processing direct transform retry for block {}",
+            block_number
+        );
+
+        {
+            let mut state = live_state.lock().await;
+            state.cleanup_for_retry(range_key);
+        }
+
+        let tracker_missing = if let Some(ref tracker) = self.progress_tracker {
+            Some(tracker.lock().await.get_pending_handlers(block_number))
+        } else {
+            None
+        };
+        let all_handlers: HashSet<String> = self
+            .registry
+            .all_handlers()
+            .iter()
+            .map(|handler| handler.handler_key())
+            .collect();
+        let missing_handlers =
+            resolve_retry_missing_handlers(request.missing_handlers, tracker_missing, all_handlers);
+
+        if missing_handlers.is_empty() {
+            return record_and_finalize
+                .finalize_range(block_number, block_number + 1)
+                .await;
+        }
+
+        let (events, calls) = self.read_live_retry_data(block_number).await?;
+        let events = filter_events_by_start_block(&self.contracts, events);
+        let calls = filter_calls_by_start_block(&self.contracts, calls);
+
+        let blocked_handlers = self
+            .execute_live_retry_handlers(block_number, events, calls, &missing_handlers)
+            .await?;
+
+        if !blocked_handlers.is_empty() {
+            tracing::warn!(
+                "Live retry for block {} is still waiting on call dependencies for handlers {:?}",
+                block_number,
+                blocked_handlers
+            );
+            return Ok(());
+        }
+
+        record_and_finalize
+            .finalize_range(block_number, block_number + 1)
+            .await
+    }
+
+    async fn read_live_retry_data(
+        &self,
+        block_number: u64,
+    ) -> Result<(Vec<DecodedEvent>, Vec<DecodedCall>), TransformationError> {
+        let storage = LiveStorage::new(&self.chain_name);
+        let mut events = Vec::new();
+        let mut calls = Vec::new();
+
+        let (regular_matchers, factory_matchers) =
+            build_event_matchers(&self.contracts, &self.factory_collections).map_err(|e| {
+                TransformationError::DecodeError(format!(
+                    "failed to build live retry event matchers: {}",
+                    e
+                ))
+            })?;
+
+        let mut event_schemas: HashMap<(String, String), ParsedEvent> = HashMap::new();
+        for matcher in regular_matchers {
+            event_schemas.insert(
+                (matcher.name.clone(), matcher.event_name.clone()),
+                matcher.event,
+            );
+        }
+        for matchers in factory_matchers.values() {
+            for matcher in matchers {
+                event_schemas.insert(
+                    (matcher.name.clone(), matcher.event_name.clone()),
+                    matcher.event.clone(),
+                );
+            }
+        }
+
+        for (source_name, event_name) in storage.list_decoded_log_types(block_number)? {
+            let parsed_event = event_schemas
+                .get(&(source_name.clone(), event_name.clone()))
+                .ok_or_else(|| {
+                    TransformationError::MissingData(format!(
+                        "missing event schema for live retry {}/{}",
+                        source_name, event_name
+                    ))
+                })?;
+
+            for log in storage.read_decoded_logs(block_number, &source_name, &event_name)? {
+                events.push(live_log_to_decoded_event(
+                    &log,
+                    parsed_event,
+                    &source_name,
+                    &event_name,
+                ));
+            }
+        }
+
+        let (regular_configs, once_configs, event_configs) =
+            build_decode_configs(&self.contracts);
+        let regular_map: HashMap<(String, String), CallDecodeConfig> = regular_configs
+            .into_iter()
+            .map(|config| {
+                (
+                    (config.contract_name.clone(), config.function_name.clone()),
+                    config,
+                )
+            })
+            .collect();
+        let once_map: HashMap<(String, String), CallDecodeConfig> = once_configs
+            .into_iter()
+            .map(|config| {
+                (
+                    (config.contract_name.clone(), config.function_name.clone()),
+                    config,
+                )
+            })
+            .collect();
+        let event_map: HashMap<(String, String), EventCallDecodeConfig> = event_configs
+            .into_iter()
+            .map(|config| {
+                (
+                    (config.contract_name.clone(), config.function_name.clone()),
+                    config,
+                )
+            })
+            .collect();
+        let regular_keys: HashSet<(String, String)> = regular_map.keys().cloned().collect();
+        let event_keys: HashSet<(String, String)> = event_map.keys().cloned().collect();
+
+        for (source_name, function_name) in storage.list_decoded_call_types(block_number)? {
+            match classify_live_retry_call_artifact(
+                &source_name,
+                &function_name,
+                &regular_keys,
+                &event_keys,
+            )? {
+                LiveRetryCallArtifactKind::Regular => {
+                    let config = regular_map
+                        .get(&(source_name.clone(), function_name.clone()))
+                        .ok_or_else(|| {
+                            TransformationError::MissingData(format!(
+                                "missing regular call schema for live retry {}/{}",
+                                source_name, function_name
+                            ))
+                        })?;
+
+                    for call in
+                        storage.read_decoded_calls(block_number, &source_name, &function_name)?
+                    {
+                        calls.push(live_call_to_decoded_call(
+                            &call,
+                            &source_name,
+                            &function_name,
+                            &config.output_type,
+                        ));
+                    }
+                }
+                LiveRetryCallArtifactKind::EventTriggered { base_name } => {
+                    let config = event_map
+                        .get(&(source_name.clone(), base_name.clone()))
+                        .ok_or_else(|| {
+                            TransformationError::MissingData(format!(
+                                "missing event call schema for live retry {}/{}",
+                                source_name, base_name
+                            ))
+                        })?;
+
+                    for call in
+                        storage.read_decoded_event_calls(block_number, &source_name, &base_name)?
+                    {
+                        calls.push(live_event_call_to_decoded_call(
+                            &call,
+                            &source_name,
+                            &base_name,
+                            &config.output_type,
+                        ));
+                    }
+                }
+            }
+        }
+
+        let mut once_sources: HashSet<String> = self.contracts.keys().cloned().collect();
+        for contract in self.contracts.values() {
+            if let Some(factories) = &contract.factories {
+                once_sources.extend(factories.iter().map(|factory| factory.collection.clone()));
+            }
+        }
+
+        for source_name in once_sources {
+            let Ok(once_calls) = storage.read_decoded_once_calls(block_number, &source_name)
+            else {
+                continue;
+            };
+
+            for call in once_calls {
+                let mut merged_result = HashMap::new();
+                for (function_name, value) in &call.decoded_values {
+                    if let Some(config) =
+                        once_map.get(&(source_name.clone(), function_name.clone()))
+                    {
+                        let partial_result =
+                            build_result_map(value, &config.output_type, function_name);
+                        merged_result.extend(partial_result);
+                    }
+                }
+                if !merged_result.is_empty() {
+                    calls.push(DecodedCall {
+                        block_number: call.block_number,
+                        block_timestamp: call.block_timestamp,
+                        contract_address: call.contract_address,
+                        source_name: source_name.clone(),
+                        function_name: "once".to_string(),
+                        trigger_log_index: None,
+                        result: merged_result,
+                    });
+                }
+            }
+        }
+
+        Ok((events, calls))
+    }
+
+    async fn execute_live_retry_handlers(
+        &self,
+        block_number: u64,
+        events: Vec<DecodedEvent>,
+        calls: Vec<DecodedCall>,
+        missing_handlers: &HashSet<String>,
+    ) -> Result<HashSet<String>, TransformationError> {
+        let range_start = block_number;
+        let range_end = block_number + 1;
+        let tx_addresses = Arc::new(read_live_receipt_addresses(
+            &self.chain_name,
+            block_number,
+        )?);
+        let semaphore = Arc::new(Semaphore::new(self.handler_concurrency));
+        let mut join_set: JoinSet<Result<Option<String>, TransformationError>> = JoinSet::new();
+        let mut blocked_handlers = HashSet::new();
+
+        for handler_info in self.registry.unique_event_handlers() {
+            let handler = handler_info.handler;
+            let handler_key = handler.handler_key();
+            if !missing_handlers.contains(&handler_key) {
+                continue;
+            }
+
+            let triggers: HashSet<(String, String)> = handler_info
+                .triggers
+                .iter()
+                .map(|trigger| {
+                    (
+                        trigger.source.clone(),
+                        extract_event_name(&trigger.event_signature),
+                    )
+                })
+                .collect();
+            let handler_events: Vec<DecodedEvent> = events
+                .iter()
+                .filter(|event| {
+                    triggers.contains(&(event.source_name.clone(), event.event_name.clone()))
+                })
+                .cloned()
+                .collect();
+
+            if handler_events.is_empty() {
+                continue;
+            }
+
+            let call_deps: HashSet<(String, String)> =
+                handler.call_dependencies().into_iter().collect();
+            let missing_deps = missing_retry_call_dependencies(&call_deps, &calls);
+            if !missing_deps.is_empty() {
+                tracing::warn!(
+                    "Skipping live retry for handler {} on block {}: missing call dependencies {:?}",
+                    handler_key,
+                    block_number,
+                    missing_deps
+                );
+                blocked_handlers.insert(handler_key);
+                continue;
+            }
+            let handler_calls: Vec<DecodedCall> = calls
+                .iter()
+                .filter(|call| {
+                    call_deps.contains(&(call.source_name.clone(), call.function_name.clone()))
+                })
+                .cloned()
+                .collect();
+
+            let permit = semaphore.clone().acquire_owned().await.unwrap();
+            let db_pool = self.db_pool.clone();
+            let chain_name = self.chain_name.clone();
+            let chain_id = self.chain_id;
+            let historical = self.historical_reader.clone();
+            let rpc = self.rpc_client.clone();
+            let contracts = self.contracts.clone();
+            let tx_addresses = tx_addresses.clone();
+            let handler_name = handler.name();
+            let handler_version = handler.version();
+
+            join_set.spawn(async move {
+                let _permit = permit;
+                let live_storage = LiveStorage::new(&chain_name);
+                let ctx = TransformationContext::new(
+                    chain_name,
+                    chain_id,
+                    range_start,
+                    range_end,
+                    Arc::new(handler_events),
+                    Arc::new(handler_calls),
+                    (*tx_addresses).clone(),
+                    historical,
+                    rpc,
+                    contracts,
+                );
+
+                match handler.handle(&ctx).await {
+                    Ok(ops) => {
+                        if !ops.is_empty() {
+                            let ops =
+                                inject_source_version(ops, handler_name, handler_version);
+                            execute_with_snapshot_capture(
+                                ops,
+                                &db_pool,
+                                Some(&live_storage),
+                                range_start,
+                                handler_name,
+                                handler_version,
+                            )
+                            .await?;
+                        }
+                        Ok(Some(handler_key))
+                    }
+                    Err(e) => Err(e),
+                }
+            });
+        }
+
+        for handler_info in self.registry.unique_call_handlers() {
+            let handler = handler_info.handler;
+            let handler_key = handler.handler_key();
+            if !missing_handlers.contains(&handler_key) {
+                continue;
+            }
+
+            let triggers: HashSet<(String, String)> = handler_info
+                .triggers
+                .iter()
+                .map(|trigger| (trigger.source.clone(), trigger.function_name.clone()))
+                .collect();
+            let handler_calls: Vec<DecodedCall> = calls
+                .iter()
+                .filter(|call| {
+                    triggers.contains(&(call.source_name.clone(), call.function_name.clone()))
+                })
+                .cloned()
+                .collect();
+
+            if handler_calls.is_empty() {
+                continue;
+            }
+
+            let permit = semaphore.clone().acquire_owned().await.unwrap();
+            let db_pool = self.db_pool.clone();
+            let chain_name = self.chain_name.clone();
+            let chain_id = self.chain_id;
+            let historical = self.historical_reader.clone();
+            let rpc = self.rpc_client.clone();
+            let contracts = self.contracts.clone();
+            let handler_name = handler.name();
+            let handler_version = handler.version();
+
+            join_set.spawn(async move {
+                let _permit = permit;
+                let live_storage = LiveStorage::new(&chain_name);
+                let ctx = TransformationContext::new(
+                    chain_name,
+                    chain_id,
+                    range_start,
+                    range_end,
+                    Arc::new(Vec::new()),
+                    Arc::new(handler_calls),
+                    HashMap::new(),
+                    historical,
+                    rpc,
+                    contracts,
+                );
+
+                match handler.handle(&ctx).await {
+                    Ok(ops) => {
+                        if !ops.is_empty() {
+                            let ops =
+                                inject_source_version(ops, handler_name, handler_version);
+                            execute_with_snapshot_capture(
+                                ops,
+                                &db_pool,
+                                Some(&live_storage),
+                                range_start,
+                                handler_name,
+                                handler_version,
+                            )
+                            .await?;
+                        }
+                        Ok(Some(handler_key))
+                    }
+                    Err(e) => Err(e),
+                }
+            });
+        }
+
+        while let Some(result) = join_set.join_next().await {
+            match result {
+                Ok(Ok(Some(handler_key))) => {
+                    if let Err(e) = self
+                        .db_pool
+                        .execute_transaction(vec![crate::db::DbOperation::Upsert {
+                            table: "_handler_progress".to_string(),
+                            columns: vec![
+                                "chain_id".to_string(),
+                                "handler_key".to_string(),
+                                "range_start".to_string(),
+                                "range_end".to_string(),
+                            ],
+                            values: vec![
+                                crate::db::DbValue::Int64(self.chain_id as i64),
+                                crate::db::DbValue::Text(handler_key.clone()),
+                                crate::db::DbValue::Int64(range_start as i64),
+                                crate::db::DbValue::Int64(range_end as i64),
+                            ],
+                            conflict_columns: vec![
+                                "chain_id".to_string(),
+                                "handler_key".to_string(),
+                                "range_start".to_string(),
+                            ],
+                            update_columns: vec!["range_end".to_string()],
+                        }])
+                        .await
+                    {
+                        tracing::warn!(
+                            "Failed to record completed range for handler {} on block {}: {}",
+                            handler_key,
+                            block_number,
+                            e
+                        );
+                    }
+
+                    if let Some(ref tracker) = self.progress_tracker {
+                        let mut tracker = tracker.lock().await;
+                        if let Err(e) = tracker.mark_complete(block_number, &handler_key).await {
+                            tracing::warn!(
+                                "Failed to mark retry progress for block {} handler {}: {}",
+                                block_number,
+                                handler_key,
+                                e
+                            );
+                        }
+                    }
+                }
+                Ok(Ok(None)) => {}
+                Ok(Err(e)) => {
+                    tracing::error!(
+                        "Handler failed during live retry for block {}: {}",
+                        block_number,
+                        e
+                    );
+                }
+                Err(e) => {
+                    tracing::error!(
+                        "Handler task panicked during live retry for block {}: {}",
+                        block_number,
+                        e
+                    );
+                }
+            }
+        }
+
+        Ok(blocked_handlers)
+    }
+}
+
+// ─── Trait for finalization callback ────────────────────────────────
+
+/// Trait to allow RetryProcessor to call back into the engine for finalization.
+#[async_trait::async_trait]
+pub(crate) trait RecordAndFinalize: Send + Sync {
+    async fn finalize_range(
+        &self,
+        range_start: u64,
+        range_end: u64,
+    ) -> Result<(), TransformationError>;
+}
+
+// ─── Live adapter functions ──────────────────────────────────────────
+
+fn live_log_to_decoded_event(
+    log: &crate::live::LiveDecodedLog,
+    parsed_event: &ParsedEvent,
+    source_name: &str,
+    event_name: &str,
+) -> DecodedEvent {
+    let mut params = HashMap::new();
+    for (flattened, value) in parsed_event
+        .flattened_fields
+        .iter()
+        .zip(log.decoded_values.iter())
+    {
+        params.insert(flattened.full_name.clone(), value.clone());
+    }
+
+    DecodedEvent {
+        block_number: log.block_number,
+        block_timestamp: log.block_timestamp,
+        transaction_hash: log.transaction_hash,
+        log_index: log.log_index,
+        contract_address: log.contract_address,
+        source_name: source_name.to_string(),
+        event_name: event_name.to_string(),
+        event_signature: parsed_event.signature.clone(),
+        params,
+    }
+}
+
+fn live_call_to_decoded_call(
+    call: &crate::live::LiveDecodedCall,
+    source_name: &str,
+    function_name: &str,
+    output_type: &EvmType,
+) -> DecodedCall {
+    DecodedCall {
+        block_number: call.block_number,
+        block_timestamp: call.block_timestamp,
+        contract_address: call.contract_address,
+        source_name: source_name.to_string(),
+        function_name: function_name.to_string(),
+        trigger_log_index: None,
+        result: build_result_map(&call.decoded_value, output_type, function_name),
+    }
+}
+
+fn live_event_call_to_decoded_call(
+    call: &crate::live::LiveDecodedEventCall,
+    source_name: &str,
+    function_name: &str,
+    output_type: &EvmType,
+) -> DecodedCall {
+    DecodedCall {
+        block_number: call.block_number,
+        block_timestamp: call.block_timestamp,
+        contract_address: call.target_address,
+        source_name: source_name.to_string(),
+        function_name: function_name.to_string(),
+        trigger_log_index: Some(call.log_index),
+        result: build_result_map(&call.decoded_value, output_type, function_name),
+    }
+}
+
+fn read_live_receipt_addresses(
+    chain_name: &str,
+    block_number: u64,
+) -> Result<HashMap<[u8; 32], TransactionAddresses>, TransformationError> {
+    let storage = LiveStorage::new(chain_name);
+    let mut tx_addresses = HashMap::new();
+
+    for receipt in storage.read_receipts(block_number)? {
+        tx_addresses.insert(
+            receipt.transaction_hash,
+            TransactionAddresses {
+                from_address: receipt.from,
+                to_address: receipt.to,
+            },
+        );
+    }
+
+    Ok(tx_addresses)
+}
+
+// ─── Start block filtering helpers ───────────────────────────────────
+
+pub(crate) fn filter_events_by_start_block(
+    contracts: &Contracts,
+    events: Vec<DecodedEvent>,
+) -> Vec<DecodedEvent> {
+    events
+        .into_iter()
+        .filter(|e| {
+            let start_block = contracts
+                .get(&e.source_name)
+                .and_then(|c| c.start_block.map(|u| u.to::<u64>()));
+            start_block.map_or(true, |sb| e.block_number >= sb)
+        })
+        .collect()
+}
+
+pub(crate) fn filter_calls_by_start_block(
+    contracts: &Contracts,
+    calls: Vec<DecodedCall>,
+) -> Vec<DecodedCall> {
+    calls
+        .into_iter()
+        .filter(|c| {
+            let start_block = contracts
+                .get(&c.source_name)
+                .and_then(|ct| ct.start_block.map(|u| u.to::<u64>()));
+            start_block.map_or(true, |sb| c.block_number >= sb)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transformations::context::DecodedValue;
+
+    #[test]
+    fn retry_missing_handlers_prefers_current_tracker_state() {
+        let requested = Some(HashSet::from([
+            "handler_a_v1".to_string(),
+            "handler_b_v1".to_string(),
+        ]));
+        let tracker = Some(HashSet::from(["handler_b_v1".to_string()]));
+        let all_handlers = HashSet::from([
+            "handler_a_v1".to_string(),
+            "handler_b_v1".to_string(),
+            "handler_c_v1".to_string(),
+        ]);
+
+        let resolved = resolve_retry_missing_handlers(requested, tracker, all_handlers);
+        assert_eq!(resolved, HashSet::from(["handler_b_v1".to_string()]));
+    }
+
+    #[test]
+    fn retry_dependency_check_detects_missing_calls() {
+        let required = HashSet::from([
+            ("Pool".to_string(), "slot0".to_string()),
+            ("Pool".to_string(), "liquidity".to_string()),
+        ]);
+        let calls = vec![DecodedCall {
+            block_number: 100,
+            block_timestamp: 1200,
+            contract_address: [0; 20],
+            source_name: "Pool".to_string(),
+            function_name: "slot0".to_string(),
+            trigger_log_index: None,
+            result: HashMap::from([("result".to_string(), DecodedValue::Uint64(1))]),
+        }];
+
+        let missing = missing_retry_call_dependencies(&required, &calls);
+        assert_eq!(
+            missing,
+            HashSet::from([("Pool".to_string(), "liquidity".to_string())])
+        );
+    }
+
+    #[test]
+    fn live_retry_call_artifact_prefers_regular_name_over_event_suffix() {
+        let regular = HashSet::from([("Pool".to_string(), "foo_event".to_string())]);
+        let event = HashSet::from([("Pool".to_string(), "foo".to_string())]);
+
+        let kind =
+            classify_live_retry_call_artifact("Pool", "foo_event", &regular, &event).unwrap();
+
+        assert_eq!(kind, LiveRetryCallArtifactKind::Regular);
+    }
+
+    #[test]
+    fn live_retry_call_artifact_still_recognizes_event_triggered_suffix() {
+        let regular = HashSet::new();
+        let event = HashSet::from([("Pool".to_string(), "foo".to_string())]);
+
+        let kind =
+            classify_live_retry_call_artifact("Pool", "foo_event", &regular, &event).unwrap();
+
+        assert_eq!(
+            kind,
+            LiveRetryCallArtifactKind::EventTriggered {
+                base_name: "foo".to_string()
+            }
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- split the transformation engine internals into dedicated executor, finalizer, live-state, and retry modules
- keep the public transformation API centered on engine.rs while moving orchestration details behind internal module boundaries
- preserve the existing live and historical processing behavior while making the engine easier to reason about and extend

## Testing
- cargo test