### PR TITLE
fix: flag deep reorgs that exceed retention window

### DIFF
--- a/src/live/collector.rs
+++ b/src/live/collector.rs
@@ -567,6 +567,16 @@ impl LiveCollector {
             event.depth
         );
 
+        if event.is_deep {
+            tracing::error!(
+                "DEEP REORG detected at block {}: reorg goes beyond retention window. \
+                 Orphaning all {} tracked blocks as best-effort cleanup. \
+                 Manual verification may be needed.",
+                event._new_block_number,
+                event.orphaned.len()
+            );
+        }
+
         // Delete orphaned blocks from storage (including decoded data)
         // Only clear progress for blocks that were successfully deleted
         let mut failed_deletions: Vec<u64> = Vec::new();

--- a/src/live/reorg.rs
+++ b/src/live/reorg.rs
@@ -23,6 +23,8 @@ pub struct ReorgEvent {
     pub _new_block_number: u64,
     /// How many blocks deep the reorg was.
     pub depth: u64,
+    /// True when reorg goes beyond retention window; orphaned list is best-effort.
+    pub is_deep: bool,
 }
 
 /// Detects chain reorganizations by tracking recent block hashes.
@@ -85,7 +87,7 @@ impl ReorgDetector {
                     hex::encode(block.hash)
                 );
 
-                let (common_ancestor, orphaned) = self.find_common_ancestor(block);
+                let (common_ancestor, orphaned, is_deep) = self.find_common_ancestor(block);
                 let depth = block.number.saturating_sub(common_ancestor);
 
                 return Some(ReorgEvent {
@@ -93,6 +95,7 @@ impl ReorgDetector {
                     orphaned,
                     _new_block_number: block.number,
                     depth,
+                    is_deep,
                 });
             }
 
@@ -119,7 +122,7 @@ impl ReorgDetector {
             hex::encode(block.parent_hash)
         );
 
-        let (common_ancestor, orphaned) = self.find_common_ancestor(block);
+        let (common_ancestor, orphaned, is_deep) = self.find_common_ancestor(block);
 
         let depth = block.number - common_ancestor;
 
@@ -128,13 +131,16 @@ impl ReorgDetector {
             orphaned,
             _new_block_number: block.number,
             depth,
+            is_deep,
         })
     }
 
     /// Find the common ancestor by walking back through tracked blocks.
     ///
-    /// Returns (common_ancestor_number, orphaned_block_numbers).
-    fn find_common_ancestor(&self, new_block: &LiveBlock) -> (u64, Vec<u64>) {
+    /// Returns (common_ancestor_number, orphaned_block_numbers, is_deep).
+    /// When `is_deep` is true, the reorg exceeds the retention window and the
+    /// orphaned list is best-effort (all tracked blocks are orphaned).
+    fn find_common_ancestor(&self, new_block: &LiveBlock) -> (u64, Vec<u64>, bool) {
         let retained_ancestor = self.recent_blocks.range(..new_block.number).rev().find_map(
             |(&block_number, tracked)| {
                 (tracked.hash == new_block.parent_hash).then_some(block_number)
@@ -148,7 +154,7 @@ impl ReorgDetector {
                     .range((common_ancestor + 1)..)
                     .map(|(&block_number, _)| block_number)
                     .collect();
-                (common_ancestor, orphaned)
+                (common_ancestor, orphaned, false)
             }
             None => {
                 let common_ancestor = self
@@ -166,7 +172,7 @@ impl ReorgDetector {
                     orphaned.len()
                 );
 
-                (common_ancestor, orphaned)
+                (common_ancestor, orphaned, true)
             }
         }
     }
@@ -286,6 +292,7 @@ mod tests {
         assert_eq!(event.common_ancestor, 1);
         assert_eq!(event.orphaned, vec![2, 3]);
         assert_eq!(event.depth, 2);
+        assert!(!event.is_deep);
     }
 
     #[test]
@@ -308,6 +315,7 @@ mod tests {
         let event = detector.process_block(&reorg_block).unwrap();
         assert_eq!(event.common_ancestor, 4);
         assert_eq!(event.orphaned, vec![5, 6]);
+        assert!(!event.is_deep);
         assert!(detector.get_block_hash(4).is_some());
         assert!(detector.get_block_hash(5).is_none());
     }
@@ -406,6 +414,7 @@ mod tests {
         let event = detector.process_block(&replacement).unwrap();
         assert_eq!(event.common_ancestor, 2);
         assert_eq!(event.orphaned, vec![3]);
+        assert!(!event.is_deep);
         assert_eq!(detector.get_block_hash(3), Some([30; 32]));
     }
 
@@ -427,6 +436,7 @@ mod tests {
 
         let event = detector.process_block(&reorg_block).unwrap();
         assert_eq!(event.orphaned, vec![8, 9, 10]);
+        assert!(event.is_deep);
         assert!(detector.get_block_hash(8).is_none());
         assert_eq!(detector.get_block_hash(11), Some([111; 32]));
     }


### PR DESCRIPTION
## Summary

When a chain reorganization exceeds the `ReorgDetector`'s retention window, `find_common_ancestor` cannot find the actual common ancestor among tracked blocks and falls back to orphaning all tracked blocks. Previously, there was no way for callers to distinguish this best-effort cleanup from a normal reorg where the orphaned set is accurate.

This PR adds an `is_deep` boolean field to `ReorgEvent` that is set to `true` when the reorg goes beyond the retention window. This enables:

- **Prominent logging**: The collector now emits an `error`-level log for deep reorgs, making them immediately visible in monitoring and alerting.
- **Future extensibility**: Callers can now branch on `is_deep` to implement additional verification (e.g., RPC lookups to confirm which blocks are actually canonical) without changing the `ReorgEvent` interface again.

## Changes

### `src/live/reorg.rs`
- Added `is_deep: bool` field to `ReorgEvent` with documentation.
- Changed `find_common_ancestor` return type from `(u64, Vec<u64>)` to `(u64, Vec<u64>, bool)` -- returns `false` when ancestor is found in tracked blocks, `true` when it falls through to the deep-reorg fallback.
- Updated both call sites in `check_for_reorg` (same-height reorg and parent-hash-mismatch reorg) to destructure and propagate the `is_deep` flag.
- Added `assert\!(event.is_deep)` to `test_deep_reorg_orphans_retained_window` and `assert\!(\!event.is_deep)` to all other reorg tests (`test_simple_reorg`, `test_reorg_does_not_orphan_entire_history`, `test_same_height_replacement_is_detected`).

### `src/live/collector.rs`
- Added an `error`-level log in `handle_reorg` when `event.is_deep` is true, reporting the triggering block number and the number of orphaned blocks.