### PR TITLE
feat: buffer and replay factory-skipped event triggers

### DIFF
--- a/src/raw_data/historical/catchup/eth_calls.rs
+++ b/src/raw_data/historical/catchup/eth_calls.rs
@@ -125,6 +125,7 @@ pub async fn collect_eth_calls(
             range_factory_data: HashMap::new(),
             range_regular_done: HashSet::new(),
             range_factory_done: HashSet::new(),
+            factory_skipped_triggers: Vec::new(),
         });
     }
 
@@ -714,7 +715,7 @@ pub async fn collect_eth_calls(
             // Process the triggers (or write empty files if no triggers)
             let range_start = log_range.start;
             let range_end = log_range.end - 1;
-            if let Some(multicall_addr) = multicall3_address {
+            let skipped = if let Some(multicall_addr) = multicall3_address {
                 let event_ctx = EthCallContext {
                     client,
                     output_dir: &base_output_dir,
@@ -734,7 +735,7 @@ pub async fn collect_eth_calls(
                     range_start,
                     range_end,
                 )
-                .await?;
+                .await?
             } else {
                 let event_ctx = EthCallContext {
                     client,
@@ -754,7 +755,13 @@ pub async fn collect_eth_calls(
                     range_start,
                     range_end,
                 )
-                .await?;
+                .await?
+            };
+            if !skipped.is_empty() {
+                tracing::warn!(
+                    "Unexpected skipped factory triggers during catchup ({} triggers) — factory addresses should be pre-loaded",
+                    skipped.len()
+                );
             }
 
             event_catchup_count += 1;
@@ -819,5 +826,6 @@ pub async fn collect_eth_calls(
         range_factory_data,
         range_regular_done,
         range_factory_done,
+        factory_skipped_triggers: Vec::new(),
     })
 }

--- a/src/raw_data/historical/current/eth_calls/events.rs
+++ b/src/raw_data/historical/current/eth_calls/events.rs
@@ -54,7 +54,7 @@ pub(super) async fn handle_event_trigger_message(
                     s3_manifest: &state.s3_manifest,
                 };
 
-                if let Some(multicall_addr) = state.multicall3_address {
+                let skipped = if let Some(multicall_addr) = state.multicall3_address {
                     process_event_triggers_multicall(
                         triggers,
                         &state.event_call_configs,
@@ -64,7 +64,7 @@ pub(super) async fn handle_event_trigger_message(
                         range_start,
                         inclusive_end,
                     )
-                    .await?;
+                    .await?
                 } else {
                     process_event_triggers(
                         triggers,
@@ -74,7 +74,15 @@ pub(super) async fn handle_event_trigger_message(
                         range_start,
                         inclusive_end,
                     )
-                    .await?;
+                    .await?
+                };
+
+                if !skipped.is_empty() {
+                    tracing::info!(
+                        "Buffered {} triggers skipped due to missing factory addresses for range {}-{}",
+                        skipped.len(), range_start, inclusive_end
+                    );
+                    state.factory_skipped_triggers.push((skipped, range_start, inclusive_end));
                 }
             } else {
                 local_state.pending_event_triggers.clear();

--- a/src/raw_data/historical/current/eth_calls/factory.rs
+++ b/src/raw_data/historical/current/eth_calls/factory.rs
@@ -5,9 +5,9 @@ use tokio::sync::mpsc::{Receiver, Sender};
 
 use crate::decoding::DecoderMessage;
 use crate::raw_data::historical::eth_calls::{
-    process_factory_once_calls, process_factory_once_calls_multicall, process_factory_range,
-    process_factory_range_multicall, BlockRange, EthCallCatchupState, EthCallCollectionError,
-    EthCallContext,
+    process_event_triggers, process_event_triggers_multicall, process_factory_once_calls,
+    process_factory_once_calls_multicall, process_factory_range, process_factory_range_multicall,
+    BlockRange, EthCallCatchupState, EthCallCollectionError, EthCallContext,
 };
 use crate::raw_data::historical::factories::{FactoryAddressData, FactoryMessage};
 use crate::rpc::UnifiedRpcClient;
@@ -40,6 +40,87 @@ pub(super) async fn handle_factory_message(
                         .or_default()
                         .insert(*addr);
                 }
+            }
+
+            // Check if any buffered triggers can now proceed
+            if !state.factory_skipped_triggers.is_empty() {
+                let mut still_skipped = Vec::new();
+                let buffered = std::mem::take(&mut state.factory_skipped_triggers);
+
+                for (skipped_triggers, buf_range_start, buf_range_end) in buffered {
+                    // Check if any of the triggers' factory collections are now known
+                    let has_new_addresses = skipped_triggers.iter().any(|st| {
+                        let key = (st.trigger.source_name.clone(), st.trigger.event_signature);
+                        state
+                            .event_call_configs
+                            .get(&key)
+                            .map(|configs| {
+                                configs.iter().any(|c| {
+                                    c.is_factory
+                                        && state
+                                            .factory_addresses
+                                            .contains_key(&c.contract_name)
+                                })
+                            })
+                            .unwrap_or(false)
+                    });
+
+                    if has_new_addresses {
+                        let triggers: Vec<_> = skipped_triggers
+                            .iter()
+                            .map(|st| st.trigger.clone())
+                            .collect();
+
+                        tracing::info!(
+                            "Replaying {} previously-skipped triggers for range {}-{} after factory addresses arrived",
+                            triggers.len(), buf_range_start, buf_range_end
+                        );
+
+                        let ctx = EthCallContext {
+                            client,
+                            output_dir: &state.base_output_dir,
+                            existing_files: &state.existing_files,
+                            rpc_batch_size: state.rpc_batch_size,
+                            decoder_tx,
+                            chain_name,
+                            storage_manager,
+                            s3_manifest: &state.s3_manifest,
+                        };
+
+                        let new_skipped = if let Some(multicall_addr) = state.multicall3_address {
+                            process_event_triggers_multicall(
+                                triggers,
+                                &state.event_call_configs,
+                                &state.factory_addresses,
+                                &ctx,
+                                multicall_addr,
+                                buf_range_start,
+                                buf_range_end,
+                            )
+                            .await?
+                        } else {
+                            process_event_triggers(
+                                triggers,
+                                &state.event_call_configs,
+                                &state.factory_addresses,
+                                &ctx,
+                                buf_range_start,
+                                buf_range_end,
+                            )
+                            .await?
+                        };
+
+                        if !new_skipped.is_empty() {
+                            still_skipped
+                                .push((new_skipped, buf_range_start, buf_range_end));
+                        }
+                    } else {
+                        still_skipped
+                            .push((skipped_triggers, buf_range_start, buf_range_end));
+                    }
+                }
+
+                state.factory_skipped_triggers = still_skipped;
             }
 
             // Merge into existing range_factory_data
@@ -146,6 +227,26 @@ pub(super) async fn handle_factory_message(
             }
         }
         Some(FactoryMessage::AllComplete) | None => {
+            if !state.factory_skipped_triggers.is_empty() {
+                let total: usize = state
+                    .factory_skipped_triggers
+                    .iter()
+                    .map(|(t, _, _)| t.len())
+                    .sum();
+                let collections: std::collections::HashSet<String> = state
+                    .factory_skipped_triggers
+                    .iter()
+                    .flat_map(|(triggers, _, _)| {
+                        triggers.iter().map(|t| t.trigger.source_name.clone())
+                    })
+                    .collect();
+                tracing::warn!(
+                    "Factory channel closed with {} unresolvable triggers still buffered across {} ranges. Collections: {:?}",
+                    total,
+                    state.factory_skipped_triggers.len(),
+                    collections
+                );
+            }
             tracing::debug!("eth_calls: factory channel closed");
             *factory_rx = None;
         }

--- a/src/raw_data/historical/current/eth_calls/factory.rs
+++ b/src/raw_data/historical/current/eth_calls/factory.rs
@@ -216,6 +216,32 @@ pub(super) async fn handle_factory_message(
                         }
                     }
                     state.range_factory_done.insert(range_start);
+
+                    // Factory address discovery is complete for this range.
+                    // Any buffered triggers for this range whose emitters still aren't
+                    // in factory_addresses are legitimately not factory instances — drop them.
+                    if !state.factory_skipped_triggers.is_empty() {
+                        let before: usize = state
+                            .factory_skipped_triggers
+                            .iter()
+                            .map(|(t, _, _)| t.len())
+                            .sum();
+                        state
+                            .factory_skipped_triggers
+                            .retain(|(_, buf_start, _)| *buf_start != range_start);
+                        let after: usize = state
+                            .factory_skipped_triggers
+                            .iter()
+                            .map(|(t, _, _)| t.len())
+                            .sum();
+                        let dropped = before - after;
+                        if dropped > 0 {
+                            tracing::debug!(
+                                "Dropped {} buffered triggers for range {} — factory discovery complete, addresses not found",
+                                dropped, range_start
+                            );
+                        }
+                    }
                 }
 
                 if state.range_regular_done.contains(&range_start)
@@ -233,18 +259,10 @@ pub(super) async fn handle_factory_message(
                     .iter()
                     .map(|(t, _, _)| t.len())
                     .sum();
-                let collections: std::collections::HashSet<String> = state
-                    .factory_skipped_triggers
-                    .iter()
-                    .flat_map(|(triggers, _, _)| {
-                        triggers.iter().map(|t| t.trigger.source_name.clone())
-                    })
-                    .collect();
-                tracing::warn!(
-                    "Factory channel closed with {} unresolvable triggers still buffered across {} ranges. Collections: {:?}",
-                    total,
-                    state.factory_skipped_triggers.len(),
-                    collections
+                tracing::error!(
+                    "BUG: {} buffered triggers remain after all factory ranges complete. \
+                     These should have been drained by RangeComplete.",
+                    total
                 );
             }
             tracing::debug!("eth_calls: factory channel closed");

--- a/src/raw_data/historical/eth_calls/event_triggers.rs
+++ b/src/raw_data/historical/eth_calls/event_triggers.rs
@@ -26,6 +26,13 @@ use crate::storage::upload_parquet_to_s3;
 use crate::types::config::contract::{AddressOrAddresses, Contracts};
 use crate::types::config::eth_call::{encode_call_with_params, EvmType, ParamConfig};
 
+/// A trigger that was skipped because its factory address wasn't known yet.
+/// Buffered for replay when factory addresses arrive via IncrementalAddresses.
+#[derive(Debug, Clone)]
+pub struct SkippedFactoryTrigger {
+    pub trigger: EventTriggerData,
+}
+
 /// An event-triggered call matched with its config and encoded parameters,
 /// ready to be grouped by output key.
 pub(super) struct PreparedEventCall {
@@ -502,7 +509,9 @@ pub(crate) async fn process_event_triggers(
     ctx: &EthCallContext<'_>,
     range_start: u64,
     range_end: u64,
-) -> Result<(), EthCallCollectionError> {
+) -> Result<Vec<SkippedFactoryTrigger>, EthCallCollectionError> {
+    let mut skipped_factory_triggers: Vec<SkippedFactoryTrigger> = Vec::new();
+
     // Collect all configured (contract_name, function_name) pairs so we can write empty files
     // for pairs with no matching events (prevents catchup from retrying)
     let configured_pairs: HashSet<(String, String)> = event_call_configs
@@ -522,7 +531,7 @@ pub(crate) async fn process_event_triggers(
                 range_end,
             )?;
         }
-        return Ok(());
+        return Ok(skipped_factory_triggers);
     }
 
     // Group triggers by (source_name, event_signature) and then by (contract_name, function_name)
@@ -562,10 +571,12 @@ pub(crate) async fn process_event_triggers(
                         }
                         None => {
                             // No factory addresses known yet for this collection
-                            // Skip this trigger - it will be caught up later when addresses are loaded
-                            // This prevents making calls to random addresses during the race window
+                            // Buffer the trigger for replay when addresses arrive
+                            skipped_factory_triggers.push(SkippedFactoryTrigger {
+                                trigger: trigger.clone(),
+                            });
                             tracing::debug!(
-                                "Skipping event trigger for {}: no factory addresses loaded yet (will be processed during catchup)",
+                                "Buffering event trigger for {}: no factory addresses loaded yet",
                                 config.contract_name
                             );
                             continue;
@@ -800,7 +811,7 @@ pub(crate) async fn process_event_triggers(
         }
     }
 
-    Ok(())
+    Ok(skipped_factory_triggers)
 }
 
 /// Write an empty parquet file for event-triggered calls when no events matched
@@ -840,7 +851,9 @@ pub(crate) async fn process_event_triggers_multicall(
     multicall3_address: Address,
     range_start: u64,
     range_end: u64,
-) -> Result<(), EthCallCollectionError> {
+) -> Result<Vec<SkippedFactoryTrigger>, EthCallCollectionError> {
+    let mut skipped_factory_triggers: Vec<SkippedFactoryTrigger> = Vec::new();
+
     // Collect all configured (contract_name, function_name) pairs so we can write empty files
     // for pairs with no matching events (prevents catchup from retrying)
     let configured_pairs: HashSet<(String, String)> = event_call_configs
@@ -860,7 +873,7 @@ pub(crate) async fn process_event_triggers_multicall(
                 range_end,
             )?;
         }
-        return Ok(());
+        return Ok(skipped_factory_triggers);
     }
 
     // Group triggers by (source_name, event_signature) and prepare call info
@@ -893,6 +906,15 @@ pub(crate) async fn process_event_triggers_multicall(
                             emitter
                         }
                         None => {
+                            // No factory addresses known yet for this collection
+                            // Buffer the trigger for replay when addresses arrive
+                            skipped_factory_triggers.push(SkippedFactoryTrigger {
+                                trigger: trigger.clone(),
+                            });
+                            tracing::debug!(
+                                "Buffering event trigger for {}: no factory addresses loaded yet",
+                                config.contract_name
+                            );
                             continue;
                         }
                     }
@@ -929,7 +951,7 @@ pub(crate) async fn process_event_triggers_multicall(
     }
 
     if calls_by_output.is_empty() {
-        return Ok(());
+        return Ok(skipped_factory_triggers);
     }
 
     // Group all calls by block number for multicall batching
@@ -987,7 +1009,7 @@ pub(crate) async fn process_event_triggers_multicall(
     }
 
     if block_multicalls.is_empty() {
-        return Ok(());
+        return Ok(skipped_factory_triggers);
     }
 
     // Get min/max blocks for logging and file naming
@@ -1132,7 +1154,7 @@ pub(crate) async fn process_event_triggers_multicall(
         }
     }
 
-    Ok(())
+    Ok(skipped_factory_triggers)
 }
 
 /// Write event-triggered call results to parquet

--- a/src/raw_data/historical/eth_calls/event_triggers.rs
+++ b/src/raw_data/historical/eth_calls/event_triggers.rs
@@ -559,9 +559,14 @@ pub(crate) async fn process_event_triggers(
                     match factory_addresses.get(&config.contract_name) {
                         Some(known_addresses) => {
                             if !known_addresses.contains(&emitter) {
-                                // Skip - event emitter is not a known factory address
-                                tracing::trace!(
-                                    "Skipping event trigger: emitter {:?} not in known addresses for {}",
+                                // Emitter not in known addresses — could be not-yet-discovered.
+                                // Buffer for replay; factory RangeComplete will drop if
+                                // this is a legitimate miss.
+                                skipped_factory_triggers.push(SkippedFactoryTrigger {
+                                    trigger: trigger.clone(),
+                                });
+                                tracing::debug!(
+                                    "Buffering event trigger: emitter {:?} not yet in known addresses for {}",
                                     emitter,
                                     config.contract_name
                                 );
@@ -901,6 +906,17 @@ pub(crate) async fn process_event_triggers_multicall(
                     match factory_addresses.get(&config.contract_name) {
                         Some(known_addresses) => {
                             if !known_addresses.contains(&emitter) {
+                                // Emitter not in known addresses — could be not-yet-discovered.
+                                // Buffer for replay; factory RangeComplete will drop if
+                                // this is a legitimate miss.
+                                skipped_factory_triggers.push(SkippedFactoryTrigger {
+                                    trigger: trigger.clone(),
+                                });
+                                tracing::debug!(
+                                    "Buffering event trigger: emitter {:?} not yet in known addresses for {}",
+                                    emitter,
+                                    config.contract_name
+                                );
                                 continue;
                             }
                             emitter

--- a/src/raw_data/historical/eth_calls/types.rs
+++ b/src/raw_data/historical/eth_calls/types.rs
@@ -9,6 +9,7 @@ use thiserror::Error;
 use tokio::sync::mpsc::Sender;
 
 use crate::decoding::DecoderMessage;
+use crate::raw_data::historical::eth_calls::event_triggers::SkippedFactoryTrigger;
 use crate::raw_data::historical::factories::FactoryAddressData;
 use crate::rpc::{RpcError, UnifiedRpcClient};
 use crate::storage::{S3Manifest, StorageManager};
@@ -219,6 +220,9 @@ pub struct EthCallCatchupState {
     pub range_factory_data: HashMap<u64, FactoryAddressData>,
     pub range_regular_done: HashSet<u64>,
     pub range_factory_done: HashSet<u64>,
+    /// Buffered triggers skipped because factory addresses weren't known yet.
+    /// Each entry: (skipped_triggers, range_start, range_end_inclusive)
+    pub factory_skipped_triggers: Vec<(Vec<SkippedFactoryTrigger>, u64, u64)>,
 }
 
 /// Configuration for a token pool call


### PR DESCRIPTION
## Summary

When event triggers are processed during the current/streaming phase, factory-based triggers can be skipped if factory addresses haven't been discovered yet via `IncrementalAddresses`. Previously these triggers were silently dropped, creating a race condition where event-triggered eth_calls are permanently lost.

This PR fixes the race by buffering skipped triggers and replaying them when factory addresses arrive. It also uses factory `RangeComplete` as the signal that address discovery is finished for a range — any triggers still unresolved at that point are legitimate misses (no factory instances deployed), not race conditions.

## What Changed

**Buffering skipped triggers**: `process_event_triggers()` and `process_event_triggers_multicall()` now return `Vec<SkippedFactoryTrigger>`. Both cases where a trigger can't resolve — collection key missing entirely (`None`) OR emitter not in the known address set (`Some`) — now buffer the trigger. Previously only the `None` case buffered; the `Some` case permanently skipped, which was wrong since addresses arrive incrementally via `IncrementalAddresses`.

**Replaying on address arrival**: In `handle_factory_message()`, after `IncrementalAddresses` updates `state.factory_addresses`, buffered triggers are checked and replayed if their factory collection now has known addresses. Triggers that still can't resolve go back into the buffer.

**Draining on factory RangeComplete**: When factory `RangeComplete` arrives for a range, any buffered triggers for that range are dropped — the factory collector has finished discovering addresses for those blocks, so missing emitters are genuinely not factory instances. This prevents triggers from a factory collection with zero deployments from buffering forever.

**AllComplete safety check**: If triggers remain in the buffer after all factory ranges complete, it's logged as an ERROR (bug) since `RangeComplete` should have drained everything.

## Files Changed

- `src/raw_data/historical/eth_calls/event_triggers.rs` — `SkippedFactoryTrigger` type; return type change for both process functions; buffer in both `None` and `Some(not found)` cases
- `src/raw_data/historical/eth_calls/types.rs` — `factory_skipped_triggers` field on `EthCallCatchupState`
- `src/raw_data/historical/catchup/eth_calls.rs` — Initialize new field; warn on unexpected skipped triggers during catchup
- `src/raw_data/historical/current/eth_calls/events.rs` — Capture returned skipped triggers into state buffer
- `src/raw_data/historical/current/eth_calls/factory.rs` — Replay on `IncrementalAddresses`; drain on `RangeComplete`; error on `AllComplete` if buffer non-empty

## Sibling PR Conflicts

This PR conflicts with the sibling `feat/reverted-call-tracking` PR in `event_triggers.rs`. This PR's signature changes should be applied first, then the reverted-call-tracking changes can be applied on top.