### PR TITLE
fix: replace config panics with Result propagation and add type-safe enums

### DIFF
--- a/src/live/collector.rs
+++ b/src/live/collector.rs
@@ -744,7 +744,8 @@ impl LiveCollector {
         let method_name = self
             .chain
             .block_receipts_method
-            .as_deref()
+            .as_ref()
+            .map(|m| m.as_str())
             .unwrap_or("eth_getBlockReceipts");
 
         let receipts = self

--- a/src/raw_data/historical/catchup/receipts.rs
+++ b/src/raw_data/historical/catchup/receipts.rs
@@ -204,7 +204,7 @@ pub async fn collect_receipts(
             event_matchers,
             rpc_batch_size,
             &mut metrics,
-            chain.block_receipts_method.as_deref(),
+            chain.block_receipts_method.as_ref().map(|m| m.as_str()),
             block_receipt_concurrency,
             storage_manager.as_ref(),
             &chain.name,

--- a/src/raw_data/historical/current/receipts.rs
+++ b/src/raw_data/historical/current/receipts.rs
@@ -170,7 +170,7 @@ pub async fn collect_receipts(
                                 &block_refs,
                                 client,
                                 receipt_fields,
-                                chain.block_receipts_method.as_deref(),
+                                chain.block_receipts_method.as_ref().map(|m| m.as_str()),
                                 block_receipt_concurrency,
                                 rpc_batch_size,
                             )
@@ -241,7 +241,7 @@ pub async fn collect_receipts(
                                     &block_refs,
                                     client,
                                     receipt_fields,
-                                    chain.block_receipts_method.as_deref(),
+                                    chain.block_receipts_method.as_ref().map(|m| m.as_str()),
                                     block_receipt_concurrency,
                                     rpc_batch_size,
                                 )
@@ -409,7 +409,7 @@ pub async fn collect_receipts(
                         &event_matchers,
                         rpc_batch_size,
                         &mut metrics,
-                        chain.block_receipts_method.as_deref(),
+                        chain.block_receipts_method.as_ref().map(|m| m.as_str()),
                         block_receipt_concurrency,
                         storage_manager.as_ref(),
                         &chain.name,
@@ -502,7 +502,7 @@ pub async fn collect_receipts(
                 &block_refs,
                 client,
                 receipt_fields,
-                chain.block_receipts_method.as_deref(),
+                chain.block_receipts_method.as_ref().map(|m| m.as_str()),
                 block_receipt_concurrency,
                 rpc_batch_size,
             )

--- a/src/raw_data/historical/eth_calls/event_triggers.rs
+++ b/src/raw_data/historical/eth_calls/event_triggers.rs
@@ -27,7 +27,9 @@ use crate::decoding::{DecoderMessage, EventCallResult as DecoderEventCallResult}
 use crate::raw_data::historical::receipts::EventTriggerData;
 use crate::storage::upload_parquet_to_s3;
 use crate::types::config::contract::{AddressOrAddresses, Contracts};
-use crate::types::config::eth_call::{encode_call_with_params, EvmType, ParamConfig};
+use crate::types::config::eth_call::{
+    encode_call_with_params, EventFieldLocation, EvmType, ParamConfig,
+};
 
 /// A trigger that was skipped because its factory address wasn't known yet.
 /// Buffered for replay when factory addresses arrive via IncrementalAddresses.
@@ -183,82 +185,53 @@ pub(crate) fn compute_event_signature_hash(signature: &str) -> [u8; 32] {
 /// Extract a parameter value from event data (topics or data fields)
 pub(crate) fn extract_param_from_event(
     trigger: &EventTriggerData,
-    from_event: &str,
+    from_event: &EventFieldLocation,
     param_type: &EvmType,
 ) -> Result<(DynSolValue, Vec<u8>), EthCallCollectionError> {
-    let from_event = from_event.trim();
-
-    // Handle "address" - extract the event emitter address
-    if from_event == "address" {
-        // Validate that the expected type is Address
-        if !matches!(param_type, EvmType::Address) {
-            return Err(EthCallCollectionError::EventParamExtraction(format!(
-                "from_event: \"address\" requires param type to be address, got {:?}",
-                param_type
-            )));
+    match from_event {
+        EventFieldLocation::Address => {
+            // Validate that the expected type is Address
+            if !matches!(param_type, EvmType::Address) {
+                return Err(EthCallCollectionError::EventParamExtraction(format!(
+                    "from_event: \"address\" requires param type to be address, got {:?}",
+                    param_type
+                )));
+            }
+            let addr = Address::from(trigger.emitter_address);
+            let encoded = DynSolValue::Address(addr).abi_encode();
+            Ok((DynSolValue::Address(addr), encoded))
         }
-        let addr = Address::from(trigger.emitter_address);
-        let encoded = DynSolValue::Address(addr).abi_encode();
-        return Ok((DynSolValue::Address(addr), encoded));
-    }
+        EventFieldLocation::Topic(idx) => {
+            let idx = *idx;
+            if idx >= trigger.topics.len() {
+                return Err(EthCallCollectionError::EventParamExtraction(format!(
+                    "Topic index {} out of bounds (event has {} topics)",
+                    idx,
+                    trigger.topics.len()
+                )));
+            }
 
-    if let Some(rest) = from_event.strip_prefix("topics[") {
-        // Extract topic index
-        let idx_str = rest.strip_suffix(']').ok_or_else(|| {
-            EthCallCollectionError::EventParamExtraction(format!(
-                "Invalid from_event format: {}",
-                from_event
-            ))
-        })?;
-        let idx: usize = idx_str.parse().map_err(|_| {
-            EthCallCollectionError::EventParamExtraction(format!(
-                "Invalid topic index: {}",
-                idx_str
-            ))
-        })?;
-
-        if idx >= trigger.topics.len() {
-            return Err(EthCallCollectionError::EventParamExtraction(format!(
-                "Topic index {} out of bounds (event has {} topics)",
-                idx,
-                trigger.topics.len()
-            )));
+            let topic_bytes = &trigger.topics[idx];
+            extract_value_from_32_bytes(topic_bytes, param_type)
         }
+        EventFieldLocation::Data(idx) => {
+            let idx = *idx;
+            // Data is stored as 32-byte words
+            let start = idx * 32;
+            let end = start + 32;
 
-        let topic_bytes = &trigger.topics[idx];
-        extract_value_from_32_bytes(topic_bytes, param_type)
-    } else if let Some(rest) = from_event.strip_prefix("data[") {
-        // Extract data word index
-        let idx_str = rest.strip_suffix(']').ok_or_else(|| {
-            EthCallCollectionError::EventParamExtraction(format!(
-                "Invalid from_event format: {}",
-                from_event
-            ))
-        })?;
-        let idx: usize = idx_str.parse().map_err(|_| {
-            EthCallCollectionError::EventParamExtraction(format!("Invalid data index: {}", idx_str))
-        })?;
+            if end > trigger.data.len() {
+                return Err(EthCallCollectionError::EventParamExtraction(format!(
+                    "Data index {} out of bounds (event data is {} bytes)",
+                    idx,
+                    trigger.data.len()
+                )));
+            }
 
-        // Data is stored as 32-byte words
-        let start = idx * 32;
-        let end = start + 32;
-
-        if end > trigger.data.len() {
-            return Err(EthCallCollectionError::EventParamExtraction(format!(
-                "Data index {} out of bounds (event data is {} bytes)",
-                idx,
-                trigger.data.len()
-            )));
+            let mut word = [0u8; 32];
+            word.copy_from_slice(&trigger.data[start..end]);
+            extract_value_from_32_bytes(&word, param_type)
         }
-
-        let mut word = [0u8; 32];
-        word.copy_from_slice(&trigger.data[start..end]);
-        extract_value_from_32_bytes(&word, param_type)
-    } else {
-        Err(EthCallCollectionError::EventParamExtraction(format!(
-            "Unknown from_event format: {} (expected \"address\", \"topics[N]\", or \"data[N]\")",
-            from_event
-        )))
     }
 }
 

--- a/src/types/config/chain.rs
+++ b/src/types/config/chain.rs
@@ -1,13 +1,37 @@
 use std::path::Path;
 
 use alloy_primitives::U256;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::types::config::contract::{
     load_contracts_from_path, load_factory_collections_from_path, Contracts, FactoryCollections,
 };
 use crate::types::config::generic::InlineOrPath;
 use crate::types::config::tokens::{load_tokens_from_path, Tokens};
+
+/// RPC method to use for fetching block receipts.
+///
+/// Different chains and RPC providers support different methods.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[allow(clippy::enum_variant_names)]
+pub enum BlockReceiptsMethod {
+    #[serde(rename = "eth_getBlockReceipts")]
+    EthGetBlockReceipts,
+    #[serde(rename = "alchemy_getTransactionReceipts")]
+    AlchemyGetTransactionReceipts,
+    #[serde(rename = "parity_getBlockReceipts")]
+    ParityGetBlockReceipts,
+}
+
+impl BlockReceiptsMethod {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::EthGetBlockReceipts => "eth_getBlockReceipts",
+            Self::AlchemyGetTransactionReceipts => "alchemy_getTransactionReceipts",
+            Self::ParityGetBlockReceipts => "parity_getBlockReceipts",
+        }
+    }
+}
 
 /// RPC client configuration for a chain.
 ///
@@ -32,7 +56,7 @@ pub struct ChainConfigRaw {
     pub start_block: Option<U256>,
     pub contracts: InlineOrPath<Contracts>,
     pub tokens: InlineOrPath<Tokens>,
-    pub block_receipts_method: Option<String>,
+    pub block_receipts_method: Option<BlockReceiptsMethod>,
     #[serde(default)]
     pub factory_collections: Option<InlineOrPath<FactoryCollections>>,
     /// RPC client configuration (rate limiting, concurrency).
@@ -50,7 +74,7 @@ pub struct ChainConfig {
     pub start_block: Option<U256>,
     pub contracts: Contracts,
     pub tokens: Tokens,
-    pub block_receipts_method: Option<String>,
+    pub block_receipts_method: Option<BlockReceiptsMethod>,
     pub factory_collections: FactoryCollections,
     /// RPC client configuration (rate limiting, concurrency).
     pub rpc: RpcConfig,
@@ -62,41 +86,26 @@ pub fn resolve_chain_config(
 ) -> anyhow::Result<ChainConfig> {
     let contracts = match raw_config.contracts {
         InlineOrPath::Inline(contracts) => contracts,
-        InlineOrPath::Path(p) => {
-            let contracts = load_contracts_from_path(base_dir, &p);
-            match contracts {
-                Ok(contracts) => contracts,
-                Err(e) => {
-                    panic!("Failed to load contracts from path {}: {}", p, e);
-                }
-            }
-        }
+        InlineOrPath::Path(p) => load_contracts_from_path(base_dir, &p)
+            .map_err(|e| anyhow::anyhow!("Failed to load contracts from path {}: {}", p, e))?,
     };
 
     let tokens = match raw_config.tokens {
         InlineOrPath::Inline(tokens) => tokens,
-        InlineOrPath::Path(p) => {
-            let tokens = load_tokens_from_path(base_dir, &p);
-            match tokens {
-                Ok(tokens) => tokens,
-                Err(e) => {
-                    panic!("Failed to load tokens from path {}: {}", p, e);
-                }
-            }
-        }
+        InlineOrPath::Path(p) => load_tokens_from_path(base_dir, &p)
+            .map_err(|e| anyhow::anyhow!("Failed to load tokens from path {}: {}", p, e))?,
     };
 
     let factory_collections = match raw_config.factory_collections {
         Some(InlineOrPath::Inline(collections)) => collections,
-        Some(InlineOrPath::Path(p)) => {
-            let collections = load_factory_collections_from_path(base_dir, &p);
-            match collections {
-                Ok(collections) => collections,
-                Err(e) => {
-                    panic!("Failed to load factory collections from path {}: {}", p, e);
-                }
-            }
-        }
+        Some(InlineOrPath::Path(p)) => load_factory_collections_from_path(base_dir, &p)
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to load factory collections from path {}: {}",
+                    p,
+                    e
+                )
+            })?,
         None => FactoryCollections::new(),
     };
 
@@ -112,4 +121,104 @@ pub fn resolve_chain_config(
         factory_collections,
         rpc: raw_config.rpc,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_block_receipts_method_serde_roundtrip() {
+        let json = r#""eth_getBlockReceipts""#;
+        let method: BlockReceiptsMethod = serde_json::from_str(json).unwrap();
+        assert_eq!(method.as_str(), "eth_getBlockReceipts");
+        let serialized = serde_json::to_string(&method).unwrap();
+        assert_eq!(serialized, json);
+
+        let json = r#""alchemy_getTransactionReceipts""#;
+        let method: BlockReceiptsMethod = serde_json::from_str(json).unwrap();
+        assert_eq!(method.as_str(), "alchemy_getTransactionReceipts");
+        let serialized = serde_json::to_string(&method).unwrap();
+        assert_eq!(serialized, json);
+
+        let json = r#""parity_getBlockReceipts""#;
+        let method: BlockReceiptsMethod = serde_json::from_str(json).unwrap();
+        assert_eq!(method.as_str(), "parity_getBlockReceipts");
+        let serialized = serde_json::to_string(&method).unwrap();
+        assert_eq!(serialized, json);
+    }
+
+    #[test]
+    fn test_block_receipts_method_invalid() {
+        let json = r#""invalid_method""#;
+        let result = serde_json::from_str::<BlockReceiptsMethod>(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_block_receipts_method_optional_none() {
+        let json = r#"null"#;
+        let method: Option<BlockReceiptsMethod> = serde_json::from_str(json).unwrap();
+        assert!(method.is_none());
+    }
+
+    #[test]
+    fn test_resolve_chain_config_nonexistent_contracts_returns_err() {
+        let raw = ChainConfigRaw {
+            name: "test".to_string(),
+            chain_id: 1,
+            rpc_url_env_var: "RPC_URL".to_string(),
+            ws_url_env_var: None,
+            start_block: None,
+            contracts: InlineOrPath::Path("nonexistent/contracts.json".to_string()),
+            tokens: InlineOrPath::Inline(Tokens::new()),
+            block_receipts_method: None,
+            factory_collections: None,
+            rpc: RpcConfig::default(),
+        };
+        let result = resolve_chain_config(raw, Path::new("/tmp"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_resolve_chain_config_nonexistent_tokens_returns_err() {
+        let raw = ChainConfigRaw {
+            name: "test".to_string(),
+            chain_id: 1,
+            rpc_url_env_var: "RPC_URL".to_string(),
+            ws_url_env_var: None,
+            start_block: None,
+            contracts: InlineOrPath::Inline(Contracts::new()),
+            tokens: InlineOrPath::Path("nonexistent/tokens.json".to_string()),
+            block_receipts_method: None,
+            factory_collections: None,
+            rpc: RpcConfig::default(),
+        };
+        let result = resolve_chain_config(raw, Path::new("/tmp"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_resolve_chain_config_inline_returns_ok() {
+        let raw = ChainConfigRaw {
+            name: "test".to_string(),
+            chain_id: 1,
+            rpc_url_env_var: "RPC_URL".to_string(),
+            ws_url_env_var: None,
+            start_block: None,
+            contracts: InlineOrPath::Inline(Contracts::new()),
+            tokens: InlineOrPath::Inline(Tokens::new()),
+            block_receipts_method: Some(BlockReceiptsMethod::EthGetBlockReceipts),
+            factory_collections: None,
+            rpc: RpcConfig::default(),
+        };
+        let result = resolve_chain_config(raw, Path::new("/tmp"));
+        assert!(result.is_ok());
+        let config = result.unwrap();
+        assert_eq!(config.name, "test");
+        assert_eq!(
+            config.block_receipts_method.unwrap().as_str(),
+            "eth_getBlockReceipts"
+        );
+    }
 }

--- a/src/types/config/contract.rs
+++ b/src/types/config/contract.rs
@@ -3,8 +3,9 @@ use std::path::Path;
 
 use crate::types::config::eth_call::EthCallConfig;
 use crate::types::config::generic::SingleOrMultiple;
-use crate::types::config::loader::{load_config_from_path, ConfigLoadError};
+use crate::types::config::loader::load_config_from_path;
 use alloy_primitives::{keccak256, Address, U256};
+use serde::de;
 use serde::Deserialize;
 
 /// Configuration for an event to decode
@@ -107,7 +108,7 @@ pub struct FactoryEventConfig {
     pub topics_signature: String,
     #[serde(default)]
     pub data_signature: Option<String>,
-    pub factory_parameters: String,
+    pub factory_parameters: FactoryParameterLocation,
 }
 
 /// Factory event config: single event or multiple events
@@ -117,6 +118,51 @@ pub type FactoryEventConfigOrArray = SingleOrMultiple<FactoryEventConfig>;
 pub enum FactoryParameterLocation {
     Topic(usize),
     Data(Vec<usize>),
+}
+
+impl std::fmt::Display for FactoryParameterLocation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Topic(idx) => write!(f, "topics[{}]", idx),
+            Self::Data(indices) => {
+                write!(f, "data")?;
+                for idx in indices {
+                    write!(f, "[{}]", idx)?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for FactoryParameterLocation {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        let param = s.trim();
+
+        if param.starts_with("topics[") {
+            let idx_str = param
+                .strip_prefix("topics[")
+                .and_then(|s| s.strip_suffix(']'))
+                .ok_or_else(|| {
+                    de::Error::custom(format!(
+                        "Invalid factory_parameters format: {} (expected \"topics[N]\")",
+                        param
+                    ))
+                })?;
+            let idx = idx_str.parse::<usize>().map_err(|_| {
+                de::Error::custom(format!("Invalid topic index in factory_parameters: {}", idx_str))
+            })?;
+            Ok(FactoryParameterLocation::Topic(idx))
+        } else if param.starts_with("data[") {
+            Ok(FactoryParameterLocation::Data(parse_bracket_indices(param)))
+        } else {
+            Ok(FactoryParameterLocation::Data(vec![0]))
+        }
+    }
 }
 
 fn parse_bracket_indices(param: &str) -> Vec<usize> {
@@ -171,21 +217,12 @@ impl FactoryEventConfig {
         keccak256(full_sig.as_bytes()).0
     }
 
+    /// Returns the parsed factory parameter location.
+    ///
+    /// The parsing now happens at deserialization time, so this just returns a clone
+    /// of the already-parsed field for backward compatibility with existing callers.
     pub fn parse_factory_parameter(&self) -> FactoryParameterLocation {
-        let param = self.factory_parameters.trim();
-
-        if param.starts_with("topics[") {
-            let idx_str = param
-                .strip_prefix("topics[")
-                .and_then(|s| s.strip_suffix(']'))
-                .unwrap_or("0");
-            let idx = idx_str.parse::<usize>().unwrap_or(0);
-            FactoryParameterLocation::Topic(idx)
-        } else if param.starts_with("data[") {
-            FactoryParameterLocation::Data(parse_bracket_indices(param))
-        } else {
-            FactoryParameterLocation::Data(vec![0])
-        }
+        self.factory_parameters.clone()
     }
 }
 
@@ -201,25 +238,135 @@ pub type Contracts = HashMap<String, ContractConfig>;
 /// Load contracts from a path (file or directory).
 ///
 /// Uses the generic config loader with duplicate key detection.
-/// Panics on error for backwards compatibility with existing code.
 pub fn load_contracts_from_path(base_dir: &Path, path: &str) -> anyhow::Result<Contracts> {
     load_config_from_path::<Contracts>(base_dir, path)
-        .map_err(|e| panic_on_load_error("contracts", e))
+        .map_err(|e| anyhow::anyhow!("Failed to load contracts: {}", e))
 }
 
 /// Load factory collections from a path (file or directory).
 ///
 /// Uses the generic config loader with duplicate key detection.
-/// Panics on error for backwards compatibility with existing code.
 pub fn load_factory_collections_from_path(
     base_dir: &Path,
     path: &str,
 ) -> anyhow::Result<FactoryCollections> {
     load_config_from_path::<FactoryCollections>(base_dir, path)
-        .map_err(|e| panic_on_load_error("factory collections", e))
+        .map_err(|e| anyhow::anyhow!("Failed to load factory collections: {}", e))
 }
 
-/// Helper to panic with a formatted error message (for backwards compatibility).
-fn panic_on_load_error(config_type: &str, error: ConfigLoadError) -> anyhow::Error {
-    panic!("Failed to load {}: {}", config_type, error)
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_load_contracts_nonexistent_path_returns_err() {
+        let dir = TempDir::new().unwrap();
+        let result = load_contracts_from_path(dir.path(), "nonexistent.json");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_load_contracts_invalid_json_returns_err() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("contracts.json"), "not valid json").unwrap();
+        let result = load_contracts_from_path(dir.path(), "contracts.json");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_load_contracts_valid_returns_ok() {
+        let dir = TempDir::new().unwrap();
+        let json = r#"{
+            "UniswapV3Factory": {
+                "address": "0x1F98431c8aD98523631AE4a59f267346ea31F984"
+            }
+        }"#;
+        fs::write(dir.path().join("contracts.json"), json).unwrap();
+        let result = load_contracts_from_path(dir.path(), "contracts.json");
+        assert!(result.is_ok());
+        let contracts = result.unwrap();
+        assert!(contracts.contains_key("UniswapV3Factory"));
+    }
+
+    #[test]
+    fn test_factory_parameter_location_deserialize_topic() {
+        let json = r#""topics[1]""#;
+        let loc: FactoryParameterLocation = serde_json::from_str(json).unwrap();
+        match loc {
+            FactoryParameterLocation::Topic(idx) => assert_eq!(idx, 1),
+            _ => panic!("Expected Topic variant"),
+        }
+    }
+
+    #[test]
+    fn test_factory_parameter_location_deserialize_data_single() {
+        let json = r#""data[0]""#;
+        let loc: FactoryParameterLocation = serde_json::from_str(json).unwrap();
+        match loc {
+            FactoryParameterLocation::Data(indices) => assert_eq!(indices, vec![0]),
+            _ => panic!("Expected Data variant"),
+        }
+    }
+
+    #[test]
+    fn test_factory_parameter_location_deserialize_data_nested() {
+        let json = r#""data[5][4]""#;
+        let loc: FactoryParameterLocation = serde_json::from_str(json).unwrap();
+        match loc {
+            FactoryParameterLocation::Data(indices) => assert_eq!(indices, vec![5, 4]),
+            _ => panic!("Expected Data variant"),
+        }
+    }
+
+    #[test]
+    fn test_factory_parameter_location_deserialize_data_deep() {
+        let json = r#""data[0][1][2]""#;
+        let loc: FactoryParameterLocation = serde_json::from_str(json).unwrap();
+        match loc {
+            FactoryParameterLocation::Data(indices) => assert_eq!(indices, vec![0, 1, 2]),
+            _ => panic!("Expected Data variant"),
+        }
+    }
+
+    #[test]
+    fn test_factory_parameter_location_deserialize_fallback() {
+        let json = r#""unknown_format""#;
+        let loc: FactoryParameterLocation = serde_json::from_str(json).unwrap();
+        match loc {
+            FactoryParameterLocation::Data(indices) => assert_eq!(indices, vec![0]),
+            _ => panic!("Expected Data variant with default"),
+        }
+    }
+
+    #[test]
+    fn test_factory_event_config_deserialization() {
+        let json = r#"{
+            "name": "PoolCreated",
+            "topics_signature": "address,address",
+            "data_signature": "uint24,int24,address",
+            "factory_parameters": "topics[1]"
+        }"#;
+        let config: FactoryEventConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.name, "PoolCreated");
+        match &config.factory_parameters {
+            FactoryParameterLocation::Topic(idx) => assert_eq!(*idx, 1),
+            _ => panic!("Expected Topic variant"),
+        }
+        // parse_factory_parameter should return the same thing
+        match config.parse_factory_parameter() {
+            FactoryParameterLocation::Topic(idx) => assert_eq!(idx, 1),
+            _ => panic!("Expected Topic variant"),
+        }
+    }
+
+    #[test]
+    fn test_factory_parameter_location_display() {
+        let topic = FactoryParameterLocation::Topic(2);
+        assert_eq!(topic.to_string(), "topics[2]");
+
+        let data = FactoryParameterLocation::Data(vec![5, 4]);
+        assert_eq!(data.to_string(), "data[5][4]");
+    }
 }

--- a/src/types/config/eth_call.rs
+++ b/src/types/config/eth_call.rs
@@ -9,6 +9,84 @@ use thiserror::Error;
 
 use crate::types::config::generic::SingleOrMultiple;
 
+/// Location within an event's data from which to extract a parameter value.
+///
+/// Supports three forms:
+/// - `"address"` - the address that emitted the event
+/// - `"topics[N]"` - topic at index N (e.g., `"topics[1]"`)
+/// - `"data[N]"` - data word at index N (e.g., `"data[0]"`)
+#[derive(Debug, Clone, PartialEq)]
+pub enum EventFieldLocation {
+    /// The address that emitted the event
+    Address,
+    /// A specific topic by index (e.g., topics[1])
+    Topic(usize),
+    /// A specific data word by index (e.g., data[0])
+    Data(usize),
+}
+
+impl EventFieldLocation {
+    /// Convert back to the canonical string representation.
+    pub fn as_str_repr(&self) -> String {
+        match self {
+            Self::Address => "address".to_string(),
+            Self::Topic(idx) => format!("topics[{}]", idx),
+            Self::Data(idx) => format!("data[{}]", idx),
+        }
+    }
+}
+
+impl fmt::Display for EventFieldLocation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str_repr())
+    }
+}
+
+impl<'de> Deserialize<'de> for EventFieldLocation {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        let s = s.trim();
+
+        if s == "address" {
+            return Ok(EventFieldLocation::Address);
+        }
+
+        if let Some(rest) = s.strip_prefix("topics[") {
+            let idx_str = rest.strip_suffix(']').ok_or_else(|| {
+                de::Error::custom(format!(
+                    "Invalid from_event format: {} (expected \"topics[N]\")",
+                    s
+                ))
+            })?;
+            let idx: usize = idx_str.parse().map_err(|_| {
+                de::Error::custom(format!("Invalid topic index in from_event: {}", idx_str))
+            })?;
+            return Ok(EventFieldLocation::Topic(idx));
+        }
+
+        if let Some(rest) = s.strip_prefix("data[") {
+            let idx_str = rest.strip_suffix(']').ok_or_else(|| {
+                de::Error::custom(format!(
+                    "Invalid from_event format: {} (expected \"data[N]\")",
+                    s
+                ))
+            })?;
+            let idx: usize = idx_str.parse().map_err(|_| {
+                de::Error::custom(format!("Invalid data index in from_event: {}", idx_str))
+            })?;
+            return Ok(EventFieldLocation::Data(idx));
+        }
+
+        Err(de::Error::custom(format!(
+            "Unknown from_event format: {} (expected \"address\", \"topics[N]\", or \"data[N]\")",
+            s
+        )))
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum ParamError {
     #[error("Invalid address format: {0}")]
@@ -373,7 +451,7 @@ pub enum ParamConfig {
     FromEvent {
         #[serde(rename = "type")]
         param_type: EvmType,
-        from_event: String,
+        from_event: EventFieldLocation,
     },
     /// Self address (event emitter, for factory collections): {"type": "address", "source": "self"}
     SelfAddress {
@@ -401,9 +479,9 @@ impl ParamConfig {
         }
     }
 
-    /// Get the event field reference if this is a FromEvent param config
+    /// Get the event field location if this is a FromEvent param config
     #[allow(dead_code)]
-    pub fn event_field(&self) -> Option<&str> {
+    pub fn event_field(&self) -> Option<&EventFieldLocation> {
         match self {
             ParamConfig::FromEvent { from_event, .. } => Some(from_event),
             _ => None,
@@ -1217,7 +1295,10 @@ mod tests {
         let param: ParamConfig = serde_json::from_str(json).unwrap();
         assert_eq!(*param.param_type(), EvmType::Address);
         assert!(param.values().is_none());
-        assert_eq!(param.event_field(), Some("topics[1]"));
+        assert_eq!(
+            param.event_field(),
+            Some(&EventFieldLocation::Topic(1))
+        );
         assert!(!param.is_self_address());
     }
 
@@ -1226,7 +1307,10 @@ mod tests {
         let json = r#"{"type": "uint256", "from_event": "data[0]"}"#;
         let param: ParamConfig = serde_json::from_str(json).unwrap();
         assert_eq!(*param.param_type(), EvmType::Uint256);
-        assert_eq!(param.event_field(), Some("data[0]"));
+        assert_eq!(
+            param.event_field(),
+            Some(&EventFieldLocation::Data(0))
+        );
     }
 
     #[test]
@@ -1258,7 +1342,10 @@ mod tests {
         assert_eq!(config.function, "balanceOf(address)");
         assert!(config.frequency.is_on_events());
         assert_eq!(config.params.len(), 1);
-        assert_eq!(config.params[0].event_field(), Some("topics[2]"));
+        assert_eq!(
+            config.params[0].event_field(),
+            Some(&EventFieldLocation::Topic(2))
+        );
     }
 
     #[test]
@@ -1575,7 +1662,7 @@ mod tests {
         let json = r#"{"type": "address", "from_event": "address"}"#;
         let param: ParamConfig = serde_json::from_str(json).unwrap();
         assert_eq!(*param.param_type(), EvmType::Address);
-        assert_eq!(param.event_field(), Some("address"));
+        assert_eq!(param.event_field(), Some(&EventFieldLocation::Address));
         assert!(!param.is_self_address());
     }
 
@@ -1711,5 +1798,54 @@ mod tests {
             assert_eq!(fields[3].0, "farTick");
             assert_eq!(*fields[3].1, EvmType::Int24);
         }
+    }
+
+    // EventFieldLocation deserialization tests
+
+    #[test]
+    fn test_event_field_location_address() {
+        let json = r#""address""#;
+        let loc: EventFieldLocation = serde_json::from_str(json).unwrap();
+        assert_eq!(loc, EventFieldLocation::Address);
+    }
+
+    #[test]
+    fn test_event_field_location_topic() {
+        let json = r#""topics[1]""#;
+        let loc: EventFieldLocation = serde_json::from_str(json).unwrap();
+        assert_eq!(loc, EventFieldLocation::Topic(1));
+
+        let json = r#""topics[0]""#;
+        let loc: EventFieldLocation = serde_json::from_str(json).unwrap();
+        assert_eq!(loc, EventFieldLocation::Topic(0));
+
+        let json = r#""topics[3]""#;
+        let loc: EventFieldLocation = serde_json::from_str(json).unwrap();
+        assert_eq!(loc, EventFieldLocation::Topic(3));
+    }
+
+    #[test]
+    fn test_event_field_location_data() {
+        let json = r#""data[0]""#;
+        let loc: EventFieldLocation = serde_json::from_str(json).unwrap();
+        assert_eq!(loc, EventFieldLocation::Data(0));
+
+        let json = r#""data[5]""#;
+        let loc: EventFieldLocation = serde_json::from_str(json).unwrap();
+        assert_eq!(loc, EventFieldLocation::Data(5));
+    }
+
+    #[test]
+    fn test_event_field_location_invalid() {
+        let json = r#""invalid_format""#;
+        let result = serde_json::from_str::<EventFieldLocation>(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_event_field_location_display() {
+        assert_eq!(EventFieldLocation::Address.as_str_repr(), "address");
+        assert_eq!(EventFieldLocation::Topic(2).as_str_repr(), "topics[2]");
+        assert_eq!(EventFieldLocation::Data(0).as_str_repr(), "data[0]");
     }
 }

--- a/src/types/config/indexer.rs
+++ b/src/types/config/indexer.rs
@@ -32,37 +32,114 @@ pub struct IndexerConfig {
 impl IndexerConfig {
     pub fn load(path: &Path) -> anyhow::Result<Self> {
         let base_dir = path.parent().unwrap_or(Path::new("."));
-        let content = std::fs::read_to_string(path);
-        match content {
-            Ok(content) => {
-                let raw_config: Result<IndexerConfigRaw, _> = serde_json::from_str(&content);
-                match raw_config {
-                    Ok(raw_config) => {
-                        let chains: Vec<ChainConfig> = raw_config
-                            .chains
-                            .into_iter()
-                            .map(|chain| match resolve_chain_config(chain, base_dir) {
-                                Ok(config) => config,
-                                Err(e) => panic!("Failed to resolve chain config: {}", e),
-                            })
-                            .collect();
+        let content = std::fs::read_to_string(path)
+            .map_err(|e| anyhow::anyhow!("Failed to read config file at {}: {}", path.display(), e))?;
 
-                        Ok(IndexerConfig {
-                            chains,
-                            raw_data_collection: raw_config.raw_data_collection,
-                            transformations: raw_config.transformations,
-                            metrics: raw_config.metrics,
-                            storage: raw_config.storage,
-                        })
-                    }
-                    Err(e) => {
-                        panic!("Failed to parse config file at {}: {}", path.display(), e);
-                    }
-                }
+        let raw_config: IndexerConfigRaw = serde_json::from_str(&content)
+            .map_err(|e| anyhow::anyhow!("Failed to parse config file at {}: {}", path.display(), e))?;
+
+        let chains: Vec<ChainConfig> = raw_config
+            .chains
+            .into_iter()
+            .map(|chain| resolve_chain_config(chain, base_dir))
+            .collect::<anyhow::Result<Vec<_>>>()
+            .map_err(|e| anyhow::anyhow!("Failed to resolve chain config: {}", e))?;
+
+        Ok(IndexerConfig {
+            chains,
+            raw_data_collection: raw_config.raw_data_collection,
+            transformations: raw_config.transformations,
+            metrics: raw_config.metrics,
+            storage: raw_config.storage,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_load_nonexistent_file_returns_err() {
+        let result = IndexerConfig::load(Path::new("/tmp/nonexistent_config_12345.json"));
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("Failed to read config file"));
+    }
+
+    #[test]
+    fn test_load_invalid_json_returns_err() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("config.json");
+        fs::write(&path, "not valid json").unwrap();
+        let result = IndexerConfig::load(&path);
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("Failed to parse config file"));
+    }
+
+    fn raw_data_collection_json() -> &'static str {
+        r#"{
+            "fields": {
+                "block_fields": ["number", "timestamp"],
+                "receipt_fields": ["block_number"],
+                "log_fields": ["block_number", "address", "topics", "data"]
             }
-            Err(e) => {
-                panic!("Failed to read config file at {}: {}", path.display(), e);
-            }
-        }
+        }"#
+    }
+
+    #[test]
+    fn test_load_valid_config_returns_ok() {
+        let dir = TempDir::new().unwrap();
+        let config_json = format!(
+            r#"{{
+                "chains": [
+                    {{
+                        "name": "test",
+                        "chain_id": 1,
+                        "rpc_url_env_var": "RPC_URL",
+                        "contracts": {{}},
+                        "tokens": {{}},
+                        "block_receipts_method": "eth_getBlockReceipts"
+                    }}
+                ],
+                "raw_data_collection": {}
+            }}"#,
+            raw_data_collection_json()
+        );
+        let path = dir.path().join("config.json");
+        fs::write(&path, config_json).unwrap();
+        let result = IndexerConfig::load(&path);
+        assert!(result.is_ok());
+        let config = result.unwrap();
+        assert_eq!(config.chains.len(), 1);
+        assert_eq!(config.chains[0].name, "test");
+    }
+
+    #[test]
+    fn test_load_config_with_bad_chain_path_returns_err() {
+        let dir = TempDir::new().unwrap();
+        let config_json = format!(
+            r#"{{
+                "chains": [
+                    {{
+                        "name": "test",
+                        "chain_id": 1,
+                        "rpc_url_env_var": "RPC_URL",
+                        "contracts": "nonexistent/contracts.json",
+                        "tokens": {{}},
+                        "block_receipts_method": "eth_getBlockReceipts"
+                    }}
+                ],
+                "raw_data_collection": {}
+            }}"#,
+            raw_data_collection_json()
+        );
+        let path = dir.path().join("config.json");
+        fs::write(&path, config_json).unwrap();
+        let result = IndexerConfig::load(&path);
+        assert!(result.is_err());
     }
 }

--- a/src/types/config/tokens.rs
+++ b/src/types/config/tokens.rs
@@ -45,8 +45,44 @@ pub type Tokens = HashMap<String, TokenConfig>;
 /// Load tokens from a path (file or directory).
 ///
 /// Uses the generic config loader with duplicate key detection.
-/// Panics on error for backwards compatibility with existing code.
 pub fn load_tokens_from_path(base_dir: &Path, path: &str) -> anyhow::Result<Tokens> {
     load_config_from_path::<Tokens>(base_dir, path)
-        .map_err(|e| panic!("Failed to load tokens: {}", e))
+        .map_err(|e| anyhow::anyhow!("Failed to load tokens: {}", e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_load_tokens_nonexistent_path_returns_err() {
+        let dir = TempDir::new().unwrap();
+        let result = load_tokens_from_path(dir.path(), "nonexistent.json");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_load_tokens_invalid_json_returns_err() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("tokens.json"), "not valid json").unwrap();
+        let result = load_tokens_from_path(dir.path(), "tokens.json");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_load_tokens_valid_returns_ok() {
+        let dir = TempDir::new().unwrap();
+        let json = r#"{
+            "WETH": {
+                "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+            }
+        }"#;
+        fs::write(dir.path().join("tokens.json"), json).unwrap();
+        let result = load_tokens_from_path(dir.path(), "tokens.json");
+        assert!(result.is_ok());
+        let tokens = result.unwrap();
+        assert!(tokens.contains_key("WETH"));
+    }
 }


### PR DESCRIPTION
## Summary

This PR eliminates 9 panic sites in the config loading subsystem and introduces type-safe enums for config values that were previously stringly typed.

### Panic removal

All `panic\!()` calls during config loading have been replaced with proper `Result` error propagation:

- **`tokens.rs`**: `load_tokens_from_path` now returns the error via `anyhow::anyhow\!()` instead of panicking
- **`contract.rs`**: Removed `panic_on_load_error()` helper; `load_contracts_from_path` and `load_factory_collections_from_path` now propagate errors
- **`chain.rs`**: `resolve_chain_config()` uses `?` operator instead of panicking on failed contract/token/factory-collection loads
- **`indexer.rs`**: `IndexerConfig::load()` flattened from deeply nested match arms with panics to clean `?`-based error chains

### Type-safe enums

**`BlockReceiptsMethod`** (in `chain.rs`):
- Replaces `Option<String>` with `Option<BlockReceiptsMethod>` on both `ChainConfigRaw` and `ChainConfig`
- Variants: `EthGetBlockReceipts`, `AlchemyGetTransactionReceipts`, `ParityGetBlockReceipts`
- Serde rename attributes match the exact RPC method name strings used in config files
- All callers updated to use `.as_ref().map(|m| m.as_str())` instead of `.as_deref()`
- Includes serde roundtrip test and invalid variant rejection test

**`EventFieldLocation`** (in `eth_call.rs`):
- Replaces the `from_event: String` field on `ParamConfig::FromEvent` with `EventFieldLocation`
- Variants: `Address`, `Topic(usize)`, `Data(usize)` -- parsed at deserialization time
- The runtime `extract_param_from_event` function now pattern-matches on the enum instead of doing string parsing
- Supports all existing patterns: `"address"`, `"topics[N]"`, `"data[N]"`

**`FactoryParameterLocation` deserialization** (in `contract.rs`):
- The `factory_parameters` field on `FactoryEventConfig` changed from `String` to `FactoryParameterLocation`
- Custom `Deserialize` impl parses `"topics[N]"`, `"data[N]"`, `"data[N][M]"` at deserialization time
- `parse_factory_parameter()` method retained for backward compatibility but now simply clones the pre-parsed field
- Supports all existing patterns including nested indices like `"data[5][4]"`

### Tests added

- `tokens.rs`: Nonexistent path returns Err, invalid JSON returns Err, valid config returns Ok
- `contract.rs`: Load error tests, `FactoryParameterLocation` deserialization (topic, data single, data nested, data deep, fallback, display), `FactoryEventConfig` deserialization
- `chain.rs`: `BlockReceiptsMethod` serde roundtrip, invalid method rejection, optional None, resolve with nonexistent paths returns Err, resolve with inline returns Ok
- `indexer.rs`: Nonexistent file returns Err, invalid JSON returns Err, valid config returns Ok, bad chain path returns Err
- `eth_call.rs`: `EventFieldLocation` deserialization for address/topic/data, invalid format rejection, display output

All existing tests updated to match new return types (e.g., `event_field()` now returns `Option<&EventFieldLocation>`).

### Files changed

- `src/types/config/tokens.rs` - panic -> Result
- `src/types/config/contract.rs` - panic -> Result, `FactoryParameterLocation` deserializer
- `src/types/config/chain.rs` - panic -> Result, `BlockReceiptsMethod` enum
- `src/types/config/indexer.rs` - panic -> Result
- `src/types/config/eth_call.rs` - `EventFieldLocation` enum, updated `ParamConfig::FromEvent`
- `src/raw_data/historical/eth_calls/event_triggers.rs` - enum-based `extract_param_from_event`
- `src/raw_data/historical/current/receipts.rs` - `as_deref()` -> `as_ref().map(|m| m.as_str())`
- `src/raw_data/historical/catchup/receipts.rs` - same
- `src/live/collector.rs` - same