### PR TITLE
feat: propagate reverted eth_call status through pipeline

### DIFF
--- a/docs/ETH_CALL_COLLECTION.md
+++ b/docs/ETH_CALL_COLLECTION.md
@@ -590,9 +590,10 @@ if 'param_0' in df.columns:
 
 ## Error Handling
 
-- **Without Multicall3:** If an eth_call reverts or fails (e.g., contract doesn't exist at that block), the result is skipped entirely — no row is written for that call
-- **With Multicall3:** Individual sub-call failures return empty bytes (due to `allowFailure=true`), so a row with an empty `value` is stored
-- Failed calls are logged with a warning but don't stop collection
+- **Event-triggered calls** (both with and without Multicall3): Reverted calls are stored with `is_reverted=true`, `revert_reason` set to the error message, and an empty `value`. This ensures the transformation engine receives the call (unblocking pending events) and can log the revert to the `_call_revert_log` table for debugging.
+- **Regular calls without Multicall3:** If an eth_call reverts or fails (e.g., contract doesn't exist at that block), the result is skipped entirely — no row is written for that call.
+- **Regular calls with Multicall3:** Individual sub-call failures return empty bytes (due to `allowFailure=true`), so a row with an empty `value` is stored.
+- Failed calls are logged with a warning but don't stop collection.
 - If the Multicall3 RPC call itself fails, all sub-calls for that block are treated as failed
 
 ## Performance Considerations

--- a/docs/ON_EVENT_CALLS.md
+++ b/docs/ON_EVENT_CALLS.md
@@ -523,7 +523,7 @@ The `target` field in call configuration allows routing event-triggered calls to
 
 2. **Factory collection race window:** During live processing, there may be a brief window where events from newly-created factory contracts are skipped because the factory address hasn't been discovered yet. These events will be processed during the next catchup phase.
 
-3. **Failed calls skipped:** If an eth_call fails (e.g., contract reverted), the result is skipped entirely rather than stored. Failed calls during catchup are not automatically retried on subsequent runs. Decode failures are logged with warnings.
+3. **Reverted calls tracked:** If an event-triggered eth_call reverts, the result is stored with `is_reverted=true` and `revert_reason` in both parquet and the decoder pipeline. This ensures the transformation engine can unblock pending events that depend on the call. Reverts are also logged to the `_call_revert_log` database table for debugging. Handlers should check `call.is_reverted` and skip gracefully.
 
 4. **No cross-event parameter passing:** Parameters can only be extracted from the triggering event itself, not from other events in the same block or transaction.
 

--- a/migrations/tables/call_revert_log.sql
+++ b/migrations/tables/call_revert_log.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS _call_revert_log (
+    id BIGSERIAL PRIMARY KEY,
+    chain_id BIGINT NOT NULL,
+    block_number BIGINT NOT NULL,
+    log_index INTEGER,
+    source_name VARCHAR(255) NOT NULL,
+    function_name VARCHAR(255) NOT NULL,
+    target_address BYTEA NOT NULL,
+    revert_reason TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_call_revert_log_lookup
+    ON _call_revert_log (chain_id, block_number);

--- a/src/decoding/current/eth_calls/events.rs
+++ b/src/decoding/current/eth_calls/events.rs
@@ -1,5 +1,7 @@
 //! Event-triggered call message handling for live mode.
 
+use std::collections::HashMap;
+
 use tokio::sync::mpsc::Sender;
 
 use crate::decoding::eth_calls::EthCallDecodingError;
@@ -25,6 +27,22 @@ pub(super) async fn handle_event_calls_live(
     let mut transform_calls: Vec<TransformDecodedCall> = Vec::with_capacity(results.len());
 
     for result in results {
+        if result.is_reverted {
+            // Don't try to decode reverted calls, but still forward to transformation engine
+            transform_calls.push(TransformDecodedCall {
+                block_number: result.block_number,
+                block_timestamp: result.block_timestamp,
+                contract_address: result.target_address,
+                source_name: contract_name.to_string(),
+                function_name: function_name.to_string(),
+                trigger_log_index: Some(result.log_index),
+                result: HashMap::new(),
+                is_reverted: true,
+                revert_reason: result.revert_reason.clone(),
+            });
+            continue;
+        }
+
         match decode_value(&result.value, &config.output_type) {
             Ok(decoded) => {
                 transform_calls.push(TransformDecodedCall {
@@ -35,6 +53,8 @@ pub(super) async fn handle_event_calls_live(
                     function_name: function_name.to_string(),
                     trigger_log_index: Some(result.log_index),
                     result: build_result_map(&decoded, &config.output_type, function_name),
+                    is_reverted: false,
+                    revert_reason: None,
                 });
 
                 decoded_event_calls.push(LiveDecodedEventCall {

--- a/src/decoding/current/eth_calls/factory.rs
+++ b/src/decoding/current/eth_calls/factory.rs
@@ -53,6 +53,8 @@ pub(super) async fn handle_once_calls_live(
                                 &config.output_type,
                                 &config.function_name,
                             ),
+                            is_reverted: false,
+                            revert_reason: None,
                         };
                         transform_calls_by_fn
                             .entry(config.function_name.clone())

--- a/src/decoding/current/eth_calls/mod.rs
+++ b/src/decoding/current/eth_calls/mod.rs
@@ -614,6 +614,8 @@ mod tests {
                     log_index: 7,
                     target_address: [3u8; 20],
                     value: encode_uint256(7),
+                    is_reverted: false,
+                    revert_reason: None,
                 }],
                 live_mode: true,
                 retry_transform_after_decode: true,

--- a/src/decoding/current/eth_calls/range_processor.rs
+++ b/src/decoding/current/eth_calls/range_processor.rs
@@ -39,6 +39,8 @@ pub(super) async fn handle_regular_calls_live(
                     function_name: function_name.to_string(),
                     trigger_log_index: None,
                     result: build_result_map(&decoded, &config.output_type, function_name),
+                    is_reverted: false,
+                    revert_reason: None,
                 });
 
                 decoded_calls.push(LiveDecodedCall {

--- a/src/decoding/eth_calls/process.rs
+++ b/src/decoding/eth_calls/process.rs
@@ -341,6 +341,8 @@ pub async fn process_once_calls(
                     function_name: "once".to_string(),
                     trigger_log_index: None,
                     result: merged_result,
+                    is_reverted: false,
+                    revert_reason: None,
                 }
             })
             .filter(|call| !call.result.is_empty())
@@ -406,6 +408,8 @@ pub async fn process_event_calls(
     let mut decode_failures = 0u64;
     let mut non_empty_count = 0u64;
 
+    let mut reverted_calls: Vec<TransformDecodedCall> = Vec::new();
+
     for result in results {
         // Skip if block is before contract's start_block
         if let Some(sb) = config.start_block {
@@ -413,6 +417,23 @@ pub async fn process_event_calls(
                 continue;
             }
         }
+
+        // Handle reverted results: skip decode, create transform call with empty result
+        if result.is_reverted {
+            reverted_calls.push(TransformDecodedCall {
+                block_number: result.block_number,
+                block_timestamp: result.block_timestamp,
+                contract_address: result.target_address,
+                source_name: config.contract_name.clone(),
+                function_name: config.function_name.clone(),
+                trigger_log_index: Some(result.log_index),
+                result: HashMap::new(),
+                is_reverted: true,
+                revert_reason: result.revert_reason.clone(),
+            });
+            continue;
+        }
+
         if result.value.is_empty() {
             continue;
         }
@@ -495,7 +516,7 @@ pub async fn process_event_calls(
 
     // Send to transformation channel if enabled
     if let Some(tx) = transform_tx {
-        let transform_calls: Vec<TransformDecodedCall> = decoded_records
+        let mut transform_calls: Vec<TransformDecodedCall> = decoded_records
             .iter()
             .map(|r| {
                 convert_event_call_to_transform_call(
@@ -506,6 +527,9 @@ pub async fn process_event_calls(
                 )
             })
             .collect();
+
+        // Include reverted calls so the engine can unblock pending events
+        transform_calls.extend(reverted_calls);
 
         if !transform_calls.is_empty() {
             let msg = DecodedCallsMessage {

--- a/src/decoding/eth_calls/transform.rs
+++ b/src/decoding/eth_calls/transform.rs
@@ -89,6 +89,8 @@ pub(super) fn convert_to_transform_call(
         function_name: function_name.to_string(),
         trigger_log_index: None,
         result: build_result_map(&record.decoded_value, output_type, function_name),
+        is_reverted: false,
+        revert_reason: None,
     }
 }
 
@@ -107,5 +109,7 @@ pub(super) fn convert_event_call_to_transform_call(
         function_name: function_name.to_string(),
         trigger_log_index: Some(record.log_index),
         result: build_result_map(&record.decoded_value, output_type, function_name),
+        is_reverted: false,
+        revert_reason: None,
     }
 }

--- a/src/decoding/types.rs
+++ b/src/decoding/types.rs
@@ -72,6 +72,8 @@ pub struct EventCallResult {
     pub log_index: u32,
     pub target_address: [u8; 20],
     pub value: Vec<u8>,
+    pub is_reverted: bool,
+    pub revert_reason: Option<String>,
 }
 
 /// Message sent through decoder channels

--- a/src/live/eth_calls.rs
+++ b/src/live/eth_calls.rs
@@ -695,6 +695,8 @@ impl LiveEthCallCollector {
                         log_index: *log_index,
                         target_address: target_address.0 .0,
                         value: result_bytes,
+                        is_reverted: false,
+                        revert_reason: None,
                     });
                 }
             }

--- a/src/raw_data/historical/eth_calls/event_triggers.rs
+++ b/src/raw_data/historical/eth_calls/event_triggers.rs
@@ -8,7 +8,10 @@ use std::sync::Arc;
 use alloy::dyn_abi::DynSolValue;
 use alloy::primitives::{Address, Bytes};
 use alloy::rpc::types::{BlockId, BlockNumberOrTag, TransactionRequest};
-use arrow::array::{ArrayRef, BinaryArray, FixedSizeBinaryBuilder, UInt32Array, UInt64Array};
+use arrow::array::{
+    ArrayRef, BinaryArray, BooleanArray, FixedSizeBinaryBuilder, StringArray, UInt32Array,
+    UInt64Array,
+};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 use futures::{stream, StreamExt, TryStreamExt};
@@ -688,20 +691,32 @@ pub(crate) async fn process_event_triggers(
                                     target_address: call.target_address.0.0,
                                     value_bytes: bytes.to_vec(),
                                     param_values: call.encoded_params.clone(),
+                                    is_reverted: false,
+                                    revert_reason: None,
                                 });
                             }
                             Err(e) => {
+                                let reason = e.to_string();
                                 let params_hex: Vec<String> = call.encoded_params.iter().map(|p| format!("0x{}", hex::encode(p))).collect();
                                 tracing::warn!(
-                                    "Event-triggered eth_call failed for {}.{} at block {} (address {}, params {:?}): {}",
+                                    "Event-triggered eth_call reverted for {}.{} at block {} (address {}, params {:?}): {}",
                                     contract_name,
                                     function_name,
                                     call.trigger.block_number,
                                     call.target_address,
                                     params_hex,
-                                    e
+                                    reason
                                 );
-                                // Skip reverted calls - don't store empty results
+                                chunk_results.push(EventCallResult {
+                                    block_number: call.trigger.block_number,
+                                    block_timestamp: call.trigger.block_timestamp,
+                                    log_index: call.trigger.log_index,
+                                    target_address: call.target_address.0.0,
+                                    value_bytes: Vec::new(),
+                                    param_values: call.encoded_params.clone(),
+                                    is_reverted: true,
+                                    revert_reason: Some(reason),
+                                });
                             }
                         }
                     }
@@ -769,6 +784,8 @@ pub(crate) async fn process_event_triggers(
                         log_index: r.log_index,
                         target_address: r.target_address,
                         value: r.value_bytes.clone(),
+                        is_reverted: r.is_reverted,
+                        revert_reason: r.revert_reason.clone(),
                     })
                     .collect();
 
@@ -1021,15 +1038,36 @@ pub(crate) async fn process_event_triggers_multicall(
     // Distribute results back to groups
     let mut group_results: HashMap<(String, String), Vec<EventCallResult>> = HashMap::new();
 
-    for ((meta, block_number, block_timestamp), return_data, _success) in results {
+    for ((meta, block_number, block_timestamp), return_data, success) in results {
         let key = (meta.contract_name.clone(), meta.function_name.clone());
+        let is_reverted = !success;
+        let revert_reason = if is_reverted {
+            Some(format!(
+                "Multicall3 reported failure for {}.{} at block {}",
+                meta.contract_name, meta.function_name, block_number
+            ))
+        } else {
+            None
+        };
+        if is_reverted {
+            tracing::warn!(
+                "Multicall event-triggered eth_call reverted for {}.{} at block {} (address {}, log_index {})",
+                meta.contract_name,
+                meta.function_name,
+                block_number,
+                meta.target_address,
+                meta.log_index
+            );
+        }
         group_results.entry(key).or_default().push(EventCallResult {
             block_number,
             block_timestamp,
             log_index: meta.log_index,
             target_address: meta.target_address.0 .0,
-            value_bytes: return_data,
+            value_bytes: if is_reverted { Vec::new() } else { return_data },
             param_values: meta.param_values,
+            is_reverted,
+            revert_reason,
         });
     }
 
@@ -1102,6 +1140,8 @@ pub(crate) async fn process_event_triggers_multicall(
                     log_index: r.log_index,
                     target_address: r.target_address,
                     value: r.value_bytes.clone(),
+                    is_reverted: r.is_reverted,
+                    revert_reason: r.revert_reason.clone(),
                 })
                 .collect();
 
@@ -1170,6 +1210,17 @@ pub(crate) fn write_event_call_results_to_parquet(
         .collect();
     arrays.push(Arc::new(arr));
 
+    // is_reverted
+    let arr: BooleanArray = results.iter().map(|r| Some(r.is_reverted)).collect();
+    arrays.push(Arc::new(arr));
+
+    // revert_reason
+    let arr: StringArray = results
+        .iter()
+        .map(|r| r.revert_reason.as_deref())
+        .collect();
+    arrays.push(Arc::new(arr));
+
     // param columns
     for i in 0..num_params {
         let arr: BinaryArray = results
@@ -1201,6 +1252,8 @@ pub(crate) fn build_event_call_schema(num_params: usize) -> Arc<Schema> {
         Field::new("log_index", DataType::UInt32, false),
         Field::new("target_address", DataType::FixedSizeBinary(20), false),
         Field::new("value", DataType::Binary, false),
+        Field::new("is_reverted", DataType::Boolean, false),
+        Field::new("revert_reason", DataType::Utf8, true),
     ];
 
     for i in 0..num_params {

--- a/src/raw_data/historical/eth_calls/types.rs
+++ b/src/raw_data/historical/eth_calls/types.rs
@@ -166,6 +166,8 @@ pub struct EventCallResult {
     pub target_address: [u8; 20],
     pub value_bytes: Vec<u8>,
     pub param_values: Vec<Vec<u8>>,
+    pub is_reverted: bool,
+    pub revert_reason: Option<String>,
 }
 
 /// Key for grouping event-triggered calls: (source_name, event_signature_hash)

--- a/src/storage/parquet_readers.rs
+++ b/src/storage/parquet_readers.rs
@@ -9,7 +9,10 @@ use std::fs::File;
 use std::path::Path;
 
 use alloy::primitives::Address;
-use arrow::array::{Array, BinaryArray, FixedSizeBinaryArray, ListArray, UInt32Array, UInt64Array};
+use arrow::array::{
+    Array, BinaryArray, BooleanArray, FixedSizeBinaryArray, ListArray, StringArray, UInt32Array,
+    UInt64Array,
+};
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use thiserror::Error;
 
@@ -416,6 +419,8 @@ pub fn read_event_calls_from_parquet(
         let log_index_idx = schema.index_of("log_index").ok();
         let address_idx = schema.index_of("target_address").ok();
         let value_idx = schema.index_of("value").ok();
+        let is_reverted_idx = schema.index_of("is_reverted").ok();
+        let revert_reason_idx = schema.index_of("revert_reason").ok();
 
         for row in 0..batch.num_rows() {
             let block_number = block_number_idx
@@ -477,12 +482,38 @@ pub fn read_event_calls_from_parquet(
                 })
                 .unwrap_or_default();
 
+            let is_reverted = is_reverted_idx
+                .and_then(|i| {
+                    batch
+                        .column(i)
+                        .as_any()
+                        .downcast_ref::<BooleanArray>()
+                        .map(|a| a.value(row))
+                })
+                .unwrap_or(false);
+
+            let revert_reason = revert_reason_idx.and_then(|i| {
+                batch
+                    .column(i)
+                    .as_any()
+                    .downcast_ref::<StringArray>()
+                    .and_then(|a| {
+                        if a.is_null(row) {
+                            None
+                        } else {
+                            Some(a.value(row).to_string())
+                        }
+                    })
+            });
+
             results.push(EventCallResult {
                 block_number,
                 block_timestamp,
                 log_index,
                 target_address,
                 value,
+                is_reverted,
+                revert_reason,
             });
         }
     }

--- a/src/transformations/context.rs
+++ b/src/transformations/context.rs
@@ -300,6 +300,10 @@ pub struct DecodedCall {
     /// For single return values, the key is the function name or "result".
     /// For tuples, uses field names from the output type.
     pub result: HashMap<String, DecodedValue>,
+    /// Whether this call reverted during execution
+    pub is_reverted: bool,
+    /// If the call reverted, the reason string
+    pub revert_reason: Option<String>,
 }
 
 #[allow(dead_code)]
@@ -816,6 +820,8 @@ mod tests {
             function_name: "testFunction".to_string(),
             trigger_log_index: None,
             result,
+            is_reverted: false,
+            revert_reason: None,
         }
     }
 

--- a/src/transformations/engine.rs
+++ b/src/transformations/engine.rs
@@ -1405,6 +1405,22 @@ impl TransformationEngine {
             msg.range_start
         );
 
+        // Log reverted calls to the database for debugging
+        let reverted: Vec<_> = msg.calls.iter().filter(|c| c.is_reverted).collect();
+        if !reverted.is_empty() {
+            tracing::warn!(
+                "{} reverted eth_calls for {}/{} in range {}-{}",
+                reverted.len(),
+                msg.source_name,
+                msg.function_name,
+                msg.range_start,
+                msg.range_end
+            );
+            if let Err(e) = self.log_reverted_calls(&reverted, msg.range_start).await {
+                tracing::warn!("Failed to log reverted calls to DB: {}", e);
+            }
+        }
+
         {
             let mut state = self.live_state.lock().await;
             state
@@ -1427,6 +1443,48 @@ impl TransformationEngine {
         self.finalizer
             .maybe_finalize_range(range_key, &self.live_state)
             .await?;
+
+        Ok(())
+    }
+
+    /// Batch-insert reverted call information into the `_call_revert_log` table.
+    async fn log_reverted_calls(
+        &self,
+        calls: &[&DecodedCall],
+        _range_start: u64,
+    ) -> Result<(), TransformationError> {
+        if calls.is_empty() {
+            return Ok(());
+        }
+
+        let pool = self.db_pool.inner();
+        let client = pool.get().await?;
+
+        for call in calls {
+            let chain_id = self.chain_id as i64;
+            let block_number = call.block_number as i64;
+            let log_index = call.trigger_log_index.map(|i| i as i32);
+            let source_name = &call.source_name;
+            let function_name = &call.function_name;
+            let target_address = call.contract_address.as_slice();
+            let revert_reason = call.revert_reason.as_deref();
+
+            client
+                .execute(
+                    "INSERT INTO _call_revert_log (chain_id, block_number, log_index, source_name, function_name, target_address, revert_reason)
+                     VALUES ($1, $2, $3, $4, $5, $6, $7)",
+                    &[
+                        &chain_id,
+                        &block_number,
+                        &log_index,
+                        &source_name,
+                        &function_name,
+                        &target_address,
+                        &revert_reason,
+                    ],
+                )
+                .await?;
+        }
 
         Ok(())
     }

--- a/src/transformations/historical.rs
+++ b/src/transformations/historical.rs
@@ -473,6 +473,8 @@ fn batch_to_calls(
             function_name: function_name.to_string(),
             trigger_log_index: log_indices.as_ref().map(|indices| indices[row]),
             result,
+            is_reverted: false,
+            revert_reason: None,
         });
     }
 

--- a/src/transformations/retry.rs
+++ b/src/transformations/retry.rs
@@ -327,6 +327,8 @@ impl RetryProcessor {
                         function_name: "once".to_string(),
                         trigger_log_index: None,
                         result: merged_result,
+                        is_reverted: false,
+                        revert_reason: None,
                     });
                 }
             }
@@ -703,6 +705,8 @@ fn live_call_to_decoded_call(
         function_name: function_name.to_string(),
         trigger_log_index: None,
         result: build_result_map(&call.decoded_value, output_type, function_name),
+        is_reverted: false,
+        revert_reason: None,
     }
 }
 
@@ -720,6 +724,8 @@ fn live_event_call_to_decoded_call(
         function_name: function_name.to_string(),
         trigger_log_index: Some(call.log_index),
         result: build_result_map(&call.decoded_value, output_type, function_name),
+        is_reverted: false,
+        revert_reason: None,
     }
 }
 
@@ -812,6 +818,8 @@ mod tests {
             function_name: "slot0".to_string(),
             trigger_log_index: None,
             result: HashMap::from([("result".to_string(), DecodedValue::Uint64(1))]),
+            is_reverted: false,
+            revert_reason: None,
         }];
 
         let missing = missing_retry_call_dependencies(&required, &calls);


### PR DESCRIPTION
## Summary

When individual event-triggered eth_calls revert, this change propagates the revert status through the entire pipeline (collection -> parquet -> decoder -> transformation engine) instead of silently skipping them. This fixes a class of handler timeouts where `call_dependencies()` never receive data because reverted calls were dropped, leaving pending events permanently blocked.

## What Changed

### Collection Layer (`event_triggers.rs`, `types.rs`)

- Added `is_reverted: bool` and `revert_reason: Option<String>` fields to the raw `EventCallResult` struct.
- In `process_event_triggers()`: the `Err(e)` branch now creates an `EventCallResult` with `is_reverted: true` and `value_bytes: Vec::new()` instead of skipping.
- In `process_event_triggers_multicall()`: the multicall `success` flag is now used — failed sub-calls produce `EventCallResult` with `is_reverted: \!success`.
- Updated `build_event_call_schema()` to include `is_reverted` (Boolean) and `revert_reason` (Utf8, nullable) columns.
- Updated `write_event_call_results_to_parquet()` to write the new columns.

### Decoder Layer (`decoding/types.rs`, `decoding/current/eth_calls/events.rs`, `decoding/eth_calls/process.rs`)

- Added `is_reverted` and `revert_reason` to the decoder's `EventCallResult`.
- In live mode (`handle_event_calls_live`): reverted results skip ABI decoding but still produce a `TransformDecodedCall` with an empty result map and `is_reverted: true`.
- In historical mode (`process_event_calls`): same logic for reverted results read from parquet. Reverted calls are included in the transform message alongside successfully decoded calls.

### Parquet Reader (`storage/parquet_readers.rs`)

- `read_event_calls_from_parquet()` now reads `is_reverted` and `revert_reason` columns (gracefully defaulting to `false`/`None` for older parquet files without these columns).

### Transformation Layer (`context.rs`, `engine.rs`)

- Added `is_reverted: bool` and `revert_reason: Option<String>` to `DecodedCall`.
- In `process_calls_message()`: before buffering, filters for reverted calls and logs them to the `_call_revert_log` database table.
- Added `log_reverted_calls()` method that batch-inserts revert information for debugging.

### Migration (`migrations/tables/call_revert_log.sql`)

- New `_call_revert_log` table: `(chain_id, block_number, log_index, source_name, function_name, target_address, revert_reason, created_at)` with a lookup index on `(chain_id, block_number)`.

### All `DecodedCall` / `TransformDecodedCall` Construction Sites

Updated every construction site across the codebase to include `is_reverted: false, revert_reason: None` for non-reverted calls:
- `decoding/eth_calls/transform.rs` (convert_to_transform_call, convert_event_call_to_transform_call)
- `decoding/current/eth_calls/range_processor.rs` (handle_regular_calls_live)
- `decoding/current/eth_calls/factory.rs` (handle_once_calls_live)
- `decoding/eth_calls/process.rs` (process_once_calls)
- `transformations/historical.rs` (read_decoded_calls_from_parquet)
- `transformations/retry.rs` (live_call_to_decoded_call, live_event_call_to_decoded_call, retry once-call merging)
- `live/eth_calls.rs` (live event call collection)
- Test construction sites in `context.rs`, `retry.rs`, `mod.rs`

## Why

Transformation handlers that depend on eth_calls via `call_dependencies()` were timing out after 5 minutes because reverted calls were silently dropped. The engine's `received_calls` tracker never registered these calls, so pending events waiting on them stayed blocked until the force-finalize timeout kicked in and dropped the data. By propagating reverts through the pipeline, handlers can now receive the call (with `is_reverted: true`) and handle it gracefully, while the `_call_revert_log` table provides visibility into which calls are reverting.

---

**Note:** This PR conflicts with the sibling `feat/buffer-factory-skipped-triggers` PR in `event_triggers.rs`. Apply that PR's signature changes first, then this PR's error handling changes.