### PR TITLE
chore: introduce domain data structs and engine config for transformations

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,9 @@ use raw_data::historical::receipts::{
 use rpc::{UnifiedRpcClient, WsClient};
 use runtime::{ChainRuntime, CommonChannels};
 use storage::{InitialSyncService, LocalBackend, RetryQueue, S3Backend, StorageManager};
-use transformations::{ExecutionMode, ReorgMessage, TransformationEngine};
+use transformations::{
+    ExecutionMode, ReorgMessage, TransformationEngine, TransformationEngineConfig,
+};
 use types::config::chain::ChainConfig;
 use types::config::defaults::{raw_data as raw_data_defaults, rpc as rpc_defaults};
 use types::config::indexer::IndexerConfig;
@@ -460,15 +462,17 @@ async fn process_chain_live_only(
             runtime.registry.clone(),
             runtime.db_pool.clone().unwrap(),
             rpc_client,
-            chain.name.clone(),
-            chain.chain_id,
-            ExecutionMode::Streaming, // Live-only mode always uses streaming
-            chain.contracts.clone(),
-            chain.factory_collections.clone(),
-            tc.handler_concurrency,
+            TransformationEngineConfig {
+                chain_name: chain.name.clone(),
+                chain_id: chain.chain_id,
+                mode: ExecutionMode::Streaming, // Live-only mode always uses streaming
+                contracts: chain.contracts.clone(),
+                factory_collections: chain.factory_collections.clone(),
+                handler_concurrency: tc.handler_concurrency,
+                expect_log_completion: runtime.features.has_events,
+                expect_eth_call_completion: runtime.features.has_calls,
+            },
             runtime.progress_tracker.clone(),
-            runtime.features.has_events,
-            runtime.features.has_calls,
         )
         .await
         .context("failed to create transformation engine")?;
@@ -1271,15 +1275,17 @@ async fn process_chain(
             pipeline.runtime.registry.clone(),
             pipeline.runtime.db_pool.clone().unwrap(),
             rpc_client,
-            pipeline.runtime.chain.name.clone(),
-            pipeline.runtime.chain.chain_id,
-            mode,
-            pipeline.runtime.chain.contracts.clone(),
-            pipeline.runtime.chain.factory_collections.clone(),
-            tc.handler_concurrency,
+            TransformationEngineConfig {
+                chain_name: pipeline.runtime.chain.name.clone(),
+                chain_id: pipeline.runtime.chain.chain_id,
+                mode,
+                contracts: pipeline.runtime.chain.contracts.clone(),
+                factory_collections: pipeline.runtime.chain.factory_collections.clone(),
+                handler_concurrency: tc.handler_concurrency,
+                expect_log_completion: has_events,
+                expect_eth_call_completion: has_calls,
+            },
             pipeline.runtime.progress_tracker.clone(),
-            has_events,
-            has_calls,
         )
         .await
         .context("failed to create transformation engine")?;

--- a/src/transformations/context.rs
+++ b/src/transformations/context.rs
@@ -421,7 +421,7 @@ pub struct TransformationContext {
     pub(crate) contracts: Arc<Contracts>,
 }
 
-#[allow(dead_code)]
+#[allow(dead_code, clippy::too_many_arguments)]
 impl TransformationContext {
     /// Create a new transformation context.
     pub fn new(

--- a/src/transformations/engine.rs
+++ b/src/transformations/engine.rs
@@ -89,6 +89,30 @@ pub enum ExecutionMode {
     Batch { batch_size: usize },
 }
 
+/// Configuration for creating a TransformationEngine.
+///
+/// Groups the chain-specific and behavior-related parameters that configure
+/// the engine, reducing the argument count of `TransformationEngine::new`.
+pub struct TransformationEngineConfig {
+    pub chain_name: String,
+    pub chain_id: u64,
+    pub mode: ExecutionMode,
+    pub contracts: Contracts,
+    pub factory_collections: FactoryCollections,
+    pub handler_concurrency: usize,
+    pub expect_log_completion: bool,
+    pub expect_eth_call_completion: bool,
+}
+
+/// Result type for individual handler task execution during catchup.
+type HandlerTaskResult = Result<Option<(String, u64, u64)>, TransformationError>;
+
+/// A handler paired with the decoded calls it needs to process.
+type ReadyHandler = (
+    Arc<dyn super::traits::TransformationHandler>,
+    Arc<Vec<DecodedCall>>,
+);
+
 
 /// The transformation engine processes decoded data and invokes handlers.
 ///
@@ -121,23 +145,21 @@ impl TransformationEngine {
         registry: Arc<TransformationRegistry>,
         db_pool: Arc<DbPool>,
         rpc_client: Arc<UnifiedRpcClient>,
-        chain_name: String,
-        chain_id: u64,
-        mode: ExecutionMode,
-        contracts: Contracts,
-        factory_collections: FactoryCollections,
-        handler_concurrency: usize,
+        config: TransformationEngineConfig,
         progress_tracker: Option<Arc<Mutex<LiveProgressTracker>>>,
-        expect_log_completion: bool,
-        expect_eth_call_completion: bool,
     ) -> Result<Self, TransformationError> {
+        let chain_name = config.chain_name;
+        let chain_id = config.chain_id;
+        let mode = config.mode;
+        let handler_concurrency = config.handler_concurrency;
+
         let historical_reader = Arc::new(HistoricalDataReader::new(&chain_name)?);
         let decoded_logs_dir = crate::storage::paths::decoded_logs_dir(&chain_name);
         let decoded_calls_dir = crate::storage::paths::decoded_eth_calls_dir(&chain_name);
         let raw_receipts_dir = crate::storage::paths::raw_receipts_dir(&chain_name);
 
-        let contracts = Arc::new(contracts);
-        let factory_collections = Arc::new(factory_collections);
+        let contracts = Arc::new(config.contracts);
+        let factory_collections = Arc::new(config.factory_collections);
 
         let executor = Arc::new(HandlerExecutor {
             db_pool: db_pool.clone(),
@@ -155,8 +177,8 @@ impl TransformationEngine {
             chain_name: chain_name.clone(),
             chain_id,
             progress_tracker: progress_tracker.clone(),
-            expect_log_completion,
-            expect_eth_call_completion,
+            expect_log_completion: config.expect_log_completion,
+            expect_eth_call_completion: config.expect_eth_call_completion,
         });
 
         let retry_processor = RetryProcessor {
@@ -482,8 +504,7 @@ impl TransformationEngine {
                 let mut skipped_ranges: Vec<(u64, u64)> = Vec::new();
 
                 let semaphore = Arc::new(Semaphore::new(self.handler_concurrency));
-                let mut join_set: JoinSet<Result<Option<(String, u64, u64)>, TransformationError>> =
-                    JoinSet::new();
+                let mut join_set: JoinSet<HandlerTaskResult> = JoinSet::new();
 
                 for (range_start, range_end) in &ranges_to_attempt {
                     let events = self
@@ -714,8 +735,7 @@ impl TransformationEngine {
             let mut processed = 0;
 
             let semaphore = Arc::new(Semaphore::new(self.handler_concurrency));
-            let mut join_set: JoinSet<Result<Option<(String, u64, u64)>, TransformationError>> =
-                JoinSet::new();
+            let mut join_set: JoinSet<HandlerTaskResult> = JoinSet::new();
 
             for (range_start, range_end) in &to_process {
                 let calls = self
@@ -1223,10 +1243,7 @@ impl TransformationEngine {
 
         // Categorize handlers: ready to run vs needs buffering
         let range_key = (msg.range_start, msg.range_end);
-        let mut ready_handlers: Vec<(
-            Arc<dyn super::traits::TransformationHandler>,
-            Arc<Vec<DecodedCall>>,
-        )> = Vec::new();
+        let mut ready_handlers: Vec<ReadyHandler> = Vec::new();
         {
             let mut state = self.live_state.lock().await;
             for handler in &handlers {

--- a/src/transformations/event/decay_multicurve/create.rs
+++ b/src/transformations/event/decay_multicurve/create.rs
@@ -8,9 +8,9 @@ use crate::transformations::error::TransformationError;
 use crate::transformations::registry::TransformationRegistry;
 use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
 
-use crate::transformations::util::db::pool::{insert_pool, BeneficiariesData, Beneficiary};
-use crate::transformations::util::db::token::insert_token;
-use crate::transformations::util::db::v4_pool_configs::insert_pool_config;
+use crate::transformations::util::db::pool::{insert_pool, BeneficiariesData, Beneficiary, PoolData};
+use crate::transformations::util::db::token::{insert_token, TokenData};
+use crate::transformations::util::db::v4_pool_configs::{insert_pool_config, PoolConfigData};
 use crate::transformations::util::metadata::get_metadata;
 use crate::types::decoded::DecodedValue;
 use crate::types::uniswap::v4::{PoolAddressOrPoolId, PoolKey, V4PoolConfig};
@@ -258,61 +258,67 @@ impl TransformationHandler for V4DecayMulticurveCreateHandler {
             };
 
             ops.push(insert_token(
-                event.block_number,
-                event.block_timestamp,
-                &event.transaction_hash,
-                ctx.tx_from(&event.transaction_hash),
-                Some(&asset_metadata.integrator.into()),
-                &asset,
-                Some(&PoolAddressOrPoolId::PoolId(pool_id.0)),
-                &asset_metadata.name,
-                &asset_metadata.symbol,
-                asset_metadata.decimals,
-                Some(&asset_metadata.total_supply),
-                Some(&asset_metadata.token_uri),
-                true,
-                false,
-                false,
-                None,
-                Some(&asset_metadata.governance),
+                &TokenData {
+                    block_number: event.block_number,
+                    block_timestamp: event.block_timestamp,
+                    tx_hash: &event.transaction_hash,
+                    creator_address: ctx.tx_from(&event.transaction_hash),
+                    integrator: Some(&asset_metadata.integrator.into()),
+                    token_address: &asset,
+                    pool: Some(&PoolAddressOrPoolId::PoolId(pool_id.0)),
+                    name: &asset_metadata.name,
+                    symbol: &asset_metadata.symbol,
+                    decimals: asset_metadata.decimals,
+                    total_supply: Some(&asset_metadata.total_supply),
+                    token_uri: Some(&asset_metadata.token_uri),
+                    is_derc20: true,
+                    is_creator_coin: false,
+                    is_content_coin: false,
+                    creator_coin_pool: None,
+                    governance: Some(&asset_metadata.governance),
+                },
                 ctx,
             ));
 
             ops.push(insert_token(
-                event.block_number,
-                event.block_timestamp,
-                &event.transaction_hash,
-                None,
-                None,
-                &numeraire,
-                None,
-                &numeraire_metadata.name,
-                &numeraire_metadata.symbol,
-                numeraire_metadata.decimals,
-                None,
-                None,
-                false,
-                false,
-                false,
-                None,
-                None,
+                &TokenData {
+                    block_number: event.block_number,
+                    block_timestamp: event.block_timestamp,
+                    tx_hash: &event.transaction_hash,
+                    creator_address: None,
+                    integrator: None,
+                    token_address: &numeraire,
+                    pool: None,
+                    name: &numeraire_metadata.name,
+                    symbol: &numeraire_metadata.symbol,
+                    decimals: numeraire_metadata.decimals,
+                    total_supply: None,
+                    token_uri: None,
+                    is_derc20: false,
+                    is_creator_coin: false,
+                    is_content_coin: false,
+                    creator_coin_pool: None,
+                    governance: None,
+                },
                 ctx,
             ));
 
             ops.push(insert_pool_config(
-                pool_id.into(),
-                hook,
-                pool_config.num_tokens_to_sell,
-                pool_config.min_proceeds,
-                pool_config.max_proceeds,
-                pool_config.starting_time,
-                pool_config.ending_time,
-                pool_config.starting_tick,
-                pool_config.ending_tick,
-                pool_config.epoch_length,
-                pool_config.gamma,
-                pool_config.is_token_0,
-                pool_config.num_pd_slugs,
+                &PoolConfigData {
+                    pool_id: pool_id.into(),
+                    hook_address: hook,
+                    num_tokens_to_sell: pool_config.num_tokens_to_sell,
+                    min_proceeds: pool_config.min_proceeds,
+                    max_proceeds: pool_config.max_proceeds,
+                    starting_time: pool_config.starting_time,
+                    ending_time: pool_config.ending_time,
+                    starting_tick: pool_config.starting_tick,
+                    ending_tick: pool_config.ending_tick,
+                    epoch_length: pool_config.epoch_length,
+                    gamma: pool_config.gamma,
+                    is_token_0: pool_config.is_token_0,
+                    num_pd_slugs: pool_config.num_pd_slugs,
+                },
                 ctx,
             ));
 
@@ -355,27 +361,29 @@ impl TransformationHandler for V4DecayMulticurveCreateHandler {
                 .unwrap_or("unknown");
 
             ops.push(insert_pool(
-                event.block_number,
-                event.block_timestamp,
-                PoolAddressOrPoolId::PoolId(pool_id.into()),
-                &asset,
-                &numeraire,
-                pool_config.is_token_0,
-                "decay_multicurve",
-                asset_metadata.integrator.into(),
-                asset_metadata.initializer.into(),
-                pool_key.fee,
-                pool_config.min_proceeds,
-                pool_config.max_proceeds,
-                asset_metadata.migrator.into(),
-                None,
-                asset_metadata.migration_pool,
-                migration_type,
-                None,
-                beneficiaries,
-                pool_key,
-                pool_config.starting_time,
-                pool_config.ending_time,
+                &PoolData {
+                    block_number: event.block_number,
+                    block_timestamp: event.block_timestamp,
+                    address: PoolAddressOrPoolId::PoolId(pool_id.into()),
+                    base_token: asset,
+                    quote_token: numeraire,
+                    is_token_0: pool_config.is_token_0,
+                    pool_type: "decay_multicurve".to_string(),
+                    integrator: asset_metadata.integrator.into(),
+                    initializer: asset_metadata.initializer.into(),
+                    fee: pool_key.fee,
+                    min_threshold: pool_config.min_proceeds,
+                    max_threshold: pool_config.max_proceeds,
+                    migrator: asset_metadata.migrator.into(),
+                    migrated_at: None,
+                    migration_pool: asset_metadata.migration_pool,
+                    migration_type: migration_type.to_string(),
+                    lock_duration: None,
+                    beneficiaries,
+                    pool_key,
+                    starting_time: pool_config.starting_time,
+                    ending_time: pool_config.ending_time,
+                },
                 ctx,
             ));
         }

--- a/src/transformations/event/multicurve/create.rs
+++ b/src/transformations/event/multicurve/create.rs
@@ -8,9 +8,9 @@ use crate::transformations::error::TransformationError;
 use crate::transformations::registry::TransformationRegistry;
 use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
 
-use crate::transformations::util::db::pool::{insert_pool, BeneficiariesData, Beneficiary};
-use crate::transformations::util::db::token::insert_token;
-use crate::transformations::util::db::v4_pool_configs::insert_pool_config;
+use crate::transformations::util::db::pool::{insert_pool, BeneficiariesData, Beneficiary, PoolData};
+use crate::transformations::util::db::token::{insert_token, TokenData};
+use crate::transformations::util::db::v4_pool_configs::{insert_pool_config, PoolConfigData};
 use crate::transformations::util::metadata::get_metadata;
 use crate::types::decoded::DecodedValue;
 use crate::types::uniswap::v4::{PoolAddressOrPoolId, PoolKey, V4PoolConfig};
@@ -258,61 +258,67 @@ impl TransformationHandler for V4MulticurveCreateHandler {
             };
 
             ops.push(insert_token(
-                event.block_number,
-                event.block_timestamp,
-                &event.transaction_hash,
-                ctx.tx_from(&event.transaction_hash),
-                Some(&asset_metadata.integrator.into()),
-                &asset,
-                Some(&PoolAddressOrPoolId::PoolId(pool_id.0)),
-                &asset_metadata.name,
-                &asset_metadata.symbol,
-                asset_metadata.decimals,
-                Some(&asset_metadata.total_supply),
-                Some(&asset_metadata.token_uri),
-                true,
-                false,
-                false,
-                None,
-                Some(&asset_metadata.governance),
+                &TokenData {
+                    block_number: event.block_number,
+                    block_timestamp: event.block_timestamp,
+                    tx_hash: &event.transaction_hash,
+                    creator_address: ctx.tx_from(&event.transaction_hash),
+                    integrator: Some(&asset_metadata.integrator.into()),
+                    token_address: &asset,
+                    pool: Some(&PoolAddressOrPoolId::PoolId(pool_id.0)),
+                    name: &asset_metadata.name,
+                    symbol: &asset_metadata.symbol,
+                    decimals: asset_metadata.decimals,
+                    total_supply: Some(&asset_metadata.total_supply),
+                    token_uri: Some(&asset_metadata.token_uri),
+                    is_derc20: true,
+                    is_creator_coin: false,
+                    is_content_coin: false,
+                    creator_coin_pool: None,
+                    governance: Some(&asset_metadata.governance),
+                },
                 ctx,
             ));
 
             ops.push(insert_token(
-                event.block_number,
-                event.block_timestamp,
-                &event.transaction_hash,
-                None,
-                None,
-                &numeraire,
-                None,
-                &numeraire_metadata.name,
-                &numeraire_metadata.symbol,
-                numeraire_metadata.decimals,
-                None,
-                None,
-                false,
-                false,
-                false,
-                None,
-                None,
+                &TokenData {
+                    block_number: event.block_number,
+                    block_timestamp: event.block_timestamp,
+                    tx_hash: &event.transaction_hash,
+                    creator_address: None,
+                    integrator: None,
+                    token_address: &numeraire,
+                    pool: None,
+                    name: &numeraire_metadata.name,
+                    symbol: &numeraire_metadata.symbol,
+                    decimals: numeraire_metadata.decimals,
+                    total_supply: None,
+                    token_uri: None,
+                    is_derc20: false,
+                    is_creator_coin: false,
+                    is_content_coin: false,
+                    creator_coin_pool: None,
+                    governance: None,
+                },
                 ctx,
             ));
 
             ops.push(insert_pool_config(
-                pool_id.into(),
-                hook,
-                pool_config.num_tokens_to_sell,
-                pool_config.min_proceeds,
-                pool_config.max_proceeds,
-                pool_config.starting_time,
-                pool_config.ending_time,
-                pool_config.starting_tick,
-                pool_config.ending_tick,
-                pool_config.epoch_length,
-                pool_config.gamma,
-                pool_config.is_token_0,
-                pool_config.num_pd_slugs,
+                &PoolConfigData {
+                    pool_id: pool_id.into(),
+                    hook_address: hook,
+                    num_tokens_to_sell: pool_config.num_tokens_to_sell,
+                    min_proceeds: pool_config.min_proceeds,
+                    max_proceeds: pool_config.max_proceeds,
+                    starting_time: pool_config.starting_time,
+                    ending_time: pool_config.ending_time,
+                    starting_tick: pool_config.starting_tick,
+                    ending_tick: pool_config.ending_tick,
+                    epoch_length: pool_config.epoch_length,
+                    gamma: pool_config.gamma,
+                    is_token_0: pool_config.is_token_0,
+                    num_pd_slugs: pool_config.num_pd_slugs,
+                },
                 ctx,
             ));
 
@@ -355,27 +361,29 @@ impl TransformationHandler for V4MulticurveCreateHandler {
                 .unwrap_or("unknown");
 
             ops.push(insert_pool(
-                event.block_number,
-                event.block_timestamp,
-                PoolAddressOrPoolId::PoolId(pool_id.into()),
-                &asset,
-                &numeraire,
-                pool_config.is_token_0,
-                "multicurve",
-                asset_metadata.integrator.into(),
-                asset_metadata.initializer.into(),
-                pool_key.fee,
-                pool_config.min_proceeds,
-                pool_config.max_proceeds,
-                asset_metadata.migrator.into(),
-                None,
-                asset_metadata.migration_pool,
-                migration_type,
-                None,
-                beneficiaries,
-                pool_key,
-                pool_config.starting_time,
-                pool_config.ending_time,
+                &PoolData {
+                    block_number: event.block_number,
+                    block_timestamp: event.block_timestamp,
+                    address: PoolAddressOrPoolId::PoolId(pool_id.into()),
+                    base_token: asset,
+                    quote_token: numeraire,
+                    is_token_0: pool_config.is_token_0,
+                    pool_type: "multicurve".to_string(),
+                    integrator: asset_metadata.integrator.into(),
+                    initializer: asset_metadata.initializer.into(),
+                    fee: pool_key.fee,
+                    min_threshold: pool_config.min_proceeds,
+                    max_threshold: pool_config.max_proceeds,
+                    migrator: asset_metadata.migrator.into(),
+                    migrated_at: None,
+                    migration_pool: asset_metadata.migration_pool,
+                    migration_type: migration_type.to_string(),
+                    lock_duration: None,
+                    beneficiaries,
+                    pool_key,
+                    starting_time: pool_config.starting_time,
+                    ending_time: pool_config.ending_time,
+                },
                 ctx,
             ));
         }

--- a/src/transformations/event/scheduled_multicurve/create.rs
+++ b/src/transformations/event/scheduled_multicurve/create.rs
@@ -9,9 +9,9 @@ use crate::transformations::error::TransformationError;
 use crate::transformations::registry::TransformationRegistry;
 use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
 
-use crate::transformations::util::db::pool::{insert_pool, BeneficiariesData, Beneficiary};
-use crate::transformations::util::db::token::insert_token;
-use crate::transformations::util::db::v4_pool_configs::insert_pool_config;
+use crate::transformations::util::db::pool::{insert_pool, BeneficiariesData, Beneficiary, PoolData};
+use crate::transformations::util::db::token::{insert_token, TokenData};
+use crate::transformations::util::db::v4_pool_configs::{insert_pool_config, PoolConfigData};
 use crate::transformations::util::metadata::get_metadata;
 use crate::types::decoded::DecodedValue;
 use crate::types::uniswap::v4::{PoolAddressOrPoolId, PoolKey, V4PoolConfig};
@@ -286,61 +286,67 @@ impl TransformationHandler for V4ScheduledMulticurveCreateHandler {
             };
 
             ops.push(insert_token(
-                event.block_number,
-                event.block_timestamp,
-                &event.transaction_hash,
-                ctx.tx_from(&event.transaction_hash),
-                Some(&asset_metadata.integrator.into()),
-                &asset,
-                Some(&PoolAddressOrPoolId::PoolId(pool_id.0)),
-                &asset_metadata.name,
-                &asset_metadata.symbol,
-                asset_metadata.decimals,
-                Some(&asset_metadata.total_supply),
-                Some(&asset_metadata.token_uri),
-                true,
-                false,
-                false,
-                None,
-                Some(&asset_metadata.governance),
+                &TokenData {
+                    block_number: event.block_number,
+                    block_timestamp: event.block_timestamp,
+                    tx_hash: &event.transaction_hash,
+                    creator_address: ctx.tx_from(&event.transaction_hash),
+                    integrator: Some(&asset_metadata.integrator.into()),
+                    token_address: &asset,
+                    pool: Some(&PoolAddressOrPoolId::PoolId(pool_id.0)),
+                    name: &asset_metadata.name,
+                    symbol: &asset_metadata.symbol,
+                    decimals: asset_metadata.decimals,
+                    total_supply: Some(&asset_metadata.total_supply),
+                    token_uri: Some(&asset_metadata.token_uri),
+                    is_derc20: true,
+                    is_creator_coin: false,
+                    is_content_coin: false,
+                    creator_coin_pool: None,
+                    governance: Some(&asset_metadata.governance),
+                },
                 ctx,
             ));
 
             ops.push(insert_token(
-                event.block_number,
-                event.block_timestamp,
-                &event.transaction_hash,
-                None,
-                None,
-                &numeraire,
-                None,
-                &numeraire_metadata.name,
-                &numeraire_metadata.symbol,
-                numeraire_metadata.decimals,
-                None,
-                None,
-                false,
-                false,
-                false,
-                None,
-                None,
+                &TokenData {
+                    block_number: event.block_number,
+                    block_timestamp: event.block_timestamp,
+                    tx_hash: &event.transaction_hash,
+                    creator_address: None,
+                    integrator: None,
+                    token_address: &numeraire,
+                    pool: None,
+                    name: &numeraire_metadata.name,
+                    symbol: &numeraire_metadata.symbol,
+                    decimals: numeraire_metadata.decimals,
+                    total_supply: None,
+                    token_uri: None,
+                    is_derc20: false,
+                    is_creator_coin: false,
+                    is_content_coin: false,
+                    creator_coin_pool: None,
+                    governance: None,
+                },
                 ctx,
             ));
 
             ops.push(insert_pool_config(
-                pool_id.into(),
-                hook,
-                pool_config.num_tokens_to_sell,
-                pool_config.min_proceeds,
-                pool_config.max_proceeds,
-                pool_config.starting_time,
-                pool_config.ending_time,
-                pool_config.starting_tick,
-                pool_config.ending_tick,
-                pool_config.epoch_length,
-                pool_config.gamma,
-                pool_config.is_token_0,
-                pool_config.num_pd_slugs,
+                &PoolConfigData {
+                    pool_id: pool_id.into(),
+                    hook_address: hook,
+                    num_tokens_to_sell: pool_config.num_tokens_to_sell,
+                    min_proceeds: pool_config.min_proceeds,
+                    max_proceeds: pool_config.max_proceeds,
+                    starting_time: pool_config.starting_time,
+                    ending_time: pool_config.ending_time,
+                    starting_tick: pool_config.starting_tick,
+                    ending_tick: pool_config.ending_tick,
+                    epoch_length: pool_config.epoch_length,
+                    gamma: pool_config.gamma,
+                    is_token_0: pool_config.is_token_0,
+                    num_pd_slugs: pool_config.num_pd_slugs,
+                },
                 ctx,
             ));
 
@@ -386,27 +392,29 @@ impl TransformationHandler for V4ScheduledMulticurveCreateHandler {
                 .unwrap_or("unknown");
 
             ops.push(insert_pool(
-                event.block_number,
-                event.block_timestamp,
-                PoolAddressOrPoolId::PoolId(pool_id.into()),
-                &asset,
-                &numeraire,
-                pool_config.is_token_0,
-                "scheduled_multicurve",
-                asset_metadata.integrator.into(),
-                asset_metadata.initializer.into(),
-                pool_key.fee,
-                pool_config.min_proceeds,
-                pool_config.max_proceeds,
-                asset_metadata.migrator.into(),
-                None,
-                asset_metadata.migration_pool,
-                migration_type,
-                None,
-                beneficiaries,
-                pool_key,
-                pool_config.starting_time,
-                pool_config.ending_time,
+                &PoolData {
+                    block_number: event.block_number,
+                    block_timestamp: event.block_timestamp,
+                    address: PoolAddressOrPoolId::PoolId(pool_id.into()),
+                    base_token: asset,
+                    quote_token: numeraire,
+                    is_token_0: pool_config.is_token_0,
+                    pool_type: "scheduled_multicurve".to_string(),
+                    integrator: asset_metadata.integrator.into(),
+                    initializer: asset_metadata.initializer.into(),
+                    fee: pool_key.fee,
+                    min_threshold: pool_config.min_proceeds,
+                    max_threshold: pool_config.max_proceeds,
+                    migrator: asset_metadata.migrator.into(),
+                    migrated_at: None,
+                    migration_pool: asset_metadata.migration_pool,
+                    migration_type: migration_type.to_string(),
+                    lock_duration: None,
+                    beneficiaries,
+                    pool_key,
+                    starting_time: pool_config.starting_time,
+                    ending_time: pool_config.ending_time,
+                },
                 ctx,
             ));
         }

--- a/src/transformations/event/v4/create.rs
+++ b/src/transformations/event/v4/create.rs
@@ -8,9 +8,9 @@ use crate::transformations::error::TransformationError;
 use crate::transformations::registry::TransformationRegistry;
 use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
 
-use crate::transformations::util::db::pool::insert_pool;
-use crate::transformations::util::db::token::insert_token;
-use crate::transformations::util::db::v4_pool_configs::insert_pool_config;
+use crate::transformations::util::db::pool::{insert_pool, PoolData};
+use crate::transformations::util::db::token::{insert_token, TokenData};
+use crate::transformations::util::db::v4_pool_configs::{insert_pool_config, PoolConfigData};
 use crate::transformations::util::metadata::get_metadata;
 
 use crate::types::uniswap::v4::{PoolAddressOrPoolId, PoolKey, V4PoolConfig};
@@ -105,61 +105,67 @@ impl TransformationHandler for V4CreateHandler {
             };
 
             ops.push(insert_token(
-                event.block_number,
-                event.block_timestamp,
-                &event.transaction_hash,
-                ctx.tx_from(&event.transaction_hash),
-                Some(&asset_metadata.integrator.into()),
-                &asset,
-                Some(&PoolAddressOrPoolId::PoolId(pool_id.0)),
-                &asset_metadata.name,
-                &asset_metadata.symbol,
-                asset_metadata.decimals,
-                Some(&asset_metadata.total_supply),
-                Some(&asset_metadata.token_uri),
-                true,
-                false,
-                false,
-                None,
-                Some(&asset_metadata.governance),
+                &TokenData {
+                    block_number: event.block_number,
+                    block_timestamp: event.block_timestamp,
+                    tx_hash: &event.transaction_hash,
+                    creator_address: ctx.tx_from(&event.transaction_hash),
+                    integrator: Some(&asset_metadata.integrator.into()),
+                    token_address: &asset,
+                    pool: Some(&PoolAddressOrPoolId::PoolId(pool_id.0)),
+                    name: &asset_metadata.name,
+                    symbol: &asset_metadata.symbol,
+                    decimals: asset_metadata.decimals,
+                    total_supply: Some(&asset_metadata.total_supply),
+                    token_uri: Some(&asset_metadata.token_uri),
+                    is_derc20: true,
+                    is_creator_coin: false,
+                    is_content_coin: false,
+                    creator_coin_pool: None,
+                    governance: Some(&asset_metadata.governance),
+                },
                 ctx,
             ));
 
             ops.push(insert_token(
-                event.block_number,
-                event.block_timestamp,
-                &event.transaction_hash,
-                None,
-                None,
-                &numeraire,
-                None,
-                &numeraire_metadata.name,
-                &numeraire_metadata.symbol,
-                numeraire_metadata.decimals,
-                None,
-                None,
-                false,
-                false,
-                false,
-                None,
-                None,
+                &TokenData {
+                    block_number: event.block_number,
+                    block_timestamp: event.block_timestamp,
+                    tx_hash: &event.transaction_hash,
+                    creator_address: None,
+                    integrator: None,
+                    token_address: &numeraire,
+                    pool: None,
+                    name: &numeraire_metadata.name,
+                    symbol: &numeraire_metadata.symbol,
+                    decimals: numeraire_metadata.decimals,
+                    total_supply: None,
+                    token_uri: None,
+                    is_derc20: false,
+                    is_creator_coin: false,
+                    is_content_coin: false,
+                    creator_coin_pool: None,
+                    governance: None,
+                },
                 ctx,
             ));
 
             ops.push(insert_pool_config(
-                pool_id.into(),
-                hook,
-                pool_config.num_tokens_to_sell,
-                pool_config.min_proceeds,
-                pool_config.max_proceeds,
-                pool_config.starting_time,
-                pool_config.ending_time,
-                pool_config.starting_tick,
-                pool_config.ending_tick,
-                pool_config.epoch_length,
-                pool_config.gamma,
-                pool_config.is_token_0,
-                pool_config.num_pd_slugs,
+                &PoolConfigData {
+                    pool_id: pool_id.into(),
+                    hook_address: hook,
+                    num_tokens_to_sell: pool_config.num_tokens_to_sell,
+                    min_proceeds: pool_config.min_proceeds,
+                    max_proceeds: pool_config.max_proceeds,
+                    starting_time: pool_config.starting_time,
+                    ending_time: pool_config.ending_time,
+                    starting_tick: pool_config.starting_tick,
+                    ending_tick: pool_config.ending_tick,
+                    epoch_length: pool_config.epoch_length,
+                    gamma: pool_config.gamma,
+                    is_token_0: pool_config.is_token_0,
+                    num_pd_slugs: pool_config.num_pd_slugs,
+                },
                 ctx,
             ));
 
@@ -183,27 +189,29 @@ impl TransformationHandler for V4CreateHandler {
                 .unwrap_or("unknown");
 
             ops.push(insert_pool(
-                event.block_number,
-                event.block_timestamp,
-                PoolAddressOrPoolId::PoolId(pool_id.into()),
-                &asset,
-                &numeraire,
-                pool_config.is_token_0,
-                "v4",
-                asset_metadata.integrator.into(),
-                asset_metadata.initializer.into(),
-                pool_key.fee,
-                pool_config.min_proceeds,
-                pool_config.max_proceeds,
-                asset_metadata.migrator.into(),
-                None,
-                asset_metadata.migration_pool,
-                migration_type,
-                None,
-                None,
-                pool_key,
-                pool_config.starting_time,
-                pool_config.ending_time,
+                &PoolData {
+                    block_number: event.block_number,
+                    block_timestamp: event.block_timestamp,
+                    address: PoolAddressOrPoolId::PoolId(pool_id.into()),
+                    base_token: asset,
+                    quote_token: numeraire,
+                    is_token_0: pool_config.is_token_0,
+                    pool_type: "v4".to_string(),
+                    integrator: asset_metadata.integrator.into(),
+                    initializer: asset_metadata.initializer.into(),
+                    fee: pool_key.fee,
+                    min_threshold: pool_config.min_proceeds,
+                    max_threshold: pool_config.max_proceeds,
+                    migrator: asset_metadata.migrator.into(),
+                    migrated_at: None,
+                    migration_pool: asset_metadata.migration_pool,
+                    migration_type: migration_type.to_string(),
+                    lock_duration: None,
+                    beneficiaries: None,
+                    pool_key,
+                    starting_time: pool_config.starting_time,
+                    ending_time: pool_config.ending_time,
+                },
                 ctx,
             ));
         }

--- a/src/transformations/historical.rs
+++ b/src/transformations/historical.rs
@@ -19,15 +19,16 @@ use super::context::{
 use super::error::TransformationError;
 use crate::storage::paths::{decoded_base_dir, scan_parquet_ranges};
 
+/// Index mapping (source_name, event_or_function_name) to available parquet file ranges.
+type FileIndex = HashMap<(String, String), Vec<(u64, u64, PathBuf)>>;
+
 /// Reader for historical decoded data stored in parquet files.
 pub struct HistoricalDataReader {
     chain_name: String,
     /// Base path for decoded data
     decoded_base: PathBuf,
     /// Cache of available file ranges per (source, event/function)
-    /// Key: (source_name, event_or_function_name)
-    /// Value: Vec<(range_start, range_end, file_path)>
-    file_index: RwLock<HashMap<(String, String), Vec<(u64, u64, PathBuf)>>>,
+    file_index: RwLock<FileIndex>,
 }
 
 impl HistoricalDataReader {
@@ -79,7 +80,7 @@ impl HistoricalDataReader {
     fn index_directory(
         &self,
         base: &Path,
-        index: &mut HashMap<(String, String), Vec<(u64, u64, PathBuf)>>,
+        index: &mut FileIndex,
     ) -> Result<(), TransformationError> {
         // Iterate over source directories
         for source_entry in std::fs::read_dir(base)? {
@@ -241,7 +242,7 @@ impl HistoricalDataReader {
     #[allow(dead_code)]
     fn find_files_for_range(
         &self,
-        index: &HashMap<(String, String), Vec<(u64, u64, PathBuf)>>,
+        index: &FileIndex,
         source_filter: Option<&str>,
         name_filter: Option<&str>,
         from_block: u64,

--- a/src/transformations/mod.rs
+++ b/src/transformations/mod.rs
@@ -70,7 +70,7 @@ pub mod util;
 pub use context::{DecodedCall, DecodedEvent, TransformationContext};
 pub use engine::{
     DecodedCallsMessage, DecodedEventsMessage, ExecutionMode, RangeCompleteKind,
-    RangeCompleteMessage, ReorgMessage, TransformationEngine,
+    RangeCompleteMessage, ReorgMessage, TransformationEngine, TransformationEngineConfig,
 };
 pub use error::TransformationError;
 pub use registry::build_registry;

--- a/src/transformations/util/db/pool.rs
+++ b/src/transformations/util/db/pool.rs
@@ -31,30 +31,32 @@ impl Beneficiary {
 
 pub type BeneficiariesData = Vec<Beneficiary>;
 
-pub fn insert_pool(
-    block_number: u64,
-    block_timestamp: u64,
-    address: PoolAddressOrPoolId,
-    base_token: &[u8; 20],
-    quote_token: &[u8; 20],
-    is_token_0: bool,
-    pool_type: &str,
-    integrator: [u8; 20],
-    initializer: [u8; 20],
-    fee: u32,
-    min_threshold: U256,
-    max_threshold: U256,
-    migrator: [u8; 20],
-    migrated_at: Option<u64>,
-    migration_pool: PoolAddressOrPoolId,
-    migration_type: &str,
-    lock_duration: Option<u32>,
-    beneficiaries: Option<BeneficiariesData>,
-    pool_key: PoolKey,
-    starting_time: u64,
-    ending_time: u64,
-    ctx: &TransformationContext,
-) -> DbOperation {
+/// Domain data for inserting a pool record into the database.
+pub struct PoolData {
+    pub block_number: u64,
+    pub block_timestamp: u64,
+    pub address: PoolAddressOrPoolId,
+    pub base_token: [u8; 20],
+    pub quote_token: [u8; 20],
+    pub is_token_0: bool,
+    pub pool_type: String,
+    pub integrator: [u8; 20],
+    pub initializer: [u8; 20],
+    pub fee: u32,
+    pub min_threshold: U256,
+    pub max_threshold: U256,
+    pub migrator: [u8; 20],
+    pub migrated_at: Option<u64>,
+    pub migration_pool: PoolAddressOrPoolId,
+    pub migration_type: String,
+    pub lock_duration: Option<u32>,
+    pub beneficiaries: Option<BeneficiariesData>,
+    pub pool_key: PoolKey,
+    pub starting_time: u64,
+    pub ending_time: u64,
+}
+
+pub fn insert_pool(data: &PoolData, ctx: &TransformationContext) -> DbOperation {
     DbOperation::Upsert {
         table: "pools".to_string(),
         conflict_columns: vec!["chain_id".to_string(), "address".to_string()],
@@ -85,42 +87,42 @@ pub fn insert_pool(
         ],
         values: vec![
             DbValue::Int64(ctx.chain_id as i64),
-            DbValue::Uint64(block_number),
-            DbValue::Timestamp(block_timestamp as i64),
-            match address {
-                PoolAddressOrPoolId::Address(address) => DbValue::Address(address),
-                PoolAddressOrPoolId::PoolId(pool_id) => DbValue::Bytes32(pool_id),
+            DbValue::Uint64(data.block_number),
+            DbValue::Timestamp(data.block_timestamp as i64),
+            match &data.address {
+                PoolAddressOrPoolId::Address(address) => DbValue::Address(*address),
+                PoolAddressOrPoolId::PoolId(pool_id) => DbValue::Bytes32(*pool_id),
             },
-            DbValue::Address(*base_token),
-            DbValue::Address(*quote_token),
-            DbValue::Bool(is_token_0),
-            DbValue::VarChar(pool_type.to_string()),
-            DbValue::Address(integrator),
-            DbValue::Address(initializer),
-            DbValue::Int32(fee as i32),
-            DbValue::Numeric(min_threshold.to_string()),
-            DbValue::Numeric(max_threshold.to_string()),
-            DbValue::Address(migrator),
-            match migrated_at {
+            DbValue::Address(data.base_token),
+            DbValue::Address(data.quote_token),
+            DbValue::Bool(data.is_token_0),
+            DbValue::VarChar(data.pool_type.clone()),
+            DbValue::Address(data.integrator),
+            DbValue::Address(data.initializer),
+            DbValue::Int32(data.fee as i32),
+            DbValue::Numeric(data.min_threshold.to_string()),
+            DbValue::Numeric(data.max_threshold.to_string()),
+            DbValue::Address(data.migrator),
+            match data.migrated_at {
                 Some(timestamp) => DbValue::Timestamp(timestamp as i64),
                 None => DbValue::Null,
             },
-            match migration_pool {
-                PoolAddressOrPoolId::Address(address) => DbValue::Address(address),
-                PoolAddressOrPoolId::PoolId(pool_id) => DbValue::Bytes32(pool_id),
+            match &data.migration_pool {
+                PoolAddressOrPoolId::Address(address) => DbValue::Address(*address),
+                PoolAddressOrPoolId::PoolId(pool_id) => DbValue::Bytes32(*pool_id),
             },
-            DbValue::VarChar(migration_type.to_string()),
-            match lock_duration {
+            DbValue::VarChar(data.migration_type.clone()),
+            match data.lock_duration {
                 Some(duration) => DbValue::Int32(duration as i32),
                 None => DbValue::Null,
             },
-            match beneficiaries {
+            match &data.beneficiaries {
                 Some(beneficiaries_data) => DbValue::jsonb(beneficiaries_data),
                 None => DbValue::Null,
             },
-            DbValue::jsonb(pool_key),
-            DbValue::Timestamp(starting_time as i64),
-            DbValue::Timestamp(ending_time as i64),
+            DbValue::jsonb(&data.pool_key),
+            DbValue::Timestamp(data.starting_time as i64),
+            DbValue::Timestamp(data.ending_time as i64),
         ],
     }
 }

--- a/src/transformations/util/db/token.rs
+++ b/src/transformations/util/db/token.rs
@@ -2,26 +2,32 @@ use crate::db::{DbOperation, DbValue};
 use crate::transformations::TransformationContext;
 use crate::types::uniswap::v4::PoolAddressOrPoolId;
 
-pub fn insert_token(
-    block_number: u64,
-    block_timestamp: u64,
-    tx_hash: &[u8; 32],
-    creator_address: Option<&[u8; 20]>,
-    integrator: Option<&[u8; 20]>,
-    token_address: &[u8; 20],
-    pool: Option<&PoolAddressOrPoolId>,
-    name: &str,
-    symbol: &str,
-    decimals: u8,
-    total_supply: Option<&alloy_primitives::Uint<256, 4>>,
-    token_uri: Option<&str>,
-    is_derc20: bool,
-    is_creator_coin: bool,
-    is_content_coin: bool,
-    creator_coin_pool: Option<&[u8; 32]>,
-    governance: Option<&[u8; 20]>,
-    ctx: &TransformationContext,
-) -> DbOperation {
+/// Domain data for inserting a token record into the database.
+///
+/// Uses lifetime references to avoid unnecessary cloning at call sites,
+/// since most data comes from decoded events and metadata that outlive
+/// the insert call.
+pub struct TokenData<'a> {
+    pub block_number: u64,
+    pub block_timestamp: u64,
+    pub tx_hash: &'a [u8; 32],
+    pub creator_address: Option<&'a [u8; 20]>,
+    pub integrator: Option<&'a [u8; 20]>,
+    pub token_address: &'a [u8; 20],
+    pub pool: Option<&'a PoolAddressOrPoolId>,
+    pub name: &'a str,
+    pub symbol: &'a str,
+    pub decimals: u8,
+    pub total_supply: Option<&'a alloy_primitives::Uint<256, 4>>,
+    pub token_uri: Option<&'a str>,
+    pub is_derc20: bool,
+    pub is_creator_coin: bool,
+    pub is_content_coin: bool,
+    pub creator_coin_pool: Option<&'a [u8; 32]>,
+    pub governance: Option<&'a [u8; 20]>,
+}
+
+pub fn insert_token(data: &TokenData<'_>, ctx: &TransformationContext) -> DbOperation {
     DbOperation::Upsert {
         table: "tokens".to_string(),
         conflict_columns: vec!["chain_id".to_string(), "address".to_string()],
@@ -48,42 +54,42 @@ pub fn insert_token(
         ],
         values: vec![
             DbValue::Int64(ctx.chain_id as i64),
-            DbValue::Bytes32(*tx_hash),
-            DbValue::Uint64(block_number),
-            DbValue::Timestamp(block_timestamp as i64),
-            match creator_address {
+            DbValue::Bytes32(*data.tx_hash),
+            DbValue::Uint64(data.block_number),
+            DbValue::Timestamp(data.block_timestamp as i64),
+            match data.creator_address {
                 Some(creator) => DbValue::Address(*creator),
                 None => DbValue::Null,
             },
-            match integrator {
+            match data.integrator {
                 Some(int_addr) => DbValue::Address(*int_addr),
                 None => DbValue::Null,
             },
-            DbValue::Address(*token_address),
-            match pool {
+            DbValue::Address(*data.token_address),
+            match data.pool {
                 Some(PoolAddressOrPoolId::Address(address)) => DbValue::Address(*address),
                 Some(PoolAddressOrPoolId::PoolId(pool_id)) => DbValue::Bytes32(*pool_id),
                 None => DbValue::Null,
             },
-            DbValue::Text(name.to_string()),
-            DbValue::Text(symbol.to_string()),
-            DbValue::Int2(decimals),
-            match total_supply {
+            DbValue::Text(data.name.to_string()),
+            DbValue::Text(data.symbol.to_string()),
+            DbValue::Int2(data.decimals),
+            match data.total_supply {
                 Some(supply) => DbValue::Numeric(supply.to_string()),
                 None => DbValue::Null,
             },
-            match token_uri {
+            match data.token_uri {
                 Some(uri) => DbValue::Text(uri.to_string()),
                 None => DbValue::Null,
             },
-            DbValue::Bool(is_derc20),
-            DbValue::Bool(is_creator_coin),
-            DbValue::Bool(is_content_coin),
-            match creator_coin_pool {
+            DbValue::Bool(data.is_derc20),
+            DbValue::Bool(data.is_creator_coin),
+            DbValue::Bool(data.is_content_coin),
+            match data.creator_coin_pool {
                 Some(creator_coin_pool) => DbValue::Bytes32(*creator_coin_pool),
                 None => DbValue::Null,
             },
-            match governance {
+            match data.governance {
                 Some(gov_addr) => DbValue::Address(*gov_addr),
                 None => DbValue::Null,
             },

--- a/src/transformations/util/db/v4_pool_configs.rs
+++ b/src/transformations/util/db/v4_pool_configs.rs
@@ -3,22 +3,24 @@ use alloy_primitives::U256;
 use crate::db::{DbOperation, DbValue};
 use crate::transformations::TransformationContext;
 
-pub fn insert_pool_config(
-    pool_id: [u8; 32],
-    hook_address: [u8; 20],
-    num_tokens_to_sell: U256,
-    min_proceeds: U256,
-    max_proceeds: U256,
-    starting_time: u64,
-    ending_time: u64,
-    starting_tick: i32,
-    ending_tick: i32,
-    epoch_length: U256,
-    gamma: u32,
-    is_token_0: bool,
-    num_pd_slugs: U256,
-    ctx: &TransformationContext,
-) -> DbOperation {
+/// Domain data for inserting a V4 pool config record into the database.
+pub struct PoolConfigData {
+    pub pool_id: [u8; 32],
+    pub hook_address: [u8; 20],
+    pub num_tokens_to_sell: U256,
+    pub min_proceeds: U256,
+    pub max_proceeds: U256,
+    pub starting_time: u64,
+    pub ending_time: u64,
+    pub starting_tick: i32,
+    pub ending_tick: i32,
+    pub epoch_length: U256,
+    pub gamma: u32,
+    pub is_token_0: bool,
+    pub num_pd_slugs: U256,
+}
+
+pub fn insert_pool_config(data: &PoolConfigData, ctx: &TransformationContext) -> DbOperation {
     DbOperation::Upsert {
         table: "v4_pool_configs".to_string(),
         conflict_columns: vec!["chain_id".to_string(), "hook_address".to_string()],
@@ -41,19 +43,19 @@ pub fn insert_pool_config(
         ],
         values: vec![
             DbValue::Int64(ctx.chain_id as i64),
-            DbValue::Bytes32(pool_id),
-            DbValue::Address(hook_address),
-            DbValue::Numeric(num_tokens_to_sell.to_string()),
-            DbValue::Numeric(min_proceeds.to_string()),
-            DbValue::Numeric(max_proceeds.to_string()),
-            DbValue::Timestamp(starting_time as i64),
-            DbValue::Timestamp(ending_time as i64),
-            DbValue::Int32(starting_tick),
-            DbValue::Int32(ending_tick),
-            DbValue::Numeric(epoch_length.to_string()),
-            DbValue::Int32(gamma as i32),
-            DbValue::Bool(is_token_0),
-            DbValue::Numeric(num_pd_slugs.to_string()),
+            DbValue::Bytes32(data.pool_id),
+            DbValue::Address(data.hook_address),
+            DbValue::Numeric(data.num_tokens_to_sell.to_string()),
+            DbValue::Numeric(data.min_proceeds.to_string()),
+            DbValue::Numeric(data.max_proceeds.to_string()),
+            DbValue::Timestamp(data.starting_time as i64),
+            DbValue::Timestamp(data.ending_time as i64),
+            DbValue::Int32(data.starting_tick),
+            DbValue::Int32(data.ending_tick),
+            DbValue::Numeric(data.epoch_length.to_string()),
+            DbValue::Int32(data.gamma as i32),
+            DbValue::Bool(data.is_token_0),
+            DbValue::Numeric(data.num_pd_slugs.to_string()),
         ],
     }
 }


### PR DESCRIPTION
## Summary

Fixes ~15 clippy warnings (`too_many_arguments` and `type_complexity`) in the transformation subsystem by introducing domain data structs and type aliases:

- **`PoolData`** struct in `src/transformations/util/db/pool.rs`: Replaces the 22-argument `insert_pool` function with a struct parameter, capturing all pool-related fields (block info, addresses, pool type, migration data, etc.).

- **`TokenData<'a>`** struct in `src/transformations/util/db/token.rs`: Replaces the 18-argument `insert_token` function with a lifetime-parameterized struct, preserving zero-copy references from decoded events and metadata.

- **`PoolConfigData`** struct in `src/transformations/util/db/v4_pool_configs.rs`: Replaces the 14-argument `insert_pool_config` function with a struct parameter for V4 pool configuration data.

- **`TransformationEngineConfig`** struct in `src/transformations/engine.rs`: Groups the 8 chain-specific and behavior-related configuration parameters for `TransformationEngine::new`, reducing its argument count from 12 to 5.

- **`HandlerTaskResult`** type alias in `src/transformations/engine.rs`: Replaces inline `JoinSet<Result<Option<(String, u64, u64)>, TransformationError>>` at two catchup JoinSet declarations.

- **`ReadyHandler`** type alias in `src/transformations/engine.rs`: Replaces inline `Vec<(Arc<dyn TransformationHandler>, Arc<Vec<DecodedCall>>)>` in live event processing.

- **`FileIndex`** type alias in `src/transformations/historical.rs`: Replaces inline `HashMap<(String, String), Vec<(u64, u64, PathBuf)>>` at 3 locations (struct field + 2 method parameters).

- **`#[allow(clippy::too_many_arguments)]`** on `TransformationContext::new`: 10 args is only 3 over the limit and all parameters are independently needed for a context constructor.

All 5 event handler call sites updated (v4, multicurve, decay_multicurve, scheduled_multicurve, dhook) plus both `TransformationEngine::new` call sites in `main.rs`.

**Note:** This PR touches `main.rs` at the `TransformationEngine::new` call sites and may conflict with sibling clippy PRs that also modify `main.rs`.