### PR TITLE
chore: unify handler catchup/retry logic and single-pass log decoding

### DIFF
--- a/src/decoding/logs.rs
+++ b/src/decoding/logs.rs
@@ -269,8 +269,13 @@ pub(crate) async fn process_logs(
 ) -> Result<(), LogDecodingError> {
     let regular_matchers = matchers.regular_matchers;
     let factory_matchers = matchers.factory_matchers;
-    // Group decoded logs by (contract_name, event_name)
+    let build_transform = outputs.transform_tx.is_some();
+
+    // Group decoded logs by (contract_name, event_name) — for parquet storage
     let mut decoded_by_event: HashMap<(String, String), (Vec<DecodedLogRecord>, &ParsedEvent)> =
+        HashMap::new();
+    // Also build transform events in the same pass when the channel is present
+    let mut transform_events_by_type: HashMap<(String, String), Vec<TransformDecodedEvent>> =
         HashMap::new();
 
     for log in logs {
@@ -296,6 +301,20 @@ pub(crate) async fn process_logs(
             }
 
             if let Some(decoded) = decode_log(log, &matcher.event)? {
+                if build_transform {
+                    let transform_event = convert_to_transform_event(
+                        &decoded,
+                        &matcher.event,
+                        &matcher.name,
+                        &matcher.event_name,
+                    );
+                    let key = (matcher.name.clone(), matcher.event_name.clone());
+                    transform_events_by_type
+                        .entry(key)
+                        .or_default()
+                        .push(transform_event);
+                }
+
                 let key = (matcher.name.clone(), matcher.event_name.clone());
                 decoded_by_event
                     .entry(key)
@@ -322,6 +341,20 @@ pub(crate) async fn process_logs(
                 }
 
                 if let Some(decoded) = decode_log(log, &matcher.event)? {
+                    if build_transform {
+                        let transform_event = convert_to_transform_event(
+                            &decoded,
+                            &matcher.event,
+                            collection_name,
+                            &matcher.event_name,
+                        );
+                        let key = (collection_name.clone(), matcher.event_name.clone());
+                        transform_events_by_type
+                            .entry(key)
+                            .or_default()
+                            .push(transform_event);
+                    }
+
                     let key = (collection_name.clone(), matcher.event_name.clone());
                     decoded_by_event
                         .entry(key)
@@ -400,83 +433,8 @@ pub(crate) async fn process_logs(
         }
     }
 
-    // Send to transformation channel if enabled
+    // Send transform events to the transformation channel (built during the single pass above)
     if let Some(tx) = outputs.transform_tx {
-        // Re-decode and send to transformation engine (we need to iterate again to build the transform messages)
-        // Group decoded logs by (contract_name, event_name) for sending
-        let mut transform_events_by_type: HashMap<(String, String), Vec<TransformDecodedEvent>> =
-            HashMap::new();
-
-        for log in logs {
-            if log.topics.is_empty() {
-                continue;
-            }
-            let topic0 = log.topics[0];
-
-            // Try regular matchers
-            for matcher in regular_matchers {
-                // Skip if block is before contract's start_block
-                if let Some(sb) = matcher.start_block {
-                    if log.block_number < sb {
-                        continue;
-                    }
-                }
-                if !matcher.addresses.contains(&log.address) {
-                    continue;
-                }
-                if topic0 != matcher.event.topic0 {
-                    continue;
-                }
-
-                if let Some(decoded) = decode_log(log, &matcher.event)? {
-                    let transform_event = convert_to_transform_event(
-                        &decoded,
-                        &matcher.event,
-                        &matcher.name,
-                        &matcher.event_name,
-                    );
-                    let key = (matcher.name.clone(), matcher.event_name.clone());
-                    transform_events_by_type
-                        .entry(key)
-                        .or_default()
-                        .push(transform_event);
-                }
-            }
-
-            // Try factory matchers
-            for (collection_name, matchers) in factory_matchers {
-                let addrs = match factory_addresses.get(collection_name) {
-                    Some(addrs) => addrs,
-                    None => continue,
-                };
-
-                if !addrs.contains(&log.address) {
-                    continue;
-                }
-
-                for matcher in matchers {
-                    if topic0 != matcher.event.topic0 {
-                        continue;
-                    }
-
-                    if let Some(decoded) = decode_log(log, &matcher.event)? {
-                        let transform_event = convert_to_transform_event(
-                            &decoded,
-                            &matcher.event,
-                            collection_name,
-                            &matcher.event_name,
-                        );
-                        let key = (collection_name.clone(), matcher.event_name.clone());
-                        transform_events_by_type
-                            .entry(key)
-                            .or_default()
-                            .push(transform_event);
-                    }
-                }
-            }
-        }
-
-        // Send each event type as a message
         for ((source_name, event_name), events) in transform_events_by_type {
             if events.is_empty() {
                 continue;

--- a/src/transformations/engine.rs
+++ b/src/transformations/engine.rs
@@ -113,6 +113,29 @@ type ReadyHandler = (
     Arc<Vec<DecodedCall>>,
 );
 
+/// Discriminates between event-based and call-based handler processing.
+///
+/// Used by the unified catchup and retry logic to handle the three divergent
+/// points: trigger extraction, call dependency checking, and context construction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum HandlerKind {
+    Event,
+    Call,
+}
+
+/// Uniform representation of a handler for catchup processing.
+///
+/// Bridges `EventHandlerInfo` and `CallHandlerInfo` so the catchup loop
+/// can iterate a single collection regardless of handler kind.
+struct CatchupHandler {
+    handler: Arc<dyn super::traits::TransformationHandler>,
+    /// (source, name) pairs — event names for Event, function names for Call.
+    triggers: Vec<(String, String)>,
+    /// Call dependencies (Event handlers only; empty for Call handlers).
+    call_deps: Vec<(String, String)>,
+    kind: HandlerKind,
+}
+
 /// The transformation engine processes decoded data and invokes handlers.
 ///
 /// Progress is tracked per handler (keyed by `handler_key()`) in the
@@ -412,34 +435,83 @@ impl TransformationEngine {
 
     /// Run catchup phase: process decoded parquet files per handler.
     pub async fn run_catchup(&self) -> Result<(), TransformationError> {
-        self.run_event_handler_catchup().await?;
-        self.run_call_handler_catchup().await?;
+        self.run_handler_catchup(HandlerKind::Event).await?;
+        self.run_handler_catchup(HandlerKind::Call).await?;
         Ok(())
     }
 
-    async fn run_event_handler_catchup(&self) -> Result<(), TransformationError> {
-        let available = self.scan_available_ranges(&self.decoded_logs_dir)?;
+    async fn run_handler_catchup(
+        &self,
+        kind: HandlerKind,
+    ) -> Result<(), TransformationError> {
+        let base_dir = match kind {
+            HandlerKind::Event => &self.decoded_logs_dir,
+            HandlerKind::Call => &self.decoded_calls_dir,
+        };
+        let kind_label = match kind {
+            HandlerKind::Event => "Event",
+            HandlerKind::Call => "Call",
+        };
+
+        let available = self.scan_available_ranges(base_dir)?;
 
         if available.is_empty() {
             tracing::info!(
-                "Event handler catchup: no parquet ranges found for chain {}",
+                "{} handler catchup: no parquet ranges found for chain {}",
+                kind_label,
                 self.chain_name
             );
             return Ok(());
         }
 
+        // Collect handler descriptors uniformly across both kinds.
+        let handlers: Vec<CatchupHandler> = match kind {
+            HandlerKind::Event => self
+                .registry
+                .unique_event_handlers()
+                .into_iter()
+                .map(|info| {
+                    let triggers: Vec<(String, String)> = info
+                        .triggers
+                        .iter()
+                        .map(|t| (t.source.clone(), extract_event_name(&t.event_signature)))
+                        .collect();
+                    let call_deps = info.handler.call_dependencies();
+                    CatchupHandler {
+                        handler: info.handler as Arc<dyn super::traits::TransformationHandler>,
+                        triggers,
+                        call_deps,
+                        kind: HandlerKind::Event,
+                    }
+                })
+                .collect(),
+            HandlerKind::Call => self
+                .registry
+                .unique_call_handlers()
+                .into_iter()
+                .map(|info| {
+                    let triggers: Vec<(String, String)> = info
+                        .triggers
+                        .iter()
+                        .map(|t| (t.source.clone(), t.function_name.clone()))
+                        .collect();
+                    CatchupHandler {
+                        handler: info.handler as Arc<dyn super::traits::TransformationHandler>,
+                        triggers,
+                        call_deps: Vec::new(),
+                        kind: HandlerKind::Call,
+                    }
+                })
+                .collect(),
+        };
+
         let mut failed_handlers: Vec<(String, String)> = vec![];
 
-        for handler_info in self.registry.unique_event_handlers() {
-            let handler = &handler_info.handler;
+        for ch in &handlers {
+            let handler = &ch.handler;
             let handler_key = handler.handler_key();
-            let event_triggers: Vec<(String, String)> = handler_info
-                .triggers
-                .iter()
-                .map(|t| (t.source.clone(), extract_event_name(&t.event_signature)))
-                .collect();
-
-            let call_deps = handler_info.handler.call_dependencies();
+            let triggers = &ch.triggers;
+            let call_deps = &ch.call_deps;
 
             let completed = self
                 .finalizer
@@ -458,11 +530,15 @@ impl TransformationEngine {
             }
 
             tracing::info!(
-                "Handler {} catchup: processing {} ranges (triggers: {:?}, call_deps: {:?})",
+                "Handler {} catchup: processing {} ranges (triggers: {:?}{})",
                 handler_key,
                 to_process.len(),
-                event_triggers,
-                call_deps
+                triggers,
+                if call_deps.is_empty() {
+                    String::new()
+                } else {
+                    format!(", call_deps: {:?}", call_deps)
+                }
             );
 
             let mut ranges_to_attempt = to_process;
@@ -486,7 +562,7 @@ impl TransformationEngine {
                     tokio::time::sleep(Duration::from_secs(1)).await;
                 }
 
-                // Re-scan available call ranges from filesystem each pass
+                // Re-scan available call ranges from filesystem each pass (event handlers only)
                 let available_call_ranges: Vec<HashSet<(u64, u64)>> = call_deps
                     .iter()
                     .map(|(source, func)| {
@@ -506,13 +582,21 @@ impl TransformationEngine {
                 let mut join_set: JoinSet<HandlerTaskResult> = JoinSet::new();
 
                 for (range_start, range_end) in &ranges_to_attempt {
-                    let events = self
-                        .read_decoded_events_for_triggers(*range_start, *range_end, &event_triggers)
-                        .await?;
+                    // Read primary data: events for event handlers, calls for call handlers
+                    let (events, primary_data_empty) = match ch.kind {
+                        HandlerKind::Event => {
+                            let evts = self
+                                .read_decoded_events_for_triggers(*range_start, *range_end, triggers)
+                                .await?;
+                            let evts = filter_events_by_start_block(&self.contracts, evts);
+                            let empty = evts.is_empty();
+                            (evts, empty)
+                        }
+                        HandlerKind::Call => (Vec::new(), false),
+                    };
 
-                    let events = filter_events_by_start_block(&self.contracts, events);
-
-                    if !events.is_empty() && !call_deps.is_empty() {
+                    // For event handlers: check call dependency readiness and load calls
+                    if !primary_data_empty && !call_deps.is_empty() {
                         let calls_ready = available_call_ranges
                             .iter()
                             .all(|ranges| ranges.contains(&(*range_start, *range_end)));
@@ -529,25 +613,44 @@ impl TransformationEngine {
                         }
                     }
 
-                    let calls = if !events.is_empty() && !call_deps.is_empty() {
-                        let calls = self
-                            .read_decoded_calls_for_triggers(*range_start, *range_end, &call_deps)
-                            .await?;
-                        filter_calls_by_start_block(&self.contracts, calls)
-                    } else {
-                        Vec::new()
+                    let calls = match ch.kind {
+                        HandlerKind::Event => {
+                            if !events.is_empty() && !call_deps.is_empty() {
+                                let calls = self
+                                    .read_decoded_calls_for_triggers(
+                                        *range_start,
+                                        *range_end,
+                                        call_deps,
+                                    )
+                                    .await?;
+                                filter_calls_by_start_block(&self.contracts, calls)
+                            } else {
+                                Vec::new()
+                            }
+                        }
+                        HandlerKind::Call => {
+                            let calls = self
+                                .read_decoded_calls_for_triggers(*range_start, *range_end, triggers)
+                                .await?;
+                            filter_calls_by_start_block(&self.contracts, calls)
+                        }
                     };
 
                     processed += 1;
 
-                    if !events.is_empty() {
+                    // Determine whether there is data to process
+                    let has_data = match ch.kind {
+                        HandlerKind::Event => !events.is_empty(),
+                        HandlerKind::Call => !calls.is_empty(),
+                    };
+
+                    if has_data {
                         let permit = semaphore.clone().acquire_owned().await.unwrap();
                         let handler = handler.clone();
                         let db_pool = self.db_pool.clone();
                         let handler_key = handler_key.clone();
                         let handler_name = handler.name();
                         let handler_version = handler.version();
-                        let tx_addresses = self.read_receipt_addresses(*range_start, *range_end);
                         let chain_name = self.chain_name.clone();
                         let chain_id = self.chain_id;
                         let historical = self.historical_reader.clone();
@@ -555,6 +658,15 @@ impl TransformationEngine {
                         let contracts = self.contracts.clone();
                         let rs = *range_start;
                         let re = *range_end;
+                        let handler_kind = ch.kind;
+
+                        // Event handlers get tx_addresses; call handlers pass empty map
+                        let tx_addresses = match handler_kind {
+                            HandlerKind::Event => {
+                                self.read_receipt_addresses(*range_start, *range_end)
+                            }
+                            HandlerKind::Call => HashMap::new(),
+                        };
 
                         join_set.spawn(async move {
                             let _permit = permit;
@@ -667,176 +779,6 @@ impl TransformationEngine {
 
             if handler_errored {
                 continue;
-            }
-        }
-
-        if !failed_handlers.is_empty() {
-            let msg = failed_handlers
-                .iter()
-                .map(|(k, e)| format!("{}: {}", k, e))
-                .collect::<Vec<_>>()
-                .join("; ");
-            return Err(TransformationError::HandlerError {
-                handler_name: "catchup".to_string(),
-                message: format!("{} handler(s) failed: {}", failed_handlers.len(), msg),
-            });
-        }
-
-        Ok(())
-    }
-
-    async fn run_call_handler_catchup(&self) -> Result<(), TransformationError> {
-        let available = self.scan_available_ranges(&self.decoded_calls_dir)?;
-
-        if available.is_empty() {
-            tracing::info!(
-                "Call handler catchup: no parquet ranges found for chain {}",
-                self.chain_name
-            );
-            return Ok(());
-        }
-
-        let mut failed_handlers: Vec<(String, String)> = vec![];
-
-        for handler_info in self.registry.unique_call_handlers() {
-            let handler = &handler_info.handler;
-            let handler_key = handler.handler_key();
-            let call_triggers: Vec<(String, String)> = handler_info
-                .triggers
-                .iter()
-                .map(|t| (t.source.clone(), t.function_name.clone()))
-                .collect();
-
-            let completed = self
-                .finalizer
-                .get_completed_ranges_for_handler(&handler_key)
-                .await?;
-
-            let to_process: Vec<_> = available
-                .iter()
-                .filter(|(start, _)| !completed.contains(start))
-                .cloned()
-                .collect();
-
-            if to_process.is_empty() {
-                tracing::info!("Handler {} catchup: already up to date", handler_key);
-                continue;
-            }
-
-            tracing::info!(
-                "Handler {} catchup: processing {} ranges (triggers: {:?})",
-                handler_key,
-                to_process.len(),
-                call_triggers
-            );
-
-            let total = to_process.len();
-            let mut processed = 0;
-
-            let semaphore = Arc::new(Semaphore::new(self.handler_concurrency));
-            let mut join_set: JoinSet<HandlerTaskResult> = JoinSet::new();
-
-            for (range_start, range_end) in &to_process {
-                let calls = self
-                    .read_decoded_calls_for_triggers(*range_start, *range_end, &call_triggers)
-                    .await?;
-
-                let calls = filter_calls_by_start_block(&self.contracts, calls);
-
-                processed += 1;
-
-                if !calls.is_empty() {
-                    let permit = semaphore.clone().acquire_owned().await.unwrap();
-                    let handler = handler.clone();
-                    let db_pool = self.db_pool.clone();
-                    let handler_key = handler_key.clone();
-                    let handler_name = handler.name();
-                    let handler_version = handler.version();
-                    let chain_name = self.chain_name.clone();
-                    let chain_id = self.chain_id;
-                    let historical = self.historical_reader.clone();
-                    let rpc = self.executor.rpc_client.clone();
-                    let contracts = self.contracts.clone();
-                    let rs = *range_start;
-                    let re = *range_end;
-
-                    join_set.spawn(async move {
-                        let _permit = permit;
-                        let ctx = TransformationContext::new(
-                            chain_name,
-                            chain_id,
-                            rs,
-                            re,
-                            Arc::new(Vec::new()),
-                            Arc::new(calls),
-                            HashMap::new(),
-                            historical,
-                            rpc,
-                            contracts,
-                        );
-
-                        match handler.handle(&ctx).await {
-                            Ok(ops) => {
-                                if !ops.is_empty() {
-                                    let ops =
-                                        inject_source_version(ops, handler_name, handler_version);
-                                    db_pool.execute_transaction(ops).await?;
-                                }
-                                Ok(Some((handler_key, rs, re)))
-                            }
-                            Err(e) => Err(e),
-                        }
-                    });
-                } else {
-                    self.finalizer
-                        .record_completed_range_for_handler(&handler_key, *range_start, *range_end)
-                        .await?;
-                }
-
-                if processed % 50 == 0 {
-                    tracing::info!(
-                        "Handler {} catchup progress: {}/{}",
-                        handler_key,
-                        processed,
-                        total
-                    );
-                }
-            }
-
-            let mut this_handler_errored = false;
-            while let Some(result) = join_set.join_next().await {
-                match result {
-                    Ok(Ok(Some((hk, rs, re)))) => {
-                        self.finalizer
-                            .record_completed_range_for_handler(&hk, rs, re)
-                            .await?;
-                    }
-                    Ok(Ok(None)) => {}
-                    Ok(Err(e)) => {
-                        tracing::error!(
-                            "Handler {} failed during catchup: {}. Stopping catchup for this handler.",
-                            handler_key, e
-                        );
-                        failed_handlers.push((handler_key.clone(), e.to_string()));
-                        this_handler_errored = true;
-                        break;
-                    }
-                    Err(e) => {
-                        tracing::error!("Handler {} catchup task panicked: {}", handler_key, e);
-                        failed_handlers
-                            .push((handler_key.clone(), format!("task panicked: {}", e)));
-                        this_handler_errored = true;
-                        break;
-                    }
-                }
-            }
-
-            if !this_handler_errored {
-                tracing::info!(
-                    "Handler {} catchup complete: processed {} ranges",
-                    handler_key,
-                    processed
-                );
             }
         }
 

--- a/src/transformations/retry.rs
+++ b/src/transformations/retry.rs
@@ -11,6 +11,7 @@ use tokio::sync::{Mutex, Semaphore};
 use tokio::task::JoinSet;
 
 use super::context::{DecodedCall, DecodedEvent, TransactionAddresses, TransformationContext};
+use super::engine::HandlerKind;
 use super::error::TransformationError;
 use super::executor::{execute_with_snapshot_capture, inject_source_version};
 use super::historical::HistoricalDataReader;
@@ -31,6 +32,19 @@ use crate::types::config::eth_call::EvmType;
 pub(crate) enum LiveRetryCallArtifactKind {
     Regular,
     EventTriggered { base_name: String },
+}
+
+/// Uniform representation of a handler for retry processing.
+///
+/// Bridges `EventHandlerInfo` and `CallHandlerInfo` so the retry loop
+/// can iterate a single collection regardless of handler kind.
+struct RetryHandler {
+    handler: Arc<dyn super::traits::TransformationHandler>,
+    /// (source, name) trigger pairs — event names for Event, function names for Call.
+    triggers: HashSet<(String, String)>,
+    /// Call dependencies (Event handlers only; empty for Call handlers).
+    call_deps: HashSet<(String, String)>,
+    kind: HandlerKind,
 }
 
 pub(crate) fn resolve_retry_missing_handlers(
@@ -352,55 +366,73 @@ impl RetryProcessor {
         let mut blocked_handlers = HashSet::new();
         let mut attempted_keys = HashSet::new();
 
-        for handler_info in self.registry.unique_event_handlers() {
-            let handler = handler_info.handler;
-            let handler_key = handler.handler_key();
+        // Build a uniform list of retry handler descriptors from both kinds.
+        let retry_handlers = self.build_retry_handler_list();
+
+        for rh in &retry_handlers {
+            let handler_key = rh.handler.handler_key();
             if !missing_handlers.contains(&handler_key) {
                 continue;
             }
 
-            let triggers: HashSet<(String, String)> = handler_info
-                .triggers
-                .iter()
-                .map(|trigger| {
-                    (
-                        trigger.source.clone(),
-                        extract_event_name(&trigger.event_signature),
-                    )
-                })
-                .collect();
-            let handler_events: Vec<DecodedEvent> = events
-                .iter()
-                .filter(|event| {
-                    triggers.contains(&(event.source_name.clone(), event.event_name.clone()))
-                })
-                .cloned()
-                .collect();
+            // Filter primary data by trigger match
+            let (handler_events, handler_calls) = match rh.kind {
+                HandlerKind::Event => {
+                    let handler_events: Vec<DecodedEvent> = events
+                        .iter()
+                        .filter(|event| {
+                            rh.triggers
+                                .contains(&(event.source_name.clone(), event.event_name.clone()))
+                        })
+                        .cloned()
+                        .collect();
 
-            if handler_events.is_empty() {
-                continue;
-            }
+                    if handler_events.is_empty() {
+                        continue;
+                    }
 
-            let call_deps: HashSet<(String, String)> =
-                handler.call_dependencies().into_iter().collect();
-            let missing_deps = missing_retry_call_dependencies(&call_deps, &calls);
-            if !missing_deps.is_empty() {
-                tracing::warn!(
-                    "Skipping live retry for handler {} on block {}: missing call dependencies {:?}",
-                    handler_key,
-                    block_number,
-                    missing_deps
-                );
-                blocked_handlers.insert(handler_key);
-                continue;
-            }
-            let handler_calls: Vec<DecodedCall> = calls
-                .iter()
-                .filter(|call| {
-                    call_deps.contains(&(call.source_name.clone(), call.function_name.clone()))
-                })
-                .cloned()
-                .collect();
+                    // Check call dependencies
+                    let missing_deps =
+                        missing_retry_call_dependencies(&rh.call_deps, &calls);
+                    if !missing_deps.is_empty() {
+                        tracing::warn!(
+                            "Skipping live retry for handler {} on block {}: missing call dependencies {:?}",
+                            handler_key,
+                            block_number,
+                            missing_deps
+                        );
+                        blocked_handlers.insert(handler_key);
+                        continue;
+                    }
+
+                    let handler_calls: Vec<DecodedCall> = calls
+                        .iter()
+                        .filter(|call| {
+                            rh.call_deps
+                                .contains(&(call.source_name.clone(), call.function_name.clone()))
+                        })
+                        .cloned()
+                        .collect();
+
+                    (handler_events, handler_calls)
+                }
+                HandlerKind::Call => {
+                    let handler_calls: Vec<DecodedCall> = calls
+                        .iter()
+                        .filter(|call| {
+                            rh.triggers
+                                .contains(&(call.source_name.clone(), call.function_name.clone()))
+                        })
+                        .cloned()
+                        .collect();
+
+                    if handler_calls.is_empty() {
+                        continue;
+                    }
+
+                    (Vec::new(), handler_calls)
+                }
+            };
 
             attempted_keys.insert(handler_key.clone());
 
@@ -411,9 +443,15 @@ impl RetryProcessor {
             let historical = self.historical_reader.clone();
             let rpc = self.rpc_client.clone();
             let contracts = self.contracts.clone();
-            let tx_addresses = tx_addresses.clone();
+            let handler = rh.handler.clone();
             let handler_name = handler.name();
             let handler_version = handler.version();
+
+            // Event handlers get tx_addresses; call handlers pass empty map
+            let task_tx_addresses = match rh.kind {
+                HandlerKind::Event => (*tx_addresses).clone(),
+                HandlerKind::Call => HashMap::new(),
+            };
 
             join_set.spawn(async move {
                 let _permit = permit;
@@ -425,80 +463,7 @@ impl RetryProcessor {
                     range_end,
                     Arc::new(handler_events),
                     Arc::new(handler_calls),
-                    (*tx_addresses).clone(),
-                    historical,
-                    rpc,
-                    contracts,
-                );
-
-                match handler.handle(&ctx).await {
-                    Ok(ops) => {
-                        if !ops.is_empty() {
-                            let ops = inject_source_version(ops, handler_name, handler_version);
-                            execute_with_snapshot_capture(
-                                ops,
-                                &db_pool,
-                                Some(&live_storage),
-                                range_start,
-                                handler_name,
-                                handler_version,
-                            )
-                            .await?;
-                        }
-                        Ok(Some(handler_key))
-                    }
-                    Err(e) => Err(e),
-                }
-            });
-        }
-
-        for handler_info in self.registry.unique_call_handlers() {
-            let handler = handler_info.handler;
-            let handler_key = handler.handler_key();
-            if !missing_handlers.contains(&handler_key) {
-                continue;
-            }
-
-            let triggers: HashSet<(String, String)> = handler_info
-                .triggers
-                .iter()
-                .map(|trigger| (trigger.source.clone(), trigger.function_name.clone()))
-                .collect();
-            let handler_calls: Vec<DecodedCall> = calls
-                .iter()
-                .filter(|call| {
-                    triggers.contains(&(call.source_name.clone(), call.function_name.clone()))
-                })
-                .cloned()
-                .collect();
-
-            if handler_calls.is_empty() {
-                continue;
-            }
-
-            attempted_keys.insert(handler_key.clone());
-
-            let permit = semaphore.clone().acquire_owned().await.unwrap();
-            let db_pool = self.db_pool.clone();
-            let chain_name = self.chain_name.clone();
-            let chain_id = self.chain_id;
-            let historical = self.historical_reader.clone();
-            let rpc = self.rpc_client.clone();
-            let contracts = self.contracts.clone();
-            let handler_name = handler.name();
-            let handler_version = handler.version();
-
-            join_set.spawn(async move {
-                let _permit = permit;
-                let live_storage = LiveStorage::new(&chain_name);
-                let ctx = TransformationContext::new(
-                    chain_name,
-                    chain_id,
-                    range_start,
-                    range_end,
-                    Arc::new(Vec::new()),
-                    Arc::new(handler_calls),
-                    HashMap::new(),
+                    task_tx_addresses,
                     historical,
                     rpc,
                     contracts,
@@ -613,6 +578,43 @@ impl RetryProcessor {
         }
 
         Ok(blocked_handlers)
+    }
+
+    /// Build a uniform list of retry handler descriptors from both event and call handlers.
+    fn build_retry_handler_list(&self) -> Vec<RetryHandler> {
+        let mut handlers = Vec::new();
+
+        for info in self.registry.unique_event_handlers() {
+            let triggers: HashSet<(String, String)> = info
+                .triggers
+                .iter()
+                .map(|t| (t.source.clone(), extract_event_name(&t.event_signature)))
+                .collect();
+            let call_deps: HashSet<(String, String)> =
+                info.handler.call_dependencies().into_iter().collect();
+            handlers.push(RetryHandler {
+                handler: info.handler as Arc<dyn super::traits::TransformationHandler>,
+                triggers,
+                call_deps,
+                kind: HandlerKind::Event,
+            });
+        }
+
+        for info in self.registry.unique_call_handlers() {
+            let triggers: HashSet<(String, String)> = info
+                .triggers
+                .iter()
+                .map(|t| (t.source.clone(), t.function_name.clone()))
+                .collect();
+            handlers.push(RetryHandler {
+                handler: info.handler as Arc<dyn super::traits::TransformationHandler>,
+                triggers,
+                call_deps: HashSet::new(),
+                kind: HandlerKind::Call,
+            });
+        }
+
+        handlers
     }
 }
 


### PR DESCRIPTION
## Summary

Eliminates structural duplication across the transformation engine catchup, retry logic, and log decoding.

### engine.rs — Unified handler catchup

`run_event_handler_catchup()` (267 lines) and `run_call_handler_catchup()` (168 lines) were structurally identical with only 3 divergence points:
- **Trigger extraction**: event handlers use `EventTrigger` (source + event signature), call handlers use `EthCallTrigger` (source + function name)
- **Call dependency checking**: event handlers check `call_dependencies()` and do multi-pass retries waiting for call data; call handlers skip this
- **Context construction**: event handlers pass populated events + loaded calls; call handlers pass empty events

Replaced both with a single `run_handler_catchup(HandlerKind)` method that uses a `CatchupHandler` struct to normalize both handler types and `match` at the 3 divergent points. Net reduction: ~100 lines.

### retry.rs — Unified retry handler loops

The event handler loop and call handler loop in `execute_live_retry_handlers()` were 95% identical with the same 3 differences. Extracted a `build_retry_handler_list()` method that normalizes both handler types into `RetryHandler` structs, then the main loop iterates a single collection with `match` at the divergence points. Net reduction: ~65 lines.

### logs.rs — Single-pass log decoding

`process_logs()` iterated all logs **twice**: once to decode and write parquet files, then again to decode the same logs for the transformation channel. The matching logic (topic0 check, address check, start_block check) and `decode_log()` calls were completely redundant.

Refactored to a single pass: when a match is found and decoded, both the `DecodedLogRecord` (for parquet) and the `TransformDecodedEvent` (for the channel) are built simultaneously. The transform events map is only populated when `outputs.transform_tx.is_some()`. Net reduction: ~35 lines, and decoding work is halved when the transformation channel is active.

### Shared infrastructure

Introduced `HandlerKind` enum (Event/Call) in `engine.rs`, used by both engine catchup and retry logic. Each module has its own internal descriptor struct (`CatchupHandler` / `RetryHandler`) to bridge the different handler info types.

All changes are purely structural — same behavior, same public APIs, same error handling. The logs.rs change produces identical output but eliminates redundant matching and decoding.