### PR TITLE
chore: live module cleanup - reduce duplication and optimize factory extraction

### DIFF
--- a/src/live/collector.rs
+++ b/src/live/collector.rs
@@ -68,6 +68,8 @@ pub struct LiveCollector {
     expected_start_block: Option<u64>,
     /// Factory matchers for extracting new contract addresses from factory events.
     factory_matchers: Arc<Vec<FactoryMatcher>>,
+    /// Pre-built index mapping topic0 -> indices into `factory_matchers` for O(n) extraction.
+    factory_topic_index: HashMap<[u8; 32], Vec<usize>>,
     /// Optional eth_call collector for live mode.
     eth_call_collector: Option<LiveEthCallCollector>,
     /// Database pool for status file reconstruction during catchup.
@@ -141,6 +143,15 @@ impl LiveCollector {
             tracing::info!("Live collector initialized with eth_call collector");
         }
 
+        // Pre-build topic0 -> matcher index map for O(n) factory extraction
+        let mut factory_topic_index: HashMap<[u8; 32], Vec<usize>> = HashMap::new();
+        for (idx, matcher) in factory_matchers.iter().enumerate() {
+            factory_topic_index
+                .entry(matcher.event_topic0)
+                .or_default()
+                .push(idx);
+        }
+
         Self {
             chain,
             http_client,
@@ -151,6 +162,7 @@ impl LiveCollector {
             progress_tracker,
             expected_start_block,
             factory_matchers,
+            factory_topic_index,
             eth_call_collector,
             db_pool,
             expectations,
@@ -791,6 +803,8 @@ impl LiveCollector {
     }
 
     /// Extract factory addresses from logs using configured matchers.
+    ///
+    /// Uses a pre-built topic0 index for O(n) lookup instead of O(n*m) nested iteration.
     fn extract_factory_addresses(
         &self,
         logs: &[LiveLog],
@@ -803,22 +817,29 @@ impl LiveCollector {
         }
 
         for log in logs {
-            for matcher in self.factory_matchers.iter() {
+            // Skip logs with no topics
+            if log.topics.is_empty() {
+                continue;
+            }
+
+            // Look up matchers by topic0
+            let Some(matcher_indices) = self.factory_topic_index.get(&log.topics[0]) else {
+                continue;
+            };
+
+            for &idx in matcher_indices {
+                let matcher = &self.factory_matchers[idx];
+
                 // Check if log address matches factory contract
                 if log.address != matcher.factory_contract_address {
                     continue;
                 }
 
-                // Check if topic0 matches the event signature
-                if log.topics.is_empty() || log.topics[0] != matcher.event_topic0 {
-                    continue;
-                }
-
                 // Extract address based on parameter location
                 let extracted_address = match &matcher.param_location {
-                    FactoryParameterLocation::Topic(idx) => {
-                        if *idx < log.topics.len() {
-                            let topic = &log.topics[*idx];
+                    FactoryParameterLocation::Topic(topic_idx) => {
+                        if *topic_idx < log.topics.len() {
+                            let topic = &log.topics[*topic_idx];
                             let mut addr = [0u8; 20];
                             addr.copy_from_slice(&topic[12..32]);
                             Some(addr)
@@ -1624,6 +1645,7 @@ mod tests {
             progress_tracker: None,
             expected_start_block: None,
             factory_matchers: Arc::new(vec![]),
+            factory_topic_index: HashMap::new(),
             eth_call_collector: None,
             db_pool: None,
             expectations: LivePipelineExpectations {

--- a/src/live/compaction.rs
+++ b/src/live/compaction.rs
@@ -539,10 +539,6 @@ impl CompactionService {
         records: &[(u64, u64, [u8; 20])],
         path: &PathBuf,
     ) -> Result<(), CompactionError> {
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-
         let schema = Arc::new(Schema::new(vec![
             Field::new("block_number", DataType::UInt64, false),
             Field::new("block_timestamp", DataType::UInt64, false),
@@ -559,24 +555,15 @@ impl CompactionService {
             addresses.append_value(addr)?;
         }
 
-        let batch = RecordBatch::try_new(
-            schema.clone(),
+        write_compaction_parquet(
+            path,
+            schema,
             vec![
                 Arc::new(block_numbers.finish()) as ArrayRef,
                 Arc::new(timestamps.finish()) as ArrayRef,
                 Arc::new(addresses.finish()) as ArrayRef,
             ],
-        )?;
-
-        let file = std::fs::File::create(path)?;
-        let props = WriterProperties::builder()
-            .set_compression(Compression::SNAPPY)
-            .build();
-        let mut writer = ArrowWriter::try_new(file, schema, Some(props))?;
-        writer.write(&batch)?;
-        writer.close()?;
-
-        Ok(())
+        )
     }
 
     /// Get path for eth_calls parquet file.
@@ -593,10 +580,6 @@ impl CompactionService {
         calls: &[super::types::LiveEthCall],
         path: &PathBuf,
     ) -> Result<(), CompactionError> {
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-
         let schema = Arc::new(Schema::new(vec![
             Field::new("block_number", DataType::UInt64, false),
             Field::new("block_timestamp", DataType::UInt64, false),
@@ -622,8 +605,9 @@ impl CompactionService {
             results.append_value(&call.result);
         }
 
-        let batch = RecordBatch::try_new(
-            schema.clone(),
+        write_compaction_parquet(
+            path,
+            schema,
             vec![
                 Arc::new(block_numbers.finish()) as ArrayRef,
                 Arc::new(timestamps.finish()) as ArrayRef,
@@ -633,14 +617,6 @@ impl CompactionService {
                 Arc::new(results.finish()) as ArrayRef,
             ],
         )?;
-
-        let file = std::fs::File::create(path)?;
-        let props = WriterProperties::builder()
-            .set_compression(Compression::SNAPPY)
-            .build();
-        let mut writer = ArrowWriter::try_new(file, schema, Some(props))?;
-        writer.write(&batch)?;
-        writer.close()?;
 
         tracing::debug!("Wrote {} eth_calls to {}", calls.len(), path.display());
 
@@ -653,10 +629,6 @@ impl CompactionService {
         blocks: &[super::types::LiveBlock],
         path: &PathBuf,
     ) -> Result<(), CompactionError> {
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-
         let schema = Arc::new(Schema::new(vec![
             Field::new("block_number", DataType::UInt64, false),
             Field::new("block_hash", DataType::Binary, false),
@@ -676,25 +648,16 @@ impl CompactionService {
             timestamps.append_value(block.timestamp);
         }
 
-        let batch = RecordBatch::try_new(
-            schema.clone(),
+        write_compaction_parquet(
+            path,
+            schema,
             vec![
                 Arc::new(block_numbers.finish()) as ArrayRef,
                 Arc::new(block_hashes.finish()) as ArrayRef,
                 Arc::new(parent_hashes.finish()) as ArrayRef,
                 Arc::new(timestamps.finish()) as ArrayRef,
             ],
-        )?;
-
-        let file = std::fs::File::create(path)?;
-        let props = WriterProperties::builder()
-            .set_compression(Compression::SNAPPY)
-            .build();
-        let mut writer = ArrowWriter::try_new(file, schema, Some(props))?;
-        writer.write(&batch)?;
-        writer.close()?;
-
-        Ok(())
+        )
     }
 
     /// Write logs to parquet file.
@@ -703,10 +666,6 @@ impl CompactionService {
         logs: &[(u64, u64, super::types::LiveLog)],
         path: &PathBuf,
     ) -> Result<(), CompactionError> {
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-
         let schema = Arc::new(Schema::new(vec![
             Field::new("block_number", DataType::UInt64, false),
             Field::new("block_timestamp", DataType::UInt64, false),
@@ -766,8 +725,9 @@ impl CompactionService {
             datas.append_value(&log.data);
         }
 
-        let batch = RecordBatch::try_new(
-            schema.clone(),
+        write_compaction_parquet(
+            path,
+            schema,
             vec![
                 Arc::new(block_numbers.finish()) as ArrayRef,
                 Arc::new(timestamps.finish()) as ArrayRef,
@@ -781,17 +741,7 @@ impl CompactionService {
                 Arc::new(topic3s.finish()) as ArrayRef,
                 Arc::new(datas.finish()) as ArrayRef,
             ],
-        )?;
-
-        let file = std::fs::File::create(path)?;
-        let props = WriterProperties::builder()
-            .set_compression(Compression::SNAPPY)
-            .build();
-        let mut writer = ArrowWriter::try_new(file, schema, Some(props))?;
-        writer.write(&batch)?;
-        writer.close()?;
-
-        Ok(())
+        )
     }
 
     /// Migrate progress entries from _live_progress to _handler_progress.
@@ -942,6 +892,28 @@ impl CompactionService {
 
         Ok(())
     }
+}
+
+/// Write a RecordBatch to a Snappy-compressed parquet file.
+///
+/// Creates parent directories if needed.
+fn write_compaction_parquet(
+    path: &std::path::Path,
+    schema: Arc<Schema>,
+    columns: Vec<ArrayRef>,
+) -> Result<(), CompactionError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let batch = RecordBatch::try_new(schema, columns)?;
+    let file = std::fs::File::create(path)?;
+    let props = WriterProperties::builder()
+        .set_compression(Compression::SNAPPY)
+        .build();
+    let mut writer = ArrowWriter::try_new(file, batch.schema(), Some(props))?;
+    writer.write(&batch)?;
+    writer.close()?;
+    Ok(())
 }
 
 impl std::fmt::Debug for CompactionService {

--- a/src/live/storage.rs
+++ b/src/live/storage.rs
@@ -308,45 +308,10 @@ impl LiveStorage {
         status: &LiveBlockStatus,
     ) -> Result<(), StorageError> {
         let path = self.status_path(block_number);
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent)?;
-        }
-
-        // Write to temp file with unique suffix to avoid race conditions
-        // when multiple writers (collector + decoder) write status for the same block
-        let random_suffix: u32 = rand::random();
-        let temp_name = format!(
-            "{}.tmp.{}",
-            path.file_name().unwrap().to_string_lossy(),
-            random_suffix
-        );
-        let temp_path = path.with_file_name(temp_name);
-
-        let file = fs::File::create(&temp_path)?;
-        let mut writer = BufWriter::new(file);
-
-        // Wrap write+flush+sync+rename so we can clean up the temp file on any failure
-        let result = (|| -> Result<(), StorageError> {
-            serde_json::to_writer_pretty(&mut writer, status)?;
-            writer.flush()?;
-            writer
-                .into_inner()
-                .map_err(std::io::Error::other)?
-                .sync_all()?;
-            fs::rename(&temp_path, &path)?;
+        atomic_write_with(&path, |writer| {
+            serde_json::to_writer_pretty(writer, status)?;
             Ok(())
-        })();
-
-        if let Err(e) = &result {
-            tracing::debug!(
-                "Cleaning up temp file after status write error: {:?} ({})",
-                temp_path,
-                e
-            );
-            let _ = fs::remove_file(&temp_path);
-        }
-
-        result
+        })
     }
 
     /// Read status for a block.
@@ -400,38 +365,10 @@ impl LiveStorage {
         update_fn(&mut status);
 
         // Write to temp file, then rename — all while holding the lock
-        let random_suffix: u32 = rand::random();
-        let temp_name = format!(
-            "{}.tmp.{}",
-            path.file_name().unwrap().to_string_lossy(),
-            random_suffix
-        );
-        let temp_path = path.with_file_name(temp_name);
-
-        let result = (|| -> Result<(), StorageError> {
-            {
-                let temp_file = fs::File::create(&temp_path)?;
-                let mut writer = BufWriter::new(temp_file);
-                serde_json::to_writer_pretty(&mut writer, &status)?;
-                writer.flush()?;
-                writer
-                    .into_inner()
-                    .map_err(std::io::Error::other)?
-                    .sync_all()?;
-            }
-
-            fs::rename(&temp_path, &path)?;
+        let result = atomic_write_with(&path, |writer| {
+            serde_json::to_writer_pretty(writer, &status)?;
             Ok(())
-        })();
-
-        if let Err(e) = &result {
-            tracing::debug!(
-                "Cleaning up temp file after atomic status write error: {:?} ({})",
-                temp_path,
-                e
-            );
-            let _ = fs::remove_file(&temp_path);
-        }
+        });
 
         // lock_file dropped here, releasing the exclusive lock
 
@@ -818,17 +755,18 @@ impl LiveStorage {
 // Helper functions
 // =========================================================================
 
-/// Atomically write bincode-serialized data to a file.
+/// Atomically write to a file using a caller-supplied write function.
 ///
 /// Uses write-to-temp, flush, sync_all, rename pattern for crash safety.
-/// Works with any serializable type including slices.
 /// Uses unique temp file names to avoid race conditions between concurrent writers.
-fn write_bincode<T: Serialize + ?Sized>(path: &Path, data: &T) -> Result<(), StorageError> {
+fn atomic_write_with<F>(path: &Path, write_fn: F) -> Result<(), StorageError>
+where
+    F: FnOnce(&mut BufWriter<fs::File>) -> Result<(), StorageError>,
+{
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
 
-    // Write to temp file with unique suffix to avoid race conditions
     let random_suffix: u32 = rand::random();
     let temp_name = format!(
         "{}.tmp.{}",
@@ -840,9 +778,8 @@ fn write_bincode<T: Serialize + ?Sized>(path: &Path, data: &T) -> Result<(), Sto
     let file = fs::File::create(&temp_path)?;
     let mut writer = BufWriter::new(file);
 
-    // Wrap write+flush+sync+rename so we can clean up the temp file on any failure
     let result = (|| -> Result<(), StorageError> {
-        bincode::serialize_into(&mut writer, data)?;
+        write_fn(&mut writer)?;
         writer.flush()?;
         writer
             .into_inner()
@@ -862,6 +799,18 @@ fn write_bincode<T: Serialize + ?Sized>(path: &Path, data: &T) -> Result<(), Sto
     }
 
     result
+}
+
+/// Atomically write bincode-serialized data to a file.
+///
+/// Uses write-to-temp, flush, sync_all, rename pattern for crash safety.
+/// Works with any serializable type including slices.
+/// Uses unique temp file names to avoid race conditions between concurrent writers.
+fn write_bincode<T: Serialize + ?Sized>(path: &Path, data: &T) -> Result<(), StorageError> {
+    atomic_write_with(path, |writer| {
+        bincode::serialize_into(writer, data)?;
+        Ok(())
+    })
 }
 
 fn read_bincode<T: DeserializeOwned>(path: &Path) -> Result<T, StorageError> {


### PR DESCRIPTION
## Summary

This PR reduces duplication and improves performance in the live mode modules (`storage.rs`, `compaction.rs`, `collector.rs`).

### Changes

**`src/live/storage.rs` — Extract `atomic_write_with()` helper**

Three functions duplicated the same atomic file write pattern (temp file with random suffix -> write -> flush -> sync_all -> rename -> cleanup on error):
- `write_bincode()` (bincode serialization)
- `write_status()` (JSON serialization)
- `update_status_atomic()` (JSON serialization under file lock)

Extracted a generic `atomic_write_with(path, write_fn)` helper that handles the temp file lifecycle, and rewrote all three to delegate to it. The `update_status_atomic` method retains its file-lock management around the call.

**`src/live/compaction.rs` — Extract shared parquet write helper**

All four parquet writers (`write_blocks_parquet`, `write_logs_parquet`, `write_factories_parquet`, `write_eth_calls_parquet`) duplicated the same boilerplate:
1. Create parent directory
2. Build RecordBatch from schema + columns
3. Create ArrowWriter with Snappy compression
4. Write batch and close

Extracted a `write_compaction_parquet(path, schema, columns)` free function that handles steps 1-4, and refactored each writer to only build its schema and column arrays before calling the helper. All compression settings (Snappy) are preserved exactly.

**`src/live/collector.rs` — HashMap-based factory address extraction**

`extract_factory_addresses()` used an O(n*m) nested loop (for each log, check every matcher). Optimized to O(n) by:
1. Pre-building a `HashMap<[u8; 32], Vec<usize>>` mapping `topic0` -> matcher indices during `LiveCollector::new()`
2. In `extract_factory_addresses()`, looking up `log.topics[0]` in the HashMap to find only the relevant matchers (address verification still needed since multiple matchers may share the same topic0)

This is stored as a `factory_topic_index` field on `LiveCollector`.

### Net effect

- 57 fewer lines of code (92 added, 149 removed)
- Identical behavior preserved across all changes
- Factory extraction scales linearly with log count instead of log count * matcher count