### PR TITLE
chore: add collection pipeline context structs and clippy allows

### DIFF
--- a/src/live/collector.rs
+++ b/src/live/collector.rs
@@ -80,6 +80,7 @@ pub struct LiveCollector {
 
 impl LiveCollector {
     /// Create a new LiveCollector.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         chain: Arc<ChainConfig>,
         http_client: Arc<UnifiedRpcClient>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -571,10 +571,12 @@ async fn process_chain_live_only(
         config,
         runtime.http_client.clone(),
         runtime.db_pool.clone(),
-        log_decoder_tx,
-        eth_call_decoder_tx,
-        transform_reorg_tx,
-        transform_retry_tx,
+        LiveModeChannels {
+            log_decoder_tx,
+            eth_call_decoder_tx,
+            transform_reorg_tx,
+            transform_retry_tx,
+        },
         runtime.progress_tracker.clone(),
         Some(storage_manager),
         &mut tasks,
@@ -674,6 +676,7 @@ impl FullPipelineContext {
     }
 
     /// Spawn the receipt collection stage (catchup + current).
+    #[allow(clippy::too_many_arguments)]
     fn spawn_receipts(
         &self,
         tasks: &mut JoinSet<anyhow::Result<()>>,
@@ -805,6 +808,7 @@ impl FullPipelineContext {
     }
 
     /// Spawn the eth_call collection stage (catchup + current).
+    #[allow(clippy::too_many_arguments)]
     fn spawn_eth_calls(
         &self,
         tasks: &mut JoinSet<anyhow::Result<()>>,
@@ -889,6 +893,7 @@ impl FullPipelineContext {
     }
 
     /// Spawn the factory collection stage (catchup + current).
+    #[allow(clippy::too_many_arguments)]
     fn spawn_factories(
         &self,
         tasks: &mut JoinSet<anyhow::Result<()>>,
@@ -996,6 +1001,7 @@ impl FullPipelineContext {
     }
 
     /// Spawn the eth_call decoder stage.
+    #[allow(clippy::too_many_arguments)]
     fn spawn_eth_call_decoder(
         &self,
         tasks: &mut JoinSet<anyhow::Result<()>>,
@@ -1340,10 +1346,12 @@ async fn process_chain(
             config,
             http_client_for_live,
             pipeline.runtime.db_pool.clone(),
-            log_decoder_tx_for_live,
-            eth_call_decoder_tx_for_live,
-            transform_reorg_tx,
-            transform_retry_tx,
+            LiveModeChannels {
+                log_decoder_tx: log_decoder_tx_for_live,
+                eth_call_decoder_tx: eth_call_decoder_tx_for_live,
+                transform_reorg_tx,
+                transform_retry_tx,
+            },
             pipeline.runtime.progress_tracker.clone(),
             Some(storage_manager.clone()),
             &mut live_tasks,
@@ -1399,6 +1407,14 @@ fn should_enable_live_mode(config: &IndexerConfig, chain: &ChainConfig) -> bool 
     true
 }
 
+/// Channels for live mode communication with decoders/transformations.
+struct LiveModeChannels {
+    log_decoder_tx: Option<mpsc::Sender<DecoderMessage>>,
+    eth_call_decoder_tx: Option<mpsc::Sender<DecoderMessage>>,
+    transform_reorg_tx: Option<mpsc::Sender<ReorgMessage>>,
+    transform_retry_tx: Option<mpsc::Sender<TransformRetryRequest>>,
+}
+
 /// Spawn live mode tasks for a chain.
 ///
 /// This sets up:
@@ -1408,15 +1424,13 @@ fn should_enable_live_mode(config: &IndexerConfig, chain: &ChainConfig) -> bool 
 ///
 /// Note: The transformation engine is NOT spawned here - it continues running from
 /// historical mode via the live_tasks JoinSet, receiving messages via the same channels.
+#[allow(clippy::too_many_arguments)]
 async fn spawn_live_mode(
     chain: Arc<ChainConfig>,
     config: &IndexerConfig,
     http_client: Arc<UnifiedRpcClient>,
     db_pool: Option<Arc<DbPool>>,
-    log_decoder_tx: Option<mpsc::Sender<DecoderMessage>>,
-    eth_call_decoder_tx: Option<mpsc::Sender<DecoderMessage>>,
-    transform_reorg_tx: Option<mpsc::Sender<ReorgMessage>>,
-    transform_retry_tx: Option<mpsc::Sender<TransformRetryRequest>>,
+    live_channels: LiveModeChannels,
     progress_tracker: Option<Arc<Mutex<LiveProgressTracker>>>,
     storage_manager: Option<Arc<StorageManager>>,
     tasks: &mut JoinSet<anyhow::Result<()>>,
@@ -1509,7 +1523,7 @@ async fn spawn_live_mode(
     });
 
     // Build eth_call collector if eth_calls are configured
-    let eth_call_collector = if eth_call_decoder_tx.is_some() {
+    let eth_call_collector = if live_channels.eth_call_decoder_tx.is_some() {
         // Get multicall3 address from contracts if available
         let multicall3_address = chain.contracts.get("Multicall3").and_then(|c| {
             use crate::types::config::contract::AddressOrAddresses;
@@ -1534,10 +1548,10 @@ async fn spawn_live_mode(
     };
 
     let live_expectations = live_pipeline_expectations(
-        log_decoder_tx.is_some(),
+        live_channels.log_decoder_tx.is_some(),
         eth_call_collector.is_some(),
-        eth_call_decoder_tx.is_some() && eth_call_collector.is_some(),
-        transform_retry_tx.is_some(),
+        live_channels.eth_call_decoder_tx.is_some() && eth_call_collector.is_some(),
+        live_channels.transform_retry_tx.is_some(),
     );
 
     // Start live collector
@@ -1550,16 +1564,16 @@ async fn spawn_live_mode(
         eth_call_collector,
         db_pool.clone(),
         live_expectations,
-        transform_retry_tx.clone(),
+        live_channels.transform_retry_tx.clone(),
     );
     tasks.spawn(async move {
         collector
             .run(
                 ws_event_rx,
                 live_msg_tx,
-                log_decoder_tx,
-                eth_call_decoder_tx,
-                transform_reorg_tx,
+                live_channels.log_decoder_tx,
+                live_channels.eth_call_decoder_tx,
+                live_channels.transform_reorg_tx,
             )
             .await
             .map_err(|e| anyhow::anyhow!("Live collector error: {}", e))
@@ -1575,7 +1589,7 @@ async fn spawn_live_mode(
         live_expectations,
         storage_manager,
     );
-    if let Some(retry_tx) = transform_retry_tx {
+    if let Some(retry_tx) = live_channels.transform_retry_tx {
         compaction = compaction.with_retry_tx(retry_tx);
     }
     tasks.spawn(async move {

--- a/src/raw_data/historical/catchup/blocks.rs
+++ b/src/raw_data/historical/catchup/blocks.rs
@@ -17,6 +17,7 @@ use crate::storage::{upload_parquet_to_s3, BlockRange, S3Manifest, StorageManage
 use crate::types::config::chain::ChainConfig;
 use crate::types::config::raw_data::{BlockField, RawDataCollectionConfig};
 
+#[allow(clippy::too_many_arguments)]
 pub async fn collect_blocks(
     chain: &ChainConfig,
     client: &UnifiedRpcClient,

--- a/src/raw_data/historical/catchup/eth_calls.rs
+++ b/src/raw_data/historical/catchup/eth_calls.rs
@@ -32,6 +32,7 @@ use crate::types::config::chain::ChainConfig;
 use crate::types::config::contract::AddressOrAddresses;
 use crate::types::config::raw_data::RawDataCollectionConfig;
 
+#[allow(clippy::too_many_arguments)]
 pub async fn collect_eth_calls(
     chain: &ChainConfig,
     client: &UnifiedRpcClient,

--- a/src/raw_data/historical/catchup/factories.rs
+++ b/src/raw_data/historical/catchup/factories.rs
@@ -19,6 +19,7 @@ use crate::storage::{DataLoader, S3Manifest, StorageManager};
 use crate::types::config::chain::ChainConfig;
 use crate::types::config::raw_data::RawDataCollectionConfig;
 
+#[allow(clippy::too_many_arguments)]
 pub async fn collect_factories(
     chain: &ChainConfig,
     raw_data_config: &RawDataCollectionConfig,

--- a/src/raw_data/historical/catchup/receipts.rs
+++ b/src/raw_data/historical/catchup/receipts.rs
@@ -9,8 +9,8 @@ use crate::raw_data::historical::blocks::{
 };
 use crate::raw_data::historical::receipts::{
     build_receipt_schema, process_range, scan_existing_logs_files, scan_existing_parquet_files,
-    send_range_complete, BlockInfo, ChannelMetrics, EventTriggerMatcher, EventTriggerMessage,
-    LogMessage, ReceiptCollectionError,
+    send_range_complete, BlockInfo, ChannelMetrics, ChannelMetricsState, EventTriggerMatcher,
+    EventTriggerMessage, LogMessage, ReceiptCollectionError, ReceiptOutputChannels,
 };
 use crate::rpc::UnifiedRpcClient;
 use crate::storage::paths::{raw_logs_dir, raw_receipts_dir};
@@ -30,6 +30,7 @@ pub struct ReceiptsCatchupState {
     pub s3_manifest: Option<S3Manifest>,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn collect_receipts(
     chain: &ChainConfig,
     client: &UnifiedRpcClient,
@@ -53,14 +54,22 @@ pub async fn collect_receipts(
 
     let has_factories = factory_log_tx.is_some();
 
-    let log_tx_capacity = log_tx.as_ref().map(|s| s.max_capacity()).unwrap_or(0);
-    let factory_log_tx_capacity = factory_log_tx
-        .as_ref()
-        .map(|s| s.max_capacity())
-        .unwrap_or(0);
+    let channels = ReceiptOutputChannels {
+        log_tx: log_tx.clone(),
+        factory_log_tx: factory_log_tx.clone(),
+        event_trigger_tx: event_trigger_tx.clone(),
+    };
 
-    let mut log_tx_metrics = ChannelMetrics::default();
-    let mut factory_log_tx_metrics = ChannelMetrics::default();
+    let mut metrics = ChannelMetricsState {
+        log_tx_metrics: ChannelMetrics::default(),
+        factory_log_tx_metrics: ChannelMetrics::default(),
+        log_tx_capacity: log_tx.as_ref().map(|s| s.max_capacity()).unwrap_or(0),
+        factory_log_tx_capacity: factory_log_tx
+            .as_ref()
+            .map(|s| s.max_capacity())
+            .unwrap_or(0),
+        total_channel_send_time: std::time::Duration::ZERO,
+    };
 
     // =========================================================================
     // Catchup phase: Process any ranges where blocks exist but receipts don't
@@ -98,11 +107,11 @@ pub async fn collect_receipts(
         if receipts_exist && (logs_exist || log_tx.is_none()) {
             // Still need to signal range complete for downstream collectors
             // when catching up, so they know this range is done
-            if has_factories || event_trigger_tx.is_some() {
+            if has_factories || channels.event_trigger_tx.is_some() {
                 send_range_complete(
-                    factory_log_tx,
-                    log_tx,
-                    event_trigger_tx,
+                    &channels.factory_log_tx,
+                    &channels.log_tx,
+                    &channels.event_trigger_tx,
                     range.start,
                     range.end,
                 )
@@ -191,15 +200,10 @@ pub async fn collect_receipts(
             receipt_fields,
             &schema,
             &output_dir,
-            log_tx,
-            factory_log_tx,
-            event_trigger_tx,
+            &channels,
             event_matchers,
             rpc_batch_size,
-            &mut log_tx_metrics,
-            &mut factory_log_tx_metrics,
-            log_tx_capacity,
-            factory_log_tx_capacity,
+            &mut metrics,
             chain.block_receipts_method.as_deref(),
             block_receipt_concurrency,
             storage_manager.as_ref(),
@@ -208,9 +212,9 @@ pub async fn collect_receipts(
         .await?;
 
         send_range_complete(
-            factory_log_tx,
-            log_tx,
-            event_trigger_tx,
+            &channels.factory_log_tx,
+            &channels.log_tx,
+            &channels.event_trigger_tx,
             range.start,
             range.end,
         )
@@ -227,11 +231,11 @@ pub async fn collect_receipts(
     }
 
     // Log channel backpressure summaries for catchup phase
-    if log_tx.is_some() {
-        log_tx_metrics.log_summary("log_tx (catchup)");
+    if channels.log_tx.is_some() {
+        metrics.log_tx_metrics.log_summary("log_tx (catchup)");
     }
-    if factory_log_tx.is_some() {
-        factory_log_tx_metrics.log_summary("factory_log_tx (catchup)");
+    if channels.factory_log_tx.is_some() {
+        metrics.factory_log_tx_metrics.log_summary("factory_log_tx (catchup)");
     }
 
     Ok(ReceiptsCatchupState {

--- a/src/raw_data/historical/current/eth_calls/collector.rs
+++ b/src/raw_data/historical/current/eth_calls/collector.rs
@@ -17,6 +17,7 @@ use crate::rpc::UnifiedRpcClient;
 use crate::storage::StorageManager;
 use crate::types::config::chain::ChainConfig;
 
+#[allow(clippy::too_many_arguments)]
 pub async fn collect_eth_calls(
     chain: &ChainConfig,
     client: &UnifiedRpcClient,

--- a/src/raw_data/historical/current/factories.rs
+++ b/src/raw_data/historical/current/factories.rs
@@ -14,6 +14,7 @@ use crate::storage::{S3Manifest, StorageManager};
 use crate::types::config::chain::ChainConfig;
 use crate::types::config::raw_data::RawDataCollectionConfig;
 
+#[allow(clippy::too_many_arguments)]
 pub async fn collect_factories(
     chain: &ChainConfig,
     raw_data_config: &RawDataCollectionConfig,

--- a/src/raw_data/historical/current/receipts.rs
+++ b/src/raw_data/historical/current/receipts.rs
@@ -11,8 +11,9 @@ use crate::raw_data::historical::factories::RecollectRequest;
 use crate::raw_data::historical::receipts::{
     build_receipt_schema, extract_event_triggers, fetch_receipts_for_blocks, process_range,
     send_logs_to_channels, send_range_complete, write_full_receipts_to_parquet,
-    write_minimal_receipts_to_parquet, BlockInfo, ChannelMetrics, EventTriggerMatcher,
-    EventTriggerMessage, LogMessage, ReceiptBatchState, ReceiptCollectionError,
+    write_minimal_receipts_to_parquet, BlockInfo, ChannelMetrics, ChannelMetricsState,
+    EventTriggerMatcher, EventTriggerMessage, LogMessage, ReceiptBatchState,
+    ReceiptCollectionError, ReceiptOutputChannels,
 };
 use crate::rpc::UnifiedRpcClient;
 use crate::storage::paths::raw_receipts_dir;
@@ -20,6 +21,7 @@ use crate::storage::{upload_parquet_to_s3, BlockRange, StorageManager};
 use crate::types::config::chain::ChainConfig;
 use crate::types::config::raw_data::RawDataCollectionConfig;
 
+#[allow(clippy::too_many_arguments)]
 pub async fn collect_receipts(
     chain: &ChainConfig,
     client: &UnifiedRpcClient,
@@ -49,24 +51,31 @@ pub async fn collect_receipts(
     // Batch states for early RPC fetching - track blocks received vs fetched
     let mut batch_states: HashMap<u64, ReceiptBatchState> = HashMap::new();
 
-    // Get channel capacities for backpressure monitoring
-    let log_tx_capacity = log_tx.as_ref().map(|s| s.max_capacity()).unwrap_or(0);
-    let factory_log_tx_capacity = factory_log_tx
-        .as_ref()
-        .map(|s| s.max_capacity())
-        .unwrap_or(0);
+    // Build output channels and metrics structs
+    let channels = ReceiptOutputChannels {
+        log_tx,
+        factory_log_tx,
+        event_trigger_tx,
+    };
 
-    // Initialize channel metrics for backpressure tracking
-    let mut log_tx_metrics = ChannelMetrics::default();
-    let mut factory_log_tx_metrics = ChannelMetrics::default();
+    let mut metrics = ChannelMetricsState {
+        log_tx_metrics: ChannelMetrics::default(),
+        factory_log_tx_metrics: ChannelMetrics::default(),
+        log_tx_capacity: channels.log_tx.as_ref().map(|s| s.max_capacity()).unwrap_or(0),
+        factory_log_tx_capacity: channels.factory_log_tx
+            .as_ref()
+            .map(|s| s.max_capacity())
+            .unwrap_or(0),
+        total_channel_send_time: std::time::Duration::ZERO,
+    };
 
     tracing::info!(
         "Starting receipt collection (current mode) for chain {} (log_tx: {}, factory_log_tx: {}, log_tx_capacity: {}, factory_log_tx_capacity: {})",
         chain.name,
-        log_tx.is_some(),
-        factory_log_tx.is_some(),
-        log_tx_capacity,
-        factory_log_tx_capacity
+        channels.log_tx.is_some(),
+        channels.factory_log_tx.is_some(),
+        metrics.log_tx_capacity,
+        metrics.factory_log_tx_capacity
     );
 
     // =========================================================================
@@ -119,7 +128,7 @@ pub async fn collect_receipts(
                                     range.end - 1
                                 );
                                 batch_states.remove(&range_start);
-                                send_range_complete(&factory_log_tx, &log_tx, &event_trigger_tx, range.start, range.end).await?;
+                                send_range_complete(&channels.factory_log_tx, &channels.log_tx, &channels.event_trigger_tx, range.start, range.end).await?;
                             }
                             continue;
                         }
@@ -181,18 +190,13 @@ pub async fn collect_receipts(
 
                                 send_logs_to_channels(
                                     result.logs,
-                                    &log_tx,
-                                    &factory_log_tx,
-                                    &mut log_tx_metrics,
-                                    &mut factory_log_tx_metrics,
-                                    log_tx_capacity,
-                                    factory_log_tx_capacity,
-                                    &mut std::time::Duration::default(),
+                                    &channels,
+                                    &mut metrics,
                                 )
                                 .await?;
 
                                 if !triggers.is_empty() {
-                                    if let Some(tx) = &event_trigger_tx {
+                                    if let Some(tx) = &channels.event_trigger_tx {
                                         tx.send(EventTriggerMessage::Triggers(triggers))
                                             .await
                                             .map_err(|e| ReceiptCollectionError::ChannelSend(e.to_string()))?;
@@ -251,18 +255,13 @@ pub async fn collect_receipts(
 
                                     send_logs_to_channels(
                                         result.logs,
-                                        &log_tx,
-                                        &factory_log_tx,
-                                        &mut log_tx_metrics,
-                                        &mut factory_log_tx_metrics,
-                                        log_tx_capacity,
-                                        factory_log_tx_capacity,
-                                        &mut std::time::Duration::default(),
+                                        &channels,
+                                        &mut metrics,
                                     )
                                     .await?;
 
                                     if !triggers.is_empty() {
-                                        if let Some(tx) = &event_trigger_tx {
+                                        if let Some(tx) = &channels.event_trigger_tx {
                                             tx.send(EventTriggerMessage::Triggers(triggers))
                                                 .await
                                                 .map_err(|e| ReceiptCollectionError::ChannelSend(e.to_string()))?;
@@ -328,7 +327,7 @@ pub async fn collect_receipts(
                                 .map_err(|e| ReceiptCollectionError::Io(std::io::Error::other(e.to_string())))?;
                             }
 
-                            send_range_complete(&factory_log_tx, &log_tx, &event_trigger_tx, range.start, range.end).await?;
+                            send_range_complete(&channels.factory_log_tx, &channels.log_tx, &channels.event_trigger_tx, range.start, range.end).await?;
                         }
                     }
                     None => {
@@ -401,15 +400,10 @@ pub async fn collect_receipts(
                         receipt_fields,
                         &schema,
                         &output_dir,
-                        &log_tx,
-                        &factory_log_tx,
-                        &event_trigger_tx,
+                        &channels,
                         &event_matchers,
                         rpc_batch_size,
-                        &mut log_tx_metrics,
-                        &mut factory_log_tx_metrics,
-                        log_tx_capacity,
-                        factory_log_tx_capacity,
+                        &mut metrics,
                         chain.block_receipts_method.as_deref(),
                         block_receipt_concurrency,
                         storage_manager.as_ref(),
@@ -417,7 +411,7 @@ pub async fn collect_receipts(
                     )
                     .await?;
 
-                    send_range_complete(&factory_log_tx, &log_tx, &event_trigger_tx, range.start, range.end).await?;
+                    send_range_complete(&channels.factory_log_tx, &channels.log_tx, &channels.event_trigger_tx, range.start, range.end).await?;
 
                     tracing::info!(
                         "Recollection complete for range {}-{}",
@@ -472,9 +466,9 @@ pub async fn collect_receipts(
                 range.end - 1
             );
             send_range_complete(
-                &factory_log_tx,
-                &log_tx,
-                &event_trigger_tx,
+                &channels.factory_log_tx,
+                &channels.log_tx,
+                &channels.event_trigger_tx,
                 range.start,
                 range.end,
             )
@@ -522,18 +516,13 @@ pub async fn collect_receipts(
 
                 send_logs_to_channels(
                     result.logs,
-                    &log_tx,
-                    &factory_log_tx,
-                    &mut log_tx_metrics,
-                    &mut factory_log_tx_metrics,
-                    log_tx_capacity,
-                    factory_log_tx_capacity,
-                    &mut std::time::Duration::default(),
+                    &channels,
+                    &mut metrics,
                 )
                 .await?;
 
                 if !triggers.is_empty() {
-                    if let Some(tx) = &event_trigger_tx {
+                    if let Some(tx) = &channels.event_trigger_tx {
                         tx.send(EventTriggerMessage::Triggers(triggers))
                             .await
                             .map_err(|e| ReceiptCollectionError::ChannelSend(e.to_string()))?;
@@ -606,16 +595,16 @@ pub async fn collect_receipts(
         }
 
         send_range_complete(
-            &factory_log_tx,
-            &log_tx,
-            &event_trigger_tx,
+            &channels.factory_log_tx,
+            &channels.log_tx,
+            &channels.event_trigger_tx,
             range.start,
             range.end,
         )
         .await?;
     }
 
-    if let Some(sender) = &factory_log_tx {
+    if let Some(sender) = &channels.factory_log_tx {
         if sender.send(LogMessage::AllRangesComplete).await.is_err() {
             tracing::error!(
                 "Failed to send AllRangesComplete to factory_log_tx - receiver dropped"
@@ -625,7 +614,7 @@ pub async fn collect_receipts(
             ));
         }
     }
-    if let Some(sender) = &log_tx {
+    if let Some(sender) = &channels.log_tx {
         if sender.send(LogMessage::AllRangesComplete).await.is_err() {
             tracing::error!("Failed to send AllRangesComplete to log_tx - receiver dropped");
             return Err(ReceiptCollectionError::ChannelSend(
@@ -633,7 +622,7 @@ pub async fn collect_receipts(
             ));
         }
     }
-    if let Some(sender) = &event_trigger_tx {
+    if let Some(sender) = &channels.event_trigger_tx {
         if sender.send(EventTriggerMessage::AllComplete).await.is_err() {
             tracing::error!("Failed to send AllComplete to event_trigger_tx - receiver dropped");
             return Err(ReceiptCollectionError::ChannelSend(
@@ -643,11 +632,11 @@ pub async fn collect_receipts(
     }
 
     // Log channel backpressure summaries
-    if log_tx.is_some() {
-        log_tx_metrics.log_summary("log_tx");
+    if channels.log_tx.is_some() {
+        metrics.log_tx_metrics.log_summary("log_tx");
     }
-    if factory_log_tx.is_some() {
-        factory_log_tx_metrics.log_summary("factory_log_tx");
+    if channels.factory_log_tx.is_some() {
+        metrics.factory_log_tx_metrics.log_summary("factory_log_tx");
     }
 
     tracing::info!("Receipt collection complete for chain {}", chain.name);

--- a/src/raw_data/historical/factories.rs
+++ b/src/raw_data/historical/factories.rs
@@ -196,6 +196,7 @@ fn parse_data_signature(sig: &str) -> Vec<DynSolType> {
         .collect()
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn process_range(
     range_start: u64,
     range_end: u64,
@@ -324,6 +325,7 @@ pub(crate) fn read_log_batches_from_parquet(
 
 /// Process log record batches using Arrow-native column access.
 /// Works directly on Arrow arrays instead of materializing LogData structs.
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn process_range_batches(
     range_start: u64,
     range_end: u64,
@@ -481,6 +483,7 @@ pub(crate) async fn process_range_batches(
 
 /// Write factory records to parquet files, grouped by collection.
 /// Writes empty parquet files for collections with no matching events.
+#[allow(clippy::too_many_arguments)]
 async fn write_factory_parquet_files(
     range_start: u64,
     range_end: u64,

--- a/src/raw_data/historical/logs.rs
+++ b/src/raw_data/historical/logs.rs
@@ -72,6 +72,7 @@ pub(crate) struct MinimalLogRecord {
     pub(crate) data: Vec<u8>,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn process_completed_range(
     range_start: u64,
     range_end: u64,

--- a/src/raw_data/historical/receipts.rs
+++ b/src/raw_data/historical/receipts.rs
@@ -312,6 +312,24 @@ pub(crate) struct ReceiptBatchState {
     pub(crate) logs: Vec<LogData>,
 }
 
+/// Channel metrics tracking state for receipt processing.
+/// Bundles the per-channel metrics and capacity info to reduce parameter counts.
+pub(crate) struct ChannelMetricsState {
+    pub(crate) log_tx_metrics: ChannelMetrics,
+    pub(crate) factory_log_tx_metrics: ChannelMetrics,
+    pub(crate) log_tx_capacity: usize,
+    pub(crate) factory_log_tx_capacity: usize,
+    pub(crate) total_channel_send_time: std::time::Duration,
+}
+
+/// Output channels for receipt log distribution.
+/// Bundles the optional output senders to reduce parameter counts.
+pub(crate) struct ReceiptOutputChannels {
+    pub(crate) log_tx: Option<Sender<LogMessage>>,
+    pub(crate) factory_log_tx: Option<Sender<LogMessage>>,
+    pub(crate) event_trigger_tx: Option<Sender<EventTriggerMessage>>,
+}
+
 /// Tracks channel backpressure metrics for monitoring
 #[derive(Debug, Default)]
 pub(crate) struct ChannelMetrics {
@@ -436,19 +454,14 @@ pub(crate) async fn send_range_complete(
 
 pub(crate) async fn send_logs_to_channels(
     batch_logs: Vec<LogData>,
-    log_tx: &Option<Sender<LogMessage>>,
-    factory_log_tx: &Option<Sender<LogMessage>>,
-    log_tx_metrics: &mut ChannelMetrics,
-    factory_log_tx_metrics: &mut ChannelMetrics,
-    log_tx_capacity: usize,
-    factory_log_tx_capacity: usize,
-    total_channel_send_time: &mut std::time::Duration,
+    channels: &ReceiptOutputChannels,
+    metrics: &mut ChannelMetricsState,
 ) -> Result<(), ReceiptCollectionError> {
     let log_count = batch_logs.len();
 
-    if let Some(sender) = factory_log_tx {
+    if let Some(sender) = &channels.factory_log_tx {
         let capacity_before = sender.capacity();
-        let fill_pct = 100.0 * (1.0 - capacity_before as f64 / factory_log_tx_capacity as f64);
+        let fill_pct = 100.0 * (1.0 - capacity_before as f64 / metrics.factory_log_tx_capacity as f64);
 
         if fill_pct > 90.0 {
             tracing::warn!(
@@ -473,15 +486,15 @@ pub(crate) async fn send_logs_to_channels(
             )));
         }
         let send_time = send_start.elapsed();
-        *total_channel_send_time += send_time;
+        metrics.total_channel_send_time += send_time;
 
-        factory_log_tx_metrics.record_send(send_time, capacity_before, factory_log_tx_capacity);
-        factory_log_tx_metrics.total_logs_sent += log_count as u64;
+        metrics.factory_log_tx_metrics.record_send(send_time, capacity_before, metrics.factory_log_tx_capacity);
+        metrics.factory_log_tx_metrics.total_logs_sent += log_count as u64;
     }
 
-    if let Some(sender) = log_tx {
+    if let Some(sender) = &channels.log_tx {
         let capacity_before = sender.capacity();
-        let fill_pct = 100.0 * (1.0 - capacity_before as f64 / log_tx_capacity as f64);
+        let fill_pct = 100.0 * (1.0 - capacity_before as f64 / metrics.log_tx_capacity as f64);
 
         if fill_pct > 90.0 {
             tracing::warn!(
@@ -502,10 +515,10 @@ pub(crate) async fn send_logs_to_channels(
             )));
         }
         let send_time = send_start.elapsed();
-        *total_channel_send_time += send_time;
+        metrics.total_channel_send_time += send_time;
 
-        log_tx_metrics.record_send(send_time, capacity_before, log_tx_capacity);
-        log_tx_metrics.total_logs_sent += log_count as u64;
+        metrics.log_tx_metrics.record_send(send_time, capacity_before, metrics.log_tx_capacity);
+        metrics.log_tx_metrics.total_logs_sent += log_count as u64;
     }
 
     Ok(())
@@ -619,6 +632,7 @@ pub(crate) async fn fetch_receipts_for_blocks(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn process_range(
     range: &BlockRange,
     blocks: Vec<BlockInfo>,
@@ -626,15 +640,10 @@ pub(crate) async fn process_range(
     receipt_fields: &Option<Vec<ReceiptField>>,
     schema: &Arc<Schema>,
     output_dir: &Path,
-    log_tx: &Option<Sender<LogMessage>>,
-    factory_log_tx: &Option<Sender<LogMessage>>,
-    event_trigger_tx: &Option<Sender<EventTriggerMessage>>,
+    channels: &ReceiptOutputChannels,
     event_matchers: &[EventTriggerMatcher],
     rpc_batch_size: usize,
-    log_tx_metrics: &mut ChannelMetrics,
-    factory_log_tx_metrics: &mut ChannelMetrics,
-    log_tx_capacity: usize,
-    factory_log_tx_capacity: usize,
+    metrics: &mut ChannelMetricsState,
     block_receipts_method: Option<&str>,
     block_receipt_concurrency: usize,
     storage_manager: Option<&Arc<StorageManager>>,
@@ -648,7 +657,8 @@ pub(crate) async fn process_range(
     // Timing metrics (always tracked)
     let mut total_rpc_time = std::time::Duration::ZERO;
     let mut total_process_time = std::time::Duration::ZERO;
-    let mut total_channel_send_time = std::time::Duration::ZERO;
+    // Reset channel send time for this range (tracked via metrics.total_channel_send_time)
+    metrics.total_channel_send_time = std::time::Duration::ZERO;
 
     #[cfg(feature = "bench")]
     let mut rpc_time = std::time::Duration::ZERO;
@@ -773,19 +783,14 @@ pub(crate) async fn process_range(
 
                 send_logs_to_channels(
                     batch_logs,
-                    log_tx,
-                    factory_log_tx,
-                    log_tx_metrics,
-                    factory_log_tx_metrics,
-                    log_tx_capacity,
-                    factory_log_tx_capacity,
-                    &mut total_channel_send_time,
+                    channels,
+                    metrics,
                 )
                 .await?;
 
                 // Send event triggers if any
                 if !triggers.is_empty() {
-                    if let Some(tx) = event_trigger_tx {
+                    if let Some(tx) = &channels.event_trigger_tx {
                         tx.send(EventTriggerMessage::Triggers(triggers))
                             .await
                             .map_err(|e| ReceiptCollectionError::ChannelSend(e.to_string()))?;
@@ -889,19 +894,14 @@ pub(crate) async fn process_range(
 
                 send_logs_to_channels(
                     batch_logs,
-                    log_tx,
-                    factory_log_tx,
-                    log_tx_metrics,
-                    factory_log_tx_metrics,
-                    log_tx_capacity,
-                    factory_log_tx_capacity,
-                    &mut total_channel_send_time,
+                    channels,
+                    metrics,
                 )
                 .await?;
 
                 // Send event triggers if any
                 if !triggers.is_empty() {
-                    if let Some(tx) = event_trigger_tx {
+                    if let Some(tx) = &channels.event_trigger_tx {
                         tx.send(EventTriggerMessage::Triggers(triggers))
                             .await
                             .map_err(|e| ReceiptCollectionError::ChannelSend(e.to_string()))?;
@@ -983,6 +983,7 @@ pub(crate) async fn process_range(
     let total_time = range_start_time.elapsed();
     let rpc_pct = (total_rpc_time.as_secs_f64() / total_time.as_secs_f64()) * 100.0;
     let process_pct = (total_process_time.as_secs_f64() / total_time.as_secs_f64()) * 100.0;
+    let total_channel_send_time = metrics.total_channel_send_time;
     let channel_pct = (total_channel_send_time.as_secs_f64() / total_time.as_secs_f64()) * 100.0;
     let write_pct = (total_write_time.as_secs_f64() / total_time.as_secs_f64()) * 100.0;
 


### PR DESCRIPTION
## What Changed

Addresses ~20 `clippy::too_many_arguments` warnings across the raw data collection pipeline and `main.rs` by introducing context structs where natural parameter groups exist, and applying `#[allow(clippy::too_many_arguments)]` where remaining parameters don't form meaningful groupings.

### New context structs

- **`ChannelMetricsState`** (receipts.rs) — bundles 5 channel metrics params (`log_tx_metrics`, `factory_log_tx_metrics`, `log_tx_capacity`, `factory_log_tx_capacity`, `total_channel_send_time`) into a single struct
- **`ReceiptOutputChannels`** (receipts.rs) — bundles 3 output channel senders (`log_tx`, `factory_log_tx`, `event_trigger_tx`)
- **`LiveModeChannels`** (main.rs) — bundles 4 decoder/transform channel senders for live mode (`log_decoder_tx`, `eth_call_decoder_tx`, `transform_reorg_tx`, `transform_retry_tx`)

### Key reductions

| Function | Before | After |
|----------|--------|-------|
| `receipts::process_range` | 19 args | 15 args (+ `#[allow]`) |
| `receipts::send_logs_to_channels` | 8 args | 3 args |
| `spawn_live_mode` | 11 args | 8 args (+ `#[allow]`) |

### `#[allow]` annotations

Applied to 18 functions at 8-14 args where the remaining parameters are unique consumed channels or configs that don't form natural groups (e.g., `collect_blocks`, `collect_eth_calls`, `collect_factories`, `collect_receipts`, `LiveCollector::new`, `spawn_receipts`, `spawn_eth_calls`, `spawn_factories`, `spawn_eth_call_decoder`).

### Conflict note

This PR touches `src/main.rs` and may have minor conflicts with sibling clippy PRs (#44, #45, #46, #47) in different sections of the same file.