### PR TITLE
chore: introduce decoder output and matcher context structs

### DIFF
--- a/src/decoding/catchup/logs.rs
+++ b/src/decoding/catchup/logs.rs
@@ -9,6 +9,7 @@ use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
 
 use crate::decoding::logs::{process_logs, EventMatcher, LogDecodingError};
+use crate::decoding::types::{FileProcessingEntry, LogDecoderOutputs, LogMatcherConfig};
 use crate::raw_data::historical::factories::RecollectRequest;
 use crate::storage::decoded_index::scan_existing_decoded_files;
 use crate::storage::factory_data::load_factory_addresses_by_range;
@@ -21,14 +22,14 @@ use crate::types::config::raw_data::RawDataCollectionConfig;
 pub async fn catchup_decode_logs(
     raw_logs_dir: &Path,
     output_base: &Path,
-    _range_size: u64,
-    regular_matchers: &[EventMatcher],
-    factory_matchers: &HashMap<String, Vec<EventMatcher>>,
+    matchers: &LogMatcherConfig<'_>,
     chain: &ChainConfig,
     raw_data_config: &RawDataCollectionConfig,
     transform_tx: Option<&Sender<DecodedEventsMessage>>,
     recollect_tx: Option<&Sender<RecollectRequest>>,
 ) -> Result<(), LogDecodingError> {
+    let regular_matchers = matchers.regular_matchers;
+    let factory_matchers = matchers.factory_matchers;
     let concurrency = raw_data_config.decoding_concurrency.unwrap_or(4);
 
     // Scan existing decoded files
@@ -84,7 +85,7 @@ pub async fn catchup_decode_logs(
     );
 
     // Filter files that need processing and compute per-range missing matchers
-    let files_to_process: Vec<(u64, u64, PathBuf, Vec<EventMatcher>, HashMap<String, Vec<EventMatcher>>)> = raw_files
+    let files_to_process: Vec<FileProcessingEntry> = raw_files
         .into_iter()
         .filter_map(|(range_start, range_end, path)| {
             let (missing_regular, missing_factory) = get_missing_matchers(
@@ -200,16 +201,22 @@ pub async fn catchup_decode_logs(
                 .cloned()
                 .unwrap_or_default();
 
+            let matchers = LogMatcherConfig {
+                regular_matchers: &missing_regular,
+                factory_matchers: &missing_factory,
+            };
+            let outputs = LogDecoderOutputs {
+                transform_tx: transform_tx.as_ref(),
+                complete_tx: None, // catchup already handles progress recording correctly
+            };
             process_logs(
                 &logs,
                 range_start,
                 range_end,
-                &missing_regular,
-                &missing_factory,
+                &matchers,
                 &factory_addrs,
                 &output_base,
-                transform_tx.as_ref(),
-                None, // catchup already handles progress recording correctly
+                &outputs,
             )
             .await
         });

--- a/src/decoding/current/eth_calls/events.rs
+++ b/src/decoding/current/eth_calls/events.rs
@@ -9,6 +9,7 @@ use crate::transformations::{DecodedCall as TransformDecodedCall, DecodedCallsMe
 
 /// Handle a live-mode `EventCallsReady` message: decode results, persist to bincode,
 /// and optionally forward to the transformation engine.
+#[allow(clippy::too_many_arguments)]
 pub(super) async fn handle_event_calls_live(
     live_storage: &LiveStorage,
     range_start: u64,

--- a/src/decoding/current/eth_calls/factory.rs
+++ b/src/decoding/current/eth_calls/factory.rs
@@ -18,6 +18,7 @@ use crate::types::decoded::DecodedValue;
 
 /// Handle a live-mode `OnceCallsReady` message: decode results, persist to bincode,
 /// and optionally forward to the transformation engine.
+#[allow(clippy::too_many_arguments)]
 pub(super) async fn handle_once_calls_live(
     live_storage: &LiveStorage,
     range_start: u64,

--- a/src/decoding/current/eth_calls/mod.rs
+++ b/src/decoding/current/eth_calls/mod.rs
@@ -7,15 +7,13 @@ mod state;
 
 use std::path::Path;
 
-use tokio::sync::mpsc::{Receiver, Sender};
+use tokio::sync::mpsc::Receiver;
 
 use crate::decoding::eth_calls::{
     process_event_calls, process_once_calls, process_regular_calls, CallDecodeConfig,
-    EthCallDecodingError, EventCallDecodeConfig,
+    EthCallDecodeConfigs, EthCallDecodingError,
 };
-use crate::decoding::types::DecoderMessage;
-use crate::live::TransformRetryRequest;
-use crate::transformations::{DecodedCallsMessage, RangeCompleteMessage};
+use crate::decoding::types::{DecoderMessage, EthCallDecoderOutputs};
 use crate::types::config::raw_data::RawDataCollectionConfig;
 
 use crate::decoding::catchup::eth_calls::catchup_decode_eth_calls;
@@ -32,14 +30,16 @@ pub async fn decode_eth_calls_live(
     raw_calls_dir: &Path,
     output_base: &Path,
     chain_name: &str,
-    regular_configs: &[CallDecodeConfig],
-    once_configs: &[CallDecodeConfig],
-    event_configs: &[EventCallDecodeConfig],
+    configs: &EthCallDecodeConfigs<'_>,
     raw_data_config: &RawDataCollectionConfig,
-    transform_tx: Option<&Sender<DecodedCallsMessage>>,
-    complete_tx: Option<&Sender<RangeCompleteMessage>>,
-    transform_retry_tx: Option<&Sender<TransformRetryRequest>>,
+    outputs: &EthCallDecoderOutputs<'_>,
 ) -> Result<(), EthCallDecodingError> {
+    let regular_configs = configs.regular;
+    let once_configs = configs.once;
+    let event_configs = configs.event;
+    let transform_tx = outputs.transform_tx;
+    let complete_tx = outputs.complete_tx;
+    let transform_retry_tx = outputs.retry_tx;
     let state = DecoderState::new(chain_name);
 
     loop {
@@ -244,7 +244,8 @@ mod tests {
     use tokio::sync::mpsc;
 
     use super::decode_eth_calls_live;
-    use crate::decoding::eth_calls::{CallDecodeConfig, EventCallDecodeConfig};
+    use crate::decoding::eth_calls::{CallDecodeConfig, EthCallDecodeConfigs, EventCallDecodeConfig};
+    use crate::decoding::types::EthCallDecoderOutputs;
     use crate::decoding::{DecoderMessage, EthCallResult, EventCallResult, OnceCallResult};
     use crate::live::{LiveBlockStatus, LiveStorage, TransformRetryRequest};
     use crate::transformations::{DecodedCallsMessage, RangeCompleteKind, RangeCompleteMessage};
@@ -313,18 +314,24 @@ mod tests {
         let output_dir = temp.path().join("decoded");
         tokio::spawn(async move {
             let _temp = temp;
+            let configs = EthCallDecodeConfigs {
+                regular: &regular_configs,
+                once: &once_configs,
+                event: &event_configs,
+            };
+            let outputs = EthCallDecoderOutputs {
+                transform_tx: transform_tx.as_ref(),
+                complete_tx: complete_tx.as_ref(),
+                retry_tx: retry_tx.as_ref(),
+            };
             decode_eth_calls_live(
                 decoder_rx,
                 raw_dir.as_path(),
                 output_dir.as_path(),
                 &chain_name,
-                &regular_configs,
-                &once_configs,
-                &event_configs,
+                &configs,
                 &raw_data_config(),
-                transform_tx.as_ref(),
-                complete_tx.as_ref(),
-                retry_tx.as_ref(),
+                &outputs,
             )
             .await
         })
@@ -336,18 +343,24 @@ mod tests {
         let (complete_tx, mut complete_rx) = mpsc::channel::<RangeCompleteMessage>(4);
 
         let handle = tokio::spawn(async move {
+            let configs = EthCallDecodeConfigs {
+                regular: &[],
+                once: &[],
+                event: &[],
+            };
+            let outputs = EthCallDecoderOutputs {
+                transform_tx: None,
+                complete_tx: Some(&complete_tx),
+                retry_tx: None,
+            };
             decode_eth_calls_live(
                 decoder_rx,
                 Path::new("data/test/raw"),
                 Path::new("data/test/decoded"),
                 "test",
-                &[],
-                &[],
-                &[],
+                &configs,
                 &raw_data_config(),
-                None,
-                Some(&complete_tx),
-                None,
+                &outputs,
             )
             .await
         });
@@ -377,18 +390,24 @@ mod tests {
         let (complete_tx, mut complete_rx) = mpsc::channel::<RangeCompleteMessage>(4);
 
         let handle = tokio::spawn(async move {
+            let configs = EthCallDecodeConfigs {
+                regular: &[],
+                once: &[],
+                event: &[],
+            };
+            let outputs = EthCallDecoderOutputs {
+                transform_tx: None,
+                complete_tx: Some(&complete_tx),
+                retry_tx: Some(&retry_tx),
+            };
             decode_eth_calls_live(
                 decoder_rx,
                 Path::new("data/test/raw"),
                 Path::new("data/test/decoded"),
                 "test",
-                &[],
-                &[],
-                &[],
+                &configs,
                 &raw_data_config(),
-                None,
-                Some(&complete_tx),
-                Some(&retry_tx),
+                &outputs,
             )
             .await
         });

--- a/src/decoding/current/eth_calls/range_processor.rs
+++ b/src/decoding/current/eth_calls/range_processor.rs
@@ -13,6 +13,7 @@ use crate::transformations::{
 
 /// Handle a live-mode `EthCallsReady` message for regular calls: decode results,
 /// persist to bincode, and optionally forward to the transformation engine.
+#[allow(clippy::too_many_arguments)]
 pub(super) async fn handle_regular_calls_live(
     live_storage: &LiveStorage,
     range_start: u64,

--- a/src/decoding/current/logs.rs
+++ b/src/decoding/current/logs.rs
@@ -3,15 +3,14 @@
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
-use tokio::sync::mpsc::{Receiver, Sender};
+use tokio::sync::mpsc::Receiver;
 
 use crate::decoding::logs::{
-    delete_decoded_logs_for_blocks, process_logs, process_logs_live, EventMatcher, LogDecodingError,
+    delete_decoded_logs_for_blocks, process_logs, process_logs_live, LogDecodingError,
 };
-use crate::decoding::types::DecoderMessage;
+use crate::decoding::types::{DecoderMessage, LogDecoderOutputs, LogMatcherConfig};
 use crate::live::LiveStorage;
 use crate::storage::parquet_readers::read_factory_addresses_from_parquet;
-use crate::transformations::{DecodedEventsMessage, RangeCompleteMessage};
 
 /// Load accumulated factory addresses from both compacted parquet and uncompacted bincode files.
 ///
@@ -93,12 +92,10 @@ fn load_accumulated_factory_addresses(
 /// Returns when AllComplete message is received or channel closes.
 pub async fn decode_logs_live(
     decoder_rx: &mut Receiver<DecoderMessage>,
-    regular_matchers: &[EventMatcher],
-    factory_matchers: &HashMap<String, Vec<EventMatcher>>,
+    matchers: &LogMatcherConfig<'_>,
     output_base: &Path,
     chain_name: &str,
-    transform_tx: Option<&Sender<DecodedEventsMessage>>,
-    complete_tx: Option<&Sender<RangeCompleteMessage>>,
+    outputs: &LogDecoderOutputs<'_>,
 ) -> Result<(), LogDecodingError> {
     // Load accumulated factory addresses from parquet and bincode files
     let mut accumulated_factory_addresses = load_accumulated_factory_addresses(chain_name)?;
@@ -130,12 +127,10 @@ pub async fn decode_logs_live(
                     process_logs_live(
                         &logs,
                         range_start,
-                        regular_matchers,
-                        factory_matchers,
+                        matchers,
                         &accumulated_factory_addresses,
                         &live_storage,
-                        transform_tx,
-                        complete_tx,
+                        outputs,
                     )
                     .await?;
                 } else {
@@ -146,12 +141,10 @@ pub async fn decode_logs_live(
                         &logs,
                         range_start,
                         range_end,
-                        regular_matchers,
-                        factory_matchers,
+                        matchers,
                         &accumulated_factory_addresses,
                         output_base,
-                        transform_tx,
-                        complete_tx,
+                        outputs,
                     )
                     .await?;
                 }

--- a/src/decoding/eth_calls/mod.rs
+++ b/src/decoding/eth_calls/mod.rs
@@ -15,13 +15,12 @@ pub use transform::{build_result_map, build_result_map_for_merge};
 
 use std::time::Instant;
 
-use tokio::sync::mpsc::{Receiver, Sender};
+use tokio::sync::mpsc::Receiver;
 use tokio::sync::oneshot;
 
 use super::catchup;
 use super::current;
-use crate::live::TransformRetryRequest;
-use crate::transformations::{DecodedCallsMessage, RangeCompleteMessage};
+use super::types::EthCallDecoderOutputs;
 use crate::types::config::chain::ChainConfig;
 use crate::types::config::raw_data::RawDataCollectionConfig;
 
@@ -29,9 +28,7 @@ pub async fn decode_eth_calls(
     chain: &ChainConfig,
     raw_data_config: &RawDataCollectionConfig,
     decoder_rx: Receiver<super::types::DecoderMessage>,
-    transform_tx: Option<Sender<DecodedCallsMessage>>,
-    complete_tx: Option<Sender<RangeCompleteMessage>>,
-    transform_retry_tx: Option<Sender<TransformRetryRequest>>,
+    outputs: EthCallDecoderOutputs<'_>,
     eth_calls_catchup_done_rx: Option<oneshot::Receiver<()>>,
     decode_catchup_done_tx: Option<oneshot::Sender<()>>,
     skip_catchup: bool,
@@ -119,18 +116,19 @@ pub async fn decode_eth_calls(
     // =========================================================================
     // Live phase: Process new data as it arrives
     // =========================================================================
+    let configs = EthCallDecodeConfigs {
+        regular: &regular_configs,
+        once: &once_configs,
+        event: &event_configs,
+    };
     current::decode_eth_calls_live(
         decoder_rx,
         &raw_calls_dir,
         &output_base,
         &chain.name,
-        &regular_configs,
-        &once_configs,
-        &event_configs,
+        &configs,
         raw_data_config,
-        transform_tx.as_ref(),
-        complete_tx.as_ref(),
-        transform_retry_tx.as_ref(),
+        &outputs,
     )
     .await?;
 

--- a/src/decoding/eth_calls/parquet_io.rs
+++ b/src/decoding/eth_calls/parquet_io.rs
@@ -882,8 +882,7 @@ pub(super) fn merge_decoded_once_calls(
 
     // Build a lookup from column name -> (config, optional tuple field info)
     // This is used to fill nulls in existing columns from new decoded records.
-    let mut col_config_lookup: HashMap<String, (&CallDecodeConfig, Option<(usize, &EvmType)>)> =
-        HashMap::new();
+    let mut col_config_lookup: super::types::ColumnConfigLookup<'_> = HashMap::new();
     for config in new_configs {
         match &config.output_type {
             EvmType::NamedTuple(tuple_fields) => {

--- a/src/decoding/eth_calls/process.rs
+++ b/src/decoding/eth_calls/process.rs
@@ -163,6 +163,7 @@ pub async fn process_regular_calls(
 /// Process "once" call results.
 /// Returns `OnceCallsResult` with column index info for batch updating (avoids race conditions).
 /// When `return_index_info` is true, skips writing the column index (caller will batch update).
+#[allow(clippy::too_many_arguments)]
 pub async fn process_once_calls(
     results: &[OnceCallResult],
     range_start: u64,

--- a/src/decoding/eth_calls/types.rs
+++ b/src/decoding/eth_calls/types.rs
@@ -78,9 +78,19 @@ pub struct DecodedOnceRecord {
     pub decoded_values: HashMap<String, DecodedValue>,
 }
 
+/// Grouped decode configs for eth_call decoding (regular, once, event-triggered).
+pub struct EthCallDecodeConfigs<'a> {
+    pub regular: &'a [CallDecodeConfig],
+    pub once: &'a [CallDecodeConfig],
+    pub event: &'a [EventCallDecodeConfig],
+}
+
 /// Result of processing once calls, used to batch update column indexes after all tasks complete.
 pub struct OnceCallsResult {
     pub contract_name: String,
     pub file_name: String,
     pub columns: Vec<String>,
 }
+
+/// Config lookup for parquet columns: column_name -> (config, optional tuple field info).
+pub type ColumnConfigLookup<'a> = HashMap<String, (&'a CallDecodeConfig, Option<(usize, &'a EvmType)>)>;

--- a/src/decoding/event_parsing.rs
+++ b/src/decoding/event_parsing.rs
@@ -388,7 +388,7 @@ fn parse_indexed_and_name(s: &str) -> (bool, String) {
 /// Returns (field_info, canonical_type_strings)
 fn parse_tuple_fields(
     content: &str,
-) -> Result<(Vec<(String, TupleFieldInfo)>, Vec<String>), EventParseError> {
+) -> Result<super::types::TupleFieldParseResult, EventParseError> {
     let content = content.trim();
     if content.is_empty() {
         return Err(EventParseError::InvalidTuple("empty tuple".to_string()));

--- a/src/decoding/logs.rs
+++ b/src/decoding/logs.rs
@@ -17,7 +17,7 @@ use thiserror::Error;
 use tokio::sync::mpsc::{Receiver, Sender};
 
 use super::event_parsing::{EventParam, ParsedEvent, TupleFieldInfo};
-use super::types::DecoderMessage;
+use super::types::{BuiltMatchers, DecoderMessage, LogDecoderOutputs, LogMatcherConfig};
 use crate::live::{LiveDecodedLog, LiveStorage};
 use crate::raw_data::historical::factories::RecollectRequest;
 use crate::raw_data::historical::receipts::LogData;
@@ -98,8 +98,6 @@ pub async fn decode_logs(
     let output_base = crate::storage::paths::decoded_logs_dir(&chain.name);
     std::fs::create_dir_all(&output_base)?;
 
-    let range_size = raw_data_config.parquet_block_range.unwrap_or(1000) as u64;
-
     // Build event matchers from contract configs
     tracing::debug!("Building event matchers for chain {}", chain.name);
     let (regular_matchers, factory_matchers) =
@@ -132,15 +130,18 @@ pub async fn decode_logs(
     // =========================================================================
     // Catchup phase: Process existing raw log files
     // =========================================================================
+    let matchers = LogMatcherConfig {
+        regular_matchers: &regular_matchers,
+        factory_matchers: &factory_matchers,
+    };
+
     if !skip_catchup {
         let raw_logs_dir = crate::storage::paths::raw_logs_dir(&chain.name);
         if raw_logs_dir.exists() {
             super::catchup::catchup_decode_logs(
                 &raw_logs_dir,
                 &output_base,
-                range_size,
-                &regular_matchers,
-                &factory_matchers,
+                &matchers,
                 chain,
                 raw_data_config,
                 transform_tx.as_ref(),
@@ -160,14 +161,16 @@ pub async fn decode_logs(
     // =========================================================================
     // Live phase: Process new data as it arrives
     // =========================================================================
+    let log_outputs = LogDecoderOutputs {
+        transform_tx: transform_tx.as_ref(),
+        complete_tx: complete_tx.as_ref(),
+    };
     super::current::decode_logs_live(
         &mut decoder_rx,
-        &regular_matchers,
-        &factory_matchers,
+        &matchers,
         &output_base,
         &chain.name,
-        transform_tx.as_ref(),
-        complete_tx.as_ref(),
+        &log_outputs,
     )
     .await?;
 
@@ -179,7 +182,7 @@ pub async fn decode_logs(
 pub(crate) fn build_event_matchers(
     contracts: &Contracts,
     factory_collections: &FactoryCollections,
-) -> Result<(Vec<EventMatcher>, HashMap<String, Vec<EventMatcher>>), LogDecodingError> {
+) -> Result<BuiltMatchers, LogDecodingError> {
     let mut regular = Vec::new();
     let mut factory: HashMap<String, Vec<EventMatcher>> = HashMap::new();
 
@@ -259,13 +262,13 @@ pub(crate) async fn process_logs(
     logs: &[LogData],
     range_start: u64,
     range_end: u64,
-    regular_matchers: &[EventMatcher],
-    factory_matchers: &HashMap<String, Vec<EventMatcher>>,
+    matchers: &LogMatcherConfig<'_>,
     factory_addresses: &HashMap<String, HashSet<[u8; 20]>>,
     output_base: &Path,
-    transform_tx: Option<&Sender<DecodedEventsMessage>>,
-    complete_tx: Option<&Sender<RangeCompleteMessage>>,
+    outputs: &LogDecoderOutputs<'_>,
 ) -> Result<(), LogDecodingError> {
+    let regular_matchers = matchers.regular_matchers;
+    let factory_matchers = matchers.factory_matchers;
     // Group decoded logs by (contract_name, event_name)
     let mut decoded_by_event: HashMap<(String, String), (Vec<DecodedLogRecord>, &ParsedEvent)> =
         HashMap::new();
@@ -398,7 +401,7 @@ pub(crate) async fn process_logs(
     }
 
     // Send to transformation channel if enabled
-    if let Some(tx) = transform_tx {
+    if let Some(tx) = outputs.transform_tx {
         // Re-decode and send to transformation engine (we need to iterate again to build the transform messages)
         // Group decoded logs by (contract_name, event_name) for sending
         let mut transform_events_by_type: HashMap<(String, String), Vec<TransformDecodedEvent>> =
@@ -495,7 +498,7 @@ pub(crate) async fn process_logs(
     }
 
     // Signal that all events for this range have been sent
-    if let Some(tx) = complete_tx {
+    if let Some(tx) = outputs.complete_tx {
         let msg = RangeCompleteMessage {
             range_start,
             range_end,
@@ -1068,13 +1071,13 @@ fn convert_to_live_decoded_log(record: &DecodedLogRecord) -> LiveDecodedLog {
 pub(crate) async fn process_logs_live(
     logs: &[LogData],
     block_number: u64,
-    regular_matchers: &[EventMatcher],
-    factory_matchers: &HashMap<String, Vec<EventMatcher>>,
+    matchers: &LogMatcherConfig<'_>,
     factory_addresses: &HashMap<String, HashSet<[u8; 20]>>,
     storage: &LiveStorage,
-    transform_tx: Option<&Sender<DecodedEventsMessage>>,
-    complete_tx: Option<&Sender<RangeCompleteMessage>>,
+    outputs: &LogDecoderOutputs<'_>,
 ) -> Result<(), LogDecodingError> {
+    let regular_matchers = matchers.regular_matchers;
+    let factory_matchers = matchers.factory_matchers;
     // Group decoded logs by (contract_name, event_name)
     let mut decoded_by_event: HashMap<(String, String), (Vec<DecodedLogRecord>, &ParsedEvent)> =
         HashMap::new();
@@ -1166,7 +1169,7 @@ pub(crate) async fn process_logs_live(
     }
 
     // Send to transformation channel if enabled
-    if let Some(tx) = transform_tx {
+    if let Some(tx) = outputs.transform_tx {
         let mut transform_events_by_type: HashMap<(String, String), Vec<TransformDecodedEvent>> =
             HashMap::new();
 
@@ -1275,7 +1278,7 @@ pub(crate) async fn process_logs_live(
     }
 
     // Signal that all events for this block have been sent
-    if let Some(tx) = complete_tx {
+    if let Some(tx) = outputs.complete_tx {
         let msg = RangeCompleteMessage {
             range_start: block_number,
             range_end: block_number + 1,

--- a/src/decoding/mod.rs
+++ b/src/decoding/mod.rs
@@ -7,4 +7,4 @@ mod types;
 
 pub use eth_calls::decode_eth_calls;
 pub use logs::decode_logs;
-pub use types::{DecoderMessage, EthCallResult, EventCallResult, OnceCallResult};
+pub use types::{DecoderMessage, EthCallDecoderOutputs, EthCallResult, EventCallResult, OnceCallResult};

--- a/src/decoding/types.rs
+++ b/src/decoding/types.rs
@@ -1,8 +1,49 @@
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 use alloy::primitives::Address;
+use tokio::sync::mpsc::Sender;
 
+use crate::live::TransformRetryRequest;
 use crate::raw_data::historical::receipts::LogData;
+use crate::transformations::{DecodedCallsMessage, DecodedEventsMessage, RangeCompleteMessage};
+
+use super::event_parsing::TupleFieldInfo;
+use super::logs::EventMatcher;
+
+/// Output channels for the eth_call decoder.
+pub struct EthCallDecoderOutputs<'a> {
+    pub transform_tx: Option<&'a Sender<DecodedCallsMessage>>,
+    pub complete_tx: Option<&'a Sender<RangeCompleteMessage>>,
+    pub retry_tx: Option<&'a Sender<TransformRetryRequest>>,
+}
+
+/// Output channels for the log decoder.
+pub struct LogDecoderOutputs<'a> {
+    pub transform_tx: Option<&'a Sender<DecodedEventsMessage>>,
+    pub complete_tx: Option<&'a Sender<RangeCompleteMessage>>,
+}
+
+/// Compiled log matchers for regular contracts and factory collections.
+pub struct LogMatcherConfig<'a> {
+    pub regular_matchers: &'a [EventMatcher],
+    pub factory_matchers: &'a HashMap<String, Vec<EventMatcher>>,
+}
+
+/// Result of building matchers: (regular_matchers, factory_matchers).
+pub type BuiltMatchers = (Vec<EventMatcher>, HashMap<String, Vec<EventMatcher>>);
+
+/// A file to process during catchup: (range_start, range_end, path, regular_matchers, factory_matchers).
+pub type FileProcessingEntry = (
+    u64,
+    u64,
+    PathBuf,
+    Vec<EventMatcher>,
+    HashMap<String, Vec<EventMatcher>>,
+);
+
+/// Parse result for tuple fields: (field_info, canonical_type_strings).
+pub type TupleFieldParseResult = (Vec<(String, TupleFieldInfo)>, Vec<String>);
 
 /// Raw eth_call result data for decoding
 #[derive(Debug, Clone)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -396,7 +396,12 @@ async fn decode_only_chain(config: &IndexerConfig, chain: &ChainConfig) -> anyho
             async move {
                 let (_tx, rx) = mpsc::channel::<DecoderMessage>(1);
                 drop(_tx);
-                decode_eth_calls(&chain, &cfg, rx, None, None, None, None, None, false)
+                let outputs = decoding::EthCallDecoderOutputs {
+                    transform_tx: None,
+                    complete_tx: None,
+                    retry_tx: None,
+                };
+                decode_eth_calls(&chain, &cfg, rx, outputs, None, None, false)
                     .await
                     .context("eth call decoding failed")
             }
@@ -543,13 +548,16 @@ async fn process_chain_live_only(
         let transform_complete_tx = transform_complete_tx.clone();
         let transform_retry_tx = transform_retry_tx.clone();
         tasks.spawn(async move {
+            let outputs = decoding::EthCallDecoderOutputs {
+                transform_tx: transform_calls_tx.as_ref(),
+                complete_tx: transform_complete_tx.as_ref(),
+                retry_tx: transform_retry_tx.as_ref(),
+            };
             decode_eth_calls(
                 &chain,
                 &cfg,
                 rx,
-                transform_calls_tx,
-                transform_complete_tx,
-                transform_retry_tx,
+                outputs,
                 None,
                 None,
                 true,
@@ -1010,13 +1018,16 @@ impl FullPipelineContext {
         let cfg = self.raw_config.clone();
 
         tasks.spawn(async move {
+            let outputs = decoding::EthCallDecoderOutputs {
+                transform_tx: transform_calls_tx.as_ref(),
+                complete_tx: transform_complete_tx.as_ref(),
+                retry_tx: transform_retry_tx.as_ref(),
+            };
             decode_eth_calls(
                 &chain,
                 &cfg,
                 call_decoder_rx,
-                transform_calls_tx,
-                transform_complete_tx,
-                transform_retry_tx,
+                outputs,
                 eth_calls_catchup_done_rx,
                 decode_catchup_done_tx,
                 false,


### PR DESCRIPTION
## What changed

Fixes ~15 clippy warnings (`too_many_arguments` and `type_complexity`) in the decoding pipeline by introducing context structs and type aliases.

### New types in `src/decoding/types.rs`

- **`EthCallDecoderOutputs`** — bundles the three output channel senders (`transform_tx`, `complete_tx`, `retry_tx`) for the eth_call decoder pipeline.
- **`LogDecoderOutputs`** — bundles the two output channel senders (`transform_tx`, `complete_tx`) for the log decoder pipeline.
- **`LogMatcherConfig`** — groups `regular_matchers` and `factory_matchers` into a single struct, replacing two separate parameters on every function that receives them.
- **`BuiltMatchers`** — type alias for the return value of `build_event_matchers`.
- **`FileProcessingEntry`** — type alias replacing a complex 5-tuple in catchup log processing.
- **`TupleFieldParseResult`** — type alias replacing a complex return type in `parse_tuple_fields`.

### New type in `src/decoding/eth_calls/types.rs`

- **`EthCallDecodeConfigs`** — groups the three config slices (`regular`, `once`, `event`) for the live eth_call decoder.
- **`ColumnConfigLookup`** — type alias replacing a complex HashMap type in parquet merge logic.

### Function signature changes

| Function | Before | After |
|---|---|---|
| `process_logs` | 9 args | 7 (matchers + outputs bundled) |
| `process_logs_live` | 8 args | 6 (matchers + outputs bundled) |
| `catchup_decode_logs` | 9 args | 7 (matchers bundled, unused `_range_size` removed) |
| `build_event_matchers` return | complex tuple | `BuiltMatchers` alias |
| `decode_eth_calls` | 9 args | 7 (3 channel senders → `EthCallDecoderOutputs`) |
| `decode_eth_calls_live` | 11 args → 9 | 7 (3 configs → `EthCallDecodeConfigs`, 3 channels → `EthCallDecoderOutputs`) |
| `decode_logs_live` | 7 args | 5 (matchers + outputs bundled) |
| `parse_tuple_fields` return | complex tuple | `TupleFieldParseResult` alias |
| `merge_decoded_once_calls` local | complex HashMap | `ColumnConfigLookup` alias |

For internal helper functions where bundling would feel forced (`handle_event_calls_live`, `handle_once_calls_live`, `handle_regular_calls_live`, `process_once_calls`), `#[allow(clippy::too_many_arguments)]` is used instead.

### Why

Reduces cognitive load when reading function signatures and eliminates clippy noise, making it easier to spot real issues in CI output.

### Conflicts

This PR touches `src/main.rs` at the `decode_eth_calls` call sites. Minor merge conflicts with sibling clippy PRs are expected if they also modify `main.rs`.