### PR TITLE
fix: S3 upload double-writes, temp file races, sync I/O, path fallback

### DIFF
--- a/src/storage/data_loader.rs
+++ b/src/storage/data_loader.rs
@@ -45,9 +45,13 @@ impl DataLoader {
     /// Returns Ok(true) if file exists (locally or downloaded).
     /// Returns Ok(false) if file doesn't exist anywhere.
     pub async fn ensure_local(&self, local_path: &Path) -> Result<bool, StorageError> {
-        // Check local first
-        if local_path.exists() {
-            return Ok(true);
+        // Check local first (async to avoid blocking the executor)
+        match tokio::fs::metadata(local_path).await {
+            Ok(_) => return Ok(true),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                // Not found locally, continue to S3 download path
+            }
+            Err(e) => return Err(StorageError::Io(e)),
         }
 
         // Try S3 if available

--- a/src/storage/local.rs
+++ b/src/storage/local.rs
@@ -3,6 +3,7 @@
 use std::path::PathBuf;
 
 use async_trait::async_trait;
+use rand::Rng;
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
 
@@ -49,8 +50,16 @@ impl StorageBackend for LocalBackend {
             fs::create_dir_all(parent).await?;
         }
 
-        // Atomic write: write to temp file, then rename
-        let tmp_path = path.with_extension("tmp");
+        // Atomic write: write to uniquely-named temp file, then rename.
+        // A random suffix prevents races when multiple tasks write to the
+        // same key concurrently (deterministic ".tmp" would collide).
+        let random_suffix: u64 = rand::rng().random();
+        let tmp_name = format!(
+            "{}.{:x}.tmp",
+            path.file_name().unwrap_or_default().to_string_lossy(),
+            random_suffix
+        );
+        let tmp_path = path.with_file_name(tmp_name);
         let mut file = fs::File::create(&tmp_path).await?;
         file.write_all(data).await?;
         file.sync_all().await?;
@@ -80,8 +89,10 @@ impl StorageBackend for LocalBackend {
     async fn list(&self, prefix: &str) -> Result<Vec<String>, StorageError> {
         let path = self.full_path(prefix);
 
-        if !path.exists() {
-            return Ok(Vec::new());
+        match fs::metadata(&path).await {
+            Ok(_) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(e) => return Err(StorageError::Io(e)),
         }
 
         let mut results = Vec::new();
@@ -188,5 +199,36 @@ mod tests {
 
         let result = backend.read("nonexistent.txt").await;
         assert!(matches!(result, Err(StorageError::NotFound(_))));
+    }
+
+    #[tokio::test]
+    async fn test_local_backend_concurrent_writes() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let backend = std::sync::Arc::new(LocalBackend::new(temp_dir.path().to_path_buf()));
+
+        // Spawn 10 concurrent writes to the same key, each with unique data
+        let mut handles = Vec::new();
+        for i in 0u8..10 {
+            let b = backend.clone();
+            handles.push(tokio::spawn(async move {
+                let data = vec![i; 1024]; // 1 KiB of repeated byte value
+                b.write("concurrent/target.parquet", &data).await.unwrap();
+            }));
+        }
+
+        for handle in handles {
+            handle.await.unwrap();
+        }
+
+        // The file must exist and contain exactly one writer's data
+        // (no corruption from interleaved writes).
+        let data = backend.read("concurrent/target.parquet").await.unwrap();
+        assert_eq!(data.len(), 1024);
+        // Every byte should be the same value (written atomically by one writer)
+        let first = data[0];
+        assert!(
+            data.iter().all(|&b| b == first),
+            "data is corrupted: not all bytes match"
+        );
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -93,6 +93,8 @@ pub trait StorageBackend: Send + Sync {
 pub struct StorageManager {
     /// The active storage backend (local-only or cached with S3)
     backend: Arc<dyn StorageBackend>,
+    /// Direct S3 backend for upload operations that bypass the cache layer
+    s3_backend: Option<S3Backend>,
     /// Manifest manager for S3 coordination (None if local-only)
     manifest_manager: Option<Arc<ManifestManager>>,
     /// Base path for local storage
@@ -127,6 +129,10 @@ impl StorageManager {
                     .cloned()
                     .unwrap_or_default();
 
+                // Clone S3 backend before moving into CachedBackend so we can
+                // keep a direct reference for upload operations that skip the cache.
+                let direct_s3 = s3_backend.clone();
+
                 let cached_backend = CachedBackend::new(
                     local_backend,
                     s3_backend,
@@ -146,6 +152,7 @@ impl StorageManager {
 
                 Ok(Self {
                     backend: Arc::new(cached_backend),
+                    s3_backend: Some(direct_s3),
                     manifest_manager: Some(manifest_manager),
                     local_base,
                     s3_enabled: true,
@@ -159,6 +166,7 @@ impl StorageManager {
 
                 Ok(Self {
                     backend: Arc::new(local_backend),
+                    s3_backend: None,
                     manifest_manager: None,
                     local_base,
                     s3_enabled: false,
@@ -170,6 +178,14 @@ impl StorageManager {
     /// Get the storage backend.
     pub fn backend(&self) -> Arc<dyn StorageBackend> {
         self.backend.clone()
+    }
+
+    /// Get the direct S3 backend (if S3 is enabled).
+    ///
+    /// This bypasses the cache layer and is intended for upload operations
+    /// where the file already exists locally (avoiding redundant local writes).
+    pub fn s3_backend(&self) -> Option<&S3Backend> {
+        self.s3_backend.as_ref()
     }
 
     /// Get the manifest manager (if S3 is enabled).

--- a/src/storage/paths.rs
+++ b/src/storage/paths.rs
@@ -7,6 +7,18 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 // ---------------------------------------------------------------------------
+// Range separator conventions
+// ---------------------------------------------------------------------------
+
+/// Separator used in parquet filenames (e.g., "blocks_0-999.parquet").
+#[allow(dead_code)]
+pub const PARQUET_RANGE_SEPARATOR: char = '-';
+
+/// Separator used in marker filenames (e.g., "0_999.marker").
+#[allow(dead_code)]
+pub const MARKER_RANGE_SEPARATOR: char = '_';
+
+// ---------------------------------------------------------------------------
 // Path builders
 // ---------------------------------------------------------------------------
 
@@ -219,16 +231,37 @@ mod tests {
     #[test]
     fn parse_range_invalid() {
         assert_eq!(parse_range_from_filename(Path::new("foo.parquet")), None);
-        assert_eq!(parse_range_from_filename(Path::new("blocks_abc.parquet")), None);
+        assert_eq!(
+            parse_range_from_filename(Path::new("blocks_abc.parquet")),
+            None
+        );
     }
 
     #[test]
     fn path_builders() {
-        assert_eq!(raw_blocks_dir("ethereum"), PathBuf::from("data/ethereum/historical/raw/blocks"));
-        assert_eq!(raw_receipts_dir("base"), PathBuf::from("data/base/historical/raw/receipts"));
-        assert_eq!(raw_logs_dir("base"), PathBuf::from("data/base/historical/raw/logs"));
-        assert_eq!(raw_eth_calls_dir("base"), PathBuf::from("data/base/historical/raw/eth_calls"));
-        assert_eq!(factories_dir("base"), PathBuf::from("data/base/historical/factories"));
-        assert_eq!(decoded_base_dir("base"), PathBuf::from("data/base/historical/decoded"));
+        assert_eq!(
+            raw_blocks_dir("ethereum"),
+            PathBuf::from("data/ethereum/historical/raw/blocks")
+        );
+        assert_eq!(
+            raw_receipts_dir("base"),
+            PathBuf::from("data/base/historical/raw/receipts")
+        );
+        assert_eq!(
+            raw_logs_dir("base"),
+            PathBuf::from("data/base/historical/raw/logs")
+        );
+        assert_eq!(
+            raw_eth_calls_dir("base"),
+            PathBuf::from("data/base/historical/raw/eth_calls")
+        );
+        assert_eq!(
+            factories_dir("base"),
+            PathBuf::from("data/base/historical/factories")
+        );
+        assert_eq!(
+            decoded_base_dir("base"),
+            PathBuf::from("data/base/historical/decoded")
+        );
     }
 }

--- a/src/storage/upload.rs
+++ b/src/storage/upload.rs
@@ -3,12 +3,13 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use crate::storage::{StorageError, StorageManager};
+use crate::storage::{StorageBackend, StorageError, StorageManager};
 
 /// Upload a parquet file to S3 and write a marker.
 ///
 /// This is a no-op if S3 is not configured or not enabled.
-/// Pattern matches `src/live/compaction.rs:824-883`.
+/// Uses the direct S3 backend to avoid redundant local writes through the
+/// cache layer (the file already exists locally).
 pub async fn upload_parquet_to_s3(
     storage_manager: &Arc<StorageManager>,
     local_path: &Path,
@@ -25,10 +26,17 @@ pub async fn upload_parquet_to_s3(
     let data = tokio::fs::read(local_path).await?;
 
     // Compute S3 key from local path (strip "data/" prefix)
-    let s3_key = compute_s3_key(local_path);
+    let s3_key = compute_s3_key(local_path)?;
 
-    // Upload to S3
-    storage_manager.backend().write(&s3_key, &data).await?;
+    // Upload directly to S3, bypassing the cache layer to avoid
+    // a redundant local write (the file already exists on disk).
+    match storage_manager.s3_backend() {
+        Some(s3) => s3.write(&s3_key, &data).await?,
+        None => {
+            // Fallback: S3 is enabled but direct backend not available (shouldn't happen)
+            storage_manager.backend().write(&s3_key, &data).await?;
+        }
+    }
 
     // Write marker
     if let Some(manifest_manager) = storage_manager.manifest_manager() {
@@ -48,19 +56,60 @@ pub async fn upload_parquet_to_s3(
 }
 
 /// Compute the S3 key from a local path by stripping the "data/" prefix.
-fn compute_s3_key(local_path: &Path) -> String {
-    // Try to strip "data/" prefix
+///
+/// Returns an error if the path does not contain a "data/" segment,
+/// since a bare filename fallback would produce incorrect S3 keys.
+fn compute_s3_key(local_path: &Path) -> Result<String, StorageError> {
     let path_str = local_path.to_string_lossy();
+
+    // Try to strip "data/" prefix (relative path)
     if let Some(rest) = path_str.strip_prefix("data/") {
-        return rest.to_string();
+        return Ok(rest.to_string());
     }
+
     // Check for absolute path containing /data/
     if let Some(idx) = path_str.find("/data/") {
-        return path_str[idx + 6..].to_string();
+        return Ok(path_str[idx + 6..].to_string());
     }
-    // Fallback: use filename
-    local_path
-        .file_name()
-        .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_else(|| path_str.to_string())
+
+    Err(StorageError::Config(format!(
+        "Cannot compute S3 key: path missing 'data/' prefix: {}",
+        local_path.display()
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compute_s3_key_relative_data_prefix() {
+        let path = Path::new("data/ethereum/historical/raw/blocks/blocks_0-999.parquet");
+        let key = compute_s3_key(path).unwrap();
+        assert_eq!(key, "ethereum/historical/raw/blocks/blocks_0-999.parquet");
+    }
+
+    #[test]
+    fn compute_s3_key_absolute_data_prefix() {
+        let path = Path::new("/home/user/project/data/base/historical/raw/logs/logs_0-999.parquet");
+        let key = compute_s3_key(path).unwrap();
+        assert_eq!(key, "base/historical/raw/logs/logs_0-999.parquet");
+    }
+
+    #[test]
+    fn compute_s3_key_missing_data_prefix_returns_error() {
+        let path = Path::new("/tmp/blocks_0-999.parquet");
+        let result = compute_s3_key(path);
+        assert!(result.is_err());
+        match result {
+            Err(StorageError::Config(msg)) => {
+                assert!(
+                    msg.contains("missing 'data/' prefix"),
+                    "unexpected message: {}",
+                    msg
+                );
+            }
+            other => panic!("expected StorageError::Config, got {:?}", other),
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Fixes five storage layer issues identified in the S3 integration review:

**Issue #4 - `upload_parquet_to_s3` double-writes via CachedBackend**
- Added `s3_backend: Option<S3Backend>` field to `StorageManager` with a `s3_backend()` accessor
- The S3Backend is cloned during `StorageManager::new()` before it's moved into the CachedBackend
- `upload_parquet_to_s3()` now writes directly to S3 via `storage_manager.s3_backend().write()`, avoiding the redundant local write that CachedBackend would perform (the file already exists locally)

**Issue #5 - Concurrent writes race on deterministic temp file**
- `LocalBackend::write()` previously used `path.with_extension("tmp")` which is deterministic, causing races when multiple tasks write to the same key concurrently
- Now uses a random u64 suffix: `{filename}.{random_hex}.tmp` to ensure unique temp files per write operation
- Added a test that spawns 10 concurrent writers to the same key and verifies data integrity (no corruption from interleaved writes)

**Issue #6 - Synchronous `path.exists()` in async context**
- `data_loader.rs` `ensure_local()`: replaced `local_path.exists()` with `tokio::fs::metadata().await`, handling NotFound to continue to S3 download path
- `local.rs` `list()`: replaced `!path.exists()` with `tokio::fs::metadata().await`, returning empty Vec on NotFound

**Issue #7 - `compute_s3_key` dangerous fallback**
- Changed return type from `String` to `Result<String, StorageError>`
- The filename-only fallback (which would produce incorrect S3 keys) is now an explicit `StorageError::Config` error
- Added tests for both success cases (relative `data/` and absolute `/data/` paths) and the error case

**Issue #11 - Two range separator conventions**
- Added `PARQUET_RANGE_SEPARATOR` (`-`) and `MARKER_RANGE_SEPARATOR` (`_`) constants to `src/storage/paths.rs` documenting the two conventions used across the codebase