### PR TITLE
fix: null addresses and factory parquet error propagation

### DIFF
--- a/src/decoding/logs.rs
+++ b/src/decoding/logs.rs
@@ -898,12 +898,13 @@ fn build_flattened_field_array(
             if records.is_empty() {
                 Ok(Arc::new(FixedSizeBinaryBuilder::new(20).finish()))
             } else {
-                let arr = FixedSizeBinaryArray::try_from_iter(records.iter().map(|r| {
+                let values: Vec<Option<&[u8]>> = records.iter().map(|r| {
                     match r.decoded_values.get(field_idx) {
-                        Some(DecodedValue::Address(addr)) => addr.as_slice(),
-                        _ => &[0u8; 20][..],
+                        Some(DecodedValue::Address(addr)) => Some(addr.as_slice()),
+                        _ => None,
                     }
-                }))?;
+                }).collect();
+                let arr = FixedSizeBinaryArray::try_from_sparse_iter_with_size(values.into_iter(), 20)?;
                 Ok(Arc::new(arr))
             }
         }
@@ -989,12 +990,13 @@ fn build_flattened_field_array(
             if records.is_empty() {
                 Ok(Arc::new(FixedSizeBinaryBuilder::new(32).finish()))
             } else {
-                let arr = FixedSizeBinaryArray::try_from_iter(records.iter().map(|r| {
+                let values: Vec<Option<&[u8]>> = records.iter().map(|r| {
                     match r.decoded_values.get(field_idx) {
-                        Some(DecodedValue::Bytes32(b)) => b.as_slice(),
-                        _ => &[0u8; 32][..],
+                        Some(DecodedValue::Bytes32(b)) => Some(b.as_slice()),
+                        _ => None,
                     }
-                }))?;
+                }).collect();
+                let arr = FixedSizeBinaryArray::try_from_sparse_iter_with_size(values.into_iter(), 32)?;
                 Ok(Arc::new(arr))
             }
         }

--- a/src/storage/factory_data.rs
+++ b/src/storage/factory_data.rs
@@ -139,11 +139,20 @@ pub async fn load_factory_addresses_by_collection(
         for file_path in file_paths {
             match data_loader.ensure_local(&file_path).await {
                 Ok(true) => {
-                    if let Ok(addresses) = read_factory_addresses_from_parquet(&file_path) {
-                        result
-                            .entry(collection_name.clone())
-                            .or_default()
-                            .extend(addresses.into_iter().map(Address::from));
+                    match read_factory_addresses_from_parquet(&file_path) {
+                        Ok(addresses) => {
+                            result
+                                .entry(collection_name.clone())
+                                .or_default()
+                                .extend(addresses.into_iter().map(Address::from));
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                "Failed to read factory addresses from {}: {}",
+                                file_path.display(),
+                                e
+                            );
+                        }
                     }
                 }
                 Ok(false) => {

--- a/src/storage/parquet_readers.rs
+++ b/src/storage/parquet_readers.rs
@@ -182,8 +182,6 @@ pub fn read_raw_logs_from_parquet(path: &Path) -> Result<Vec<LogData>, ParquetRe
 /// Read factory addresses from a parquet file, returning a set of raw 20-byte addresses.
 ///
 /// Reads the `factory_address` column from a factory parquet file.
-/// Parquet read errors are logged as warnings and result in an empty set (not a hard error),
-/// matching the original behavior.
 pub fn read_factory_addresses_from_parquet(
     path: &Path,
 ) -> Result<HashSet<[u8; 20]>, ParquetReadError> {
@@ -192,21 +190,11 @@ pub fn read_factory_addresses_from_parquet(
         Ok(builder) => match builder.build() {
             Ok(r) => r,
             Err(e) => {
-                tracing::warn!(
-                    "Failed to build parquet reader for {}: {}",
-                    path.display(),
-                    e
-                );
-                return Ok(HashSet::new());
+                return Err(ParquetReadError::Parquet(e));
             }
         },
         Err(e) => {
-            tracing::warn!(
-                "Failed to create parquet reader for {}: {}",
-                path.display(),
-                e
-            );
-            return Ok(HashSet::new());
+            return Err(ParquetReadError::Parquet(e));
         }
     };
 


### PR DESCRIPTION
## Summary

This PR fixes two bugs in the parquet encoding and reading logic:

### Bug 11: Zero addresses instead of null in parquet

In `src/decoding/logs.rs`, the `build_flattened_field_array` function used `&[0u8; 20]` as a fallback for missing `Address` values and `&[0u8; 32]` for missing `FixedBytes(32)` values. This made it impossible to distinguish between "no address present" and the actual zero address (`0x0000...0000`), which is a valid on-chain address (e.g., the burn address).

The fix switches both the `Address` and `FixedBytes(32)` arms to use `FixedSizeBinaryArray::try_from_sparse_iter_with_size`, which supports nullable entries via `Option<&[u8]>`. Missing values now produce proper Arrow nulls instead of zero-filled byte arrays. This pattern is already used elsewhere in the codebase (e.g., `receipts.rs` and `blocks.rs`).

### Bug 13: Silent factory parquet read errors

In `src/storage/parquet_readers.rs`, `read_factory_addresses_from_parquet` was returning `Ok(HashSet::new())` when parquet reader construction failed, silently dropping all factory contract addresses for that file. This could cause the indexer to miss factory-created contracts entirely without any indication of failure.

The fix propagates `ParquetReadError::Parquet` errors to the caller. The caller in `src/storage/factory_data.rs` now handles the error with a `match` and logs a warning, making failures visible while still allowing processing of other files to continue.

## Files Changed

- `src/decoding/logs.rs` -- Use nullable sparse iterator for Address and FixedBytes(32) arrays
- `src/storage/parquet_readers.rs` -- Propagate parquet reader errors instead of swallowing them
- `src/storage/factory_data.rs` -- Handle propagated errors with warning log at call site