### PR TITLE
fix: return errors on integer overflow and handle factory channel failures

### DIFF
--- a/src/decoding/eth_calls/decode.rs
+++ b/src/decoding/eth_calls/decode.rs
@@ -140,16 +140,32 @@ fn convert_dyn_sol_value(
     match value {
         DynSolValue::Address(addr) => Ok(DecodedValue::Address(addr.0 .0)),
         DynSolValue::Uint(val, _) => match output_type {
-            EvmType::Uint8 => Ok(DecodedValue::Uint8((*val).try_into().unwrap_or(u8::MAX))),
+            EvmType::Uint8 => {
+                let v: u8 = (*val).try_into().map_err(|_| {
+                    EthCallDecodingError::Decode(format!("Uint value {} overflows u8", val))
+                })?;
+                Ok(DecodedValue::Uint8(v))
+            }
             EvmType::Uint64 | EvmType::Uint32 | EvmType::Uint24 | EvmType::Uint16 => {
-                Ok(DecodedValue::Uint64((*val).try_into().unwrap_or(u64::MAX)))
+                let v: u64 = (*val).try_into().map_err(|_| {
+                    EthCallDecodingError::Decode(format!("Uint value {} overflows u64", val))
+                })?;
+                Ok(DecodedValue::Uint64(v))
             }
             _ => Ok(DecodedValue::Uint256(*val)),
         },
         DynSolValue::Int(val, _) => match output_type {
-            EvmType::Int8 => Ok(DecodedValue::Int8((*val).try_into().unwrap_or(i8::MAX))),
+            EvmType::Int8 => {
+                let v: i8 = (*val).try_into().map_err(|_| {
+                    EthCallDecodingError::Decode(format!("Int value {} overflows i8", val))
+                })?;
+                Ok(DecodedValue::Int8(v))
+            }
             EvmType::Int64 | EvmType::Int32 | EvmType::Int24 | EvmType::Int16 => {
-                Ok(DecodedValue::Int64((*val).try_into().unwrap_or(i64::MAX)))
+                let v: i64 = (*val).try_into().map_err(|_| {
+                    EthCallDecodingError::Decode(format!("Int value {} overflows i64", val))
+                })?;
+                Ok(DecodedValue::Int64(v))
             }
             _ => Ok(DecodedValue::Int256(*val)),
         },
@@ -166,5 +182,108 @@ fn convert_dyn_sol_value(
             "Unsupported value type: {:?}",
             value
         ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::{I256, U256};
+
+    #[test]
+    fn test_uint8_overflow_returns_error() {
+        let val = DynSolValue::Uint(U256::from(256u64), 8);
+        let result = convert_dyn_sol_value(&val, &EvmType::Uint8);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("overflows u8"),
+            "Expected overflow error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_uint64_overflow_returns_error() {
+        // U256::MAX is well above u64::MAX
+        let val = DynSolValue::Uint(U256::MAX, 256);
+        let result = convert_dyn_sol_value(&val, &EvmType::Uint64);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("overflows u64"),
+            "Expected overflow error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_int8_overflow_returns_error() {
+        // 128 is outside i8 range [-128, 127]
+        let val = DynSolValue::Int(I256::try_from(128i64).unwrap(), 8);
+        let result = convert_dyn_sol_value(&val, &EvmType::Int8);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("overflows i8"),
+            "Expected overflow error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_int64_overflow_returns_error() {
+        // I256::MAX is well above i64::MAX
+        let val = DynSolValue::Int(I256::MAX, 256);
+        let result = convert_dyn_sol_value(&val, &EvmType::Int64);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("overflows i64"),
+            "Expected overflow error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_valid_values_still_decode() {
+        // Valid u8
+        let val = DynSolValue::Uint(U256::from(255u64), 8);
+        let result = convert_dyn_sol_value(&val, &EvmType::Uint8).unwrap();
+        assert!(matches!(result, DecodedValue::Uint8(255)));
+
+        // Valid u64
+        let val = DynSolValue::Uint(U256::from(u64::MAX), 64);
+        let result = convert_dyn_sol_value(&val, &EvmType::Uint64).unwrap();
+        assert!(matches!(result, DecodedValue::Uint64(v) if v == u64::MAX));
+
+        // Valid i8
+        let val = DynSolValue::Int(I256::try_from(-128i64).unwrap(), 8);
+        let result = convert_dyn_sol_value(&val, &EvmType::Int8).unwrap();
+        assert!(matches!(result, DecodedValue::Int8(-128)));
+
+        // Valid i64
+        let val = DynSolValue::Int(I256::try_from(i64::MAX).unwrap(), 64);
+        let result = convert_dyn_sol_value(&val, &EvmType::Int64).unwrap();
+        assert!(matches!(result, DecodedValue::Int64(v) if v == i64::MAX));
+
+        // Uint256 passthrough
+        let val = DynSolValue::Uint(U256::MAX, 256);
+        let result = convert_dyn_sol_value(&val, &EvmType::Uint256).unwrap();
+        assert!(matches!(result, DecodedValue::Uint256(v) if v == U256::MAX));
+
+        // Int256 passthrough
+        let val = DynSolValue::Int(I256::MIN, 256);
+        let result = convert_dyn_sol_value(&val, &EvmType::Int256).unwrap();
+        assert!(matches!(result, DecodedValue::Int256(v) if v == I256::MIN));
+
+        // Zero values
+        let val = DynSolValue::Uint(U256::ZERO, 8);
+        let result = convert_dyn_sol_value(&val, &EvmType::Uint8).unwrap();
+        assert!(matches!(result, DecodedValue::Uint8(0)));
+
+        let val = DynSolValue::Int(I256::ZERO, 8);
+        let result = convert_dyn_sol_value(&val, &EvmType::Int8).unwrap();
+        assert!(matches!(result, DecodedValue::Int8(0)));
     }
 }

--- a/src/raw_data/historical/catchup/factories.rs
+++ b/src/raw_data/historical/catchup/factories.rs
@@ -72,13 +72,24 @@ pub async fn collect_factories(
                 });
 
             if let Some(ref tx) = log_decoder_tx {
-                let _ = tx
+                if tx
                     .send(DecoderMessage::FactoryAddresses {
                         range_start: factory_data.range_start,
                         range_end: factory_data.range_end,
                         addresses,
                     })
-                    .await;
+                    .await
+                    .is_err()
+                {
+                    tracing::error!(
+                        "Failed to send factory addresses to log decoder for range {}-{} - receiver dropped",
+                        factory_data.range_start, factory_data.range_end
+                    );
+                    return Err(FactoryCollectionError::ChannelSend(format!(
+                        "log_decoder_tx (existing factory data {}-{}) - receiver dropped",
+                        factory_data.range_start, factory_data.range_end
+                    )));
+                }
             }
         }
     }
@@ -315,13 +326,24 @@ pub async fn collect_factories(
                 });
 
             if let Some(ref tx) = log_decoder_tx {
-                let _ = tx
+                if tx
                     .send(DecoderMessage::FactoryAddresses {
                         range_start: factory_data.range_start,
                         range_end: factory_data.range_end,
                         addresses,
                     })
-                    .await;
+                    .await
+                    .is_err()
+                {
+                    tracing::error!(
+                        "Failed to send factory addresses to log decoder for range {}-{} - receiver dropped",
+                        factory_data.range_start, factory_data.range_end
+                    );
+                    return Err(FactoryCollectionError::ChannelSend(format!(
+                        "log_decoder_tx (catchup factory data {}-{}) - receiver dropped",
+                        factory_data.range_start, factory_data.range_end
+                    )));
+                }
             }
 
             catchup_count += 1;


### PR DESCRIPTION
## Summary

This PR fixes two bugs in the indexer:

### Bug 1 (Critical): Silent data truncation in integer decoding

In `src/decoding/eth_calls/decode.rs`, the `convert_dyn_sol_value` function used `unwrap_or(MAX)` when converting `U256`/`I256` values to smaller integer types (`u8`, `u64`, `i8`, `i64`). This silently clamped out-of-range values to the maximum representable value, producing incorrect data in the decoded output with no indication of a problem.

**Before:** A `U256` value of 256 decoded as `EvmType::Uint8` would silently become `255` (`u8::MAX`).

**After:** The same conversion returns `Err(EthCallDecodingError::Decode("Uint value 256 overflows u8"))`. All callers in `src/decoding/eth_calls/process.rs` already handle `Err` gracefully by logging a warning and continuing to the next record, so no caller changes were needed.

Five tests were added covering:
- `test_uint8_overflow_returns_error` - u8 overflow detection
- `test_uint64_overflow_returns_error` - u64 overflow detection
- `test_int8_overflow_returns_error` - i8 overflow detection
- `test_int64_overflow_returns_error` - i64 overflow detection
- `test_valid_values_still_decode` - regression test ensuring normal values (boundary values, zero, MAX, MIN, passthrough types) still decode correctly

### Bug 9 (Low): Factory catchup discards channel send failures

In `src/raw_data/historical/catchup/factories.rs`, two `log_decoder_tx.send(...)` calls used `let _ =` to discard send errors, silently dropping factory address data when the decoder channel receiver was closed. This could cause downstream decoders to miss factory addresses without any error propagation.

The fix applies the same error-handling pattern already used for `logs_factory_tx` in the same file: log an error and return `FactoryCollectionError::ChannelSend`. Both occurrences were fixed:
1. The existing factory data forwarding loop (sending pre-loaded parquet data)
2. The catchup phase results forwarding loop (sending newly-discovered factory data)

The oneshot completion signals (`let _ = tx.send(())`) were intentionally left as-is since they are non-critical completion signals where the receiver may have already moved on.