### PR TITLE
Refactor: centralize path construction, range parsing, and parquet scanning

### DIFF
--- a/src/raw_data/historical/blocks.rs
+++ b/src/raw_data/historical/blocks.rs
@@ -15,6 +15,7 @@ use parquet::file::properties::WriterProperties;
 use thiserror::Error;
 
 use crate::rpc::RpcError;
+use crate::storage::paths::{parse_range_from_filename, raw_blocks_dir};
 use crate::storage::S3Manifest;
 use crate::types::config::raw_data::BlockField;
 
@@ -395,7 +396,7 @@ pub fn get_existing_block_ranges(
 ) -> Vec<ExistingBlockRange> {
     use std::collections::HashSet;
 
-    let blocks_dir = PathBuf::from(format!("data/{}/historical/raw/blocks", chain_name));
+    let blocks_dir = raw_blocks_dir(chain_name);
     let mut ranges = Vec::new();
     let mut local_ranges: HashSet<(u64, u64)> = HashSet::new();
 
@@ -425,31 +426,11 @@ pub fn get_existing_block_ranges(
             continue;
         }
 
-        let file_name = match path.file_stem().and_then(|s| s.to_str()) {
-            Some(name) => name,
-            None => continue,
-        };
-
-        // Parse "blocks_START-END" format
-        if !file_name.starts_with("blocks_") {
+        let Some((start, end_inclusive)) = parse_range_from_filename(&path) else {
             continue;
-        }
-
-        let range_part = &file_name[7..]; // Skip "blocks_"
-        let range_parts: Vec<&str> = range_part.split('-').collect();
-        if range_parts.len() != 2 {
-            continue;
-        }
-
-        let start: u64 = match range_parts[0].parse() {
-            Ok(v) => v,
-            Err(_) => continue,
-        };
-        let end: u64 = match range_parts[1].parse::<u64>() {
-            Ok(v) => v + 1, // Convert inclusive end to exclusive
-            Err(_) => continue,
         };
 
+        let end = end_inclusive + 1; // Convert inclusive end to exclusive
         local_ranges.insert((start, end));
         ranges.push(ExistingBlockRange {
             start,

--- a/src/raw_data/historical/catchup/blocks.rs
+++ b/src/raw_data/historical/catchup/blocks.rs
@@ -1,5 +1,5 @@
 use std::collections::{BTreeMap, HashSet};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 
 use alloy::primitives::B256;
@@ -12,6 +12,7 @@ use crate::raw_data::historical::blocks::{
     write_minimal_blocks_to_parquet, BlockCollectionError, FullBlockRecord, MinimalBlockRecord,
 };
 use crate::rpc::{RpcError, UnifiedRpcClient};
+use crate::storage::paths::{parse_range_from_filename, raw_blocks_dir, scan_parquet_filenames};
 use crate::storage::{upload_parquet_to_s3, S3Manifest, StorageManager};
 use crate::types::config::chain::ChainConfig;
 use crate::types::config::raw_data::{BlockField, RawDataCollectionConfig};
@@ -38,7 +39,7 @@ pub async fn collect_blocks(
     storage_manager: Option<Arc<StorageManager>>,
     catch_up_only: bool,
 ) -> Result<(), BlockCollectionError> {
-    let output_dir = PathBuf::from(format!("data/{}/historical/raw/blocks", chain.name));
+    let output_dir = raw_blocks_dir(&chain.name);
     std::fs::create_dir_all(&output_dir)?;
 
     let range_size = raw_data_config.parquet_block_range.unwrap_or(1000) as u64;
@@ -409,14 +410,8 @@ fn highest_block_from_files(
 
     // Parse "blocks_{start}-{end}.parquet" file names
     for name in local_files {
-        if let Some(end_str) = name
-            .strip_prefix("blocks_")
-            .and_then(|s| s.strip_suffix(".parquet"))
-            .and_then(|s| s.split('-').last())
-        {
-            if let Ok(end) = end_str.parse::<u64>() {
-                max_block = Some(max_block.map_or(end, |m: u64| m.max(end)));
-            }
+        if let Some((_start, end)) = parse_range_from_filename(Path::new(name)) {
+            max_block = Some(max_block.map_or(end, |m: u64| m.max(end)));
         }
     }
 
@@ -431,15 +426,5 @@ fn highest_block_from_files(
 }
 
 fn scan_existing_parquet_files(dir: &Path) -> HashSet<String> {
-    let mut files = HashSet::new();
-    if let Ok(entries) = std::fs::read_dir(dir) {
-        for entry in entries.flatten() {
-            if let Some(name) = entry.file_name().to_str() {
-                if name.starts_with("blocks_") && name.ends_with(".parquet") {
-                    files.insert(name.to_string());
-                }
-            }
-        }
-    }
-    files
+    scan_parquet_filenames(dir, "blocks_")
 }

--- a/src/raw_data/historical/catchup/eth_calls.rs
+++ b/src/raw_data/historical/catchup/eth_calls.rs
@@ -10,6 +10,7 @@ use crate::decoding::DecoderMessage;
 use crate::raw_data::historical::blocks::{
     get_existing_block_ranges, read_block_info_from_parquet,
 };
+use crate::storage::paths::raw_eth_calls_dir;
 use crate::raw_data::historical::eth_calls::{
     build_call_configs, build_event_triggered_call_configs, build_factory_once_call_configs,
     build_once_call_configs, build_token_call_configs, event_output_exists,
@@ -41,7 +42,7 @@ pub async fn collect_eth_calls(
     s3_manifest: Option<S3Manifest>,
     storage_manager: Option<Arc<StorageManager>>,
 ) -> Result<EthCallCatchupState, EthCallCollectionError> {
-    let base_output_dir = PathBuf::from(format!("data/{}/historical/raw/eth_calls", chain.name));
+    let base_output_dir = raw_eth_calls_dir(&chain.name);
     std::fs::create_dir_all(&base_output_dir)?;
 
     let range_size = raw_data_config.parquet_block_range.unwrap_or(1000) as u64;

--- a/src/raw_data/historical/catchup/factories.rs
+++ b/src/raw_data/historical/catchup/factories.rs
@@ -9,6 +9,7 @@ use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
 
 use crate::decoding::DecoderMessage;
+use crate::storage::paths::factories_dir as factories_dir_path;
 use crate::raw_data::historical::factories::{
     build_factory_matchers, get_existing_log_ranges, load_factory_addresses_from_parquet,
     process_range_batches, read_log_batches_from_parquet, scan_existing_parquet_files,
@@ -29,7 +30,7 @@ pub async fn collect_factories(
     s3_manifest: Option<S3Manifest>,
     storage_manager: Option<Arc<StorageManager>>,
 ) -> Result<FactoryCatchupState, FactoryCollectionError> {
-    let output_dir = PathBuf::from(format!("data/{}/historical/factories", chain.name));
+    let output_dir = factories_dir_path(&chain.name);
     std::fs::create_dir_all(&output_dir)?;
 
     let existing_factory_data = load_factory_addresses_from_parquet(&output_dir)?;

--- a/src/raw_data/historical/catchup/logs.rs
+++ b/src/raw_data/historical/catchup/logs.rs
@@ -1,11 +1,11 @@
 use std::collections::HashSet;
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::raw_data::historical::logs::{
     build_configured_addresses, build_log_schema, scan_existing_parquet_files, LogCollectionError,
     LogsCatchupState,
 };
+use crate::storage::paths::raw_logs_dir;
 use crate::storage::{S3Manifest, StorageManager};
 use crate::types::config::chain::ChainConfig;
 use crate::types::config::raw_data::RawDataCollectionConfig;
@@ -16,7 +16,7 @@ pub async fn collect_logs(
     s3_manifest: Option<S3Manifest>,
     storage_manager: Option<Arc<StorageManager>>,
 ) -> Result<LogsCatchupState, LogCollectionError> {
-    let output_dir = PathBuf::from(format!("data/{}/historical/raw/logs", chain.name));
+    let output_dir = raw_logs_dir(&chain.name);
     std::fs::create_dir_all(&output_dir)?;
 
     let range_size = raw_data_config.parquet_block_range.unwrap_or(1000) as u64;

--- a/src/raw_data/historical/catchup/receipts.rs
+++ b/src/raw_data/historical/catchup/receipts.rs
@@ -13,6 +13,7 @@ use crate::raw_data::historical::receipts::{
     EventTriggerMessage, LogMessage, ReceiptCollectionError,
 };
 use crate::rpc::UnifiedRpcClient;
+use crate::storage::paths::{raw_logs_dir, raw_receipts_dir};
 use crate::storage::{DataLoader, S3Manifest, StorageManager};
 use crate::types::config::chain::ChainConfig;
 use crate::types::config::raw_data::RawDataCollectionConfig;
@@ -39,7 +40,7 @@ pub async fn collect_receipts(
     s3_manifest: Option<S3Manifest>,
     storage_manager: Option<Arc<StorageManager>>,
 ) -> Result<ReceiptsCatchupState, ReceiptCollectionError> {
-    let output_dir = PathBuf::from(format!("data/{}/historical/raw/receipts", chain.name));
+    let output_dir = raw_receipts_dir(&chain.name);
     std::fs::create_dir_all(&output_dir)?;
 
     let rpc_batch_size = raw_data_config.rpc_batch_size.unwrap_or(100) as usize;
@@ -69,7 +70,7 @@ pub async fn collect_receipts(
     let mut catchup_count = 0;
 
     // Check existing logs files
-    let logs_dir = PathBuf::from(format!("data/{}/historical/raw/logs", chain.name));
+    let logs_dir = raw_logs_dir(&chain.name);
     let existing_logs_files = scan_existing_logs_files(&logs_dir);
 
     // Note: Factory catchup is handled by the factories module reading from logs files directly.

--- a/src/raw_data/historical/current/receipts.rs
+++ b/src/raw_data/historical/current/receipts.rs
@@ -15,6 +15,7 @@ use crate::raw_data::historical::receipts::{
     EventTriggerMessage, LogMessage, ReceiptBatchState, ReceiptCollectionError,
 };
 use crate::rpc::UnifiedRpcClient;
+use crate::storage::paths::raw_receipts_dir;
 use crate::storage::{upload_parquet_to_s3, StorageManager};
 use crate::types::config::chain::ChainConfig;
 use crate::types::config::raw_data::RawDataCollectionConfig;
@@ -32,7 +33,7 @@ pub async fn collect_receipts(
     catchup_state: ReceiptsCatchupState,
     storage_manager: Option<Arc<StorageManager>>,
 ) -> Result<(), ReceiptCollectionError> {
-    let output_dir = PathBuf::from(format!("data/{}/historical/raw/receipts", chain.name));
+    let output_dir = raw_receipts_dir(&chain.name);
     std::fs::create_dir_all(&output_dir)?;
 
     let range_size = raw_data_config.parquet_block_range.unwrap_or(1000) as u64;

--- a/src/raw_data/historical/eth_calls/factory.rs
+++ b/src/raw_data/historical/eth_calls/factory.rs
@@ -12,6 +12,7 @@ use super::types::{
     EthCallCollectionError, EventCallKey, EventTriggeredCallConfig, OnceCallConfig,
 };
 use crate::raw_data::historical::receipts::LogData;
+use crate::storage::paths::{factories_dir as factories_dir_path, parse_range_from_filename, raw_logs_dir};
 use crate::storage::{DataLoader, S3Manifest, StorageManager};
 
 /// Load historical factory addresses from parquet files for event trigger catchup
@@ -36,7 +37,7 @@ pub(crate) async fn load_historical_factory_addresses(
         return result;
     }
 
-    let factories_dir = PathBuf::from(format!("data/{}/historical/factories", chain_name));
+    let factories_dir = factories_dir_path(chain_name);
     let data_loader = DataLoader::new(
         storage_manager.map(|sm| sm.clone()),
         chain_name,
@@ -169,7 +170,7 @@ pub(crate) async fn load_factory_addresses_for_once_catchup(
         return result;
     }
 
-    let factories_dir = PathBuf::from(format!("data/{}/historical/factories", chain_name));
+    let factories_dir = factories_dir_path(chain_name);
     let data_loader = DataLoader::new(
         storage_manager.map(|sm| sm.clone()),
         chain_name,
@@ -441,7 +442,7 @@ pub(crate) fn get_existing_log_ranges(
     chain_name: &str,
     s3_manifest: Option<&S3Manifest>,
 ) -> Vec<ExistingLogRange> {
-    let logs_dir = PathBuf::from(format!("data/{}/historical/raw/logs", chain_name));
+    let logs_dir = raw_logs_dir(chain_name);
     let mut ranges = Vec::new();
     let mut local_ranges: HashSet<(u64, u64)> = HashSet::new();
 
@@ -471,31 +472,11 @@ pub(crate) fn get_existing_log_ranges(
             continue;
         }
 
-        let file_name = match path.file_stem().and_then(|s| s.to_str()) {
-            Some(name) => name,
-            None => continue,
-        };
-
-        // Parse "logs_START-END" format
-        if !file_name.starts_with("logs_") {
+        let Some((start, end_inclusive)) = parse_range_from_filename(&path) else {
             continue;
-        }
-
-        let range_part = &file_name[5..]; // Skip "logs_"
-        let range_parts: Vec<&str> = range_part.split('-').collect();
-        if range_parts.len() != 2 {
-            continue;
-        }
-
-        let start: u64 = match range_parts[0].parse() {
-            Ok(v) => v,
-            Err(_) => continue,
-        };
-        let end: u64 = match range_parts[1].parse::<u64>() {
-            Ok(v) => v + 1, // Convert inclusive end to exclusive
-            Err(_) => continue,
         };
 
+        let end = end_inclusive + 1; // Convert inclusive end to exclusive
         local_ranges.insert((start, end));
         ranges.push(ExistingLogRange {
             start,

--- a/src/raw_data/historical/eth_calls/parquet_io.rs
+++ b/src/raw_data/historical/eth_calls/parquet_io.rs
@@ -14,51 +14,10 @@ use parquet::arrow::ArrowWriter;
 use parquet::file::properties::WriterProperties;
 
 use super::types::{CallResult, EthCallCollectionError, OnceCallResult};
+use crate::storage::paths::scan_nested_parquet_files_2;
 
 pub(crate) fn scan_existing_parquet_files(dir: &Path) -> HashSet<String> {
-    let mut files = HashSet::new();
-
-    // Scan nested directories: dir/contract/function/*.parquet
-    if let Ok(contract_entries) = std::fs::read_dir(dir) {
-        for contract_entry in contract_entries.flatten() {
-            let contract_path = contract_entry.path();
-            if !contract_path.is_dir() {
-                continue;
-            }
-            let contract_name = match contract_entry.file_name().to_str() {
-                Some(name) => name.to_string(),
-                None => continue,
-            };
-
-            if let Ok(function_entries) = std::fs::read_dir(&contract_path) {
-                for function_entry in function_entries.flatten() {
-                    let function_path = function_entry.path();
-                    if !function_path.is_dir() {
-                        continue;
-                    }
-                    let function_name = match function_entry.file_name().to_str() {
-                        Some(name) => name.to_string(),
-                        None => continue,
-                    };
-
-                    if let Ok(file_entries) = std::fs::read_dir(&function_path) {
-                        for file_entry in file_entries.flatten() {
-                            if let Some(name) = file_entry.file_name().to_str() {
-                                if name.ends_with(".parquet") {
-                                    // Store as contract/function/filename
-                                    files.insert(format!(
-                                        "{}/{}/{}",
-                                        contract_name, function_name, name
-                                    ));
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-    files
+    scan_nested_parquet_files_2(dir)
 }
 
 pub(crate) fn build_schema(num_params: usize) -> Arc<Schema> {

--- a/src/raw_data/historical/factories.rs
+++ b/src/raw_data/historical/factories.rs
@@ -17,6 +17,7 @@ use parquet::file::properties::WriterProperties;
 use thiserror::Error;
 
 use crate::raw_data::historical::receipts::LogData;
+use crate::storage::paths::{parse_range_from_filename, raw_logs_dir, scan_nested_parquet_files_1};
 use crate::storage::{S3Manifest, StorageManager};
 use crate::types::config::contract::{
     resolve_factory_config, AddressOrAddresses, Contracts, FactoryCollections,
@@ -693,33 +694,7 @@ fn write_factory_records_to_parquet(
 }
 
 pub(crate) fn scan_existing_parquet_files(dir: &Path) -> HashSet<String> {
-    let mut files = HashSet::new();
-
-    // Scan nested directories: dir/collection/*.parquet
-    if let Ok(collection_entries) = std::fs::read_dir(dir) {
-        for collection_entry in collection_entries.flatten() {
-            let collection_path = collection_entry.path();
-            if !collection_path.is_dir() {
-                continue;
-            }
-            let collection_name = match collection_entry.file_name().to_str() {
-                Some(name) => name.to_string(),
-                None => continue,
-            };
-
-            if let Ok(file_entries) = std::fs::read_dir(&collection_path) {
-                for file_entry in file_entries.flatten() {
-                    if let Some(name) = file_entry.file_name().to_str() {
-                        if name.ends_with(".parquet") {
-                            // Store as collection/filename
-                            files.insert(format!("{}/{}", collection_name, name));
-                        }
-                    }
-                }
-            }
-        }
-    }
-    files
+    scan_nested_parquet_files_1(dir)
 }
 
 pub(crate) fn load_factory_addresses_from_parquet(
@@ -750,25 +725,12 @@ pub(crate) fn load_factory_addresses_from_parquet(
                 continue;
             }
 
-            // Filename is now just "start-end.parquet"
-            let file_name = match path.file_stem().and_then(|s| s.to_str()) {
-                Some(name) => name,
-                None => continue,
-            };
-
-            let range_parts: Vec<&str> = file_name.split('-').collect();
-            if range_parts.len() != 2 {
+            // Filename is "start-end.parquet" (no prefix)
+            let Some((start_inclusive, end_inclusive)) = parse_range_from_filename(&path) else {
                 continue;
-            }
-
-            let range_start: u64 = match range_parts[0].parse() {
-                Ok(v) => v,
-                Err(_) => continue,
             };
-            let range_end: u64 = match range_parts[1].parse::<u64>() {
-                Ok(v) => v + 1,
-                Err(_) => continue,
-            };
+            let range_start: u64 = start_inclusive;
+            let range_end: u64 = end_inclusive + 1;
 
             let file = match File::open(&path) {
                 Ok(f) => f,
@@ -972,7 +934,7 @@ pub(crate) fn get_existing_log_ranges(
     chain_name: &str,
     s3_manifest: Option<&S3Manifest>,
 ) -> Vec<ExistingLogRange> {
-    let logs_dir = PathBuf::from(format!("data/{}/historical/raw/logs", chain_name));
+    let logs_dir = raw_logs_dir(chain_name);
     let mut ranges = Vec::new();
     let mut local_ranges: HashSet<(u64, u64)> = HashSet::new();
 
@@ -1002,31 +964,11 @@ pub(crate) fn get_existing_log_ranges(
             continue;
         }
 
-        let file_name = match path.file_stem().and_then(|s| s.to_str()) {
-            Some(name) => name,
-            None => continue,
-        };
-
-        // Parse "logs_START-END" format
-        if !file_name.starts_with("logs_") {
+        let Some((start, end_inclusive)) = parse_range_from_filename(&path) else {
             continue;
-        }
-
-        let range_part = &file_name[5..]; // Skip "logs_"
-        let range_parts: Vec<&str> = range_part.split('-').collect();
-        if range_parts.len() != 2 {
-            continue;
-        }
-
-        let start: u64 = match range_parts[0].parse() {
-            Ok(v) => v,
-            Err(_) => continue,
-        };
-        let end: u64 = match range_parts[1].parse::<u64>() {
-            Ok(v) => v + 1, // Convert inclusive end to exclusive
-            Err(_) => continue,
         };
 
+        let end = end_inclusive + 1; // Convert inclusive end to exclusive
         local_ranges.insert((start, end));
         ranges.push(ExistingLogRange {
             start,

--- a/src/raw_data/historical/logs.rs
+++ b/src/raw_data/historical/logs.rs
@@ -16,6 +16,7 @@ use tokio::sync::mpsc::Sender;
 
 use crate::decoding::DecoderMessage;
 use crate::raw_data::historical::receipts::LogData;
+use crate::storage::paths::scan_parquet_filenames;
 use crate::storage::{S3Manifest, StorageManager};
 use crate::types::config::contract::{AddressOrAddresses, Contracts};
 use crate::types::config::raw_data::LogField;
@@ -275,17 +276,7 @@ pub(crate) async fn process_range(
 }
 
 pub(crate) fn scan_existing_parquet_files(dir: &Path) -> HashSet<String> {
-    let mut files = HashSet::new();
-    if let Ok(entries) = std::fs::read_dir(dir) {
-        for entry in entries.flatten() {
-            if let Some(name) = entry.file_name().to_str() {
-                if name.starts_with("logs_") && name.ends_with(".parquet") {
-                    files.insert(name.to_string());
-                }
-            }
-        }
-    }
-    files
+    scan_parquet_filenames(dir, "logs_")
 }
 
 pub(crate) fn build_log_schema(fields: &Option<Vec<LogField>>) -> Arc<Schema> {

--- a/src/raw_data/historical/receipts.rs
+++ b/src/raw_data/historical/receipts.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use crate::rpc::{RpcError, UnifiedRpcClient};
+use crate::storage::paths::scan_parquet_filenames;
 use crate::storage::{upload_parquet_to_s3, StorageManager};
 use crate::types::config::contract::{AddressOrAddresses, Contracts};
 use crate::types::config::raw_data::ReceiptField;
@@ -1111,31 +1112,11 @@ fn extract_logs(
 }
 
 pub(crate) fn scan_existing_parquet_files(dir: &Path) -> HashSet<String> {
-    let mut files = HashSet::new();
-    if let Ok(entries) = std::fs::read_dir(dir) {
-        for entry in entries.flatten() {
-            if let Some(name) = entry.file_name().to_str() {
-                if name.starts_with("receipts_") && name.ends_with(".parquet") {
-                    files.insert(name.to_string());
-                }
-            }
-        }
-    }
-    files
+    scan_parquet_filenames(dir, "receipts_")
 }
 
 pub(crate) fn scan_existing_logs_files(dir: &Path) -> HashSet<String> {
-    let mut files = HashSet::new();
-    if let Ok(entries) = std::fs::read_dir(dir) {
-        for entry in entries.flatten() {
-            if let Some(name) = entry.file_name().to_str() {
-                if name.starts_with("logs_") && name.ends_with(".parquet") {
-                    files.insert(name.to_string());
-                }
-            }
-        }
-    }
-    files
+    scan_parquet_filenames(dir, "logs_")
 }
 
 pub(crate) fn build_receipt_schema(fields: &Option<Vec<ReceiptField>>) -> Arc<Schema> {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -35,6 +35,7 @@ mod error;
 mod initial_sync;
 mod local;
 mod manifest;
+pub mod paths;
 mod retry;
 mod s3;
 mod upload;

--- a/src/storage/paths.rs
+++ b/src/storage/paths.rs
@@ -1,0 +1,234 @@
+//! Shared path builders, range parsing, and parquet file scanning utilities.
+//!
+//! These functions centralise duplicated file I/O patterns that were previously
+//! scattered across the collector / catchup modules.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+// ---------------------------------------------------------------------------
+// Path builders
+// ---------------------------------------------------------------------------
+
+/// `data/{chain}/historical/raw/blocks`
+pub fn raw_blocks_dir(chain: &str) -> PathBuf {
+    PathBuf::from(format!("data/{}/historical/raw/blocks", chain))
+}
+
+/// `data/{chain}/historical/raw/receipts`
+pub fn raw_receipts_dir(chain: &str) -> PathBuf {
+    PathBuf::from(format!("data/{}/historical/raw/receipts", chain))
+}
+
+/// `data/{chain}/historical/raw/logs`
+pub fn raw_logs_dir(chain: &str) -> PathBuf {
+    PathBuf::from(format!("data/{}/historical/raw/logs", chain))
+}
+
+/// `data/{chain}/historical/raw/eth_calls`
+pub fn raw_eth_calls_dir(chain: &str) -> PathBuf {
+    PathBuf::from(format!("data/{}/historical/raw/eth_calls", chain))
+}
+
+/// `data/{chain}/historical/factories`
+pub fn factories_dir(chain: &str) -> PathBuf {
+    PathBuf::from(format!("data/{}/historical/factories", chain))
+}
+
+/// `data/{chain}/historical/decoded`
+pub fn decoded_base_dir(chain: &str) -> PathBuf {
+    PathBuf::from(format!("data/{}/historical/decoded", chain))
+}
+
+// ---------------------------------------------------------------------------
+// Range parsing
+// ---------------------------------------------------------------------------
+
+/// Parse a filename like `"blocks_0-999.parquet"`, `"logs_0-999.parquet"`,
+/// `"decoded_0-999.parquet"`, or `"0-999.parquet"` into `(start, end_inclusive)`.
+///
+/// Returns `None` when the filename does not match any recognised pattern.
+pub fn parse_range_from_filename(path: &Path) -> Option<(u64, u64)> {
+    let stem = path.file_stem()?.to_str()?;
+
+    // Strip any known prefix to get the "START-END" part.
+    let range_part = stem
+        .strip_prefix("blocks_")
+        .or_else(|| stem.strip_prefix("receipts_"))
+        .or_else(|| stem.strip_prefix("logs_"))
+        .or_else(|| stem.strip_prefix("decoded_"))
+        .unwrap_or(stem);
+
+    let mut parts = range_part.splitn(2, '-');
+    let start: u64 = parts.next()?.parse().ok()?;
+    let end: u64 = parts.next()?.parse().ok()?;
+
+    Some((start, end))
+}
+
+// ---------------------------------------------------------------------------
+// Flat-directory parquet scanners
+// ---------------------------------------------------------------------------
+
+/// List parquet files in a flat directory whose names start with `prefix`
+/// (e.g. `"blocks_"`). Returns a `HashSet` of file names (not full paths).
+pub fn scan_parquet_filenames(dir: &Path, prefix: &str) -> HashSet<String> {
+    let mut files = HashSet::new();
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            if let Some(name) = entry.file_name().to_str() {
+                if name.starts_with(prefix) && name.ends_with(".parquet") {
+                    files.insert(name.to_string());
+                }
+            }
+        }
+    }
+    files
+}
+
+/// Scan a flat directory for `.parquet` files, parse ranges from filenames,
+/// and return sorted `(start, end_inclusive, path)` tuples.
+///
+/// Returns an I/O error if the directory cannot be read, so callers that need
+/// fail-fast behaviour (e.g. `HistoricalDataReader::rebuild_index`) can
+/// propagate the error instead of silently treating it as empty.
+pub fn scan_parquet_ranges(dir: &Path) -> std::io::Result<Vec<(u64, u64, PathBuf)>> {
+    let mut results = Vec::new();
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().map(|e| e == "parquet").unwrap_or(false) {
+            if let Some((start, end)) = parse_range_from_filename(&path) {
+                results.push((start, end, path));
+            }
+        }
+    }
+    results.sort_by_key(|(start, _, _)| *start);
+    Ok(results)
+}
+
+// ---------------------------------------------------------------------------
+// Nested-directory parquet scanners
+// ---------------------------------------------------------------------------
+
+/// Scan a two-level nested directory (`dir/sub1/sub2/*.parquet`) and return
+/// relative paths like `"ContractName/functionName/0-999.parquet"`.
+///
+/// Used by eth_calls where files live at `eth_calls/{contract}/{function}/`.
+pub fn scan_nested_parquet_files_2(dir: &Path) -> HashSet<String> {
+    let mut files = HashSet::new();
+    let Ok(level1) = std::fs::read_dir(dir) else {
+        return files;
+    };
+    for l1 in level1.flatten() {
+        let l1_path = l1.path();
+        if !l1_path.is_dir() {
+            continue;
+        }
+        let l1_name = match l1.file_name().to_str() {
+            Some(n) => n.to_string(),
+            None => continue,
+        };
+        let Ok(level2) = std::fs::read_dir(&l1_path) else {
+            continue;
+        };
+        for l2 in level2.flatten() {
+            let l2_path = l2.path();
+            if !l2_path.is_dir() {
+                continue;
+            }
+            let l2_name = match l2.file_name().to_str() {
+                Some(n) => n.to_string(),
+                None => continue,
+            };
+            let Ok(file_entries) = std::fs::read_dir(&l2_path) else {
+                continue;
+            };
+            for fe in file_entries.flatten() {
+                if let Some(name) = fe.file_name().to_str() {
+                    if name.ends_with(".parquet") {
+                        files.insert(format!("{}/{}/{}", l1_name, l2_name, name));
+                    }
+                }
+            }
+        }
+    }
+    files
+}
+
+/// Scan a one-level nested directory (`dir/sub/*.parquet`) and return
+/// relative paths like `"collection/0-999.parquet"`.
+///
+/// Used by factories where files live at `factories/{collection}/`.
+pub fn scan_nested_parquet_files_1(dir: &Path) -> HashSet<String> {
+    let mut files = HashSet::new();
+    let Ok(level1) = std::fs::read_dir(dir) else {
+        return files;
+    };
+    for l1 in level1.flatten() {
+        let l1_path = l1.path();
+        if !l1_path.is_dir() {
+            continue;
+        }
+        let l1_name = match l1.file_name().to_str() {
+            Some(n) => n.to_string(),
+            None => continue,
+        };
+        let Ok(file_entries) = std::fs::read_dir(&l1_path) else {
+            continue;
+        };
+        for fe in file_entries.flatten() {
+            if let Some(name) = fe.file_name().to_str() {
+                if name.ends_with(".parquet") {
+                    files.insert(format!("{}/{}", l1_name, name));
+                }
+            }
+        }
+    }
+    files
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_range_blocks() {
+        let p = Path::new("blocks_0-999.parquet");
+        assert_eq!(parse_range_from_filename(p), Some((0, 999)));
+    }
+
+    #[test]
+    fn parse_range_logs() {
+        let p = Path::new("logs_1000-1999.parquet");
+        assert_eq!(parse_range_from_filename(p), Some((1000, 1999)));
+    }
+
+    #[test]
+    fn parse_range_decoded() {
+        let p = Path::new("decoded_0-9999.parquet");
+        assert_eq!(parse_range_from_filename(p), Some((0, 9999)));
+    }
+
+    #[test]
+    fn parse_range_bare() {
+        let p = Path::new("0-999.parquet");
+        assert_eq!(parse_range_from_filename(p), Some((0, 999)));
+    }
+
+    #[test]
+    fn parse_range_invalid() {
+        assert_eq!(parse_range_from_filename(Path::new("foo.parquet")), None);
+        assert_eq!(parse_range_from_filename(Path::new("blocks_abc.parquet")), None);
+    }
+
+    #[test]
+    fn path_builders() {
+        assert_eq!(raw_blocks_dir("ethereum"), PathBuf::from("data/ethereum/historical/raw/blocks"));
+        assert_eq!(raw_receipts_dir("base"), PathBuf::from("data/base/historical/raw/receipts"));
+        assert_eq!(raw_logs_dir("base"), PathBuf::from("data/base/historical/raw/logs"));
+        assert_eq!(raw_eth_calls_dir("base"), PathBuf::from("data/base/historical/raw/eth_calls"));
+        assert_eq!(factories_dir("base"), PathBuf::from("data/base/historical/factories"));
+        assert_eq!(decoded_base_dir("base"), PathBuf::from("data/base/historical/decoded"));
+    }
+}

--- a/src/transformations/historical.rs
+++ b/src/transformations/historical.rs
@@ -17,6 +17,7 @@ use super::context::{
     DecodedCall, DecodedEvent, DecodedValue, HistoricalCallQuery, HistoricalEventQuery,
 };
 use super::error::TransformationError;
+use crate::storage::paths::{decoded_base_dir, scan_parquet_ranges};
 
 /// Reader for historical decoded data stored in parquet files.
 pub struct HistoricalDataReader {
@@ -32,7 +33,7 @@ pub struct HistoricalDataReader {
 impl HistoricalDataReader {
     /// Create a new historical data reader for a chain.
     pub fn new(chain_name: &str) -> Result<Self, TransformationError> {
-        let decoded_base = PathBuf::from(format!("data/{}/historical/decoded", chain_name));
+        let decoded_base = decoded_base_dir(chain_name);
 
         let reader = Self {
             chain_name: chain_name.to_string(),
@@ -96,23 +97,8 @@ impl HistoricalDataReader {
                 }
                 let name = name_entry.file_name().to_string_lossy().to_string();
 
-                // Find parquet files and extract ranges
-                let mut files: Vec<(u64, u64, PathBuf)> = Vec::new();
-
-                for file_entry in std::fs::read_dir(name_entry.path())? {
-                    let file_entry = file_entry?;
-                    let path = file_entry.path();
-
-                    if path.extension().map(|e| e == "parquet").unwrap_or(false) {
-                        // Parse range from filename like "decoded_0-9999.parquet"
-                        if let Some(range) = parse_range_from_filename(&path) {
-                            files.push((range.0, range.1, path));
-                        }
-                    }
-                }
-
-                // Sort by range start
-                files.sort_by_key(|(start, _, _)| *start);
+                // Find parquet files and extract ranges (already sorted by start)
+                let files = scan_parquet_ranges(&name_entry.path())?;
 
                 let key = (source_name.clone(), name);
                 index.insert(key, files);
@@ -295,24 +281,6 @@ impl HistoricalDataReader {
         files.sort_by_key(|(_, _, _, start, _)| *start);
         files
     }
-}
-
-/// Parse range from filename like "decoded_0-9999.parquet".
-fn parse_range_from_filename(path: &Path) -> Option<(u64, u64)> {
-    let filename = path.file_stem()?.to_str()?;
-
-    // Try different filename patterns
-    // Pattern 1: "decoded_0-9999"
-    // Pattern 2: "0-9999"
-    let parts: Vec<&str> = filename.trim_start_matches("decoded_").split('-').collect();
-
-    if parts.len() == 2 {
-        let start = parts[0].parse().ok()?;
-        let end = parts[1].parse().ok()?;
-        return Some((start, end));
-    }
-
-    None
 }
 
 /// Read events from a parquet file with filtering.


### PR DESCRIPTION
## Summary
- Adds `src/storage/paths.rs` with shared path builders, range parsing, and parquet file scanners
- Migrates 12 files from inline `format!("data/{}/...")` and duplicated range parsing to shared utilities
- Replaces 7 independent range-parsing implementations with one `parse_range_from_filename()`
- Adds unit tests for parsing and path builder variants