### PR TITLE
perf: send receipt RangeComplete before parquet write

### DIFF
--- a/src/raw_data/historical/current/receipts.rs
+++ b/src/raw_data/historical/current/receipts.rs
@@ -284,6 +284,11 @@ pub async fn collect_receipts(
                             minimal_records.sort_by_key(|r| r.block_number);
                             full_records.sort_by_key(|r| r.block_number);
 
+                            // Signal range complete before parquet write/S3 upload.
+                            // All log data has already been sent via send_logs_to_channels,
+                            // so downstream can start processing immediately.
+                            send_range_complete(&channels.factory_log_tx, &channels.log_tx, &channels.event_trigger_tx, range.start, range.end).await?;
+
                             let output_path = output_dir.join(range.file_name("receipts"));
                             let total_receipts = match receipt_fields {
                                 Some(fields) => {
@@ -329,8 +334,6 @@ pub async fn collect_receipts(
                                 .await
                                 .map_err(|e| ReceiptCollectionError::Io(std::io::Error::other(e.to_string())))?;
                             }
-
-                            send_range_complete(&channels.factory_log_tx, &channels.log_tx, &channels.event_trigger_tx, range.start, range.end).await?;
                         }
                     }
                     None => {
@@ -533,6 +536,18 @@ pub async fn collect_receipts(
         state.minimal_records.sort_by_key(|r| r.block_number);
         state.full_records.sort_by_key(|r| r.block_number);
 
+        // Signal range complete before parquet write/S3 upload.
+        // All log data has already been sent via send_logs_to_channels,
+        // so downstream can start processing immediately.
+        send_range_complete(
+            &channels.factory_log_tx,
+            &channels.log_tx,
+            &channels.event_trigger_tx,
+            range.start,
+            range.end,
+        )
+        .await?;
+
         let output_path = output_dir.join(range.file_name("receipts"));
         let total_receipts = match receipt_fields {
             Some(fields) => {
@@ -578,15 +593,6 @@ pub async fn collect_receipts(
             .await
             .map_err(|e| ReceiptCollectionError::Io(std::io::Error::other(e.to_string())))?;
         }
-
-        send_range_complete(
-            &channels.factory_log_tx,
-            &channels.log_tx,
-            &channels.event_trigger_tx,
-            range.start,
-            range.end,
-        )
-        .await?;
     }
 
     if let Some(sender) = &channels.factory_log_tx {


### PR DESCRIPTION
## Summary

Moves the `send_range_complete(...)` call earlier in the receipt collector pipeline — from after the parquet write + S3 upload to immediately after sorting records. This applies to both the main loop range-complete path and the shutdown cleanup path.

**Why this matters**: The log collector buffers incoming logs but cannot process a range until it receives the `RangeComplete` signal. Previously, that signal was blocked behind the parquet write (spawn_blocking) and optional S3 upload, adding unnecessary latency. Since all log data has already been sent to downstream channels via `send_logs_to_channels` before this point, `RangeComplete` is purely a "no more logs coming for this range" signal and is safe to send early.

## Changes

- **Main loop path** (`collect_receipts`, range-complete branch): Moved `send_range_complete` from after S3 upload to right after record sorting, before the parquet write.
- **Shutdown cleanup path** (incomplete range drain loop): Same reorder — `send_range_complete` now fires before parquet write and S3 upload.
- The skip path (file already exists) is unchanged since it already sends `RangeComplete` without writing parquet.

This is a pure reorder of existing code. No new functions, types, or logic were introduced.

**Depends on**: #70 (async file IO for historical collection)

## Benchmark Results

Tested on Base chain, 30000 blocks (3x 10000-block parquet ranges), 3 runs each, using `bench/historical_benchmark.sh`:

| Metric | Baseline (main) | This PR | Delta |
|--------|-----------------|---------|-------|
| Wall clock (mean) | 109.7s | 98.6s | **-10.1%** |
| Wall clock (median) | 110.6s | 90.9s | **-17.8%** |
| Throughput (blocks/sec) | 273.5 | 304.2 | **+11.2%** |
| Per-range fetch+write (mean) | 36.4s | 32.7s | -10.2% |
| Per-range fetch+write (p95) | 43.1s | 41.7s | -3.2% |

The improvement comes from unblocking the log collector sooner — it can start processing logs for range N while the receipt parquet write for range N is still in flight.