### PR TITLE
chore: introduce EthCallContext and type aliases for eth_calls execution

### DIFF
--- a/src/raw_data/historical/catchup/eth_calls.rs
+++ b/src/raw_data/historical/catchup/eth_calls.rs
@@ -18,7 +18,7 @@ use crate::raw_data::historical::eth_calls::{
     process_once_calls_regular, process_range, process_range_multicall, process_token_range,
     process_token_range_multicall, read_logs_from_parquet, read_once_column_index,
     scan_existing_parquet_files, BlockInfo, BlockRange, EthCallCatchupState,
-    EthCallCollectionError, FrequencyState,
+    EthCallCollectionError, EthCallContext, FrequencyState,
 };
 use crate::raw_data::historical::factories::{get_factory_call_configs, FactoryAddressData};
 use crate::raw_data::historical::receipts::{build_event_trigger_matchers, extract_event_triggers};
@@ -369,40 +369,37 @@ pub async fn collect_eth_calls(
 
             range_data.insert(range.start, blocks.clone());
 
+            let catchup_ctx = EthCallContext {
+                client,
+                output_dir: &base_output_dir,
+                existing_files: &existing_files,
+                rpc_batch_size,
+                decoder_tx: &None,
+                chain_name: &chain.name,
+                storage_manager: storage_manager.as_ref(),
+                s3_manifest: &s3_manifest,
+            };
+
             if has_regular_calls {
                 if let Some(multicall_addr) = multicall3_address {
                     process_range_multicall(
                         &range,
                         blocks.clone(),
-                        client,
+                        &catchup_ctx,
                         &call_configs,
-                        &base_output_dir,
-                        &existing_files,
-                        &s3_manifest,
-                        rpc_batch_size,
                         max_params,
                         &mut frequency_state,
                         multicall_addr,
-                        &None,
-                        &chain.name,
-                        storage_manager.as_ref(),
                     )
                     .await?;
                 } else {
                     process_range(
                         &range,
                         blocks.clone(),
-                        client,
+                        &catchup_ctx,
                         &call_configs,
-                        &base_output_dir,
-                        &existing_files,
-                        &s3_manifest,
-                        rpc_batch_size,
                         max_params,
                         &mut frequency_state,
-                        &None,
-                        &chain.name,
-                        storage_manager.as_ref(),
                     )
                     .await?;
                 }
@@ -413,31 +410,19 @@ pub async fn collect_eth_calls(
                     process_token_range_multicall(
                         &range,
                         blocks.clone(),
-                        client,
+                        &catchup_ctx,
                         &token_call_configs,
-                        &base_output_dir,
-                        &existing_files,
-                        rpc_batch_size,
                         &mut frequency_state,
                         multicall_addr,
-                        &None,
-                        &chain.name,
-                        storage_manager.as_ref(),
                     )
                     .await?;
                 } else {
                     process_token_range(
                         &range,
                         blocks.clone(),
-                        client,
+                        &catchup_ctx,
                         &token_call_configs,
-                        &base_output_dir,
-                        &existing_files,
-                        rpc_batch_size,
                         &mut frequency_state,
-                        &None,
-                        &chain.name,
-                        storage_manager.as_ref(),
                     )
                     .await?;
                 }
@@ -448,30 +433,19 @@ pub async fn collect_eth_calls(
                     process_once_calls_multicall(
                         &range,
                         &blocks,
-                        client,
+                        &catchup_ctx,
                         &once_configs,
                         &chain.contracts,
-                        &base_output_dir,
-                        &existing_files,
                         multicall_addr,
-                        rpc_batch_size,
-                        &None,
-                        &chain.name,
-                        storage_manager.as_ref(),
                     )
                     .await?;
                 } else {
                     process_once_calls_regular(
                         &range,
                         &blocks,
-                        client,
+                        &catchup_ctx,
                         &once_configs,
                         &chain.contracts,
-                        &base_output_dir,
-                        &existing_files,
-                        &None,
-                        &chain.name,
-                        storage_manager.as_ref(),
                     )
                     .await?;
                 }
@@ -573,17 +547,22 @@ pub async fn collect_eth_calls(
                     addresses_by_block,
                 };
 
+                let factory_once_ctx = EthCallContext {
+                    client,
+                    output_dir: &base_output_dir,
+                    existing_files: &existing_files,
+                    rpc_batch_size,
+                    decoder_tx,
+                    chain_name: &chain.name,
+                    storage_manager: storage_manager.as_ref(),
+                    s3_manifest: &s3_manifest,
+                };
                 process_factory_once_calls(
                     &range,
-                    client,
+                    &factory_once_ctx,
                     &factory_data,
                     &factory_once_configs,
-                    &base_output_dir,
-                    &existing_files,
                     &factory_once_column_indexes,
-                    decoder_tx,
-                    &chain.name,
-                    storage_manager.as_ref(),
                 )
                 .await?;
 
@@ -735,34 +714,44 @@ pub async fn collect_eth_calls(
             let range_start = log_range.start;
             let range_end = log_range.end - 1;
             if let Some(multicall_addr) = multicall3_address {
+                let event_ctx = EthCallContext {
+                    client,
+                    output_dir: &base_output_dir,
+                    existing_files: &existing_files,
+                    rpc_batch_size,
+                    decoder_tx,
+                    chain_name: &chain.name,
+                    storage_manager: storage_manager.as_ref(),
+                    s3_manifest: &s3_manifest,
+                };
                 process_event_triggers_multicall(
                     triggers,
                     &event_call_configs,
                     &factory_addresses,
-                    client,
-                    &base_output_dir,
-                    rpc_batch_size,
-                    decoder_tx,
+                    &event_ctx,
                     multicall_addr,
                     range_start,
                     range_end,
-                    &chain.name,
-                    storage_manager.as_ref(),
                 )
                 .await?;
             } else {
+                let event_ctx = EthCallContext {
+                    client,
+                    output_dir: &base_output_dir,
+                    existing_files: &existing_files,
+                    rpc_batch_size,
+                    decoder_tx,
+                    chain_name: &chain.name,
+                    storage_manager: storage_manager.as_ref(),
+                    s3_manifest: &s3_manifest,
+                };
                 process_event_triggers(
                     triggers,
                     &event_call_configs,
                     &factory_addresses,
-                    client,
-                    &base_output_dir,
-                    rpc_batch_size,
-                    decoder_tx,
+                    &event_ctx,
                     range_start,
                     range_end,
-                    &chain.name,
-                    storage_manager.as_ref(),
                 )
                 .await?;
             }

--- a/src/raw_data/historical/current/eth_calls/events.rs
+++ b/src/raw_data/historical/current/eth_calls/events.rs
@@ -7,7 +7,7 @@ use super::state::CollectorState;
 use crate::decoding::DecoderMessage;
 use crate::raw_data::historical::eth_calls::{
     process_event_triggers, process_event_triggers_multicall, EthCallCatchupState,
-    EthCallCollectionError,
+    EthCallCollectionError, EthCallContext,
 };
 use crate::raw_data::historical::receipts::EventTriggerMessage;
 use crate::rpc::UnifiedRpcClient;
@@ -42,20 +42,27 @@ pub(super) async fn handle_event_trigger_message(
             // Process all buffered triggers for this range
             if !local_state.pending_event_triggers.is_empty() {
                 let triggers = std::mem::take(&mut local_state.pending_event_triggers);
+
+                let ctx = EthCallContext {
+                    client,
+                    output_dir: &state.base_output_dir,
+                    existing_files: &state.existing_files,
+                    rpc_batch_size: state.rpc_batch_size,
+                    decoder_tx,
+                    chain_name,
+                    storage_manager,
+                    s3_manifest: &state.s3_manifest,
+                };
+
                 if let Some(multicall_addr) = state.multicall3_address {
                     process_event_triggers_multicall(
                         triggers,
                         &state.event_call_configs,
                         &state.factory_addresses,
-                        client,
-                        &state.base_output_dir,
-                        state.rpc_batch_size,
-                        decoder_tx,
+                        &ctx,
                         multicall_addr,
                         range_start,
                         inclusive_end,
-                        chain_name,
-                        storage_manager,
                     )
                     .await?;
                 } else {
@@ -63,14 +70,9 @@ pub(super) async fn handle_event_trigger_message(
                         triggers,
                         &state.event_call_configs,
                         &state.factory_addresses,
-                        client,
-                        &state.base_output_dir,
-                        state.rpc_batch_size,
-                        decoder_tx,
+                        &ctx,
                         range_start,
                         inclusive_end,
-                        chain_name,
-                        storage_manager,
                     )
                     .await?;
                 }

--- a/src/raw_data/historical/current/eth_calls/factory.rs
+++ b/src/raw_data/historical/current/eth_calls/factory.rs
@@ -7,6 +7,7 @@ use crate::decoding::DecoderMessage;
 use crate::raw_data::historical::eth_calls::{
     process_factory_once_calls, process_factory_once_calls_multicall, process_factory_range,
     process_factory_range_multicall, BlockRange, EthCallCatchupState, EthCallCollectionError,
+    EthCallContext,
 };
 use crate::raw_data::historical::factories::{FactoryAddressData, FactoryMessage};
 use crate::rpc::UnifiedRpcClient;
@@ -73,39 +74,38 @@ pub(super) async fn handle_factory_message(
                         state.range_data.get(&range_start),
                         state.range_factory_data.get(&range_start),
                     ) {
+                        let ctx = EthCallContext {
+                            client,
+                            output_dir: &state.base_output_dir,
+                            existing_files: &state.existing_files,
+                            rpc_batch_size: state.rpc_batch_size,
+                            decoder_tx,
+                            chain_name,
+                            storage_manager,
+                            s3_manifest: &state.s3_manifest,
+                        };
+
                         if let Some(multicall_addr) = state.multicall3_address {
                             process_factory_range_multicall(
                                 &range,
                                 blocks,
-                                client,
+                                &ctx,
                                 factory_data,
                                 &state.factory_call_configs,
-                                &state.base_output_dir,
-                                &state.existing_files,
-                                state.rpc_batch_size,
                                 state.factory_max_params,
                                 &mut state.frequency_state,
                                 multicall_addr,
-                                decoder_tx,
-                                chain_name,
-                                storage_manager,
                             )
                             .await?;
                         } else {
                             process_factory_range(
                                 &range,
                                 blocks,
-                                client,
+                                &ctx,
                                 factory_data,
                                 &state.factory_call_configs,
-                                &state.base_output_dir,
-                                &state.existing_files,
-                                state.rpc_batch_size,
                                 state.factory_max_params,
                                 &mut state.frequency_state,
-                                decoder_tx,
-                                chain_name,
-                                storage_manager,
                             )
                             .await?;
                         }
@@ -115,31 +115,20 @@ pub(super) async fn handle_factory_message(
                             if let Some(multicall_addr) = state.multicall3_address {
                                 process_factory_once_calls_multicall(
                                     &range,
-                                    client,
+                                    &ctx,
                                     factory_data,
                                     &state.factory_once_configs,
-                                    &state.base_output_dir,
-                                    &state.existing_files,
                                     &empty_index,
                                     multicall_addr,
-                                    state.rpc_batch_size,
-                                    decoder_tx,
-                                    chain_name,
-                                    storage_manager,
                                 )
                                 .await?;
                             } else {
                                 process_factory_once_calls(
                                     &range,
-                                    client,
+                                    &ctx,
                                     factory_data,
                                     &state.factory_once_configs,
-                                    &state.base_output_dir,
-                                    &state.existing_files,
                                     &empty_index,
-                                    decoder_tx,
-                                    chain_name,
-                                    storage_manager,
                                 )
                                 .await?;
                             }

--- a/src/raw_data/historical/current/eth_calls/range_processor.rs
+++ b/src/raw_data/historical/current/eth_calls/range_processor.rs
@@ -8,7 +8,7 @@ use crate::raw_data::historical::eth_calls::{
     process_factory_once_calls, process_factory_once_calls_multicall, process_factory_range,
     process_factory_range_multicall, process_once_calls_multicall, process_once_calls_regular,
     process_range, process_range_multicall, process_token_range, process_token_range_multicall,
-    BlockInfo, BlockRange, EthCallCatchupState, EthCallCollectionError,
+    BlockInfo, BlockRange, EthCallCatchupState, EthCallCollectionError, EthCallContext,
 };
 use crate::rpc::UnifiedRpcClient;
 use crate::storage::StorageManager;
@@ -38,40 +38,37 @@ pub(super) async fn process_complete_range(
         end: range_start + state.range_size,
     };
 
+    let ctx = EthCallContext {
+        client,
+        output_dir: &state.base_output_dir,
+        existing_files: &state.existing_files,
+        rpc_batch_size: state.rpc_batch_size,
+        decoder_tx,
+        chain_name: &chain.name,
+        storage_manager,
+        s3_manifest: &state.s3_manifest,
+    };
+
     if state.has_regular_calls {
         if let Some(multicall_addr) = state.multicall3_address {
             process_range_multicall(
                 &range,
                 blocks.clone(),
-                client,
+                &ctx,
                 &state.call_configs,
-                &state.base_output_dir,
-                &state.existing_files,
-                &state.s3_manifest,
-                state.rpc_batch_size,
                 state.max_params,
                 &mut state.frequency_state,
                 multicall_addr,
-                decoder_tx,
-                &chain.name,
-                storage_manager,
             )
             .await?;
         } else {
             process_range(
                 &range,
                 blocks.clone(),
-                client,
+                &ctx,
                 &state.call_configs,
-                &state.base_output_dir,
-                &state.existing_files,
-                &state.s3_manifest,
-                state.rpc_batch_size,
                 state.max_params,
                 &mut state.frequency_state,
-                decoder_tx,
-                &chain.name,
-                storage_manager,
             )
             .await?;
         }
@@ -82,31 +79,19 @@ pub(super) async fn process_complete_range(
             process_token_range_multicall(
                 &range,
                 blocks.clone(),
-                client,
+                &ctx,
                 &state.token_call_configs,
-                &state.base_output_dir,
-                &state.existing_files,
-                state.rpc_batch_size,
                 &mut state.frequency_state,
                 multicall_addr,
-                decoder_tx,
-                &chain.name,
-                storage_manager,
             )
             .await?;
         } else {
             process_token_range(
                 &range,
                 blocks.clone(),
-                client,
+                &ctx,
                 &state.token_call_configs,
-                &state.base_output_dir,
-                &state.existing_files,
-                state.rpc_batch_size,
                 &mut state.frequency_state,
-                decoder_tx,
-                &chain.name,
-                storage_manager,
             )
             .await?;
         }
@@ -117,30 +102,19 @@ pub(super) async fn process_complete_range(
             process_once_calls_multicall(
                 &range,
                 blocks,
-                client,
+                &ctx,
                 &state.once_configs,
                 &chain.contracts,
-                &state.base_output_dir,
-                &state.existing_files,
                 multicall_addr,
-                state.rpc_batch_size,
-                decoder_tx,
-                &chain.name,
-                storage_manager,
             )
             .await?;
         } else {
             process_once_calls_regular(
                 &range,
                 blocks,
-                client,
+                &ctx,
                 &state.once_configs,
                 &chain.contracts,
-                &state.base_output_dir,
-                &state.existing_files,
-                decoder_tx,
-                &chain.name,
-                storage_manager,
             )
             .await?;
         }
@@ -153,35 +127,23 @@ pub(super) async fn process_complete_range(
                 process_factory_range_multicall(
                     &range,
                     blocks,
-                    client,
+                    &ctx,
                     factory_data,
                     &state.factory_call_configs,
-                    &state.base_output_dir,
-                    &state.existing_files,
-                    state.rpc_batch_size,
                     state.factory_max_params,
                     &mut state.frequency_state,
                     multicall_addr,
-                    decoder_tx,
-                    &chain.name,
-                    storage_manager,
                 )
                 .await?;
             } else {
                 process_factory_range(
                     &range,
                     blocks,
-                    client,
+                    &ctx,
                     factory_data,
                     &state.factory_call_configs,
-                    &state.base_output_dir,
-                    &state.existing_files,
-                    state.rpc_batch_size,
                     state.factory_max_params,
                     &mut state.frequency_state,
-                    decoder_tx,
-                    &chain.name,
-                    storage_manager,
                 )
                 .await?;
             }
@@ -192,31 +154,20 @@ pub(super) async fn process_complete_range(
             if let Some(multicall_addr) = state.multicall3_address {
                 process_factory_once_calls_multicall(
                     &range,
-                    client,
+                    &ctx,
                     factory_data,
                     &state.factory_once_configs,
-                    &state.base_output_dir,
-                    &state.existing_files,
                     &empty_index,
                     multicall_addr,
-                    state.rpc_batch_size,
-                    decoder_tx,
-                    &chain.name,
-                    storage_manager,
                 )
                 .await?;
             } else {
                 process_factory_once_calls(
                     &range,
-                    client,
+                    &ctx,
                     factory_data,
                     &state.factory_once_configs,
-                    &state.base_output_dir,
-                    &state.existing_files,
                     &empty_index,
-                    decoder_tx,
-                    &chain.name,
-                    storage_manager,
                 )
                 .await?;
             }
@@ -262,40 +213,37 @@ pub(super) async fn process_incomplete_range(
         end: max_block + 1,
     };
 
+    let ctx = EthCallContext {
+        client,
+        output_dir: &state.base_output_dir,
+        existing_files: &state.existing_files,
+        rpc_batch_size: state.rpc_batch_size,
+        decoder_tx,
+        chain_name: &chain.name,
+        storage_manager,
+        s3_manifest: &state.s3_manifest,
+    };
+
     if state.has_regular_calls && !state.range_regular_done.contains(&range_start) {
         if let Some(multicall_addr) = state.multicall3_address {
             process_range_multicall(
                 &range,
                 blocks.clone(),
-                client,
+                &ctx,
                 &state.call_configs,
-                &state.base_output_dir,
-                &state.existing_files,
-                &state.s3_manifest,
-                state.rpc_batch_size,
                 state.max_params,
                 &mut state.frequency_state,
                 multicall_addr,
-                decoder_tx,
-                &chain.name,
-                storage_manager,
             )
             .await?;
         } else {
             process_range(
                 &range,
                 blocks.clone(),
-                client,
+                &ctx,
                 &state.call_configs,
-                &state.base_output_dir,
-                &state.existing_files,
-                &state.s3_manifest,
-                state.rpc_batch_size,
                 state.max_params,
                 &mut state.frequency_state,
-                decoder_tx,
-                &chain.name,
-                storage_manager,
             )
             .await?;
         }
@@ -306,31 +254,19 @@ pub(super) async fn process_incomplete_range(
             process_token_range_multicall(
                 &range,
                 blocks.clone(),
-                client,
+                &ctx,
                 &state.token_call_configs,
-                &state.base_output_dir,
-                &state.existing_files,
-                state.rpc_batch_size,
                 &mut state.frequency_state,
                 multicall_addr,
-                decoder_tx,
-                &chain.name,
-                storage_manager,
             )
             .await?;
         } else {
             process_token_range(
                 &range,
                 blocks.clone(),
-                client,
+                &ctx,
                 &state.token_call_configs,
-                &state.base_output_dir,
-                &state.existing_files,
-                state.rpc_batch_size,
                 &mut state.frequency_state,
-                decoder_tx,
-                &chain.name,
-                storage_manager,
             )
             .await?;
         }
@@ -341,30 +277,19 @@ pub(super) async fn process_incomplete_range(
             process_once_calls_multicall(
                 &range,
                 &blocks,
-                client,
+                &ctx,
                 &state.once_configs,
                 &chain.contracts,
-                &state.base_output_dir,
-                &state.existing_files,
                 multicall_addr,
-                state.rpc_batch_size,
-                decoder_tx,
-                &chain.name,
-                storage_manager,
             )
             .await?;
         } else {
             process_once_calls_regular(
                 &range,
                 &blocks,
-                client,
+                &ctx,
                 &state.once_configs,
                 &chain.contracts,
-                &state.base_output_dir,
-                &state.existing_files,
-                decoder_tx,
-                &chain.name,
-                storage_manager,
             )
             .await?;
         }
@@ -377,35 +302,23 @@ pub(super) async fn process_incomplete_range(
                     process_factory_range_multicall(
                         &range,
                         &blocks,
-                        client,
+                        &ctx,
                         factory_data,
                         &state.factory_call_configs,
-                        &state.base_output_dir,
-                        &state.existing_files,
-                        state.rpc_batch_size,
                         state.factory_max_params,
                         &mut state.frequency_state,
                         multicall_addr,
-                        decoder_tx,
-                        &chain.name,
-                        storage_manager,
                     )
                     .await?;
                 } else {
                     process_factory_range(
                         &range,
                         &blocks,
-                        client,
+                        &ctx,
                         factory_data,
                         &state.factory_call_configs,
-                        &state.base_output_dir,
-                        &state.existing_files,
-                        state.rpc_batch_size,
                         state.factory_max_params,
                         &mut state.frequency_state,
-                        decoder_tx,
-                        &chain.name,
-                        storage_manager,
                     )
                     .await?;
                 }
@@ -415,31 +328,20 @@ pub(super) async fn process_incomplete_range(
                     if let Some(multicall_addr) = state.multicall3_address {
                         process_factory_once_calls_multicall(
                             &range,
-                            client,
+                            &ctx,
                             factory_data,
                             &state.factory_once_configs,
-                            &state.base_output_dir,
-                            &state.existing_files,
                             &empty_index,
                             multicall_addr,
-                            state.rpc_batch_size,
-                            decoder_tx,
-                            &chain.name,
-                            storage_manager,
                         )
                         .await?;
                     } else {
                         process_factory_once_calls(
                             &range,
-                            client,
+                            &ctx,
                             factory_data,
                             &state.factory_once_configs,
-                            &state.base_output_dir,
-                            &state.existing_files,
                             &empty_index,
-                            decoder_tx,
-                            &chain.name,
-                            storage_manager,
                         )
                         .await?;
                     }

--- a/src/raw_data/historical/eth_calls/event_triggers.rs
+++ b/src/raw_data/historical/eth_calls/event_triggers.rs
@@ -14,17 +14,16 @@ use arrow::record_batch::RecordBatch;
 use futures::{stream, StreamExt, TryStreamExt};
 use parquet::arrow::ArrowWriter;
 use parquet::file::properties::WriterProperties;
-use tokio::sync::mpsc::Sender;
 
 use super::config::compute_function_selector;
 use super::types::{
-    EthCallCollectionError, EventCallKey, EventCallResult, EventTriggeredCallConfig,
+    EthCallCollectionError, EthCallContext, EventCallKey, EventCallResult,
+    EventTriggeredCallConfig,
 };
 use super::{execute_multicalls_generic, BlockMulticall, EventCallMeta, MulticallSlotGeneric};
 use crate::decoding::{DecoderMessage, EventCallResult as DecoderEventCallResult};
 use crate::raw_data::historical::receipts::EventTriggerData;
-use crate::rpc::UnifiedRpcClient;
-use crate::storage::{upload_parquet_to_s3, StorageManager};
+use crate::storage::upload_parquet_to_s3;
 use crate::types::config::contract::{AddressOrAddresses, Contracts};
 use crate::types::config::eth_call::{encode_call_with_params, EvmType, ParamConfig};
 
@@ -481,14 +480,9 @@ pub(crate) async fn process_event_triggers(
     triggers: Vec<EventTriggerData>,
     event_call_configs: &HashMap<EventCallKey, Vec<EventTriggeredCallConfig>>,
     factory_addresses: &HashMap<String, HashSet<Address>>,
-    client: &UnifiedRpcClient,
-    output_dir: &Path,
-    rpc_batch_size: usize,
-    decoder_tx: &Option<Sender<DecoderMessage>>,
+    ctx: &EthCallContext<'_>,
     range_start: u64,
     range_end: u64,
-    chain_name: &str,
-    storage_manager: Option<&Arc<StorageManager>>,
 ) -> Result<(), EthCallCollectionError> {
     // Collect all configured (contract_name, function_name) pairs so we can write empty files
     // for pairs with no matching events (prevents catchup from retrying)
@@ -502,7 +496,7 @@ pub(crate) async fn process_event_triggers(
         // Write empty files for all configured pairs
         for (contract_name, function_name) in &configured_pairs {
             write_empty_event_call_file(
-                output_dir,
+                ctx.output_dir,
                 contract_name,
                 function_name,
                 range_start,
@@ -673,7 +667,7 @@ pub(crate) async fn process_event_triggers(
                 Vec<Vec<u8>>,
             )>,
         > = pending_calls
-            .chunks(rpc_batch_size)
+            .chunks(ctx.rpc_batch_size)
             .map(|chunk| {
                 chunk
                     .iter()
@@ -700,7 +694,7 @@ pub(crate) async fn process_event_triggers(
                         .map(|(tx, block_id, _, _, _)| (tx.clone(), *block_id))
                         .collect();
 
-                    let results = client.call_batch(batch_calls).await?;
+                    let results = ctx.client.call_batch(batch_calls).await?;
 
                     let mut chunk_results = Vec::with_capacity(results.len());
                     for (i, result) in results.into_iter().enumerate() {
@@ -747,7 +741,7 @@ pub(crate) async fn process_event_triggers(
 
         // Write to parquet and send to decoder
         if !all_results.is_empty() {
-            let sub_dir = output_dir
+            let sub_dir = ctx.output_dir
                 .join(&contract_name)
                 .join(&function_name)
                 .join("on_events");
@@ -768,7 +762,7 @@ pub(crate) async fn process_event_triggers(
             );
 
             // Upload to S3 if configured
-            if let Some(sm) = storage_manager {
+            if let Some(sm) = ctx.storage_manager {
                 let data_type = format!(
                     "raw/eth_calls/{}/{}/on_events",
                     contract_name, function_name
@@ -776,7 +770,7 @@ pub(crate) async fn process_event_triggers(
                 upload_parquet_to_s3(
                     sm,
                     &output_path,
-                    chain_name,
+                    ctx.chain_name,
                     &data_type,
                     range_start,
                     range_end,
@@ -786,7 +780,7 @@ pub(crate) async fn process_event_triggers(
             }
 
             // Send to decoder for decoding (range_end + 1 for exclusive convention)
-            if let Some(tx) = decoder_tx {
+            if let Some(tx) = ctx.decoder_tx {
                 let decoder_results: Vec<DecoderEventCallResult> = all_results
                     .iter()
                     .map(|r| DecoderEventCallResult {
@@ -817,7 +811,7 @@ pub(crate) async fn process_event_triggers(
     for (contract_name, function_name) in configured_pairs {
         if !written_pairs.contains(&(contract_name.clone(), function_name.clone())) {
             write_empty_event_call_file(
-                output_dir,
+                ctx.output_dir,
                 &contract_name,
                 &function_name,
                 range_start,
@@ -862,15 +856,10 @@ pub(crate) async fn process_event_triggers_multicall(
     triggers: Vec<EventTriggerData>,
     event_call_configs: &HashMap<EventCallKey, Vec<EventTriggeredCallConfig>>,
     factory_addresses: &HashMap<String, HashSet<Address>>,
-    client: &UnifiedRpcClient,
-    output_dir: &Path,
-    rpc_batch_size: usize,
-    decoder_tx: &Option<Sender<DecoderMessage>>,
+    ctx: &EthCallContext<'_>,
     multicall3_address: Address,
     range_start: u64,
     range_end: u64,
-    chain_name: &str,
-    storage_manager: Option<&Arc<StorageManager>>,
 ) -> Result<(), EthCallCollectionError> {
     // Collect all configured (contract_name, function_name) pairs so we can write empty files
     // for pairs with no matching events (prevents catchup from retrying)
@@ -884,7 +873,7 @@ pub(crate) async fn process_event_triggers_multicall(
         // Write empty files for all configured pairs
         for (contract_name, function_name) in &configured_pairs {
             write_empty_event_call_file(
-                output_dir,
+                ctx.output_dir,
                 contract_name,
                 function_name,
                 range_start,
@@ -1063,7 +1052,7 @@ pub(crate) async fn process_event_triggers_multicall(
 
     // Execute all multicalls
     let results =
-        execute_multicalls_generic(client, multicall3_address, block_multicalls, rpc_batch_size)
+        execute_multicalls_generic(ctx.client, multicall3_address, block_multicalls, ctx.rpc_batch_size)
             .await?;
 
     // Distribute results back to groups
@@ -1096,7 +1085,7 @@ pub(crate) async fn process_event_triggers_multicall(
         // Sort by block number, log index
         results.sort_by_key(|r| (r.block_number, r.log_index, r.target_address));
 
-        let sub_dir = output_dir
+        let sub_dir = ctx.output_dir
             .join(&contract_name)
             .join(&function_name)
             .join("on_events");
@@ -1122,7 +1111,7 @@ pub(crate) async fn process_event_triggers_multicall(
         );
 
         // Upload to S3 if configured
-        if let Some(sm) = storage_manager {
+        if let Some(sm) = ctx.storage_manager {
             let data_type = format!(
                 "raw/eth_calls/{}/{}/on_events",
                 contract_name, function_name
@@ -1130,7 +1119,7 @@ pub(crate) async fn process_event_triggers_multicall(
             upload_parquet_to_s3(
                 sm,
                 &output_path,
-                chain_name,
+                ctx.chain_name,
                 &data_type,
                 range_start,
                 range_end,
@@ -1140,7 +1129,7 @@ pub(crate) async fn process_event_triggers_multicall(
         }
 
         // Send to decoder (range_end + 1 for exclusive convention)
-        if let Some(tx) = decoder_tx {
+        if let Some(tx) = ctx.decoder_tx {
             let decoder_results: Vec<DecoderEventCallResult> = results
                 .iter()
                 .map(|r| DecoderEventCallResult {
@@ -1170,7 +1159,7 @@ pub(crate) async fn process_event_triggers_multicall(
     for (contract_name, function_name) in configured_pairs {
         if !written_pairs.contains(&(contract_name.clone(), function_name.clone())) {
             write_empty_event_call_file(
-                output_dir,
+                ctx.output_dir,
                 &contract_name,
                 &function_name,
                 range_start,

--- a/src/raw_data/historical/eth_calls/execution.rs
+++ b/src/raw_data/historical/eth_calls/execution.rs
@@ -2,8 +2,6 @@
 
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
 #[cfg(feature = "bench")]
 use std::time::Instant;
 
@@ -13,7 +11,6 @@ use alloy::rpc::types::{BlockId, BlockNumberOrTag, TransactionRequest};
 use futures::{stream, StreamExt, TryStreamExt};
 use parquet::arrow::ArrowWriter;
 use parquet::file::properties::WriterProperties;
-use tokio::sync::mpsc::Sender;
 
 use super::config::{compute_function_selector, generate_param_combinations};
 use super::event_triggers::encode_once_call_params;
@@ -25,32 +22,27 @@ use super::parquet_io::{
     write_results_to_parquet,
 };
 use super::types::{
-    BlockInfo, BlockRange, CallConfig, CallResult, EthCallCollectionError, FrequencyState,
-    OnceCallConfig, OnceCallResult, TokenCallConfig,
+    AddressResults, BlockInfo, BlockRange, CallConfig, CallResult, CollectionResults,
+    ContractProcessingInfo, EthCallCollectionError, EthCallContext, FactoryContractProcessingInfo,
+    FrequencyState, OnceCallConfig, OnceCallResult, TokenCallConfig,
 };
 use crate::decoding::{
     DecoderMessage, EthCallResult as DecoderEthCallResult, OnceCallResult as DecoderOnceCallResult,
 };
 use crate::raw_data::historical::factories::FactoryAddressData;
 use crate::rpc::UnifiedRpcClient;
-use crate::storage::{upload_parquet_to_s3, S3Manifest, StorageManager};
+use crate::storage::upload_parquet_to_s3;
 use crate::types::config::contract::{AddressOrAddresses, Contracts};
 use crate::types::config::eth_call::{encode_call_with_params, EthCallConfig, Frequency};
 
 pub(crate) async fn process_factory_range(
     range: &BlockRange,
     blocks: &[BlockInfo],
-    client: &UnifiedRpcClient,
+    ctx: &EthCallContext<'_>,
     factory_data: &FactoryAddressData,
     factory_call_configs: &HashMap<String, Vec<EthCallConfig>>,
-    output_dir: &Path,
-    existing_files: &HashSet<String>,
-    rpc_batch_size: usize,
     max_params: usize,
     frequency_state: &mut FrequencyState,
-    decoder_tx: &Option<Sender<DecoderMessage>>,
-    chain_name: &str,
-    storage_manager: Option<&Arc<StorageManager>>,
 ) -> Result<(), EthCallCollectionError> {
     let mut addresses_by_collection: HashMap<String, HashSet<Address>> = HashMap::new();
     for addrs in factory_data.addresses_by_block.values() {
@@ -84,7 +76,7 @@ pub(crate) async fn process_factory_range(
             let file_name = range.file_name("");
             let rel_path = format!("{}/{}/{}", collection_name, function_name, file_name);
 
-            if existing_files.contains(&rel_path) {
+            if ctx.existing_files.contains(&rel_path) {
                 tracing::debug!(
                     "Skipping factory eth_calls for {}.{} blocks {}-{} (already exists)",
                     collection_name,
@@ -181,7 +173,7 @@ pub(crate) async fn process_factory_range(
                 }
             }
 
-            for chunk in pending_calls.chunks(rpc_batch_size) {
+            for chunk in pending_calls.chunks(ctx.rpc_batch_size) {
                 let calls: Vec<(TransactionRequest, BlockId)> = chunk
                     .iter()
                     .map(|(tx, block_id, _, _)| (tx.clone(), *block_id))
@@ -189,7 +181,7 @@ pub(crate) async fn process_factory_range(
 
                 #[cfg(feature = "bench")]
                 let rpc_start = Instant::now();
-                let results = client.call_batch(calls).await?;
+                let results = ctx.client.call_batch(calls).await?;
                 #[cfg(feature = "bench")]
                 {
                     rpc_time += rpc_start.elapsed();
@@ -238,11 +230,11 @@ pub(crate) async fn process_factory_range(
                 .sort_by_key(|r| (r.block_number, r.contract_address, r.param_values.clone()));
 
             let result_count = all_results.len();
-            let sub_dir = output_dir.join(collection_name).join(&function_name);
+            let sub_dir = ctx.output_dir.join(collection_name).join(&function_name);
             std::fs::create_dir_all(&sub_dir)?;
             let output_path = sub_dir.join(&file_name);
 
-            let decoder_results: Option<Vec<DecoderEthCallResult>> = if decoder_tx.is_some() {
+            let decoder_results: Option<Vec<DecoderEthCallResult>> = if ctx.decoder_tx.is_some() {
                 Some(
                     all_results
                         .iter()
@@ -287,12 +279,12 @@ pub(crate) async fn process_factory_range(
             );
 
             // Upload to S3 if configured
-            if let Some(sm) = storage_manager {
+            if let Some(sm) = ctx.storage_manager {
                 let data_type = format!("raw/eth_calls/{}/{}", collection_name, function_name);
                 upload_parquet_to_s3(
                     sm,
                     &output_path_for_upload,
-                    chain_name,
+                    ctx.chain_name,
                     &data_type,
                     range.start,
                     range.end - 1,
@@ -301,7 +293,7 @@ pub(crate) async fn process_factory_range(
                 .map_err(|e| EthCallCollectionError::Io(std::io::Error::other(e.to_string())))?;
             }
 
-            if let Some(tx) = decoder_tx {
+            if let Some(tx) = ctx.decoder_tx {
                 if let Some(results) = decoder_results {
                     let _ = tx
                         .send(DecoderMessage::EthCallsReady {
@@ -335,18 +327,12 @@ pub(crate) async fn process_factory_range(
 pub(crate) async fn process_factory_range_multicall(
     range: &BlockRange,
     blocks: &[BlockInfo],
-    client: &UnifiedRpcClient,
+    ctx: &EthCallContext<'_>,
     factory_data: &FactoryAddressData,
     factory_call_configs: &HashMap<String, Vec<EthCallConfig>>,
-    output_dir: &Path,
-    existing_files: &HashSet<String>,
-    rpc_batch_size: usize,
     max_params: usize,
     frequency_state: &mut FrequencyState,
     multicall3_address: Address,
-    decoder_tx: &Option<Sender<DecoderMessage>>,
-    chain_name: &str,
-    storage_manager: Option<&Arc<StorageManager>>,
 ) -> Result<(), EthCallCollectionError> {
     // Collect factory addresses by collection
     let mut addresses_by_collection: HashMap<String, HashSet<Address>> = HashMap::new();
@@ -392,7 +378,7 @@ pub(crate) async fn process_factory_range_multicall(
             let file_name = range.file_name("");
             let rel_path = format!("{}/{}/{}", collection_name, function_name, file_name);
 
-            if existing_files.contains(&rel_path) {
+            if ctx.existing_files.contains(&rel_path) {
                 tracing::debug!(
                     "Skipping factory eth_calls for {}.{} blocks {}-{} (already exists)",
                     collection_name,
@@ -533,7 +519,7 @@ pub(crate) async fn process_factory_range_multicall(
 
     // Execute all multicalls
     let results =
-        execute_multicalls_generic(client, multicall3_address, block_multicalls, rpc_batch_size)
+        execute_multicalls_generic(ctx.client, multicall3_address, block_multicalls, ctx.rpc_batch_size)
             .await?;
 
     // Distribute results back to groups
@@ -566,13 +552,13 @@ pub(crate) async fn process_factory_range_multicall(
 
             let result_count = results.len();
             let file_name = range.file_name("");
-            let sub_dir = output_dir
+            let sub_dir = ctx.output_dir
                 .join(&group.collection_name)
                 .join(&group.function_name);
             std::fs::create_dir_all(&sub_dir)?;
             let output_path = sub_dir.join(&file_name);
 
-            let decoder_results: Option<Vec<DecoderEthCallResult>> = if decoder_tx.is_some() {
+            let decoder_results: Option<Vec<DecoderEthCallResult>> = if ctx.decoder_tx.is_some() {
                 Some(
                     results
                         .iter()
@@ -603,7 +589,7 @@ pub(crate) async fn process_factory_range_multicall(
             );
 
             // Upload to S3 if configured
-            if let Some(sm) = storage_manager {
+            if let Some(sm) = ctx.storage_manager {
                 let data_type = format!(
                     "raw/eth_calls/{}/{}",
                     group.collection_name, group.function_name
@@ -611,7 +597,7 @@ pub(crate) async fn process_factory_range_multicall(
                 upload_parquet_to_s3(
                     sm,
                     &output_path_for_upload,
-                    chain_name,
+                    ctx.chain_name,
                     &data_type,
                     range.start,
                     range.end - 1,
@@ -620,7 +606,7 @@ pub(crate) async fn process_factory_range_multicall(
                 .map_err(|e| EthCallCollectionError::Io(std::io::Error::other(e.to_string())))?;
             }
 
-            if let Some(tx) = decoder_tx {
+            if let Some(tx) = ctx.decoder_tx {
                 if let Some(results) = decoder_results {
                     let _ = tx
                         .send(DecoderMessage::EthCallsReady {
@@ -652,14 +638,9 @@ pub(crate) async fn process_factory_range_multicall(
 pub(crate) async fn process_once_calls_regular(
     range: &BlockRange,
     blocks: &[BlockInfo],
-    client: &UnifiedRpcClient,
+    ctx: &EthCallContext<'_>,
     once_configs: &HashMap<String, Vec<OnceCallConfig>>,
     contracts: &Contracts,
-    output_dir: &Path,
-    existing_files: &HashSet<String>,
-    decoder_tx: &Option<Sender<DecoderMessage>>,
-    chain_name: &str,
-    storage_manager: Option<&Arc<StorageManager>>,
 ) -> Result<(), EthCallCollectionError> {
     let first_block = match blocks.first() {
         Some(b) => b,
@@ -673,7 +654,7 @@ pub(crate) async fn process_once_calls_regular(
 
         let file_name = range.file_name("");
         let rel_path = format!("{}/once/{}", contract_name, file_name);
-        let sub_dir = output_dir.join(contract_name).join("once");
+        let sub_dir = ctx.output_dir.join(contract_name).join("once");
         let output_path = sub_dir.join(&file_name);
 
         // Determine which function calls are missing from the existing file
@@ -683,7 +664,7 @@ pub(crate) async fn process_once_calls_regular(
             .collect();
 
         let (missing_fn_names, has_existing_file, null_entries) =
-            if existing_files.contains(&rel_path) {
+            if ctx.existing_files.contains(&rel_path) {
                 let index = read_once_column_index(&sub_dir);
                 let existing_cols: HashSet<String> = if let Some(cols) = index.get(&file_name) {
                     cols.iter().cloned().collect()
@@ -838,7 +819,7 @@ pub(crate) async fn process_once_calls_regular(
             .map(|(tx, bid, _, _)| (tx.clone(), *bid))
             .collect();
 
-        let batch_results = client.call_batch(batch_calls).await?;
+        let batch_results = ctx.client.call_batch(batch_calls).await?;
 
         let mut results_by_address: HashMap<Address, HashMap<String, Vec<u8>>> = HashMap::new();
 
@@ -874,7 +855,7 @@ pub(crate) async fn process_once_calls_regular(
 
         std::fs::create_dir_all(&sub_dir)?;
 
-        let decoder_once_results: Option<Vec<DecoderOnceCallResult>> = if decoder_tx.is_some() {
+        let decoder_once_results: Option<Vec<DecoderOnceCallResult>> = if ctx.decoder_tx.is_some() {
             Some(
                 results_by_address
                     .iter()
@@ -961,12 +942,12 @@ pub(crate) async fn process_once_calls_regular(
         }
 
         // Upload to S3 if configured
-        if let Some(sm) = storage_manager {
+        if let Some(sm) = ctx.storage_manager {
             let data_type = format!("raw/eth_calls/{}/once", contract_name);
             upload_parquet_to_s3(
                 sm,
                 &output_path,
-                chain_name,
+                ctx.chain_name,
                 &data_type,
                 range.start,
                 range.end - 1,
@@ -990,7 +971,7 @@ pub(crate) async fn process_once_calls_regular(
             actual_cols
         );
 
-        if let Some(tx) = decoder_tx {
+        if let Some(tx) = ctx.decoder_tx {
             if let Some(results) = decoder_once_results {
                 let _ = tx
                     .send(DecoderMessage::OnceCallsReady {
@@ -1011,15 +992,10 @@ pub(crate) async fn process_once_calls_regular(
 
 pub(crate) async fn process_factory_once_calls(
     range: &BlockRange,
-    client: &UnifiedRpcClient,
+    ctx: &EthCallContext<'_>,
     factory_data: &FactoryAddressData,
     once_configs: &HashMap<String, Vec<OnceCallConfig>>,
-    output_dir: &Path,
-    existing_files: &HashSet<String>,
     column_indexes: &HashMap<String, HashMap<String, Vec<String>>>,
-    decoder_tx: &Option<Sender<DecoderMessage>>,
-    chain_name: &str,
-    storage_manager: Option<&Arc<StorageManager>>,
 ) -> Result<(), EthCallCollectionError> {
     for (collection_name, call_configs) in once_configs {
         if call_configs.is_empty() {
@@ -1028,7 +1004,7 @@ pub(crate) async fn process_factory_once_calls(
 
         let file_name = range.file_name("");
         let rel_path = format!("{}/once/{}", collection_name, file_name);
-        let sub_dir = output_dir.join(collection_name).join("once");
+        let sub_dir = ctx.output_dir.join(collection_name).join("once");
         let output_path = sub_dir.join(&file_name);
 
         let all_fn_names: Vec<String> = call_configs
@@ -1036,7 +1012,7 @@ pub(crate) async fn process_factory_once_calls(
             .map(|c| c.function_name.clone())
             .collect();
 
-        let (missing_fn_names, has_existing_file, null_entries) = if existing_files
+        let (missing_fn_names, has_existing_file, null_entries) = if ctx.existing_files
             .contains(&rel_path)
         {
             let index = column_indexes.get(collection_name);
@@ -1141,7 +1117,7 @@ pub(crate) async fn process_factory_once_calls(
             let mut index = read_once_column_index(&sub_dir);
             index.insert(file_name.clone(), all_fn_names.clone());
             write_once_column_index(&sub_dir, &index)?;
-            if let Some(tx) = decoder_tx {
+            if let Some(tx) = ctx.decoder_tx {
                 let _ = tx
                     .send(DecoderMessage::OnceFileBackfilled {
                         range_start: range.start,
@@ -1241,10 +1217,9 @@ pub(crate) async fn process_factory_once_calls(
                     .map(|(tx, bid, _, _, _, _)| (tx.clone(), *bid))
                     .collect();
 
-                let batch_results = client.call_batch(batch_calls).await?;
+                let batch_results = ctx.client.call_batch(batch_calls).await?;
 
-                let mut results_map: HashMap<Address, (u64, u64, HashMap<String, Vec<u8>>)> =
-                    HashMap::new();
+                let mut results_map: AddressResults = HashMap::new();
 
                 for (i, result) in batch_results.into_iter().enumerate() {
                     let (tx, _, address, block_number, timestamp, function_name) =
@@ -1373,7 +1348,7 @@ pub(crate) async fn process_factory_once_calls(
                         .map(|(tx, bid, _, _)| (tx.clone(), *bid))
                         .collect();
 
-                    let batch_results = client.call_batch(batch_calls).await?;
+                    let batch_results = ctx.client.call_batch(batch_calls).await?;
 
                     for (i, result) in batch_results.into_iter().enumerate() {
                         let (_, _, addr_bytes, function_name) = &backfill_calls[i];
@@ -1446,12 +1421,12 @@ pub(crate) async fn process_factory_once_calls(
         }
 
         // Upload to S3 if configured
-        if let Some(sm) = storage_manager {
+        if let Some(sm) = ctx.storage_manager {
             let data_type = format!("raw/eth_calls/{}/once", collection_name);
             upload_parquet_to_s3(
                 sm,
                 &output_path,
-                chain_name,
+                ctx.chain_name,
                 &data_type,
                 range.start,
                 range.end - 1,
@@ -1476,7 +1451,7 @@ pub(crate) async fn process_factory_once_calls(
         );
 
         // Notify decoder that this file was updated so it can decode new columns
-        if let Some(tx) = decoder_tx {
+        if let Some(tx) = ctx.decoder_tx {
             let _ = tx
                 .send(DecoderMessage::OnceFileBackfilled {
                     range_start: range.start,
@@ -1494,16 +1469,10 @@ pub(crate) async fn process_factory_once_calls(
 pub(crate) async fn process_once_calls_multicall(
     range: &BlockRange,
     blocks: &[BlockInfo],
-    client: &UnifiedRpcClient,
+    ctx: &EthCallContext<'_>,
     once_configs: &HashMap<String, Vec<OnceCallConfig>>,
     contracts: &Contracts,
-    output_dir: &Path,
-    existing_files: &HashSet<String>,
     multicall3_address: Address,
-    rpc_batch_size: usize,
-    decoder_tx: &Option<Sender<DecoderMessage>>,
-    chain_name: &str,
-    storage_manager: Option<&Arc<StorageManager>>,
 ) -> Result<(), EthCallCollectionError> {
     let first_block = match blocks.first() {
         Some(b) => b,
@@ -1511,15 +1480,7 @@ pub(crate) async fn process_once_calls_multicall(
     };
 
     let mut all_slots: Vec<MulticallSlotGeneric<OnceCallMeta>> = Vec::new();
-    // (contract_name, all_fn_names, missing_fn_names, patch_fn_names, output_path, has_existing_file)
-    let mut contracts_to_process: Vec<(
-        String,
-        Vec<String>,
-        Vec<String>,
-        Vec<String>,
-        PathBuf,
-        bool,
-    )> = Vec::new();
+    let mut contracts_to_process: Vec<ContractProcessingInfo> = Vec::new();
 
     for (contract_name, call_configs) in once_configs {
         if call_configs.is_empty() {
@@ -1528,7 +1489,7 @@ pub(crate) async fn process_once_calls_multicall(
 
         let file_name = range.file_name("");
         let rel_path = format!("{}/once/{}", contract_name, file_name);
-        let sub_dir = output_dir.join(contract_name).join("once");
+        let sub_dir = ctx.output_dir.join(contract_name).join("once");
         let output_path = sub_dir.join(&file_name);
 
         let all_fn_names: Vec<String> = call_configs
@@ -1537,7 +1498,7 @@ pub(crate) async fn process_once_calls_multicall(
             .collect();
 
         let (missing_fn_names, has_existing_file, null_entries) =
-            if existing_files.contains(&rel_path) {
+            if ctx.existing_files.contains(&rel_path) {
                 let index = read_once_column_index(&sub_dir);
                 let existing_cols: HashSet<String> = if let Some(cols) = index.get(&file_name) {
                     cols.iter().cloned().collect()
@@ -1666,14 +1627,14 @@ pub(crate) async fn process_once_calls_multicall(
         }
 
         let patch_fn_names: Vec<String> = null_entries.keys().cloned().collect();
-        contracts_to_process.push((
-            contract_name.clone(),
+        contracts_to_process.push(ContractProcessingInfo {
+            name: contract_name.clone(),
             all_fn_names,
             missing_fn_names,
             patch_fn_names,
             output_path,
             has_existing_file,
-        ));
+        });
     }
 
     if all_slots.is_empty() {
@@ -1695,7 +1656,7 @@ pub(crate) async fn process_once_calls_multicall(
 
     // Execute multicall
     let results =
-        execute_multicalls_generic(client, multicall3_address, block_multicalls, rpc_batch_size)
+        execute_multicalls_generic(ctx.client, multicall3_address, block_multicalls, ctx.rpc_batch_size)
             .await?;
 
     // Group results by contract_name -> address -> function_name -> value
@@ -1712,20 +1673,20 @@ pub(crate) async fn process_once_calls_multicall(
     }
 
     // Write parquet for each contract
-    for (
-        contract_name,
+    for ContractProcessingInfo {
+        name: contract_name,
         all_fn_names,
         missing_fn_names,
         patch_fn_names,
         output_path,
         has_existing_file,
-    ) in contracts_to_process
+    } in contracts_to_process
     {
         let sub_dir = output_path.parent().unwrap();
         std::fs::create_dir_all(sub_dir)?;
 
         if let Some(results_by_address) = results_by_contract.remove(&contract_name) {
-            let decoder_once_results: Option<Vec<DecoderOnceCallResult>> = if decoder_tx.is_some() {
+            let decoder_once_results: Option<Vec<DecoderOnceCallResult>> = if ctx.decoder_tx.is_some() {
                 Some(
                     results_by_address
                         .iter()
@@ -1797,12 +1758,12 @@ pub(crate) async fn process_once_calls_multicall(
             }
 
             // Upload to S3 if configured
-            if let Some(sm) = storage_manager {
+            if let Some(sm) = ctx.storage_manager {
                 let data_type = format!("raw/eth_calls/{}/once", contract_name);
                 upload_parquet_to_s3(
                     sm,
                     &output_path,
-                    chain_name,
+                    ctx.chain_name,
                     &data_type,
                     range.start,
                     range.end - 1,
@@ -1824,7 +1785,7 @@ pub(crate) async fn process_once_calls_multicall(
             index.insert(file_name.clone(), actual_cols.clone());
             write_once_column_index(sub_dir, &index)?;
 
-            if let Some(tx) = decoder_tx {
+            if let Some(tx) = ctx.decoder_tx {
                 if let Some(results) = decoder_once_results {
                     let _ = tx
                         .send(DecoderMessage::OnceCallsReady {
@@ -1847,17 +1808,11 @@ pub(crate) async fn process_once_calls_multicall(
 /// Process factory once calls using Multicall3 aggregate3
 pub(crate) async fn process_factory_once_calls_multicall(
     range: &BlockRange,
-    client: &UnifiedRpcClient,
+    ctx: &EthCallContext<'_>,
     factory_data: &FactoryAddressData,
     once_configs: &HashMap<String, Vec<OnceCallConfig>>,
-    output_dir: &Path,
-    existing_files: &HashSet<String>,
     column_indexes: &HashMap<String, HashMap<String, Vec<String>>>,
     multicall3_address: Address,
-    rpc_batch_size: usize,
-    decoder_tx: &Option<Sender<DecoderMessage>>,
-    chain_name: &str,
-    storage_manager: Option<&Arc<StorageManager>>,
 ) -> Result<(), EthCallCollectionError> {
     // Collect all calls across all collections into one multicall
     #[derive(Clone)]
@@ -1870,16 +1825,7 @@ pub(crate) async fn process_factory_once_calls_multicall(
     }
 
     let mut all_slots: Vec<MulticallSlotGeneric<FactoryOnceSlotMeta>> = Vec::new();
-    // (collection_name, all_fn_names, missing_fn_names, patch_fn_names, output_path, has_existing_file, configs_to_call)
-    let mut collections_to_process: Vec<(
-        String,
-        Vec<String>,
-        Vec<String>,
-        Vec<String>,
-        PathBuf,
-        bool,
-        Vec<OnceCallConfig>,
-    )> = Vec::new();
+    let mut collections_to_process: Vec<FactoryContractProcessingInfo> = Vec::new();
 
     for (collection_name, call_configs) in once_configs {
         if call_configs.is_empty() {
@@ -1888,7 +1834,7 @@ pub(crate) async fn process_factory_once_calls_multicall(
 
         let file_name = range.file_name("");
         let rel_path = format!("{}/once/{}", collection_name, file_name);
-        let sub_dir = output_dir.join(collection_name).join("once");
+        let sub_dir = ctx.output_dir.join(collection_name).join("once");
         let output_path = sub_dir.join(&file_name);
 
         let all_fn_names: Vec<String> = call_configs
@@ -1897,7 +1843,7 @@ pub(crate) async fn process_factory_once_calls_multicall(
             .collect();
 
         let (missing_fn_names, has_existing_file, null_entries) =
-            if existing_files.contains(&rel_path) {
+            if ctx.existing_files.contains(&rel_path) {
                 let index = column_indexes.get(collection_name);
                 let indexed_cols: HashSet<String> = index
                     .and_then(|idx| idx.get(&file_name))
@@ -2057,30 +2003,27 @@ pub(crate) async fn process_factory_once_calls_multicall(
 
         // Always add to collections_to_process - even with empty address_discovery,
         // existing files may need backfill for missing columns
-        collections_to_process.push((
-            collection_name.clone(),
+        collections_to_process.push(FactoryContractProcessingInfo {
+            name: collection_name.clone(),
             all_fn_names,
             missing_fn_names,
             patch_fn_names,
             output_path,
             has_existing_file,
-            configs_for_backfill,
-        ));
+            once_configs: configs_for_backfill,
+        });
     }
 
     // Skip multicall execution only if there are no slots AND no collections need backfill
     let any_need_backfill = collections_to_process
         .iter()
-        .any(|(_, _, _, _, _, has_existing, _)| *has_existing);
+        .any(|info| info.has_existing_file);
     if all_slots.is_empty() && !any_need_backfill {
         return Ok(());
     }
 
     // Group results by collection_name -> address -> (block_num, timestamp, function_results)
-    let mut results_by_collection: HashMap<
-        String,
-        HashMap<Address, (u64, u64, HashMap<String, Vec<u8>>)>,
-    > = HashMap::new();
+    let mut results_by_collection: CollectionResults = HashMap::new();
 
     // Execute multicalls only if there are slots to process
     if !all_slots.is_empty() {
@@ -2112,10 +2055,10 @@ pub(crate) async fn process_factory_once_calls_multicall(
 
         // Execute multicalls
         let results = execute_multicalls_generic(
-            client,
+            ctx.client,
             multicall3_address,
             block_multicalls,
-            rpc_batch_size,
+            ctx.rpc_batch_size,
         )
         .await?;
 
@@ -2130,15 +2073,15 @@ pub(crate) async fn process_factory_once_calls_multicall(
     }
 
     // Write parquet for each collection
-    for (
-        collection_name,
+    for FactoryContractProcessingInfo {
+        name: collection_name,
         all_fn_names,
         missing_fn_names,
         patch_fn_names,
         output_path,
         has_existing_file,
-        configs_to_call,
-    ) in collections_to_process
+        once_configs: configs_to_call,
+    } in collections_to_process
     {
         let sub_dir = output_path.parent().unwrap();
         std::fs::create_dir_all(sub_dir)?;
@@ -2264,10 +2207,10 @@ pub(crate) async fn process_factory_once_calls_multicall(
                                 .collect();
 
                         let backfill_results = execute_multicalls_generic(
-                            client,
+                            ctx.client,
                             multicall3_address,
                             backfill_multicalls,
-                            rpc_batch_size,
+                            ctx.rpc_batch_size,
                         )
                         .await?;
 
@@ -2328,12 +2271,12 @@ pub(crate) async fn process_factory_once_calls_multicall(
             }
 
             // Upload to S3 if configured
-            if let Some(sm) = storage_manager {
+            if let Some(sm) = ctx.storage_manager {
                 let data_type = format!("raw/eth_calls/{}/once", collection_name);
                 upload_parquet_to_s3(
                     sm,
                     &output_path,
-                    chain_name,
+                    ctx.chain_name,
                     &data_type,
                     range.start,
                     range.end - 1,
@@ -2355,7 +2298,7 @@ pub(crate) async fn process_factory_once_calls_multicall(
             index.insert(file_name.clone(), actual_cols.clone());
             write_once_column_index(sub_dir, &index)?;
 
-            if let Some(tx) = decoder_tx {
+            if let Some(tx) = ctx.decoder_tx {
                 let _ = tx
                     .send(DecoderMessage::OnceFileBackfilled {
                         range_start: range.start,
@@ -2373,17 +2316,10 @@ pub(crate) async fn process_factory_once_calls_multicall(
 pub(crate) async fn process_range(
     range: &BlockRange,
     blocks: Vec<BlockInfo>,
-    client: &UnifiedRpcClient,
+    ctx: &EthCallContext<'_>,
     call_configs: &[CallConfig],
-    output_dir: &Path,
-    existing_files: &HashSet<String>,
-    s3_manifest: &Option<S3Manifest>,
-    rpc_batch_size: usize,
     max_params: usize,
     frequency_state: &mut FrequencyState,
-    decoder_tx: &Option<Sender<DecoderMessage>>,
-    chain_name: &str,
-    storage_manager: Option<&Arc<StorageManager>>,
 ) -> Result<(), EthCallCollectionError> {
     let mut grouped_configs: HashMap<(String, String), Vec<&CallConfig>> = HashMap::new();
     for config in call_configs {
@@ -2397,8 +2333,8 @@ pub(crate) async fn process_range(
         let file_name = range.file_name("");
         let rel_path = format!("{}/{}/{}", contract_name, function_name, file_name);
 
-        if existing_files.contains(&rel_path)
-            || s3_manifest.as_ref().is_some_and(|m| {
+        if ctx.existing_files.contains(&rel_path)
+            || ctx.s3_manifest.as_ref().is_some_and(|m| {
                 m.has_raw_eth_calls_granular(
                     contract_name,
                     function_name,
@@ -2471,7 +2407,7 @@ pub(crate) async fn process_range(
             }
         }
 
-        for chunk in pending_calls.chunks(rpc_batch_size) {
+        for chunk in pending_calls.chunks(ctx.rpc_batch_size) {
             let calls: Vec<(TransactionRequest, BlockId)> = chunk
                 .iter()
                 .map(|(tx, block_id, _, _)| (tx.clone(), *block_id))
@@ -2479,7 +2415,7 @@ pub(crate) async fn process_range(
 
             #[cfg(feature = "bench")]
             let rpc_start = Instant::now();
-            let results = client.call_batch(calls).await?;
+            let results = ctx.client.call_batch(calls).await?;
             #[cfg(feature = "bench")]
             {
                 rpc_time += rpc_start.elapsed();
@@ -2527,11 +2463,11 @@ pub(crate) async fn process_range(
         all_results.sort_by_key(|r| (r.block_number, r.contract_address, r.param_values.clone()));
 
         let result_count = all_results.len();
-        let sub_dir = output_dir.join(contract_name).join(function_name);
+        let sub_dir = ctx.output_dir.join(contract_name).join(function_name);
         std::fs::create_dir_all(&sub_dir)?;
         let output_path = sub_dir.join(&file_name);
 
-        let decoder_results: Option<Vec<DecoderEthCallResult>> = if decoder_tx.is_some() {
+        let decoder_results: Option<Vec<DecoderEthCallResult>> = if ctx.decoder_tx.is_some() {
             Some(
                 all_results
                     .iter()
@@ -2576,12 +2512,12 @@ pub(crate) async fn process_range(
         );
 
         // Upload to S3 if configured
-        if let Some(sm) = storage_manager {
+        if let Some(sm) = ctx.storage_manager {
             let data_type = format!("raw/eth_calls/{}/{}", contract_name, function_name);
             upload_parquet_to_s3(
                 sm,
                 &output_path_for_upload,
-                chain_name,
+                ctx.chain_name,
                 &data_type,
                 range.start,
                 range.end - 1,
@@ -2590,7 +2526,7 @@ pub(crate) async fn process_range(
             .map_err(|e| EthCallCollectionError::Io(std::io::Error::other(e.to_string())))?;
         }
 
-        if let Some(tx) = decoder_tx {
+        if let Some(tx) = ctx.decoder_tx {
             if let Some(results) = decoder_results {
                 let _ = tx
                     .send(DecoderMessage::EthCallsReady {
@@ -2623,18 +2559,11 @@ pub(crate) async fn process_range(
 pub(crate) async fn process_range_multicall(
     range: &BlockRange,
     blocks: Vec<BlockInfo>,
-    client: &UnifiedRpcClient,
+    ctx: &EthCallContext<'_>,
     call_configs: &[CallConfig],
-    output_dir: &Path,
-    existing_files: &HashSet<String>,
-    s3_manifest: &Option<S3Manifest>,
-    rpc_batch_size: usize,
     max_params: usize,
     frequency_state: &mut FrequencyState,
     multicall3_address: Address,
-    decoder_tx: &Option<Sender<DecoderMessage>>,
-    chain_name: &str,
-    storage_manager: Option<&Arc<StorageManager>>,
 ) -> Result<(), EthCallCollectionError> {
     // Group configs by (contract_name, function_name)
     let mut grouped_configs: HashMap<(String, String), Vec<&CallConfig>> = HashMap::new();
@@ -2660,8 +2589,8 @@ pub(crate) async fn process_range_multicall(
         let file_name = range.file_name("");
         let rel_path = format!("{}/{}/{}", contract_name, function_name, file_name);
 
-        if existing_files.contains(&rel_path)
-            || s3_manifest.as_ref().is_some_and(|m| {
+        if ctx.existing_files.contains(&rel_path)
+            || ctx.s3_manifest.as_ref().is_some_and(|m| {
                 m.has_raw_eth_calls_granular(
                     contract_name,
                     function_name,
@@ -2782,7 +2711,7 @@ pub(crate) async fn process_range_multicall(
 
     // Execute all multicalls
     let results =
-        execute_multicalls_generic(client, multicall3_address, block_multicalls, rpc_batch_size)
+        execute_multicalls_generic(ctx.client, multicall3_address, block_multicalls, ctx.rpc_batch_size)
             .await?;
 
     // Distribute results back to groups
@@ -2815,13 +2744,13 @@ pub(crate) async fn process_range_multicall(
 
             let result_count = results.len();
             let file_name = range.file_name("");
-            let sub_dir = output_dir
+            let sub_dir = ctx.output_dir
                 .join(&group.contract_name)
                 .join(&group.function_name);
             std::fs::create_dir_all(&sub_dir)?;
             let output_path = sub_dir.join(&file_name);
 
-            let decoder_results: Option<Vec<DecoderEthCallResult>> = if decoder_tx.is_some() {
+            let decoder_results: Option<Vec<DecoderEthCallResult>> = if ctx.decoder_tx.is_some() {
                 Some(
                     results
                         .iter()
@@ -2852,7 +2781,7 @@ pub(crate) async fn process_range_multicall(
             );
 
             // Upload to S3 if configured
-            if let Some(sm) = storage_manager {
+            if let Some(sm) = ctx.storage_manager {
                 let data_type = format!(
                     "raw/eth_calls/{}/{}",
                     group.contract_name, group.function_name
@@ -2860,7 +2789,7 @@ pub(crate) async fn process_range_multicall(
                 upload_parquet_to_s3(
                     sm,
                     &output_path_for_upload,
-                    chain_name,
+                    ctx.chain_name,
                     &data_type,
                     range.start,
                     range.end - 1,
@@ -2869,7 +2798,7 @@ pub(crate) async fn process_range_multicall(
                 .map_err(|e| EthCallCollectionError::Io(std::io::Error::other(e.to_string())))?;
             }
 
-            if let Some(tx) = decoder_tx {
+            if let Some(tx) = ctx.decoder_tx {
                 if let Some(results) = decoder_results {
                     let _ = tx
                         .send(DecoderMessage::EthCallsReady {
@@ -3244,16 +3173,10 @@ pub(crate) async fn execute_multicalls_generic<M: Clone + Send + Sync>(
 pub(crate) async fn process_token_range_multicall(
     range: &BlockRange,
     blocks: Vec<BlockInfo>,
-    client: &UnifiedRpcClient,
+    ctx: &EthCallContext<'_>,
     token_configs: &[TokenCallConfig],
-    output_dir: &Path,
-    existing_files: &HashSet<String>,
-    rpc_batch_size: usize,
     frequency_state: &mut FrequencyState,
     multicall3_address: Address,
-    decoder_tx: &Option<Sender<DecoderMessage>>,
-    chain_name: &str,
-    storage_manager: Option<&Arc<StorageManager>>,
 ) -> Result<(), EthCallCollectionError> {
     // Group configs by (token_name, function_name) — same as process_token_range
     let mut grouped_configs: HashMap<(String, String), Vec<&TokenCallConfig>> = HashMap::new();
@@ -3281,7 +3204,7 @@ pub(crate) async fn process_token_range_multicall(
         let file_name = range.file_name("");
         let rel_path = format!("{}/{}/{}", output_name, function_name, file_name);
 
-        if existing_files.contains(&rel_path) {
+        if ctx.existing_files.contains(&rel_path) {
             tracing::debug!(
                 "Skipping token calls for {}.{} blocks {}-{} (already exists)",
                 output_name,
@@ -3395,7 +3318,7 @@ pub(crate) async fn process_token_range_multicall(
     }
 
     // Execute multicalls in RPC batch chunks
-    for chunk in pending_multicalls.chunks(rpc_batch_size) {
+    for chunk in pending_multicalls.chunks(ctx.rpc_batch_size) {
         let calls: Vec<(TransactionRequest, BlockId)> = chunk
             .iter()
             .map(|pm| {
@@ -3413,7 +3336,7 @@ pub(crate) async fn process_token_range_multicall(
             })
             .collect();
 
-        let results = client.call_batch(calls).await?;
+        let results = ctx.client.call_batch(calls).await?;
 
         for (i, result) in results.into_iter().enumerate() {
             let pm = &chunk[i];
@@ -3466,13 +3389,13 @@ pub(crate) async fn process_token_range_multicall(
 
             let result_count = results.len();
             let file_name = range.file_name("");
-            let sub_dir = output_dir
+            let sub_dir = ctx.output_dir
                 .join(&group.output_name)
                 .join(&group.function_name);
             std::fs::create_dir_all(&sub_dir)?;
             let output_path = sub_dir.join(&file_name);
 
-            let decoder_results: Option<Vec<DecoderEthCallResult>> = if decoder_tx.is_some() {
+            let decoder_results: Option<Vec<DecoderEthCallResult>> = if ctx.decoder_tx.is_some() {
                 Some(
                     results
                         .iter()
@@ -3503,7 +3426,7 @@ pub(crate) async fn process_token_range_multicall(
             );
 
             // Upload to S3 if configured
-            if let Some(sm) = storage_manager {
+            if let Some(sm) = ctx.storage_manager {
                 let data_type = format!(
                     "raw/eth_calls/{}/{}",
                     group.output_name, group.function_name
@@ -3511,7 +3434,7 @@ pub(crate) async fn process_token_range_multicall(
                 upload_parquet_to_s3(
                     sm,
                     &output_path_for_upload,
-                    chain_name,
+                    ctx.chain_name,
                     &data_type,
                     range.start,
                     range.end - 1,
@@ -3520,7 +3443,7 @@ pub(crate) async fn process_token_range_multicall(
                 .map_err(|e| EthCallCollectionError::Io(std::io::Error::other(e.to_string())))?;
             }
 
-            if let Some(tx) = decoder_tx {
+            if let Some(tx) = ctx.decoder_tx {
                 if let Some(results) = decoder_results {
                     let _ = tx
                         .send(DecoderMessage::EthCallsReady {
@@ -3553,15 +3476,9 @@ pub(crate) async fn process_token_range_multicall(
 pub(crate) async fn process_token_range(
     range: &BlockRange,
     blocks: Vec<BlockInfo>,
-    client: &UnifiedRpcClient,
+    ctx: &EthCallContext<'_>,
     token_configs: &[TokenCallConfig],
-    output_dir: &Path,
-    existing_files: &HashSet<String>,
-    rpc_batch_size: usize,
     frequency_state: &mut FrequencyState,
-    decoder_tx: &Option<Sender<DecoderMessage>>,
-    chain_name: &str,
-    storage_manager: Option<&Arc<StorageManager>>,
 ) -> Result<(), EthCallCollectionError> {
     // Group configs by (token_name, function_name)
     let mut grouped_configs: HashMap<(String, String), Vec<&TokenCallConfig>> = HashMap::new();
@@ -3577,7 +3494,7 @@ pub(crate) async fn process_token_range(
         let file_name = range.file_name("");
         let rel_path = format!("{}/{}/{}", output_name, function_name, file_name);
 
-        if existing_files.contains(&rel_path) {
+        if ctx.existing_files.contains(&rel_path) {
             tracing::debug!(
                 "Skipping token calls for {}.{} blocks {}-{} (already exists)",
                 output_name,
@@ -3628,13 +3545,13 @@ pub(crate) async fn process_token_range(
             }
         }
 
-        for chunk in pending_calls.chunks(rpc_batch_size) {
+        for chunk in pending_calls.chunks(ctx.rpc_batch_size) {
             let calls: Vec<(TransactionRequest, BlockId)> = chunk
                 .iter()
                 .map(|(tx, block_id, _, _)| (tx.clone(), *block_id))
                 .collect();
 
-            let results = client.call_batch(calls).await?;
+            let results = ctx.client.call_batch(calls).await?;
 
             for (i, result) in results.into_iter().enumerate() {
                 let (_, _, block, config) = &chunk[i];
@@ -3665,11 +3582,11 @@ pub(crate) async fn process_token_range(
         all_results.sort_by_key(|r| (r.block_number, r.contract_address));
 
         let result_count = all_results.len();
-        let sub_dir = output_dir.join(&output_name).join(function_name);
+        let sub_dir = ctx.output_dir.join(&output_name).join(function_name);
         std::fs::create_dir_all(&sub_dir)?;
         let output_path = sub_dir.join(&file_name);
 
-        let decoder_results: Option<Vec<DecoderEthCallResult>> = if decoder_tx.is_some() {
+        let decoder_results: Option<Vec<DecoderEthCallResult>> = if ctx.decoder_tx.is_some() {
             Some(
                 all_results
                     .iter()
@@ -3699,12 +3616,12 @@ pub(crate) async fn process_token_range(
         );
 
         // Upload to S3 if configured
-        if let Some(sm) = storage_manager {
+        if let Some(sm) = ctx.storage_manager {
             let data_type = format!("raw/eth_calls/{}/{}", output_name, function_name);
             upload_parquet_to_s3(
                 sm,
                 &output_path_for_upload,
-                chain_name,
+                ctx.chain_name,
                 &data_type,
                 range.start,
                 range.end - 1,
@@ -3713,7 +3630,7 @@ pub(crate) async fn process_token_range(
             .map_err(|e| EthCallCollectionError::Io(std::io::Error::other(e.to_string())))?;
         }
 
-        if let Some(tx) = decoder_tx {
+        if let Some(tx) = ctx.decoder_tx {
             if let Some(results) = decoder_results {
                 let _ = tx
                     .send(DecoderMessage::EthCallsReady {

--- a/src/raw_data/historical/eth_calls/types.rs
+++ b/src/raw_data/historical/eth_calls/types.rs
@@ -1,14 +1,17 @@
 //! Types for eth_call collection: error types, config structs, result structs, and state.
 
 use std::collections::{HashMap, HashSet};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use alloy::primitives::Address;
 use thiserror::Error;
+use tokio::sync::mpsc::Sender;
 
+use crate::decoding::DecoderMessage;
 use crate::raw_data::historical::factories::FactoryAddressData;
-use crate::rpc::RpcError;
-use crate::storage::S3Manifest;
+use crate::rpc::{RpcError, UnifiedRpcClient};
+use crate::storage::{S3Manifest, StorageManager};
 use crate::types::config::eth_call::{EthCallConfig, EvmType, Frequency, ParamConfig, ParamError};
 use crate::types::config::tokens::PoolType;
 use alloy::primitives::Bytes;
@@ -41,6 +44,53 @@ pub enum EthCallCollectionError {
 }
 
 pub use crate::storage::BlockRange;
+
+/// Shared context for eth_call processing functions.
+///
+/// Bundles the RPC client, output paths, and chain info that are threaded
+/// through every `process_*` function in the execution and event_triggers
+/// modules.
+pub struct EthCallContext<'a> {
+    pub client: &'a UnifiedRpcClient,
+    pub output_dir: &'a Path,
+    pub existing_files: &'a HashSet<String>,
+    pub rpc_batch_size: usize,
+    pub decoder_tx: &'a Option<Sender<DecoderMessage>>,
+    pub chain_name: &'a str,
+    pub storage_manager: Option<&'a Arc<StorageManager>>,
+    pub s3_manifest: &'a Option<S3Manifest>,
+}
+
+/// Results indexed by address: maps `Address -> (block_number, timestamp, function_name -> raw_bytes)`.
+pub type AddressResults = HashMap<Address, (u64, u64, HashMap<String, Vec<u8>>)>;
+
+/// Results indexed by collection name, then by address.
+pub type CollectionResults = HashMap<String, AddressResults>;
+
+/// Info needed to process a single contract's once-calls through the multicall
+/// pipeline. Replaces the six-element tuple that was previously threaded through
+/// `process_once_calls_multicall`.
+pub struct ContractProcessingInfo {
+    pub name: String,
+    pub all_fn_names: Vec<String>,
+    pub missing_fn_names: Vec<String>,
+    pub patch_fn_names: Vec<String>,
+    pub output_path: PathBuf,
+    pub has_existing_file: bool,
+}
+
+/// Info needed to process a factory collection's once-calls through the
+/// multicall pipeline. Extends `ContractProcessingInfo` with the call configs
+/// needed for the backfill phase.
+pub struct FactoryContractProcessingInfo {
+    pub name: String,
+    pub all_fn_names: Vec<String>,
+    pub missing_fn_names: Vec<String>,
+    pub patch_fn_names: Vec<String>,
+    pub output_path: PathBuf,
+    pub has_existing_file: bool,
+    pub once_configs: Vec<OnceCallConfig>,
+}
 
 #[derive(Debug, Clone)]
 pub struct BlockInfo {


### PR DESCRIPTION
## Summary

Introduces `EthCallContext` struct and supporting type aliases to eliminate ~24 clippy warnings (`too_many_arguments` and `type_complexity`) in the eth_calls execution and event_triggers modules.

### New types in `types.rs`

- **`EthCallContext<'a>`** — Bundles the 7-8 parameters that were threaded through every `process_*` function: `client`, `output_dir`, `existing_files`, `rpc_batch_size`, `decoder_tx`, `chain_name`, `storage_manager`, and `s3_manifest`. Function-specific params (like `max_params`, `multicall3_address`, `frequency_state`, and domain configs) remain as separate arguments.

- **`AddressResults`** — Type alias for `HashMap<Address, (u64, u64, HashMap<String, Vec<u8>>)>`, replacing the inline `type_complexity` pattern.

- **`CollectionResults`** — Type alias for `HashMap<String, AddressResults>`, used in `process_factory_once_calls_multicall`.

- **`ContractProcessingInfo`** — Named struct replacing the 6-element tuple `(String, Vec<String>, Vec<String>, Vec<String>, PathBuf, bool)` used in `process_once_calls_multicall`.

- **`FactoryContractProcessingInfo`** — Named struct replacing the 7-element tuple in `process_factory_once_calls_multicall`, extends with `once_configs` field for the backfill phase.

### Refactored functions in `execution.rs`

All 10 `process_*` functions now take `ctx: &EthCallContext<'_>` instead of the recurring parameter group:
- `process_factory_range` / `process_factory_range_multicall`
- `process_once_calls_regular` / `process_once_calls_multicall`
- `process_factory_once_calls` / `process_factory_once_calls_multicall`
- `process_range` / `process_range_multicall`
- `process_token_range` / `process_token_range_multicall`

### Refactored functions in `event_triggers.rs`

- `process_event_triggers`
- `process_event_triggers_multicall`

### Updated call sites

- `catchup/eth_calls.rs` — Constructs `EthCallContext` at each call site boundary
- `current/eth_calls/range_processor.rs` — Constructs `EthCallContext` once per function, passes to all process calls
- `current/eth_calls/factory.rs` — Constructs `EthCallContext` inside the `RangeComplete` handler
- `current/eth_calls/events.rs` — Constructs `EthCallContext` inside the `RangeComplete` handler

### Impact

- Removes all `too_many_arguments` and `type_complexity` warnings from `execution.rs` and `event_triggers.rs`
- Net reduction of ~162 lines across 7 files
- No behavioral changes

**Note:** This PR may conflict with sibling PRs that touch `main.rs` or other modules in the clippy warning fix plan.