### PR TITLE
refactor: deduplicate repeated patterns in transformation engine

### DIFF
--- a/src/transformations/engine.rs
+++ b/src/transformations/engine.rs
@@ -1286,33 +1286,49 @@ impl TransformationEngine {
                     outcome.range_end,
                 )
                 .await?;
-
-            if outcome.range_end - outcome.range_start == 1 {
-                if let Some(ref tracker) = self.progress_tracker {
-                    let mut t = tracker.lock().await;
-                    if let Err(e) = t
-                        .mark_complete(outcome.range_start, &outcome.handler_key)
-                        .await
-                    {
-                        tracing::warn!(
-                            "Failed to mark live progress for block {} handler {}: {}",
-                            outcome.range_start,
-                            outcome.handler_key,
-                            e
-                        );
-                    }
-                }
-            }
         }
 
-        // Persist failed handlers to status file (single-block live mode only)
-        let failed_keys: HashSet<String> = submitted_keys
-            .difference(&succeeded_keys)
-            .cloned()
-            .collect();
-        if !failed_keys.is_empty() && msg.range_end - msg.range_start == 1 {
+        self.record_handler_outcomes(
+            msg.range_start,
+            msg.range_end,
+            &submitted_keys,
+            &succeeded_keys,
+            &outcomes,
+        )
+        .await;
+
+        Ok(())
+    }
+
+    // ─── Shared outcome recording ────────────────────────────────────
+
+    /// Mark a single block as complete for a handler in the live progress tracker.
+    async fn record_live_progress(&self, block_number: u64, handler_key: &str) {
+        if let Some(ref tracker) = self.progress_tracker {
+            let mut t = tracker.lock().await;
+            if let Err(e) = t.mark_complete(block_number, handler_key).await {
+                tracing::warn!(
+                    "Failed to mark live progress for block {} handler {}: {}",
+                    block_number,
+                    handler_key,
+                    e
+                );
+            }
+        }
+    }
+
+    /// Persist the set of failed handlers into the live status file for a block.
+    async fn persist_failed_handlers(
+        &self,
+        block_number: u64,
+        submitted_keys: &HashSet<String>,
+        succeeded_keys: &HashSet<String>,
+    ) {
+        let failed_keys: HashSet<String> =
+            submitted_keys.difference(succeeded_keys).cloned().collect();
+        if !failed_keys.is_empty() {
             let storage = LiveStorage::new(&self.chain_name);
-            if let Err(e) = storage.update_status_atomic(msg.range_start, |status| {
+            if let Err(e) = storage.update_status_atomic(block_number, |status| {
                 status.failed_handlers.extend(failed_keys.iter().cloned());
                 for h in &failed_keys {
                     status.completed_handlers.remove(h);
@@ -1321,14 +1337,33 @@ impl TransformationEngine {
                 if !matches!(e, StorageError::NotFound(_)) {
                     tracing::warn!(
                         "Failed to persist failed handlers for block {}: {}",
-                        msg.range_start,
+                        block_number,
                         e
                     );
                 }
             }
         }
+    }
 
-        Ok(())
+    /// Record progress and persist failures for handler outcomes from a single
+    /// block range execution.  For single-block (live) ranges this records
+    /// per-handler live progress and writes failures to the status file.
+    async fn record_handler_outcomes(
+        &self,
+        range_start: u64,
+        range_end: u64,
+        submitted_keys: &HashSet<String>,
+        succeeded_keys: &HashSet<String>,
+        outcomes: &[super::executor::HandlerOutcome],
+    ) {
+        if range_end - range_start == 1 {
+            for outcome in outcomes {
+                self.record_live_progress(outcome.range_start, &outcome.handler_key)
+                    .await;
+            }
+            self.persist_failed_handlers(range_start, submitted_keys, succeeded_keys)
+                .await;
+        }
     }
 
     /// Process a calls message and check if any pending events can now be processed.
@@ -1546,47 +1581,16 @@ impl TransformationEngine {
                     outcome.range_end,
                 )
                 .await?;
-
-            if outcome.range_end - outcome.range_start == 1 {
-                if let Some(ref tracker) = self.progress_tracker {
-                    let mut t = tracker.lock().await;
-                    if let Err(e) = t
-                        .mark_complete(outcome.range_start, &outcome.handler_key)
-                        .await
-                    {
-                        tracing::warn!(
-                            "Failed to mark live progress for block {} handler {}: {}",
-                            outcome.range_start,
-                            outcome.handler_key,
-                            e
-                        );
-                    }
-                }
-            }
         }
 
-        // Persist failed handlers to status file (single-block live mode only)
-        let failed_keys: HashSet<String> = submitted_keys
-            .difference(&succeeded_keys)
-            .cloned()
-            .collect();
-        if !failed_keys.is_empty() && range_key.1 - range_key.0 == 1 {
-            let storage = LiveStorage::new(&self.chain_name);
-            if let Err(e) = storage.update_status_atomic(range_key.0, |status| {
-                status.failed_handlers.extend(failed_keys.iter().cloned());
-                for h in &failed_keys {
-                    status.completed_handlers.remove(h);
-                }
-            }) {
-                if !matches!(e, StorageError::NotFound(_)) {
-                    tracing::warn!(
-                        "Failed to persist failed handlers for block {}: {}",
-                        range_key.0,
-                        e
-                    );
-                }
-            }
-        }
+        self.record_handler_outcomes(
+            range_key.0,
+            range_key.1,
+            &submitted_keys,
+            &succeeded_keys,
+            &outcomes,
+        )
+        .await;
 
         Ok(())
     }
@@ -1674,47 +1678,16 @@ impl TransformationEngine {
                     outcome.range_end,
                 )
                 .await?;
-
-            if outcome.range_end - outcome.range_start == 1 {
-                if let Some(ref tracker) = self.progress_tracker {
-                    let mut t = tracker.lock().await;
-                    if let Err(e) = t
-                        .mark_complete(outcome.range_start, &outcome.handler_key)
-                        .await
-                    {
-                        tracing::warn!(
-                            "Failed to mark live progress for block {} handler {}: {}",
-                            outcome.range_start,
-                            outcome.handler_key,
-                            e
-                        );
-                    }
-                }
-            }
         }
 
-        // Persist failed handlers to status file (single-block live mode only)
-        let failed_keys: HashSet<String> = submitted_keys
-            .difference(&succeeded_keys)
-            .cloned()
-            .collect();
-        if !failed_keys.is_empty() && range_end - range_start == 1 {
-            let storage = LiveStorage::new(&self.chain_name);
-            if let Err(e) = storage.update_status_atomic(range_start, |status| {
-                status.failed_handlers.extend(failed_keys.iter().cloned());
-                for h in &failed_keys {
-                    status.completed_handlers.remove(h);
-                }
-            }) {
-                if !matches!(e, StorageError::NotFound(_)) {
-                    tracing::warn!(
-                        "Failed to persist failed handlers for block {}: {}",
-                        range_start,
-                        e
-                    );
-                }
-            }
-        }
+        self.record_handler_outcomes(
+            range_start,
+            range_end,
+            &submitted_keys,
+            &succeeded_keys,
+            &outcomes,
+        )
+        .await;
 
         Ok(())
     }

--- a/src/transformations/engine.rs
+++ b/src/transformations/engine.rs
@@ -1084,11 +1084,18 @@ impl TransformationEngine {
             call_triggers,
             |source, function| {
                 let base_dir = calls_dir.join(source).join(function);
-                vec![
+                // Use first-match semantics: only the first existing path is returned,
+                // matching the original behavior where base > on_events > once priority
+                // prevents duplicate data when multiple paths exist.
+                [
                     base_dir.join(&file_name),
                     base_dir.join("on_events").join(&file_name),
                     base_dir.join("once").join(&file_name),
                 ]
+                .into_iter()
+                .find(|p| p.exists())
+                .into_iter()
+                .collect()
             },
             |reader, path, src, func| reader.read_calls_from_file(path, src, func),
         )

--- a/src/transformations/engine.rs
+++ b/src/transformations/engine.rs
@@ -932,57 +932,67 @@ impl TransformationEngine {
 
     // ─── Parquet Reading ─────────────────────────────────────────────
 
-    async fn read_decoded_events_for_triggers(
+    /// Read decoded parquet files for a set of triggers, spawning one blocking
+    /// read task per trigger.
+    ///
+    /// `resolve_paths` turns each `(source, name)` trigger into zero or more
+    /// file paths to read.  `read_file` performs the actual parquet read.
+    async fn read_decoded_parquet_for_triggers<T>(
         &self,
-        range_start: u64,
-        range_end: u64,
-        event_triggers: &[(String, String)],
-    ) -> Result<Vec<DecodedEvent>, TransformationError> {
-        let file_name = format!("{}-{}.parquet", range_start, range_end - 1);
+        triggers: &[(String, String)],
+        resolve_paths: impl Fn(&str, &str) -> Vec<PathBuf>,
+        read_file: impl Fn(Arc<HistoricalDataReader>, &Path, &str, &str) -> Result<Vec<T>, TransformationError>
+            + Send
+            + Sync
+            + 'static,
+    ) -> Result<Vec<T>, TransformationError>
+    where
+        T: Send + 'static,
+    {
         let mut read_tasks = JoinSet::new();
+        let read_fn = Arc::new(read_file);
 
-        for (source_name, event_name) in event_triggers {
-            let file_path = self
-                .decoded_logs_dir
-                .join(source_name)
-                .join(event_name)
-                .join(&file_name);
+        for (source_name, secondary_name) in triggers {
+            let paths = resolve_paths(source_name, secondary_name);
 
-            if !file_path.exists() {
-                continue;
-            }
-
-            let reader = self.historical_reader.clone();
-            let src = source_name.clone();
-            let evt = event_name.clone();
-
-            read_tasks.spawn_blocking(move || {
-                tracing::debug!("Reading decoded events from {}", file_path.display());
-                match reader.read_events_from_file(&file_path, &src, &evt) {
-                    Ok(events) => {
-                        tracing::debug!(
-                            "Read {} events from {}",
-                            events.len(),
-                            file_path.display()
-                        );
-                        Ok(events)
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            "Failed to read decoded events from {}: {}",
-                            file_path.display(),
-                            e
-                        );
-                        Ok(Vec::new())
-                    }
+            for file_path in paths {
+                if !file_path.exists() {
+                    continue;
                 }
-            });
+
+                let reader = self.historical_reader.clone();
+                let src = source_name.clone();
+                let name = secondary_name.clone();
+                let read_fn = read_fn.clone();
+
+                read_tasks.spawn_blocking(move || {
+                    tracing::debug!("Reading decoded data from {}", file_path.display());
+                    match read_fn(reader, &file_path, &src, &name) {
+                        Ok(items) => {
+                            tracing::debug!(
+                                "Read {} items from {}",
+                                items.len(),
+                                file_path.display()
+                            );
+                            Ok(items)
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                "Failed to read decoded data from {}: {}",
+                                file_path.display(),
+                                e
+                            );
+                            Ok(Vec::new())
+                        }
+                    }
+                });
+            }
         }
 
-        let mut all_events = Vec::new();
+        let mut all_items = Vec::new();
         while let Some(result) = read_tasks.join_next().await {
             match result {
-                Ok(Ok(events)) => all_events.extend(events),
+                Ok(Ok(items)) => all_items.extend(items),
                 Ok(Err(e)) => return Err(e),
                 Err(e) => {
                     return Err(TransformationError::IoError(std::io::Error::other(
@@ -992,7 +1002,24 @@ impl TransformationEngine {
             }
         }
 
-        Ok(all_events)
+        Ok(all_items)
+    }
+
+    async fn read_decoded_events_for_triggers(
+        &self,
+        range_start: u64,
+        range_end: u64,
+        event_triggers: &[(String, String)],
+    ) -> Result<Vec<DecodedEvent>, TransformationError> {
+        let file_name = format!("{}-{}.parquet", range_start, range_end - 1);
+        let logs_dir = self.decoded_logs_dir.clone();
+
+        self.read_decoded_parquet_for_triggers(
+            event_triggers,
+            |source, event| vec![logs_dir.join(source).join(event).join(&file_name)],
+            |reader, path, src, evt| reader.read_events_from_file(path, src, evt),
+        )
+        .await
     }
 
     async fn read_decoded_calls_for_triggers(
@@ -1002,62 +1029,21 @@ impl TransformationEngine {
         call_triggers: &[(String, String)],
     ) -> Result<Vec<DecodedCall>, TransformationError> {
         let file_name = format!("{}-{}.parquet", range_start, range_end - 1);
-        let mut read_tasks = JoinSet::new();
+        let calls_dir = self.decoded_calls_dir.clone();
 
-        for (source_name, function_name) in call_triggers {
-            let base_dir = self.decoded_calls_dir.join(source_name).join(function_name);
-
-            // Check base path, then subdirectories (on_events/, once/)
-            let file_path = [
-                base_dir.join(&file_name),
-                base_dir.join("on_events").join(&file_name),
-                base_dir.join("once").join(&file_name),
-            ]
-            .into_iter()
-            .find(|p| p.exists());
-
-            let file_path = match file_path {
-                Some(p) => p,
-                None => continue,
-            };
-
-            let reader = self.historical_reader.clone();
-            let src = source_name.clone();
-            let func = function_name.clone();
-
-            read_tasks.spawn_blocking(move || {
-                tracing::debug!("Reading decoded calls from {}", file_path.display());
-                match reader.read_calls_from_file(&file_path, &src, &func) {
-                    Ok(calls) => {
-                        tracing::debug!("Read {} calls from {}", calls.len(), file_path.display());
-                        Ok(calls)
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            "Failed to read decoded calls from {}: {}",
-                            file_path.display(),
-                            e
-                        );
-                        Ok(Vec::new())
-                    }
-                }
-            });
-        }
-
-        let mut all_calls = Vec::new();
-        while let Some(result) = read_tasks.join_next().await {
-            match result {
-                Ok(Ok(calls)) => all_calls.extend(calls),
-                Ok(Err(e)) => return Err(e),
-                Err(e) => {
-                    return Err(TransformationError::IoError(std::io::Error::other(
-                        e.to_string(),
-                    )))
-                }
-            }
-        }
-
-        Ok(all_calls)
+        self.read_decoded_parquet_for_triggers(
+            call_triggers,
+            |source, function| {
+                let base_dir = calls_dir.join(source).join(function);
+                vec![
+                    base_dir.join(&file_name),
+                    base_dir.join("on_events").join(&file_name),
+                    base_dir.join("once").join(&file_name),
+                ]
+            },
+            |reader, path, src, func| reader.read_calls_from_file(path, src, func),
+        )
+        .await
     }
 
     // ─── Live Processing ─────────────────────────────────────────────

--- a/src/transformations/engine.rs
+++ b/src/transformations/engine.rs
@@ -1595,6 +1595,44 @@ impl TransformationEngine {
         Ok(())
     }
 
+    /// Build handler tasks for all event and call triggers in a block range.
+    fn build_handler_tasks(
+        &self,
+        event_triggers: &[(String, String)],
+        call_triggers: &[(String, String)],
+        events: Arc<Vec<DecodedEvent>>,
+        calls: Arc<Vec<DecodedCall>>,
+        tx_addresses: HashMap<[u8; 32], TransactionAddresses>,
+    ) -> Vec<HandlerTask> {
+        let mut tasks = Vec::new();
+
+        for (source, event_name) in event_triggers {
+            for handler in self.registry.handlers_for_event(source, event_name) {
+                let handler: Arc<dyn super::traits::TransformationHandler> = handler;
+                tasks.push(HandlerTask {
+                    handler,
+                    events: events.clone(),
+                    calls: calls.clone(),
+                    tx_addresses: tx_addresses.clone(),
+                });
+            }
+        }
+
+        for (source, function_name) in call_triggers {
+            for handler in self.registry.handlers_for_call(source, function_name) {
+                let handler: Arc<dyn super::traits::TransformationHandler> = handler;
+                tasks.push(HandlerTask {
+                    handler,
+                    events: events.clone(),
+                    calls: calls.clone(),
+                    tx_addresses: tx_addresses.clone(),
+                });
+            }
+        }
+
+        tasks
+    }
+
     /// Process a block range with per-handler transactions.
     async fn process_range(
         &self,
@@ -1633,31 +1671,13 @@ impl TransformationEngine {
             DbExecMode::Direct
         };
 
-        let mut tasks = Vec::new();
-
-        for (source, event_name) in &event_triggers {
-            for handler in self.registry.handlers_for_event(source, event_name) {
-                let handler: Arc<dyn super::traits::TransformationHandler> = handler;
-                tasks.push(HandlerTask {
-                    handler,
-                    events: events.clone(),
-                    calls: calls.clone(),
-                    tx_addresses: tx_addresses.clone(),
-                });
-            }
-        }
-
-        for (source, function_name) in &call_triggers {
-            for handler in self.registry.handlers_for_call(source, function_name) {
-                let handler: Arc<dyn super::traits::TransformationHandler> = handler;
-                tasks.push(HandlerTask {
-                    handler,
-                    events: events.clone(),
-                    calls: calls.clone(),
-                    tx_addresses: tx_addresses.clone(),
-                });
-            }
-        }
+        let tasks = self.build_handler_tasks(
+            &event_triggers.into_iter().collect::<Vec<_>>(),
+            &call_triggers.into_iter().collect::<Vec<_>>(),
+            events,
+            calls,
+            tx_addresses,
+        );
 
         let submitted_keys: HashSet<String> =
             tasks.iter().map(|t| t.handler.handler_key()).collect();

--- a/src/transformations/engine.rs
+++ b/src/transformations/engine.rs
@@ -440,6 +440,122 @@ impl TransformationEngine {
         Ok(())
     }
 
+    /// Spawn a single catchup handler task into the provided JoinSet.
+    ///
+    /// Acquires a semaphore permit, clones all shared state, and spawns an
+    /// async task that invokes the handler and executes the resulting database
+    /// operations.
+    async fn spawn_catchup_handler_task<H>(
+        &self,
+        join_set: &mut JoinSet<HandlerTaskResult>,
+        semaphore: &Arc<Semaphore>,
+        handler: &Arc<H>,
+        handler_key: &str,
+        range_start: u64,
+        range_end: u64,
+        events: Vec<DecodedEvent>,
+        calls: Vec<DecodedCall>,
+        tx_addresses: HashMap<[u8; 32], TransactionAddresses>,
+    ) where
+        H: super::traits::TransformationHandler + ?Sized,
+    {
+        let permit = semaphore.clone().acquire_owned().await.unwrap();
+        let handler = handler.clone();
+        let db_pool = self.db_pool.clone();
+        let handler_key = handler_key.to_string();
+        let handler_name = handler.name();
+        let handler_version = handler.version();
+        let chain_name = self.chain_name.clone();
+        let chain_id = self.chain_id;
+        let historical = self.historical_reader.clone();
+        let rpc = self.executor.rpc_client.clone();
+        let contracts = self.contracts.clone();
+
+        join_set.spawn(async move {
+            let _permit = permit;
+            let ctx = TransformationContext::new(
+                chain_name,
+                chain_id,
+                range_start,
+                range_end,
+                Arc::new(events),
+                Arc::new(calls),
+                tx_addresses,
+                historical,
+                rpc,
+                contracts,
+            );
+
+            match handler.handle(&ctx).await {
+                Ok(ops) => {
+                    if !ops.is_empty() {
+                        let ops = inject_source_version(ops, handler_name, handler_version);
+                        db_pool.execute_transaction(ops).await?;
+                    }
+                    Ok(Some((handler_key, range_start, range_end)))
+                }
+                Err(e) => Err(e),
+            }
+        });
+    }
+
+    /// Drain completed tasks from a catchup JoinSet, recording completed
+    /// ranges and collecting failures.
+    ///
+    /// Returns `true` if at least one handler errored or panicked.
+    async fn drain_catchup_results(
+        &self,
+        join_set: &mut JoinSet<HandlerTaskResult>,
+        handler_key: &str,
+        failed_handlers: &mut Vec<(String, String)>,
+    ) -> Result<bool, TransformationError> {
+        let mut errored = false;
+        while let Some(result) = join_set.join_next().await {
+            match result {
+                Ok(Ok(Some((hk, rs, re)))) => {
+                    self.finalizer
+                        .record_completed_range_for_handler(&hk, rs, re)
+                        .await?;
+                }
+                Ok(Ok(None)) => {}
+                Ok(Err(e)) => {
+                    tracing::error!(
+                        "Handler {} failed during catchup: {}. Stopping catchup for this handler.",
+                        handler_key, e
+                    );
+                    failed_handlers.push((handler_key.to_string(), e.to_string()));
+                    errored = true;
+                    break;
+                }
+                Err(e) => {
+                    tracing::error!("Handler {} catchup task panicked: {}", handler_key, e);
+                    failed_handlers.push((handler_key.to_string(), format!("task panicked: {}", e)));
+                    errored = true;
+                    break;
+                }
+            }
+        }
+        Ok(errored)
+    }
+
+    /// Format and return a catchup failure error from accumulated handler failures.
+    fn catchup_failure_error(
+        failed_handlers: &[(String, String)],
+    ) -> Result<(), TransformationError> {
+        if failed_handlers.is_empty() {
+            return Ok(());
+        }
+        let msg = failed_handlers
+            .iter()
+            .map(|(k, e)| format!("{}: {}", k, e))
+            .collect::<Vec<_>>()
+            .join("; ");
+        Err(TransformationError::HandlerError {
+            handler_name: "catchup".to_string(),
+            message: format!("{} handler(s) failed: {}", failed_handlers.len(), msg),
+        })
+    }
+
     async fn run_handler_catchup(
         &self,
         kind: HandlerKind,
@@ -645,59 +761,25 @@ impl TransformationEngine {
                     };
 
                     if has_data {
-                        let permit = semaphore.clone().acquire_owned().await.unwrap();
-                        let handler = handler.clone();
-                        let db_pool = self.db_pool.clone();
-                        let handler_key = handler_key.clone();
-                        let handler_name = handler.name();
-                        let handler_version = handler.version();
-                        let chain_name = self.chain_name.clone();
-                        let chain_id = self.chain_id;
-                        let historical = self.historical_reader.clone();
-                        let rpc = self.executor.rpc_client.clone();
-                        let contracts = self.contracts.clone();
-                        let rs = *range_start;
-                        let re = *range_end;
-                        let handler_kind = ch.kind;
-
                         // Event handlers get tx_addresses; call handlers pass empty map
-                        let tx_addresses = match handler_kind {
+                        let tx_addresses = match ch.kind {
                             HandlerKind::Event => {
                                 self.read_receipt_addresses(*range_start, *range_end)
                             }
                             HandlerKind::Call => HashMap::new(),
                         };
-
-                        join_set.spawn(async move {
-                            let _permit = permit;
-                            let ctx = TransformationContext::new(
-                                chain_name,
-                                chain_id,
-                                rs,
-                                re,
-                                Arc::new(events),
-                                Arc::new(calls),
-                                tx_addresses,
-                                historical,
-                                rpc,
-                                contracts,
-                            );
-
-                            match handler.handle(&ctx).await {
-                                Ok(ops) => {
-                                    if !ops.is_empty() {
-                                        let ops = inject_source_version(
-                                            ops,
-                                            handler_name,
-                                            handler_version,
-                                        );
-                                        db_pool.execute_transaction(ops).await?;
-                                    }
-                                    Ok(Some((handler_key, rs, re)))
-                                }
-                                Err(e) => Err(e),
-                            }
-                        });
+                        self.spawn_catchup_handler_task(
+                            &mut join_set,
+                            &semaphore,
+                            handler,
+                            &handler_key,
+                            *range_start,
+                            *range_end,
+                            events,
+                            calls,
+                            tx_addresses,
+                        )
+                        .await;
                     } else {
                         self.finalizer
                             .record_completed_range_for_handler(
@@ -720,34 +802,13 @@ impl TransformationEngine {
                     }
                 }
 
-                while let Some(result) = join_set.join_next().await {
-                    match result {
-                        Ok(Ok(Some((hk, rs, re)))) => {
-                            self.finalizer
-                                .record_completed_range_for_handler(&hk, rs, re)
-                                .await?;
-                        }
-                        Ok(Ok(None)) => {}
-                        Ok(Err(e)) => {
-                            tracing::error!(
-                                "Handler {} failed during catchup: {}. Stopping catchup for this handler.",
-                                handler_key, e
-                            );
-                            failed_handlers.push((handler_key.clone(), e.to_string()));
-                            break;
-                        }
-                        Err(e) => {
-                            tracing::error!("Handler {} catchup task panicked: {}", handler_key, e);
-                            failed_handlers
-                                .push((handler_key.clone(), format!("task panicked: {}", e)));
-                            break;
-                        }
-                    }
-                }
+                let handler_errored_this_pass = self
+                    .drain_catchup_results(&mut join_set, &handler_key, &mut failed_handlers)
+                    .await?;
 
                 total_processed += processed;
 
-                if !failed_handlers.iter().any(|(k, _)| k == &handler_key) {
+                if !handler_errored_this_pass {
                     if skipped_ranges.is_empty() {
                         tracing::info!(
                             "Handler {} catchup complete in {} pass(es): processed {} ranges",
@@ -782,19 +843,7 @@ impl TransformationEngine {
             }
         }
 
-        if !failed_handlers.is_empty() {
-            let msg = failed_handlers
-                .iter()
-                .map(|(k, e)| format!("{}: {}", k, e))
-                .collect::<Vec<_>>()
-                .join("; ");
-            return Err(TransformationError::HandlerError {
-                handler_name: "catchup".to_string(),
-                message: format!("{} handler(s) failed: {}", failed_handlers.len(), msg),
-            });
-        }
-
-        Ok(())
+        Self::catchup_failure_error(&failed_handlers)
     }
 
     // ─── Receipt Address Reading ────────────────────────────────────


### PR DESCRIPTION
## Summary

This PR deduplicates several repeated code patterns in `src/transformations/engine.rs` (previously 1794 lines, now 1759). While the line count reduction is modest, the key benefit is eliminating 3x-duplicated logic blocks, so future changes to any of these patterns only need to happen in one place.

### Extracted methods

**`record_live_progress(block_number, handler_key)`**
A 15-line block that marks a single block as complete for a handler in the live progress tracker. Previously copy-pasted identically in `process_events_message`, `try_process_pending_events`, and `process_range`.

**`persist_failed_handlers(block_number, submitted_keys, succeeded_keys)`**
A 20-line block that computes the set difference of submitted vs succeeded handler keys and persists failures to the live status file. Previously copy-pasted in the same 3 methods.

**`record_handler_outcomes(range_start, range_end, submitted_keys, succeeded_keys, outcomes)`**
Combines the above two methods into a single call that handles both live progress recording and failure persistence. All 3 call sites now use this single method.

**`build_handler_tasks(event_triggers, call_triggers, events, calls, tx_addresses)`**
Unifies two nearly identical loops in `process_range` that built `HandlerTask` structs -- one iterating event triggers and one iterating call triggers. Now a single method handles both.

**`read_decoded_parquet_for_triggers<T>(triggers, resolve_paths, read_file)`**
Generalizes the shared JoinSet-based async file reading pattern used by both `read_decoded_events_for_triggers` and `read_decoded_calls_for_triggers`. The differences (path resolution strategy, reader function) are parameterized via closures.

**`spawn_catchup_handler_task<H>(join_set, semaphore, handler, ...)`**
Extracts the ~30-line pattern of acquiring a semaphore permit, cloning shared state, and spawning a handler task into a JoinSet. Used by both `run_event_handler_catchup` and `run_call_handler_catchup`. Generic over `H: TransformationHandler + ?Sized` to accept both `Arc<dyn EventHandler>` and `Arc<dyn EthCallHandler>`.

**`drain_catchup_results(join_set, handler_key, failed_handlers)`**
Extracts the ~20-line pattern of draining completed tasks from a JoinSet, recording completed ranges, and collecting failures. Used by both catchup methods.

**`catchup_failure_error(failed_handlers)`**
Extracts the identical error formatting block at the end of both catchup methods.

### What was NOT changed

- The event-specific multi-pass call dependency resolution loop in `run_event_handler_catchup` stays as-is since it has no equivalent in the call handler catchup.
- No behavioral changes -- pure refactoring. All 262 tests pass.