### PR TITLE
fix: eliminate blocking file IO from historical data collection

### DIFF
--- a/bench/historical_benchmark.sh
+++ b/bench/historical_benchmark.sh
@@ -1,0 +1,449 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ── Configuration ────────────────────────────────────────────────────────────
+BLOCK_COUNT=${BENCH_BLOCKS:-3000}
+RUNS=${BENCH_RUNS:-3}
+BASE_BRANCH=${BENCH_BASE:-main}
+PR_BRANCH=${BENCH_PR:-fix/blocking-io-in-historical}
+CLEANUP=${BENCH_CLEANUP:-1}
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+BENCH_DIR="${REPO_ROOT}/bench"
+WORKTREE_BASE="${BENCH_DIR}/wt-${BASE_BRANCH//\//-}"
+WORKTREE_PR="${BENCH_DIR}/wt-${PR_BRANCH//\//-}"
+
+# ── Load .env from repo root ────────────────────────────────────────────────
+if [[ -f "${REPO_ROOT}/.env" ]]; then
+    set -a
+    source "${REPO_ROOT}/.env"
+    set +a
+fi
+
+# ── Validation ───────────────────────────────────────────────────────────────
+if [[ -z "${BASE_RPC_URL:-}" ]]; then
+    echo "ERROR: BASE_RPC_URL is not set (and not found in .env)" >&2
+    exit 1
+fi
+
+# ── Query chain head ─────────────────────────────────────────────────────────
+echo "Querying chain head..."
+CHAIN_HEAD_HEX=$(curl -s -X POST "$BASE_RPC_URL" \
+    -H "Content-Type: application/json" \
+    -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
+    | python3 -c "import json,sys; print(json.load(sys.stdin)['result'])")
+CHAIN_HEAD=$((CHAIN_HEAD_HEX))
+START_BLOCK=$((CHAIN_HEAD - BLOCK_COUNT))
+
+# Align start_block to parquet_block_range boundary (1000)
+START_BLOCK=$(( (START_BLOCK / 1000) * 1000 ))
+
+echo "============================================================"
+echo "  Historical Collection Benchmark"
+echo "  Baseline: ${BASE_BRANCH}  |  Candidate: ${PR_BRANCH}"
+echo "  Chain head: ${CHAIN_HEAD}  |  Start block: ${START_BLOCK}"
+echo "  Blocks: ~${BLOCK_COUNT}  |  Runs: ${RUNS}"
+echo "============================================================"
+echo ""
+
+# ── Cleanup handler ──────────────────────────────────────────────────────────
+cleanup() {
+    echo ""
+    echo "Cleaning up worktrees..."
+    for wt in "$WORKTREE_BASE" "$WORKTREE_PR"; do
+        git worktree remove --force "$wt" 2>/dev/null || true
+        [[ -d "$wt" ]] && rm -rf "$wt"
+    done
+    git worktree prune 2>/dev/null || true
+}
+
+if [[ "$CLEANUP" == "1" ]]; then
+    trap cleanup EXIT
+fi
+
+# ── Phase 1: Create worktrees ───────────────────────────────────────────────
+echo "Creating worktrees..."
+for wt in "$WORKTREE_BASE" "$WORKTREE_PR"; do
+    git worktree remove --force "$wt" 2>/dev/null || true
+    if [[ -d "$wt" ]]; then
+        rm -rf "$wt"
+        git worktree prune
+    fi
+done
+git worktree add --detach "$WORKTREE_BASE" "$BASE_BRANCH"
+git worktree add --detach "$WORKTREE_PR" "$PR_BRANCH"
+echo "  Worktrees created."
+
+# ── Phase 2: Write benchmark config ─────────────────────────────────────────
+write_bench_config() {
+    local worktree_dir="$1"
+    mkdir -p "${worktree_dir}/config"
+    cat > "${worktree_dir}/config/config.json" << CONFIGEOF
+{
+    "chains": [
+        {
+            "name": "base",
+            "chain_id": 8453,
+            "rpc_url_env_var": "BASE_RPC_URL",
+            "contracts": "contracts/base",
+            "tokens": "tokens/base.json",
+            "block_receipts_method": "eth_getBlockReceipts",
+            "start_block": ${START_BLOCK}
+        }
+    ],
+    "raw_data_collection": {
+        "parquet_block_range": 1000,
+        "rpc_batch_size": 1000,
+        "block_receipt_concurrency": 100,
+        "channel_capacity": 5000,
+        "factory_channel_capacity": 5000,
+        "fields": {
+            "block_fields": ["number", "timestamp", "transactions", "uncles"],
+            "receipt_fields": ["block_number", "timestamp", "transaction_hash", "from", "to"],
+            "log_fields": ["block_number", "timestamp", "transaction_hash", "log_index", "address", "topics", "data"]
+        },
+        "contract_logs_only": false
+    }
+}
+CONFIGEOF
+}
+
+write_bench_config "$WORKTREE_BASE"
+write_bench_config "$WORKTREE_PR"
+echo "  Benchmark configs written (start_block=${START_BLOCK})."
+
+# ── Phase 3: Build both in release mode ──────────────────────────────────────
+echo ""
+echo "Building baseline (${BASE_BRANCH})..."
+(cd "$WORKTREE_BASE" && cargo build --release 2>&1 | tail -3) &
+PID_BUILD_BASE=$!
+
+echo "Building candidate (${PR_BRANCH})..."
+(cd "$WORKTREE_PR" && cargo build --release 2>&1 | tail -3) &
+PID_BUILD_PR=$!
+
+wait $PID_BUILD_BASE || { echo "ERROR: baseline build failed" >&2; exit 1; }
+echo "  Baseline built."
+wait $PID_BUILD_PR || { echo "ERROR: candidate build failed" >&2; exit 1; }
+echo "  Candidate built."
+
+# ── Phase 4: Run benchmarks ─────────────────────────────────────────────────
+run_single() {
+    local label="$1"
+    local worktree_dir="$2"
+    local run_num="$3"
+    local log_file="${BENCH_DIR}/${label}_run${run_num}.log"
+
+    # Clean data directory for fresh run
+    rm -rf "${worktree_dir}/data"
+
+    local start_ts=$(date +%s%N)
+
+    # Seed the data directory with a dummy blocks parquet file so --catch-up-only
+    # has a frontier to work towards (otherwise it exits immediately on empty data).
+    local frontier_start=$(( START_BLOCK + BLOCK_COUNT ))
+    local frontier_end=$(( frontier_start + 999 ))
+    local blocks_dir="${worktree_dir}/data/base/historical/raw/blocks"
+    mkdir -p "$blocks_dir"
+    touch "${blocks_dir}/blocks_${frontier_start}-${frontier_end}.parquet"
+
+    # Run with --catch-up-only: collects from start_block to frontier, then exits
+    (
+        cd "$worktree_dir"
+        NO_COLOR=1 RUST_LOG=info ./target/release/doppler-indexer-rs --catch-up-only 2>&1 | cat
+    ) > "$log_file" 2>&1
+    local exit_code=$?
+
+    local end_ts=$(date +%s%N)
+    local elapsed_ms=$(( (end_ts - start_ts) / 1000000 ))
+
+    if [[ $exit_code -ne 0 ]]; then
+        echo "    run ${run_num}: FAILED (exit code ${exit_code})" >&2
+        tail -5 "$log_file" >&2
+        echo "0"
+        return
+    fi
+
+    echo "    run ${run_num}: ${elapsed_ms}ms" >&2
+    echo "$elapsed_ms"
+}
+
+run_benchmark() {
+    local label="$1"
+    local worktree_dir="$2"
+
+    echo ""
+    echo "Running ${label} benchmark (${RUNS} runs of ~${BLOCK_COUNT} blocks)..."
+
+    local times=()
+    for i in $(seq 1 "$RUNS"); do
+        local ms
+        ms=$(run_single "$label" "$worktree_dir" "$i")
+        times+=("$ms")
+
+        # Cooldown between runs (not after last)
+        if [[ $i -lt $RUNS ]]; then
+            echo "    cooldown (5s)..." >&2
+            sleep 5
+        fi
+    done
+
+    # Write times to file for parsing
+    printf "%s\n" "${times[@]}" > "${BENCH_DIR}/${label}_times.txt"
+}
+
+run_benchmark "baseline" "$WORKTREE_BASE"
+
+echo ""
+echo "Cooldown between branches (10s)..."
+sleep 10
+
+run_benchmark "candidate" "$WORKTREE_PR"
+
+# ── Phase 5: Parse results ───────────────────────────────────────────────────
+echo ""
+echo "Parsing results..."
+
+parse_results() {
+    local label="$1"
+    local times_file="${BENCH_DIR}/${label}_times.txt"
+
+    python3 - "$times_file" "$BENCH_DIR" "$label" "$RUNS" << 'PYEOF'
+import sys
+import re
+import statistics
+from datetime import datetime
+
+times_file = sys.argv[1]
+bench_dir = sys.argv[2]
+label = sys.argv[3]
+num_runs = int(sys.argv[4])
+
+# Read wall clock times
+with open(times_file) as f:
+    wall_times_ms = [int(line.strip()) for line in f if line.strip() and line.strip() != "0"]
+
+if not wall_times_ms:
+    print("RUNS=0")
+    print("ERROR=all_failed")
+    sys.exit(0)
+
+# Parse log files for sub-phase timing
+phase_times = {
+    "collection": [],  # "Collecting N block ranges" -> "Completed historical processing"
+}
+write_durations = []  # per-range: "Fetching blocks X-Y" -> "Wrote N blocks to ..."
+
+def parse_ts(s):
+    return datetime.fromisoformat(s.replace('Z', '+00:00'))
+
+for i in range(1, num_runs + 1):
+    log_file = f"{bench_dir}/{label}_run{i}.log"
+    try:
+        with open(log_file) as f:
+            lines = f.readlines()
+    except FileNotFoundError:
+        continue
+
+    collection_start = None
+    collection_end = None
+    cur_fetch_start = None
+
+    for line in lines:
+        line = line.strip()
+        line = re.sub(r'\x1b\[[0-9;]*m', '', line)
+
+        ts_match = re.match(r'^(\S+)\s+INFO\s+', line)
+        if not ts_match:
+            continue
+        ts_str = ts_match.group(1)
+
+        if "Collecting" in line and "block ranges" in line:
+            try:
+                collection_start = parse_ts(ts_str)
+            except Exception:
+                pass
+
+        if "Completed historical processing" in line:
+            try:
+                collection_end = parse_ts(ts_str)
+            except Exception:
+                pass
+
+        if "Fetching blocks" in line:
+            try:
+                cur_fetch_start = parse_ts(ts_str)
+            except Exception:
+                pass
+
+        if "Wrote" in line and "blocks to" in line and cur_fetch_start:
+            try:
+                wrote_ts = parse_ts(ts_str)
+                dur = (wrote_ts - cur_fetch_start).total_seconds() * 1000
+                write_durations.append(dur)
+                cur_fetch_start = None
+            except Exception:
+                pass
+
+    if collection_start and collection_end:
+        phase_times["collection"].append(
+            (collection_end - collection_start).total_seconds() * 1000
+        )
+
+# Output stats
+n = len(wall_times_ms)
+print(f"RUNS={n}")
+print(f"WALL_MEAN={statistics.mean(wall_times_ms):.0f}")
+print(f"WALL_MEDIAN={sorted(wall_times_ms)[n//2]:.0f}")
+print(f"WALL_MIN={min(wall_times_ms):.0f}")
+print(f"WALL_MAX={max(wall_times_ms):.0f}")
+if n > 1:
+    print(f"WALL_STDEV={statistics.stdev(wall_times_ms):.0f}")
+else:
+    print("WALL_STDEV=0")
+
+# Blocks per second (using mean wall time)
+block_count = 0
+# Try to extract from log
+for i in range(1, num_runs + 1):
+    log_file = f"{bench_dir}/{label}_run{i}.log"
+    try:
+        with open(log_file) as f:
+            for line in f:
+                m = re.search(r'Collecting (\d+) block ranges.*blocks (\d+)-(\d+)', line)
+                if m:
+                    start, end = int(m.group(2)), int(m.group(3))
+                    block_count = end - start + 1
+                    break
+        if block_count > 0:
+            break
+    except FileNotFoundError:
+        continue
+
+if block_count > 0 and statistics.mean(wall_times_ms) > 0:
+    bps = block_count / (statistics.mean(wall_times_ms) / 1000)
+    print(f"BLOCKS={block_count}")
+    print(f"BLOCKS_PER_SEC={bps:.1f}")
+else:
+    print("BLOCKS=0")
+    print("BLOCKS_PER_SEC=0")
+
+# Collection phase timing
+ct = phase_times["collection"]
+if ct:
+    print(f"COLLECTION_MEAN={statistics.mean(ct):.0f}")
+else:
+    print("COLLECTION_MEAN=N/A")
+
+# Per-range fetch+write timing (across all runs)
+if write_durations:
+    write_durations.sort()
+    n_wr = len(write_durations)
+    print(f"RANGE_WRITES={n_wr}")
+    print(f"RANGE_MEAN={statistics.mean(write_durations):.0f}")
+    print(f"RANGE_MEDIAN={write_durations[n_wr//2]:.0f}")
+    print(f"RANGE_P95={write_durations[int(n_wr*0.95)]:.0f}")
+    print(f"RANGE_MAX={max(write_durations):.0f}")
+else:
+    print("RANGE_WRITES=0")
+    print("RANGE_MEAN=N/A")
+    print("RANGE_MEDIAN=N/A")
+    print("RANGE_P95=N/A")
+    print("RANGE_MAX=N/A")
+PYEOF
+}
+
+BASELINE_STATS=$(parse_results "baseline")
+CANDIDATE_STATS=$(parse_results "candidate")
+
+get_stat() {
+    echo "$1" | grep "^${2}=" | cut -d= -f2
+}
+
+# ── Phase 6: Print comparison ────────────────────────────────────────────────
+print_row() {
+    local label="$1" bval="$2" cval="$3" bnum="${4:-}" cnum="${5:-}"
+    local delta=""
+    if [[ -n "$bnum" && -n "$cnum" && "$bnum" != "N/A" && "$cnum" != "N/A" && "$bnum" != "0" ]]; then
+        delta=$(python3 -c "
+b, c = float('$bnum'), float('$cnum')
+if b > 0:
+    pct = ((c - b) / b) * 100
+    sign = '+' if pct >= 0 else ''
+    print(f'{sign}{pct:.1f}%')
+else:
+    print('N/A')
+" 2>/dev/null || echo "N/A")
+    fi
+    printf "  %-28s %15s %15s %10s\n" "$label" "$bval" "$cval" "$delta"
+}
+
+fmt_ms() {
+    local ms="$1"
+    if [[ "$ms" == "N/A" || "$ms" == "0" ]]; then
+        echo "N/A"
+        return
+    fi
+    local secs=$(python3 -c "print(f'{int($ms)/1000:.1f}')" 2>/dev/null || echo "N/A")
+    echo "${secs}s"
+}
+
+B_RUNS=$(get_stat "$BASELINE_STATS" RUNS)
+C_RUNS=$(get_stat "$CANDIDATE_STATS" RUNS)
+B_MEAN=$(get_stat "$BASELINE_STATS" WALL_MEAN)
+C_MEAN=$(get_stat "$CANDIDATE_STATS" WALL_MEAN)
+B_MEDIAN=$(get_stat "$BASELINE_STATS" WALL_MEDIAN)
+C_MEDIAN=$(get_stat "$CANDIDATE_STATS" WALL_MEDIAN)
+B_MIN=$(get_stat "$BASELINE_STATS" WALL_MIN)
+C_MIN=$(get_stat "$CANDIDATE_STATS" WALL_MIN)
+B_MAX=$(get_stat "$BASELINE_STATS" WALL_MAX)
+C_MAX=$(get_stat "$CANDIDATE_STATS" WALL_MAX)
+B_STDEV=$(get_stat "$BASELINE_STATS" WALL_STDEV)
+C_STDEV=$(get_stat "$CANDIDATE_STATS" WALL_STDEV)
+B_BLOCKS=$(get_stat "$BASELINE_STATS" BLOCKS)
+C_BLOCKS=$(get_stat "$CANDIDATE_STATS" BLOCKS)
+B_BPS=$(get_stat "$BASELINE_STATS" BLOCKS_PER_SEC)
+C_BPS=$(get_stat "$CANDIDATE_STATS" BLOCKS_PER_SEC)
+B_COLL=$(get_stat "$BASELINE_STATS" COLLECTION_MEAN)
+C_COLL=$(get_stat "$CANDIDATE_STATS" COLLECTION_MEAN)
+B_RMEAN=$(get_stat "$BASELINE_STATS" RANGE_MEAN)
+C_RMEAN=$(get_stat "$CANDIDATE_STATS" RANGE_MEAN)
+B_RMED=$(get_stat "$BASELINE_STATS" RANGE_MEDIAN)
+C_RMED=$(get_stat "$CANDIDATE_STATS" RANGE_MEDIAN)
+B_RP95=$(get_stat "$BASELINE_STATS" RANGE_P95)
+C_RP95=$(get_stat "$CANDIDATE_STATS" RANGE_P95)
+B_RMAX=$(get_stat "$BASELINE_STATS" RANGE_MAX)
+C_RMAX=$(get_stat "$CANDIDATE_STATS" RANGE_MAX)
+
+echo ""
+echo "======================================================================"
+echo "  HISTORICAL COLLECTION BENCHMARK RESULTS"
+echo "  Baseline: ${BASE_BRANCH}  |  Candidate: ${PR_BRANCH}"
+echo "  ~${BLOCK_COUNT} blocks, ${RUNS} runs each"
+echo "======================================================================"
+echo ""
+printf "  %-28s %15s %15s %10s\n" "Metric" "Baseline" "Candidate" "Delta"
+printf "  %-28s %15s %15s %10s\n" "----------------------------" "---------------" "---------------" "----------"
+
+print_row "Successful runs" "$B_RUNS / $RUNS" "$C_RUNS / $RUNS"
+print_row "Blocks collected" "$B_BLOCKS" "$C_BLOCKS"
+echo ""
+printf "  %-28s %15s %15s %10s\n" "  Wall clock" "" "" ""
+print_row "  mean" "$(fmt_ms "$B_MEAN")" "$(fmt_ms "$C_MEAN")" "$B_MEAN" "$C_MEAN"
+print_row "  median" "$(fmt_ms "$B_MEDIAN")" "$(fmt_ms "$C_MEDIAN")" "$B_MEDIAN" "$C_MEDIAN"
+print_row "  min" "$(fmt_ms "$B_MIN")" "$(fmt_ms "$C_MIN")" "$B_MIN" "$C_MIN"
+print_row "  max" "$(fmt_ms "$B_MAX")" "$(fmt_ms "$C_MAX")" "$B_MAX" "$C_MAX"
+print_row "  stdev" "$(fmt_ms "$B_STDEV")" "$(fmt_ms "$C_STDEV")"
+echo ""
+print_row "Throughput (blocks/sec)" "$B_BPS" "$C_BPS" "$B_BPS" "$C_BPS"
+print_row "Collection phase (mean)" "$(fmt_ms "$B_COLL")" "$(fmt_ms "$C_COLL")" "$B_COLL" "$C_COLL"
+echo ""
+printf "  %-28s %15s %15s %10s\n" "  Per-range fetch+write" "" "" ""
+print_row "  mean" "$(fmt_ms "$B_RMEAN")" "$(fmt_ms "$C_RMEAN")" "$B_RMEAN" "$C_RMEAN"
+print_row "  median" "$(fmt_ms "$B_RMED")" "$(fmt_ms "$C_RMED")" "$B_RMED" "$C_RMED"
+print_row "  p95" "$(fmt_ms "$B_RP95")" "$(fmt_ms "$C_RP95")" "$B_RP95" "$C_RP95"
+print_row "  max" "$(fmt_ms "$B_RMAX")" "$(fmt_ms "$C_RMAX")" "$B_RMAX" "$C_RMAX"
+
+echo ""
+echo "  Logs: bench/{baseline,candidate}_run{1..${RUNS}}.log"
+echo ""

--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -571,6 +571,7 @@ The indexer is designed for high throughput:
 - **Rate limit aware** - Sliding window rate limiter matches Alchemy's 10-second window
 - **Shared rate limiter** - Single limiter across all clients for account-level limiting
 - **Semaphore-bounded concurrency** - `rpc.concurrency` config controls in-flight requests
+- **Non-blocking file I/O** - All file operations use `spawn_blocking` or `tokio::fs` to keep the async runtime responsive
 - **Efficient storage** - Snappy-compressed Parquet with configurable schemas
 - **Resumable** - Automatic catchup skips already-processed ranges
 - **Incremental decoding** - New events/calls only process what's missing

--- a/src/raw_data/historical/blocks.rs
+++ b/src/raw_data/historical/blocks.rs
@@ -459,6 +459,50 @@ pub fn get_existing_block_ranges(
     ranges
 }
 
+pub(crate) async fn write_minimal_blocks_to_parquet_async(
+    records: Vec<MinimalBlockRecord>,
+    schema: Arc<Schema>,
+    fields: Vec<BlockField>,
+    output_path: PathBuf,
+) -> Result<(), BlockCollectionError> {
+    tokio::task::spawn_blocking(move || {
+        write_minimal_blocks_to_parquet(&records, &schema, &fields, &output_path)
+    })
+    .await
+    .map_err(|e| BlockCollectionError::JoinError(e.to_string()))?
+}
+
+pub(crate) async fn write_full_blocks_to_parquet_async(
+    records: Vec<FullBlockRecord>,
+    schema: Arc<Schema>,
+    output_path: PathBuf,
+) -> Result<(), BlockCollectionError> {
+    tokio::task::spawn_blocking(move || {
+        write_full_blocks_to_parquet(&records, &schema, &output_path)
+    })
+    .await
+    .map_err(|e| BlockCollectionError::JoinError(e.to_string()))?
+}
+
+pub async fn get_existing_block_ranges_async(
+    chain_name: String,
+    s3_manifest: Option<S3Manifest>,
+) -> Vec<ExistingBlockRange> {
+    tokio::task::spawn_blocking(move || {
+        get_existing_block_ranges(&chain_name, s3_manifest.as_ref())
+    })
+    .await
+    .unwrap_or_default()
+}
+
+pub async fn read_block_info_from_parquet_async(
+    file_path: PathBuf,
+) -> Result<Vec<BlockInfoForDownstream>, BlockCollectionError> {
+    tokio::task::spawn_blocking(move || read_block_info_from_parquet(&file_path))
+        .await
+        .map_err(|e| BlockCollectionError::JoinError(e.to_string()))?
+}
+
 pub fn read_block_info_from_parquet(
     file_path: &Path,
 ) -> Result<Vec<BlockInfoForDownstream>, BlockCollectionError> {

--- a/src/raw_data/historical/catchup/blocks.rs
+++ b/src/raw_data/historical/catchup/blocks.rs
@@ -8,8 +8,9 @@ use arrow::datatypes::Schema;
 use tokio::sync::mpsc::{self, Sender};
 
 use crate::raw_data::historical::blocks::{
-    build_block_schema, process_single_block_full, write_full_blocks_to_parquet,
-    write_minimal_blocks_to_parquet, BlockCollectionError, FullBlockRecord, MinimalBlockRecord,
+    build_block_schema, process_single_block_full, write_full_blocks_to_parquet_async,
+    write_minimal_blocks_to_parquet_async, BlockCollectionError, FullBlockRecord,
+    MinimalBlockRecord,
 };
 use crate::rpc::{RpcError, UnifiedRpcClient};
 use crate::storage::paths::{parse_range_from_filename, raw_blocks_dir, scan_parquet_filenames};
@@ -29,7 +30,7 @@ pub async fn collect_blocks(
     catch_up_only: bool,
 ) -> Result<(), BlockCollectionError> {
     let output_dir = raw_blocks_dir(&chain.name);
-    std::fs::create_dir_all(&output_dir)?;
+    tokio::fs::create_dir_all(&output_dir).await?;
 
     let range_size = raw_data_config.parquet_block_range.unwrap_or(1000) as u64;
     let start_block = chain.start_block.map(|u| u.to::<u64>()).unwrap_or(0);
@@ -46,7 +47,10 @@ pub async fn collect_blocks(
     // In catch-up-only mode, only fill gaps within existing data — don't extend
     // to chain head. The upper bound is the highest block in existing files.
     let effective_head = if catch_up_only {
-        let existing = scan_existing_parquet_files(&output_dir);
+        let dir = output_dir.clone();
+        let existing = tokio::task::spawn_blocking(move || scan_existing_parquet_files(&dir))
+            .await
+            .map_err(|e| BlockCollectionError::JoinError(e.to_string()))?;
         let max_existing = highest_block_from_files(&existing, s3_manifest);
         match max_existing {
             Some(max) => {
@@ -67,13 +71,19 @@ pub async fn collect_blocks(
         chain_head
     };
 
-    let ranges = compute_ranges_to_fetch(
-        start_block,
-        effective_head,
-        range_size,
-        &output_dir,
-        s3_manifest,
-    );
+    let dir = output_dir.clone();
+    let s3_manifest_owned = s3_manifest.cloned();
+    let ranges = tokio::task::spawn_blocking(move || {
+        compute_ranges_to_fetch(
+            start_block,
+            effective_head,
+            range_size,
+            &dir,
+            s3_manifest_owned.as_ref(),
+        )
+    })
+    .await
+    .map_err(|e| BlockCollectionError::JoinError(e.to_string()))?;
 
     if ranges.is_empty() {
         tracing::info!(
@@ -242,19 +252,14 @@ async fn collect_blocks_streaming(
             }
 
             // Write to parquet
-            let schema_clone = schema.clone();
-            let fields_vec = fields.to_vec();
             let output_path = output_dir.join(range.file_name("blocks"));
-            tokio::task::spawn_blocking(move || {
-                write_minimal_blocks_to_parquet(
-                    &all_records,
-                    &schema_clone,
-                    &fields_vec,
-                    &output_path,
-                )
-            })
-            .await
-            .map_err(|e| BlockCollectionError::JoinError(e.to_string()))??;
+            write_minimal_blocks_to_parquet_async(
+                all_records,
+                schema.clone(),
+                fields.to_vec(),
+                output_path,
+            )
+            .await?;
 
             Ok(count)
         }
@@ -327,13 +332,8 @@ async fn collect_blocks_streaming(
             let count = all_records.len();
 
             // Write to parquet
-            let schema_clone = schema.clone();
             let output_path = output_dir.join(range.file_name("blocks"));
-            tokio::task::spawn_blocking(move || {
-                write_full_blocks_to_parquet(&all_records, &schema_clone, &output_path)
-            })
-            .await
-            .map_err(|e| BlockCollectionError::JoinError(e.to_string()))??;
+            write_full_blocks_to_parquet_async(all_records, schema.clone(), output_path).await?;
 
             Ok(count)
         }

--- a/src/raw_data/historical/catchup/eth_calls.rs
+++ b/src/raw_data/historical/catchup/eth_calls.rs
@@ -8,17 +8,20 @@ use tokio::sync::oneshot;
 
 use crate::decoding::DecoderMessage;
 use crate::raw_data::historical::blocks::{
-    get_existing_block_ranges, read_block_info_from_parquet,
+    get_existing_block_ranges_async, read_block_info_from_parquet_async,
 };
 use crate::raw_data::historical::eth_calls::{
     build_call_configs, build_event_triggered_call_configs, build_factory_once_call_configs,
-    build_once_call_configs, build_token_call_configs, event_output_exists,
-    get_existing_log_ranges, load_or_build_once_column_index, process_event_triggers,
+    build_once_call_configs, build_token_call_configs, event_output_exists_async,
+    get_existing_log_ranges_async, process_event_triggers,
     process_event_triggers_multicall, process_factory_once_calls, process_once_calls_multicall,
     process_once_calls_regular, process_range, process_range_multicall, process_token_range,
-    process_token_range_multicall, read_logs_from_parquet, read_once_column_index,
-    scan_existing_parquet_files, BlockInfo, BlockRange, EthCallCatchupState,
+    process_token_range_multicall, read_logs_from_parquet_async,
+    scan_existing_parquet_files_async, BlockInfo, BlockRange, EthCallCatchupState,
     EthCallCollectionError, EthCallContext, FrequencyState,
+};
+use crate::raw_data::historical::eth_calls::parquet_io::{
+    load_or_build_once_column_index_async, read_once_column_index_async,
 };
 use crate::raw_data::historical::factories::{get_factory_call_configs, FactoryAddressData};
 use crate::raw_data::historical::receipts::{build_event_trigger_matchers, extract_event_triggers};
@@ -46,7 +49,7 @@ pub async fn collect_eth_calls(
     storage_manager: Option<Arc<StorageManager>>,
 ) -> Result<EthCallCatchupState, EthCallCollectionError> {
     let base_output_dir = raw_eth_calls_dir(&chain.name);
-    std::fs::create_dir_all(&base_output_dir)?;
+    tokio::fs::create_dir_all(&base_output_dir).await?;
 
     let range_size = raw_data_config.parquet_block_range.unwrap_or(1000) as u64;
     let rpc_batch_size = raw_data_config.rpc_batch_size.unwrap_or(100) as usize;
@@ -159,7 +162,7 @@ pub async fn collect_eth_calls(
         token_call_configs.len()
     );
 
-    let existing_files = scan_existing_parquet_files(&base_output_dir);
+    let existing_files = scan_existing_parquet_files_async(base_output_dir.clone()).await;
 
     let mut range_data: HashMap<u64, Vec<BlockInfo>> = HashMap::new();
     let range_factory_data: HashMap<u64, FactoryAddressData> = HashMap::new();
@@ -167,7 +170,7 @@ pub async fn collect_eth_calls(
     let range_factory_done: HashSet<u64> = HashSet::new();
 
     if has_regular_calls || has_token_calls || has_once_calls {
-        let block_ranges = get_existing_block_ranges(&chain.name, s3_manifest.as_ref());
+        let block_ranges = get_existing_block_ranges_async(chain.name.clone(), s3_manifest.as_ref().cloned()).await;
         tracing::info!(
             "eth_calls catchup: checking {} block ranges (regular={}, token={}, once={})",
             block_ranges.len(),
@@ -180,7 +183,7 @@ pub async fn collect_eth_calls(
         let mut once_column_indexes: HashMap<String, HashMap<String, Vec<String>>> = HashMap::new();
         for contract_name in once_configs.keys() {
             let once_dir = base_output_dir.join(contract_name).join("once");
-            let index = load_or_build_once_column_index(&once_dir);
+            let index = load_or_build_once_column_index_async(once_dir).await;
             once_column_indexes.insert(contract_name.clone(), index);
         }
 
@@ -337,7 +340,7 @@ pub async fn collect_eth_calls(
                 }
             }
 
-            let block_infos = match read_block_info_from_parquet(&block_range.file_path) {
+            let block_infos = match read_block_info_from_parquet_async(block_range.file_path.clone()).await {
                 Ok(infos) => infos,
                 Err(e) => {
                     tracing::warn!(
@@ -499,7 +502,7 @@ pub async fn collect_eth_calls(
             HashMap::new();
         for collection_name in factory_once_configs.keys() {
             let once_dir = base_output_dir.join(collection_name).join("once");
-            let index = read_once_column_index(&once_dir);
+            let index = read_once_column_index_async(once_dir).await;
             factory_once_column_indexes.insert(collection_name.clone(), index);
         }
 
@@ -514,7 +517,7 @@ pub async fn collect_eth_calls(
         .await;
 
         if !factory_catchup_data.is_empty() {
-            let block_ranges = get_existing_block_ranges(&chain.name, s3_manifest.as_ref());
+            let block_ranges = get_existing_block_ranges_async(chain.name.clone(), s3_manifest.as_ref().cloned()).await;
             let total_factory_ranges = block_ranges.len();
             let mut factory_once_catchup_count = 0;
 
@@ -627,7 +630,7 @@ pub async fn collect_eth_calls(
                 .extend(addrs);
         }
 
-        let log_ranges = get_existing_log_ranges(&chain.name, s3_manifest.as_ref());
+        let log_ranges = get_existing_log_ranges_async(chain.name.clone(), s3_manifest.as_ref().cloned()).await;
         let event_matchers = build_event_trigger_matchers(&chain.contracts);
         let total_log_ranges = log_ranges.len();
         let mut event_catchup_count = 0;
@@ -649,14 +652,15 @@ pub async fn collect_eth_calls(
                             continue;
                         }
                     }
-                    if !event_output_exists(
-                        &base_output_dir,
-                        &config.contract_name,
-                        &config.function_name,
+                    if !event_output_exists_async(
+                        base_output_dir.clone(),
+                        config.contract_name.clone(),
+                        config.function_name.clone(),
                         log_range.start,
                         log_range.end,
-                        s3_manifest.as_ref(),
-                    ) {
+                        s3_manifest.as_ref().cloned(),
+                    )
+                    .await? {
                         needs_processing = true;
                         break;
                     }
@@ -676,7 +680,7 @@ pub async fn collect_eth_calls(
             }
 
             // Read logs from parquet file
-            let logs = match read_logs_from_parquet(&log_range.file_path) {
+            let logs = match read_logs_from_parquet_async(log_range.file_path.clone()).await {
                 Ok(logs) => logs,
                 Err(e) => {
                     tracing::warn!(

--- a/src/raw_data/historical/catchup/eth_calls.rs
+++ b/src/raw_data/historical/catchup/eth_calls.rs
@@ -634,6 +634,7 @@ pub async fn collect_eth_calls(
         let event_matchers = build_event_trigger_matchers(&chain.contracts);
         let total_log_ranges = log_ranges.len();
         let mut event_catchup_count = 0;
+        let s3_manifest_arc = s3_manifest.as_ref().map(|m| Arc::new(m.clone()));
 
         tracing::info!(
             "Event-triggered calls catchup: checking {} log ranges for chain {}",
@@ -658,7 +659,7 @@ pub async fn collect_eth_calls(
                         config.function_name.clone(),
                         log_range.start,
                         log_range.end,
-                        s3_manifest.as_ref().cloned(),
+                        s3_manifest_arc.clone(),
                     )
                     .await? {
                         needs_processing = true;

--- a/src/raw_data/historical/catchup/factories.rs
+++ b/src/raw_data/historical/catchup/factories.rs
@@ -232,6 +232,11 @@ pub async fn collect_factories(
 
                 let batches = match read_log_batches_from_parquet_async(file_path.clone()).await {
                     Ok(b) => b,
+                    Err(e @ FactoryCollectionError::JoinError(_)) => {
+                        // spawn_blocking failure (panic/cancellation) — not file corruption.
+                        // Propagate so the caller can abort catchup instead of deleting valid data.
+                        return Err(e);
+                    }
                     Err(e) => {
                         tracing::warn!(
                             "Corrupted log file {}: {} - deleting and requesting recollection for range {}-{}",

--- a/src/raw_data/historical/catchup/factories.rs
+++ b/src/raw_data/historical/catchup/factories.rs
@@ -10,8 +10,8 @@ use tokio::task::JoinSet;
 
 use crate::decoding::DecoderMessage;
 use crate::raw_data::historical::factories::{
-    build_factory_matchers, get_existing_log_ranges, load_factory_addresses_from_parquet,
-    process_range_batches, read_log_batches_from_parquet, scan_existing_parquet_files,
+    build_factory_matchers, get_existing_log_ranges, load_factory_addresses_from_parquet_async,
+    process_range_batches, read_log_batches_from_parquet_async, scan_existing_parquet_files,
     FactoryAddressData, FactoryCatchupState, FactoryCollectionError, RecollectRequest,
 };
 use crate::storage::paths::factories_dir as factories_dir_path;
@@ -31,9 +31,9 @@ pub async fn collect_factories(
     storage_manager: Option<Arc<StorageManager>>,
 ) -> Result<FactoryCatchupState, FactoryCollectionError> {
     let output_dir = factories_dir_path(&chain.name);
-    std::fs::create_dir_all(&output_dir)?;
+    tokio::fs::create_dir_all(&output_dir).await?;
 
-    let existing_factory_data = load_factory_addresses_from_parquet(&output_dir)?;
+    let existing_factory_data = load_factory_addresses_from_parquet_async(output_dir.clone()).await?;
     if !existing_factory_data.is_empty() {
         tracing::info!(
             "Loaded {} existing factory ranges from parquet for chain {}",
@@ -117,7 +117,12 @@ pub async fn collect_factories(
         });
     }
 
-    let existing_files = scan_existing_parquet_files(&output_dir);
+    let existing_files = {
+        let output_dir_clone = output_dir.clone();
+        tokio::task::spawn_blocking(move || scan_existing_parquet_files(&output_dir_clone))
+            .await
+            .map_err(|e| FactoryCollectionError::JoinError(e.to_string()))?
+    };
 
     // Get the factory collection names from matchers
     let factory_collection_names: HashSet<String> =
@@ -127,7 +132,15 @@ pub async fn collect_factories(
     // Catchup phase: Process existing logs files where factory files are missing
     // This avoids re-fetching receipts when logs already exist
     // =========================================================================
-    let log_ranges = get_existing_log_ranges(&chain.name, s3_manifest.as_ref());
+    let log_ranges = {
+        let chain_name = chain.name.clone();
+        let s3_manifest_clone = s3_manifest.clone();
+        tokio::task::spawn_blocking(move || {
+            get_existing_log_ranges(&chain_name, s3_manifest_clone.as_ref())
+        })
+        .await
+        .map_err(|e| FactoryCollectionError::JoinError(e.to_string()))?
+    };
     let mut catchup_count = 0;
 
     let factory_concurrency = raw_data_config.factory_concurrency.unwrap_or(4);
@@ -217,25 +230,19 @@ pub async fn collect_factories(
                     }
                 }
 
-                let file_path_for_read = file_path.clone();
-                let file_path_display = file_path.display().to_string();
-                let batches = match tokio::task::spawn_blocking(move || {
-                    read_log_batches_from_parquet(&file_path_for_read)
-                })
-                .await
-                {
-                    Ok(Ok(b)) => b,
-                    Ok(Err(e)) => {
+                let batches = match read_log_batches_from_parquet_async(file_path.clone()).await {
+                    Ok(b) => b,
+                    Err(e) => {
                         tracing::warn!(
                             "Corrupted log file {}: {} - deleting and requesting recollection for range {}-{}",
-                            file_path_display,
+                            file_path.display(),
                             e,
                             start,
                             end - 1
                         );
 
                         // Delete the corrupted file
-                        if let Err(del_err) = std::fs::remove_file(&file_path) {
+                        if let Err(del_err) = tokio::fs::remove_file(&file_path).await {
                             tracing::error!(
                                 "Failed to delete corrupted log file {}: {}",
                                 file_path.display(),
@@ -263,9 +270,6 @@ pub async fn collect_factories(
                         }
 
                         return Ok(None);
-                    }
-                    Err(e) => {
-                        return Err(FactoryCollectionError::JoinError(e.to_string()));
                     }
                 };
 

--- a/src/raw_data/historical/catchup/logs.rs
+++ b/src/raw_data/historical/catchup/logs.rs
@@ -17,7 +17,7 @@ pub async fn collect_logs(
     storage_manager: Option<Arc<StorageManager>>,
 ) -> Result<LogsCatchupState, LogCollectionError> {
     let output_dir = raw_logs_dir(&chain.name);
-    std::fs::create_dir_all(&output_dir)?;
+    tokio::fs::create_dir_all(&output_dir).await?;
 
     let range_size = raw_data_config.parquet_block_range.unwrap_or(1000) as u64;
     let log_fields = &raw_data_config.fields.log_fields;
@@ -30,7 +30,12 @@ pub async fn collect_logs(
         HashSet::new()
     };
 
-    let existing_files = scan_existing_parquet_files(&output_dir);
+    let existing_files = {
+        let dir = output_dir.clone();
+        tokio::task::spawn_blocking(move || scan_existing_parquet_files(&dir))
+            .await
+            .map_err(|e| LogCollectionError::JoinError(e.to_string()))?
+    };
 
     Ok(LogsCatchupState {
         output_dir,

--- a/src/raw_data/historical/catchup/receipts.rs
+++ b/src/raw_data/historical/catchup/receipts.rs
@@ -5,12 +5,13 @@ use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
 
 use crate::raw_data::historical::blocks::{
-    get_existing_block_ranges, read_block_info_from_parquet,
+    get_existing_block_ranges_async, read_block_info_from_parquet_async,
 };
 use crate::raw_data::historical::receipts::{
-    build_receipt_schema, process_range, scan_existing_logs_files, scan_existing_parquet_files,
-    send_range_complete, BlockInfo, ChannelMetrics, ChannelMetricsState, EventTriggerMatcher,
-    EventTriggerMessage, LogMessage, ReceiptCollectionError, ReceiptOutputChannels,
+    build_receipt_schema, process_range, scan_existing_logs_files_async,
+    scan_existing_parquet_files_async, send_range_complete, BlockInfo, ChannelMetrics,
+    ChannelMetricsState, EventTriggerMatcher, EventTriggerMessage, LogMessage,
+    ReceiptCollectionError, ReceiptOutputChannels,
 };
 use crate::rpc::UnifiedRpcClient;
 use crate::storage::paths::{raw_logs_dir, raw_receipts_dir};
@@ -43,14 +44,14 @@ pub async fn collect_receipts(
     storage_manager: Option<Arc<StorageManager>>,
 ) -> Result<ReceiptsCatchupState, ReceiptCollectionError> {
     let output_dir = raw_receipts_dir(&chain.name);
-    std::fs::create_dir_all(&output_dir)?;
+    tokio::fs::create_dir_all(&output_dir).await?;
 
     let rpc_batch_size = raw_data_config.rpc_batch_size.unwrap_or(100) as usize;
     let block_receipt_concurrency = raw_data_config.block_receipt_concurrency.unwrap_or(10);
     let receipt_fields = &raw_data_config.fields.receipt_fields;
     let schema = build_receipt_schema(receipt_fields);
 
-    let existing_files = scan_existing_parquet_files(&output_dir);
+    let existing_files = scan_existing_parquet_files_async(output_dir.clone()).await?;
 
     let has_factories = factory_log_tx.is_some();
 
@@ -76,12 +77,16 @@ pub async fn collect_receipts(
     // Also check for missing logs files - if receipts exist but logs don't, we
     // need to re-process to regenerate the logs data
     // =========================================================================
-    let block_ranges = get_existing_block_ranges(&chain.name, s3_manifest.as_ref());
+    let block_ranges = get_existing_block_ranges_async(
+        chain.name.clone(),
+        s3_manifest.as_ref().cloned(),
+    )
+    .await;
     let mut catchup_count = 0;
 
     // Check existing logs files
     let logs_dir = raw_logs_dir(&chain.name);
-    let existing_logs_files = scan_existing_logs_files(&logs_dir);
+    let existing_logs_files = scan_existing_logs_files_async(logs_dir).await?;
 
     // Note: Factory catchup is handled by the factories module reading from logs files directly.
     // Receipts catchup only needs to check for receipts and logs.
@@ -162,17 +167,18 @@ pub async fn collect_receipts(
         }
 
         // Read block info from the existing parquet file
-        let block_infos = match read_block_info_from_parquet(&block_range.file_path) {
-            Ok(infos) => infos,
-            Err(e) => {
-                tracing::warn!(
-                    "Failed to read block info from {}: {}",
-                    block_range.file_path.display(),
-                    e
-                );
-                continue;
-            }
-        };
+        let block_infos =
+            match read_block_info_from_parquet_async(block_range.file_path.clone()).await {
+                Ok(infos) => infos,
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to read block info from {}: {}",
+                        block_range.file_path.display(),
+                        e
+                    );
+                    continue;
+                }
+            };
 
         if block_infos.is_empty() {
             continue;

--- a/src/raw_data/historical/current/eth_calls/events.rs
+++ b/src/raw_data/historical/current/eth_calls/events.rs
@@ -112,16 +112,17 @@ pub(super) async fn handle_event_trigger_message(
                 let output_path = sub_dir.join(&file_name);
                 // Only write if file doesn't exist (don't overwrite if we already wrote results)
                 if !output_path.exists() {
-                    if let Err(e) = std::fs::create_dir_all(&sub_dir) {
+                    if let Err(e) = tokio::fs::create_dir_all(&sub_dir).await {
                         tracing::warn!("Failed to create dir for empty event file: {}", e);
                         continue;
                     }
                     if let Err(e) =
-                        crate::raw_data::historical::eth_calls::write_event_call_results_to_parquet(
-                            &[],
-                            &output_path,
+                        crate::raw_data::historical::eth_calls::event_triggers::write_event_call_results_to_parquet_async(
+                            vec![],
+                            output_path.clone(),
                             0,
                         )
+                        .await
                     {
                         tracing::warn!("Failed to write empty event file: {}", e);
                     } else {

--- a/src/raw_data/historical/current/receipts.rs
+++ b/src/raw_data/historical/current/receipts.rs
@@ -5,13 +5,13 @@ use std::sync::Arc;
 use alloy::primitives::B256;
 use tokio::sync::mpsc::{Receiver, Sender};
 
-use crate::raw_data::historical::blocks::read_block_info_from_parquet;
+use crate::raw_data::historical::blocks::read_block_info_from_parquet_async;
 use crate::raw_data::historical::catchup::receipts::ReceiptsCatchupState;
 use crate::raw_data::historical::factories::RecollectRequest;
 use crate::raw_data::historical::receipts::{
     build_receipt_schema, extract_event_triggers, fetch_receipts_for_blocks, process_range,
-    send_logs_to_channels, send_range_complete, write_full_receipts_to_parquet,
-    write_minimal_receipts_to_parquet, BlockInfo, ChannelMetrics, ChannelMetricsState,
+    send_logs_to_channels, send_range_complete, write_full_receipts_to_parquet_async,
+    write_minimal_receipts_to_parquet_async, BlockInfo, ChannelMetrics, ChannelMetricsState,
     EventTriggerMatcher, EventTriggerMessage, LogMessage, ReceiptBatchState,
     ReceiptCollectionError, ReceiptOutputChannels,
 };
@@ -36,7 +36,7 @@ pub async fn collect_receipts(
     storage_manager: Option<Arc<StorageManager>>,
 ) -> Result<(), ReceiptCollectionError> {
     let output_dir = raw_receipts_dir(&chain.name);
-    std::fs::create_dir_all(&output_dir)?;
+    tokio::fs::create_dir_all(&output_dir).await?;
 
     let range_size = raw_data_config.parquet_block_range.unwrap_or(1000) as u64;
     let rpc_batch_size = raw_data_config.rpc_batch_size.unwrap_or(100) as usize;
@@ -288,25 +288,23 @@ pub async fn collect_receipts(
                             let total_receipts = match receipt_fields {
                                 Some(fields) => {
                                     let count = minimal_records.len();
-                                    let schema_clone = schema.clone();
-                                    let fields_vec = fields.to_vec();
-                                    let output_path_clone = output_path.clone();
-                                    tokio::task::spawn_blocking(move || {
-                                        write_minimal_receipts_to_parquet(&minimal_records, &schema_clone, &fields_vec, &output_path_clone)
-                                    })
-                                    .await
-                                    .map_err(|e| ReceiptCollectionError::JoinError(e.to_string()))??;
+                                    write_minimal_receipts_to_parquet_async(
+                                        minimal_records,
+                                        schema.clone(),
+                                        fields.to_vec(),
+                                        output_path.clone(),
+                                    )
+                                    .await?;
                                     count
                                 }
                                 None => {
                                     let count = full_records.len();
-                                    let schema_clone = schema.clone();
-                                    let output_path_clone = output_path.clone();
-                                    tokio::task::spawn_blocking(move || {
-                                        write_full_receipts_to_parquet(&full_records, &schema_clone, &output_path_clone)
-                                    })
-                                    .await
-                                    .map_err(|e| ReceiptCollectionError::JoinError(e.to_string()))??;
+                                    write_full_receipts_to_parquet_async(
+                                        full_records,
+                                        schema.clone(),
+                                        output_path.clone(),
+                                    )
+                                    .await?;
                                     count
                                 }
                             };
@@ -362,7 +360,7 @@ pub async fn collect_receipts(
                         request.range_end - 1
                     ));
 
-                    let block_infos = match read_block_info_from_parquet(&block_file_path) {
+                    let block_infos = match read_block_info_from_parquet_async(block_file_path).await {
                         Ok(infos) => infos,
                         Err(e) => {
                             tracing::error!(
@@ -539,32 +537,23 @@ pub async fn collect_receipts(
         let total_receipts = match receipt_fields {
             Some(fields) => {
                 let count = state.minimal_records.len();
-                let schema_clone = schema.clone();
-                let fields_vec = fields.to_vec();
-                let output_path_clone = output_path.clone();
-                let minimal_records = state.minimal_records;
-                tokio::task::spawn_blocking(move || {
-                    write_minimal_receipts_to_parquet(
-                        &minimal_records,
-                        &schema_clone,
-                        &fields_vec,
-                        &output_path_clone,
-                    )
-                })
-                .await
-                .map_err(|e| ReceiptCollectionError::JoinError(e.to_string()))??;
+                write_minimal_receipts_to_parquet_async(
+                    state.minimal_records,
+                    schema.clone(),
+                    fields.to_vec(),
+                    output_path.clone(),
+                )
+                .await?;
                 count
             }
             None => {
                 let count = state.full_records.len();
-                let schema_clone = schema.clone();
-                let output_path_clone = output_path.clone();
-                let full_records = state.full_records;
-                tokio::task::spawn_blocking(move || {
-                    write_full_receipts_to_parquet(&full_records, &schema_clone, &output_path_clone)
-                })
-                .await
-                .map_err(|e| ReceiptCollectionError::JoinError(e.to_string()))??;
+                write_full_receipts_to_parquet_async(
+                    state.full_records,
+                    schema.clone(),
+                    output_path.clone(),
+                )
+                .await?;
                 count
             }
         };

--- a/src/raw_data/historical/eth_calls/event_triggers.rs
+++ b/src/raw_data/historical/eth_calls/event_triggers.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use alloy::dyn_abi::DynSolValue;
@@ -505,7 +505,8 @@ pub(crate) async fn process_event_triggers(
                 function_name,
                 range_start,
                 range_end,
-            )?;
+            )
+            .await?;
         }
         return Ok(skipped_factory_triggers);
     }
@@ -729,13 +730,34 @@ pub(crate) async fn process_event_triggers(
                 .join(&contract_name)
                 .join(&function_name)
                 .join("on_events");
-            std::fs::create_dir_all(&sub_dir)?;
+            tokio::fs::create_dir_all(&sub_dir).await?;
 
             let file_name = format!("{}-{}.parquet", range_start, range_end);
             let output_path = sub_dir.join(&file_name);
 
             let result_count = all_results.len();
-            write_event_call_results_to_parquet(&all_results, &output_path, max_params)?;
+
+            // Build decoder results before moving all_results into the async write
+            let decoder_results: Option<Vec<DecoderEventCallResult>> = if ctx.decoder_tx.is_some() {
+                Some(
+                    all_results
+                        .iter()
+                        .map(|r| DecoderEventCallResult {
+                            block_number: r.block_number,
+                            block_timestamp: r.block_timestamp,
+                            log_index: r.log_index,
+                            target_address: r.target_address,
+                            value: r.value_bytes.clone(),
+                            is_reverted: r.is_reverted,
+                            revert_reason: r.revert_reason.clone(),
+                        })
+                        .collect(),
+                )
+            } else {
+                None
+            };
+
+            write_event_call_results_to_parquet_async(all_results, output_path.clone(), max_params).await?;
 
             tracing::info!(
                 "Wrote {} event-triggered eth_call results to {} (event blocks {}-{})",
@@ -765,30 +787,19 @@ pub(crate) async fn process_event_triggers(
 
             // Send to decoder for decoding (range_end + 1 for exclusive convention)
             if let Some(tx) = ctx.decoder_tx {
-                let decoder_results: Vec<DecoderEventCallResult> = all_results
-                    .iter()
-                    .map(|r| DecoderEventCallResult {
-                        block_number: r.block_number,
-                        block_timestamp: r.block_timestamp,
-                        log_index: r.log_index,
-                        target_address: r.target_address,
-                        value: r.value_bytes.clone(),
-                        is_reverted: r.is_reverted,
-                        revert_reason: r.revert_reason.clone(),
-                    })
-                    .collect();
-
-                let _ = tx
-                    .send(DecoderMessage::EventCallsReady {
-                        range_start,
-                        range_end: range_end + 1,
-                        contract_name: contract_name.clone(),
-                        function_name: function_name.clone(),
-                        results: decoder_results,
-                        live_mode: false,
-                        retry_transform_after_decode: false,
-                    })
-                    .await;
+                if let Some(decoder_results) = decoder_results {
+                    let _ = tx
+                        .send(DecoderMessage::EventCallsReady {
+                            range_start,
+                            range_end: range_end + 1,
+                            contract_name: contract_name.clone(),
+                            function_name: function_name.clone(),
+                            results: decoder_results,
+                            live_mode: false,
+                            retry_transform_after_decode: false,
+                        })
+                        .await;
+                }
             }
         }
     }
@@ -802,7 +813,8 @@ pub(crate) async fn process_event_triggers(
                 &function_name,
                 range_start,
                 range_end,
-            )?;
+            )
+            .await?;
         }
     }
 
@@ -810,7 +822,7 @@ pub(crate) async fn process_event_triggers(
 }
 
 /// Write an empty parquet file for event-triggered calls when no events matched
-fn write_empty_event_call_file(
+async fn write_empty_event_call_file(
     output_dir: &Path,
     contract_name: &str,
     function_name: &str,
@@ -821,13 +833,13 @@ fn write_empty_event_call_file(
         .join(contract_name)
         .join(function_name)
         .join("on_events");
-    std::fs::create_dir_all(&sub_dir)?;
+    tokio::fs::create_dir_all(&sub_dir).await?;
 
     let file_name = format!("{}-{}.parquet", range_start, range_end);
     let output_path = sub_dir.join(&file_name);
 
     // Write empty parquet with 0 params
-    write_event_call_results_to_parquet(&[], &output_path, 0)?;
+    write_event_call_results_to_parquet_async(vec![], output_path.clone(), 0).await?;
 
     tracing::debug!(
         "Wrote empty event-triggered eth_call file to {} (no matching events)",
@@ -866,7 +878,8 @@ pub(crate) async fn process_event_triggers_multicall(
                 function_name,
                 range_start,
                 range_end,
-            )?;
+            )
+            .await?;
         }
         return Ok(skipped_factory_triggers);
     }
@@ -1102,7 +1115,7 @@ pub(crate) async fn process_event_triggers_multicall(
             .join(&contract_name)
             .join(&function_name)
             .join("on_events");
-        std::fs::create_dir_all(&sub_dir)?;
+        tokio::fs::create_dir_all(&sub_dir).await?;
 
         let file_name = format!("{}-{}.parquet", range_start, range_end);
         let output_path = sub_dir.join(&file_name);
@@ -1113,7 +1126,28 @@ pub(crate) async fn process_event_triggers_multicall(
             .map(|r| r.param_values.len())
             .max()
             .unwrap_or(0);
-        write_event_call_results_to_parquet(&results, &output_path, max_params)?;
+
+        // Build decoder results before moving results into the async write
+        let decoder_results: Option<Vec<DecoderEventCallResult>> = if ctx.decoder_tx.is_some() {
+            Some(
+                results
+                    .iter()
+                    .map(|r| DecoderEventCallResult {
+                        block_number: r.block_number,
+                        block_timestamp: r.block_timestamp,
+                        log_index: r.log_index,
+                        target_address: r.target_address,
+                        value: r.value_bytes.clone(),
+                        is_reverted: r.is_reverted,
+                        revert_reason: r.revert_reason.clone(),
+                    })
+                    .collect(),
+            )
+        } else {
+            None
+        };
+
+        write_event_call_results_to_parquet_async(results, output_path.clone(), max_params).await?;
 
         tracing::info!(
             "Wrote {} multicall event-triggered eth_call results to {} (event blocks {}-{})",
@@ -1143,30 +1177,19 @@ pub(crate) async fn process_event_triggers_multicall(
 
         // Send to decoder (range_end + 1 for exclusive convention)
         if let Some(tx) = ctx.decoder_tx {
-            let decoder_results: Vec<DecoderEventCallResult> = results
-                .iter()
-                .map(|r| DecoderEventCallResult {
-                    block_number: r.block_number,
-                    block_timestamp: r.block_timestamp,
-                    log_index: r.log_index,
-                    target_address: r.target_address,
-                    value: r.value_bytes.clone(),
-                    is_reverted: r.is_reverted,
-                    revert_reason: r.revert_reason.clone(),
-                })
-                .collect();
-
-            let _ = tx
-                .send(DecoderMessage::EventCallsReady {
-                    range_start,
-                    range_end: range_end + 1,
-                    contract_name: contract_name.clone(),
-                    function_name: function_name.clone(),
-                    results: decoder_results,
-                    live_mode: false,
-                    retry_transform_after_decode: false,
-                })
-                .await;
+            if let Some(decoder_results) = decoder_results {
+                let _ = tx
+                    .send(DecoderMessage::EventCallsReady {
+                        range_start,
+                        range_end: range_end + 1,
+                        contract_name: contract_name.clone(),
+                        function_name: function_name.clone(),
+                        results: decoder_results,
+                        live_mode: false,
+                        retry_transform_after_decode: false,
+                    })
+                    .await;
+            }
         }
     }
 
@@ -1179,7 +1202,8 @@ pub(crate) async fn process_event_triggers_multicall(
                 &function_name,
                 range_start,
                 range_end,
-            )?;
+            )
+            .await?;
         }
     }
 
@@ -1250,6 +1274,19 @@ pub(crate) fn write_event_call_results_to_parquet(
     writer.close()?;
 
     Ok(())
+}
+
+/// Async wrapper for write_event_call_results_to_parquet
+pub(crate) async fn write_event_call_results_to_parquet_async(
+    results: Vec<EventCallResult>,
+    output_path: PathBuf,
+    num_params: usize,
+) -> Result<(), EthCallCollectionError> {
+    tokio::task::spawn_blocking(move || {
+        write_event_call_results_to_parquet(&results, &output_path, num_params)
+    })
+    .await
+    .map_err(|e| EthCallCollectionError::JoinError(e.to_string()))?
 }
 
 /// Build schema for event-triggered call results

--- a/src/raw_data/historical/eth_calls/factory.rs
+++ b/src/raw_data/historical/eth_calls/factory.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use super::types::EthCallCollectionError;
 use crate::storage::paths::{parse_range_from_filename, raw_logs_dir};
@@ -178,7 +179,7 @@ pub(crate) async fn event_output_exists_async(
     function_name: String,
     range_start: u64,
     range_end: u64,
-    s3_manifest: Option<S3Manifest>,
+    s3_manifest: Option<Arc<S3Manifest>>,
 ) -> Result<bool, EthCallCollectionError> {
     tokio::task::spawn_blocking(move || {
         event_output_exists(
@@ -187,7 +188,7 @@ pub(crate) async fn event_output_exists_async(
             &function_name,
             range_start,
             range_end,
-            s3_manifest.as_ref(),
+            s3_manifest.as_deref(),
         )
     })
     .await

--- a/src/raw_data/historical/eth_calls/factory.rs
+++ b/src/raw_data/historical/eth_calls/factory.rs
@@ -3,6 +3,7 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
+use super::types::EthCallCollectionError;
 use crate::storage::paths::{parse_range_from_filename, raw_logs_dir};
 use crate::storage::S3Manifest;
 
@@ -142,4 +143,53 @@ pub(crate) fn event_output_exists(
     }
 
     false
+}
+
+/// Async wrapper for read_logs_from_parquet
+pub(crate) async fn read_logs_from_parquet_async(
+    file_path: PathBuf,
+) -> Result<Vec<crate::raw_data::historical::receipts::LogData>, crate::storage::parquet_readers::ParquetReadError>
+{
+    tokio::task::spawn_blocking(move || read_logs_from_parquet(&file_path))
+        .await
+        .map_err(|e| {
+            crate::storage::parquet_readers::ParquetReadError::Io(std::io::Error::other(
+                e.to_string(),
+            ))
+        })?
+}
+
+/// Async wrapper for get_existing_log_ranges
+pub(crate) async fn get_existing_log_ranges_async(
+    chain_name: String,
+    s3_manifest: Option<S3Manifest>,
+) -> Vec<ExistingLogRange> {
+    tokio::task::spawn_blocking(move || {
+        get_existing_log_ranges(&chain_name, s3_manifest.as_ref())
+    })
+    .await
+    .unwrap_or_default()
+}
+
+/// Async wrapper for event_output_exists
+pub(crate) async fn event_output_exists_async(
+    output_dir: PathBuf,
+    contract_name: String,
+    function_name: String,
+    range_start: u64,
+    range_end: u64,
+    s3_manifest: Option<S3Manifest>,
+) -> Result<bool, EthCallCollectionError> {
+    tokio::task::spawn_blocking(move || {
+        event_output_exists(
+            &output_dir,
+            &contract_name,
+            &function_name,
+            range_start,
+            range_end,
+            s3_manifest.as_ref(),
+        )
+    })
+    .await
+    .map_err(|e| EthCallCollectionError::JoinError(e.to_string()))
 }

--- a/src/raw_data/historical/eth_calls/once_calls.rs
+++ b/src/raw_data/historical/eth_calls/once_calls.rs
@@ -2,12 +2,9 @@
 //! process_factory_once_calls, process_factory_once_calls_multicall.
 
 use std::collections::{HashMap, HashSet};
-use std::fs::File;
 
 use alloy::primitives::Address;
 use alloy::rpc::types::{BlockId, BlockNumberOrTag, TransactionRequest};
-use parquet::arrow::ArrowWriter;
-use parquet::file::properties::WriterProperties;
 
 use super::event_triggers::encode_once_call_params;
 use super::multicall::{
@@ -15,9 +12,11 @@ use super::multicall::{
     OnceCallMeta,
 };
 use super::parquet_io::{
-    extract_addresses_from_once_parquet, extract_existing_results_from_parquet, find_null_entries,
-    merge_once_columns, read_existing_once_parquet, read_once_column_index,
-    read_parquet_column_names, write_once_column_index, write_once_results_to_parquet,
+    extract_addresses_from_once_parquet, extract_existing_results_from_parquet,
+    find_null_entries_async, merge_once_columns, read_existing_once_parquet_async,
+    read_once_column_index_async, read_parquet_column_names_async,
+    write_once_column_index_async, write_once_results_to_parquet_async,
+    write_record_batch_to_parquet_async,
 };
 use super::types::{
     AddressResults, BlockInfo, BlockRange, CollectionResults, ContractProcessingInfo,
@@ -59,7 +58,7 @@ pub(crate) async fn process_once_calls_regular(
 
         let (missing_fn_names, has_existing_file, null_entries) =
             if ctx.existing_files.contains(&rel_path) {
-                let index = read_once_column_index(&sub_dir);
+                let index = read_once_column_index_async(sub_dir.clone()).await;
                 let existing_cols: HashSet<String> = if let Some(cols) = index.get(&file_name) {
                     cols.iter().cloned().collect()
                 } else {
@@ -67,7 +66,7 @@ pub(crate) async fn process_once_calls_regular(
                         "File {} exists but not in index, reading schema from parquet",
                         output_path.display()
                     );
-                    read_parquet_column_names(&output_path)
+                    read_parquet_column_names_async(output_path.clone()).await
                 };
                 let missing: Vec<String> = all_fn_names
                     .iter()
@@ -75,7 +74,7 @@ pub(crate) async fn process_once_calls_regular(
                     .cloned()
                     .collect();
                 // Find addresses with null values for existing columns
-                let all_null_entries = find_null_entries(&output_path);
+                let all_null_entries = find_null_entries_async(output_path.clone()).await;
                 let null_entries: HashMap<String, HashSet<[u8; 20]>> = all_null_entries
                     .into_iter()
                     .filter(|(k, _)| existing_cols.contains(k) && !missing.contains(k))
@@ -247,7 +246,7 @@ pub(crate) async fn process_once_calls_regular(
             }
         }
 
-        std::fs::create_dir_all(&sub_dir)?;
+        tokio::fs::create_dir_all(&sub_dir).await?;
 
         let decoder_once_results: Option<Vec<DecoderOnceCallResult>> = if ctx.decoder_tx.is_some() {
             Some(
@@ -272,7 +271,7 @@ pub(crate) async fn process_once_calls_regular(
                 .map(|(addr, fns)| (addr.0 .0, fns))
                 .collect();
 
-            let existing_batches = read_existing_once_parquet(&output_path)?;
+            let existing_batches = read_existing_once_parquet_async(output_path.clone()).await?;
             if !existing_batches.is_empty() {
                 // Combine missing + patch function names for merge
                 let patch_fn_names: Vec<String> = null_entries.keys().cloned().collect();
@@ -284,13 +283,7 @@ pub(crate) async fn process_once_calls_regular(
                 let merged =
                     merge_once_columns(&existing_batches, &new_results, &all_new_fn_names)?;
 
-                let file = File::create(&output_path)?;
-                let props = WriterProperties::builder()
-                    .set_compression(parquet::basic::Compression::SNAPPY)
-                    .build();
-                let mut writer = ArrowWriter::try_new(file, merged.schema(), Some(props))?;
-                writer.write(&merged)?;
-                writer.close()?;
+                write_record_batch_to_parquet_async(merged, output_path.clone()).await?;
 
                 tracing::info!(
                     "Merged {} new + {} patched once columns into {} for {}",
@@ -331,7 +324,7 @@ pub(crate) async fn process_once_calls_regular(
                     output_path.display()
                 );
 
-                write_once_results_to_parquet(&results, &output_path, &all_fn_names)?;
+                write_once_results_to_parquet_async(results, output_path, all_fn_names.clone()).await?;
             }
         }
 
@@ -351,12 +344,13 @@ pub(crate) async fn process_once_calls_regular(
         }
 
         // Update the column index with all columns present in the file
-        let actual_cols: Vec<String> = read_parquet_column_names(&output_path)
+        let actual_cols: Vec<String> = read_parquet_column_names_async(output_path.clone())
+            .await
             .into_iter()
             .collect();
-        let mut index = read_once_column_index(&sub_dir);
+        let mut index = read_once_column_index_async(sub_dir.clone()).await;
         index.insert(file_name.clone(), actual_cols.clone());
-        write_once_column_index(&sub_dir, &index)?;
+        write_once_column_index_async(sub_dir.to_path_buf(), index).await?;
         tracing::info!(
             "Updated column index for {}: {} now has {} columns: {:?}",
             contract_name,
@@ -417,7 +411,7 @@ pub(crate) async fn process_factory_once_calls(
                 .unwrap_or_default();
 
             // Check actual parquet schema to determine truly missing columns
-            let parquet_cols = read_parquet_column_names(&output_path);
+            let parquet_cols = read_parquet_column_names_async(output_path.clone()).await;
 
             // Missing: in config but not in the parquet file
             let missing: Vec<String> = all_fn_names
@@ -439,7 +433,7 @@ pub(crate) async fn process_factory_once_calls(
                 if unindexed_in_parquet.is_empty() {
                     HashMap::new()
                 } else {
-                    let all_null_entries = find_null_entries(&output_path);
+                    let all_null_entries = find_null_entries_async(output_path.clone()).await;
                     all_null_entries
                         .into_iter()
                         .filter(|(k, _)| !indexed_cols.contains(k))
@@ -507,11 +501,11 @@ pub(crate) async fn process_factory_once_calls(
 
         // Write empty file when no factory addresses discovered (no data for this range)
         if address_discovery.is_empty() && !has_existing_file {
-            std::fs::create_dir_all(&sub_dir)?;
-            write_once_results_to_parquet(&[], &output_path, &all_fn_names)?;
-            let mut index = read_once_column_index(&sub_dir);
+            tokio::fs::create_dir_all(&sub_dir).await?;
+            write_once_results_to_parquet_async(vec![], output_path.clone(), all_fn_names.clone()).await?;
+            let mut index = read_once_column_index_async(sub_dir.clone()).await;
             index.insert(file_name.clone(), all_fn_names.clone());
-            write_once_column_index(&sub_dir, &index)?;
+            write_once_column_index_async(sub_dir.to_path_buf(), index).await?;
             if let Some(tx) = ctx.decoder_tx {
                 let _ = tx
                     .send(DecoderMessage::OnceFileBackfilled {
@@ -651,7 +645,7 @@ pub(crate) async fn process_factory_once_calls(
             HashMap::new()
         };
 
-        std::fs::create_dir_all(&sub_dir)?;
+        tokio::fs::create_dir_all(&sub_dir).await?;
 
         if has_existing_file {
             // Merge new columns into existing parquet
@@ -660,7 +654,7 @@ pub(crate) async fn process_factory_once_calls(
                 .map(|(addr, (_, _, fns))| (addr.0 .0, fns))
                 .collect();
 
-            let existing_batches = read_existing_once_parquet(&output_path)?;
+            let existing_batches = read_existing_once_parquet_async(output_path.clone()).await?;
             if !existing_batches.is_empty() {
                 // Check which addresses already have data for the missing functions
                 let existing_results =
@@ -773,13 +767,7 @@ pub(crate) async fn process_factory_once_calls(
                 let merged =
                     merge_once_columns(&existing_batches, &new_results, &all_new_fn_names)?;
 
-                let file = File::create(&output_path)?;
-                let props = WriterProperties::builder()
-                    .set_compression(parquet::basic::Compression::SNAPPY)
-                    .build();
-                let mut writer = ArrowWriter::try_new(file, merged.schema(), Some(props))?;
-                writer.write(&merged)?;
-                writer.close()?;
+                write_record_batch_to_parquet_async(merged, output_path.clone()).await?;
 
                 tracing::info!(
                     "Merged {} new + {} patched factory once columns into {} for {}",
@@ -809,7 +797,7 @@ pub(crate) async fn process_factory_once_calls(
                     output_path.display()
                 );
 
-                write_once_results_to_parquet(&results, &output_path, &all_fn_names)?;
+                write_once_results_to_parquet_async(results, output_path.clone(), all_fn_names.clone()).await?;
             }
         }
 
@@ -829,12 +817,13 @@ pub(crate) async fn process_factory_once_calls(
         }
 
         // Update the column index with all columns present in the file
-        let actual_cols: Vec<String> = read_parquet_column_names(&output_path)
+        let actual_cols: Vec<String> = read_parquet_column_names_async(output_path.clone())
+            .await
             .into_iter()
             .collect();
-        let mut index = read_once_column_index(&sub_dir);
+        let mut index = read_once_column_index_async(sub_dir.clone()).await;
         index.insert(file_name.clone(), actual_cols.clone());
-        write_once_column_index(&sub_dir, &index)?;
+        write_once_column_index_async(sub_dir.to_path_buf(), index).await?;
         tracing::info!(
             "Updated column index for factory {}: {} now has {} columns: {:?}",
             collection_name,
@@ -892,11 +881,11 @@ pub(crate) async fn process_once_calls_multicall(
 
         let (missing_fn_names, has_existing_file, null_entries) =
             if ctx.existing_files.contains(&rel_path) {
-                let index = read_once_column_index(&sub_dir);
+                let index = read_once_column_index_async(sub_dir.clone()).await;
                 let existing_cols: HashSet<String> = if let Some(cols) = index.get(&file_name) {
                     cols.iter().cloned().collect()
                 } else {
-                    read_parquet_column_names(&output_path)
+                    read_parquet_column_names_async(output_path.clone()).await
                 };
                 let missing: Vec<String> = all_fn_names
                     .iter()
@@ -904,7 +893,7 @@ pub(crate) async fn process_once_calls_multicall(
                     .cloned()
                     .collect();
                 // Find addresses with null values for existing columns
-                let all_null_entries = find_null_entries(&output_path);
+                let all_null_entries = find_null_entries_async(output_path.clone()).await;
                 let null_entries: HashMap<String, HashSet<[u8; 20]>> = all_null_entries
                     .into_iter()
                     .filter(|(k, _)| existing_cols.contains(k) && !missing.contains(k))
@@ -1080,7 +1069,7 @@ pub(crate) async fn process_once_calls_multicall(
     } in contracts_to_process
     {
         let sub_dir = output_path.parent().unwrap();
-        std::fs::create_dir_all(sub_dir)?;
+        tokio::fs::create_dir_all(sub_dir).await?;
 
         if let Some(results_by_address) = results_by_contract.remove(&contract_name) {
             let decoder_once_results: Option<Vec<DecoderOnceCallResult>> =
@@ -1106,7 +1095,7 @@ pub(crate) async fn process_once_calls_multicall(
                     .map(|(addr, fns)| (addr.0 .0, fns))
                     .collect();
 
-                let existing_batches = read_existing_once_parquet(&output_path)?;
+                let existing_batches = read_existing_once_parquet_async(output_path.clone()).await?;
                 if !existing_batches.is_empty() {
                     // Combine missing + patch function names for merge
                     let all_new_fn_names: Vec<String> = missing_fn_names
@@ -1117,13 +1106,7 @@ pub(crate) async fn process_once_calls_multicall(
                     let merged =
                         merge_once_columns(&existing_batches, &new_results, &all_new_fn_names)?;
 
-                    let file = File::create(&output_path)?;
-                    let props = WriterProperties::builder()
-                        .set_compression(parquet::basic::Compression::SNAPPY)
-                        .build();
-                    let mut writer = ArrowWriter::try_new(file, merged.schema(), Some(props))?;
-                    writer.write(&merged)?;
-                    writer.close()?;
+                    write_record_batch_to_parquet_async(merged, output_path.clone()).await?;
 
                     tracing::info!(
                         "Merged {} new + {} patched multicall once columns into {} for {}",
@@ -1151,7 +1134,7 @@ pub(crate) async fn process_once_calls_multicall(
                         output_path.display()
                     );
 
-                    write_once_results_to_parquet(&results, &output_path, &all_fn_names)?;
+                    write_once_results_to_parquet_async(results, output_path.clone(), all_fn_names.clone()).await?;
                 }
             }
 
@@ -1176,12 +1159,13 @@ pub(crate) async fn process_once_calls_multicall(
                 .unwrap()
                 .to_string_lossy()
                 .to_string();
-            let actual_cols: Vec<String> = read_parquet_column_names(&output_path)
+            let actual_cols: Vec<String> = read_parquet_column_names_async(output_path.clone())
+                .await
                 .into_iter()
                 .collect();
-            let mut index = read_once_column_index(sub_dir);
+            let mut index = read_once_column_index_async(sub_dir.to_path_buf()).await;
             index.insert(file_name.clone(), actual_cols.clone());
-            write_once_column_index(sub_dir, &index)?;
+            write_once_column_index_async(sub_dir.to_path_buf(), index).await?;
 
             if let Some(tx) = ctx.decoder_tx {
                 if let Some(results) = decoder_once_results {
@@ -1240,7 +1224,7 @@ pub(crate) async fn process_factory_once_calls_multicall(
                     .unwrap_or_default();
 
                 // Check actual parquet schema to determine truly missing columns
-                let parquet_cols = read_parquet_column_names(&output_path);
+                let parquet_cols = read_parquet_column_names_async(output_path.clone()).await;
 
                 // Missing: in config but not in the parquet file
                 let missing: Vec<String> = all_fn_names
@@ -1262,7 +1246,7 @@ pub(crate) async fn process_factory_once_calls_multicall(
                     if unindexed_in_parquet.is_empty() {
                         HashMap::new()
                     } else {
-                        let all_null_entries = find_null_entries(&output_path);
+                        let all_null_entries = find_null_entries_async(output_path.clone()).await;
                         all_null_entries
                             .into_iter()
                             .filter(|(k, _)| !indexed_cols.contains(k))
@@ -1302,11 +1286,11 @@ pub(crate) async fn process_factory_once_calls_multicall(
 
         // Write empty file when no factory addresses discovered (no data for this range)
         if address_discovery.is_empty() && !has_existing_file {
-            std::fs::create_dir_all(&sub_dir)?;
-            write_once_results_to_parquet(&[], &output_path, &all_fn_names)?;
-            let mut index = read_once_column_index(&sub_dir);
+            tokio::fs::create_dir_all(&sub_dir).await?;
+            write_once_results_to_parquet_async(vec![], output_path.clone(), all_fn_names.clone()).await?;
+            let mut index = read_once_column_index_async(sub_dir.clone()).await;
             index.insert(file_name.clone(), all_fn_names.clone());
-            write_once_column_index(&sub_dir, &index)?;
+            write_once_column_index_async(sub_dir.to_path_buf(), index).await?;
             continue;
         }
 
@@ -1473,7 +1457,7 @@ pub(crate) async fn process_factory_once_calls_multicall(
     } in collections_to_process
     {
         let sub_dir = output_path.parent().unwrap();
-        std::fs::create_dir_all(sub_dir)?;
+        tokio::fs::create_dir_all(sub_dir).await?;
 
         // Get results for this collection (may be None if no new addresses discovered)
         let results_by_address = results_by_collection.remove(&collection_name);
@@ -1489,7 +1473,7 @@ pub(crate) async fn process_factory_once_calls_multicall(
                         .map(|(addr, (_, _, fns))| (addr.0 .0, fns))
                         .collect();
 
-                let existing_batches = read_existing_once_parquet(&output_path)?;
+                let existing_batches = read_existing_once_parquet_async(output_path.clone()).await?;
                 if !existing_batches.is_empty() {
                     // Check which addresses already have data for the missing functions
                     let existing_results =
@@ -1619,13 +1603,7 @@ pub(crate) async fn process_factory_once_calls_multicall(
                     let merged =
                         merge_once_columns(&existing_batches, &new_results, &all_new_fn_names)?;
 
-                    let file = File::create(&output_path)?;
-                    let props = WriterProperties::builder()
-                        .set_compression(parquet::basic::Compression::SNAPPY)
-                        .build();
-                    let mut writer = ArrowWriter::try_new(file, merged.schema(), Some(props))?;
-                    writer.write(&merged)?;
-                    writer.close()?;
+                    write_record_batch_to_parquet_async(merged, output_path.clone()).await?;
 
                     tracing::info!(
                         "Merged {} new + {} patched multicall factory once columns into {} for {}",
@@ -1655,7 +1633,7 @@ pub(crate) async fn process_factory_once_calls_multicall(
                         output_path.display()
                     );
 
-                    write_once_results_to_parquet(&results, &output_path, &all_fn_names)?;
+                    write_once_results_to_parquet_async(results, output_path.clone(), all_fn_names.clone()).await?;
                 }
             }
 
@@ -1680,12 +1658,13 @@ pub(crate) async fn process_factory_once_calls_multicall(
                 .unwrap()
                 .to_string_lossy()
                 .to_string();
-            let actual_cols: Vec<String> = read_parquet_column_names(&output_path)
+            let actual_cols: Vec<String> = read_parquet_column_names_async(output_path.clone())
+                .await
                 .into_iter()
                 .collect();
-            let mut index = read_once_column_index(sub_dir);
+            let mut index = read_once_column_index_async(sub_dir.to_path_buf()).await;
             index.insert(file_name.clone(), actual_cols.clone());
-            write_once_column_index(sub_dir, &index)?;
+            write_once_column_index_async(sub_dir.to_path_buf(), index).await?;
 
             if let Some(tx) = ctx.decoder_tx {
                 let _ = tx

--- a/src/raw_data/historical/eth_calls/parquet_io.rs
+++ b/src/raw_data/historical/eth_calls/parquet_io.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use arrow::array::{
@@ -18,6 +18,12 @@ use crate::storage::paths::scan_nested_parquet_files_2;
 
 pub(crate) fn scan_existing_parquet_files(dir: &Path) -> HashSet<String> {
     scan_nested_parquet_files_2(dir)
+}
+
+pub(crate) async fn scan_existing_parquet_files_async(dir: PathBuf) -> HashSet<String> {
+    tokio::task::spawn_blocking(move || scan_existing_parquet_files(&dir))
+        .await
+        .unwrap_or_default()
 }
 
 pub(crate) fn build_schema(num_params: usize) -> Arc<Schema> {
@@ -614,4 +620,106 @@ pub(crate) fn write_once_results_to_parquet(
     writer.close()?;
 
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Sync helper: write a RecordBatch directly to a parquet file
+// ---------------------------------------------------------------------------
+
+pub(crate) fn write_record_batch_to_parquet(
+    batch: &RecordBatch,
+    output_path: &Path,
+) -> Result<(), EthCallCollectionError> {
+    let file = File::create(output_path)?;
+    let props = WriterProperties::builder()
+        .set_compression(parquet::basic::Compression::SNAPPY)
+        .build();
+    let mut writer = ArrowWriter::try_new(file, batch.schema(), Some(props))?;
+    writer.write(batch)?;
+    writer.close()?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Async wrappers: offload blocking file I/O to spawn_blocking
+// ---------------------------------------------------------------------------
+
+pub(crate) async fn write_results_to_parquet_async(
+    results: Vec<CallResult>,
+    output_path: PathBuf,
+    num_params: usize,
+) -> Result<(), EthCallCollectionError> {
+    tokio::task::spawn_blocking(move || {
+        write_results_to_parquet(&results, &output_path, num_params)
+    })
+    .await
+    .map_err(|e| EthCallCollectionError::JoinError(e.to_string()))?
+}
+
+pub(crate) async fn write_once_results_to_parquet_async(
+    results: Vec<OnceCallResult>,
+    output_path: PathBuf,
+    function_names: Vec<String>,
+) -> Result<(), EthCallCollectionError> {
+    tokio::task::spawn_blocking(move || {
+        write_once_results_to_parquet(&results, &output_path, &function_names)
+    })
+    .await
+    .map_err(|e| EthCallCollectionError::JoinError(e.to_string()))?
+}
+
+pub(crate) async fn write_record_batch_to_parquet_async(
+    batch: RecordBatch,
+    output_path: PathBuf,
+) -> Result<(), EthCallCollectionError> {
+    tokio::task::spawn_blocking(move || write_record_batch_to_parquet(&batch, &output_path))
+        .await
+        .map_err(|e| EthCallCollectionError::JoinError(e.to_string()))?
+}
+
+pub(crate) async fn read_parquet_column_names_async(path: PathBuf) -> HashSet<String> {
+    tokio::task::spawn_blocking(move || read_parquet_column_names(&path))
+        .await
+        .unwrap_or_default()
+}
+
+pub(crate) async fn read_existing_once_parquet_async(
+    path: PathBuf,
+) -> Result<Vec<RecordBatch>, EthCallCollectionError> {
+    tokio::task::spawn_blocking(move || read_existing_once_parquet(&path))
+        .await
+        .map_err(|e| EthCallCollectionError::JoinError(e.to_string()))?
+}
+
+pub(crate) async fn load_or_build_once_column_index_async(
+    once_dir: PathBuf,
+) -> HashMap<String, Vec<String>> {
+    tokio::task::spawn_blocking(move || load_or_build_once_column_index(&once_dir))
+        .await
+        .unwrap_or_default()
+}
+
+pub(crate) async fn read_once_column_index_async(
+    once_dir: PathBuf,
+) -> HashMap<String, Vec<String>> {
+    tokio::task::spawn_blocking(move || read_once_column_index(&once_dir))
+        .await
+        .unwrap_or_default()
+}
+
+pub(crate) async fn write_once_column_index_async(
+    once_dir: PathBuf,
+    index: HashMap<String, Vec<String>>,
+) -> Result<(), EthCallCollectionError> {
+    tokio::task::spawn_blocking(move || write_once_column_index(&once_dir, &index))
+        .await
+        .map_err(|e| EthCallCollectionError::JoinError(e.to_string()))?
+}
+
+pub(crate) async fn find_null_entries_async(
+    path: PathBuf,
+) -> HashMap<String, HashSet<[u8; 20]>> {
+    tokio::task::spawn_blocking(move || find_null_entries(&path))
+        .await
+        .unwrap_or_default()
 }

--- a/src/raw_data/historical/eth_calls/postprocessing.rs
+++ b/src/raw_data/historical/eth_calls/postprocessing.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use tokio::sync::mpsc::Sender;
 
-use super::parquet_io::write_results_to_parquet;
+use super::parquet_io::write_results_to_parquet_async;
 use super::types::{CallResult, EthCallCollectionError, FrequencyState};
 use crate::decoding::{DecoderMessage, EthCallResult as DecoderEthCallResult};
 use crate::storage::{upload_parquet_to_s3, StorageManager};
@@ -85,16 +85,12 @@ pub(crate) async fn finalize_regular_results(
         None
     };
 
-    // 1. Parquet write via spawn_blocking
+    // 1. Parquet write via async wrapper
     let max_params = params.max_params;
     let results = params.results;
     #[cfg(feature = "bench")]
     let write_start = std::time::Instant::now();
-    tokio::task::spawn_blocking(move || {
-        write_results_to_parquet(&results, &output_path, max_params)
-    })
-    .await
-    .map_err(|e| EthCallCollectionError::JoinError(e.to_string()))??;
+    write_results_to_parquet_async(results, output_path.clone(), max_params).await?;
 
     // 2. Bench recording
     #[cfg(feature = "bench")]

--- a/src/raw_data/historical/eth_calls/regular_calls.rs
+++ b/src/raw_data/historical/eth_calls/regular_calls.rs
@@ -218,7 +218,7 @@ pub(crate) async fn process_factory_range(
                 .sort_by_key(|r| (r.block_number, r.contract_address, r.param_values.clone()));
 
             let sub_dir = ctx.output_dir.join(collection_name).join(&function_name);
-            std::fs::create_dir_all(&sub_dir)?;
+            tokio::fs::create_dir_all(&sub_dir).await?;
 
             let last_ts = filtered_blocks.last().map(|b| b.timestamp);
 
@@ -482,7 +482,7 @@ pub(crate) async fn process_factory_range_multicall(
                 .output_dir
                 .join(&group.collection_name)
                 .join(&group.function_name);
-            std::fs::create_dir_all(&sub_dir)?;
+            tokio::fs::create_dir_all(&sub_dir).await?;
 
             let last_ts = group.filtered_blocks.last().map(|b| b.timestamp);
 
@@ -666,7 +666,7 @@ pub(crate) async fn process_range(
         all_results.sort_by_key(|r| (r.block_number, r.contract_address, r.param_values.clone()));
 
         let sub_dir = ctx.output_dir.join(contract_name).join(function_name);
-        std::fs::create_dir_all(&sub_dir)?;
+        tokio::fs::create_dir_all(&sub_dir).await?;
 
         let last_ts = filtered_blocks.last().map(|b| b.timestamp);
 
@@ -888,7 +888,7 @@ pub(crate) async fn process_range_multicall(
                 .output_dir
                 .join(&group.contract_name)
                 .join(&group.function_name);
-            std::fs::create_dir_all(&sub_dir)?;
+            tokio::fs::create_dir_all(&sub_dir).await?;
 
             let last_ts = group.filtered_blocks.last().map(|b| b.timestamp);
 

--- a/src/raw_data/historical/eth_calls/token_calls.rs
+++ b/src/raw_data/historical/eth_calls/token_calls.rs
@@ -224,7 +224,7 @@ pub(crate) async fn process_token_range_multicall(
                 .output_dir
                 .join(&group.output_name)
                 .join(&group.function_name);
-            std::fs::create_dir_all(&sub_dir)?;
+            tokio::fs::create_dir_all(&sub_dir).await?;
 
             let last_ts = group.filtered_blocks.last().map(|b| b.timestamp);
 
@@ -368,7 +368,7 @@ pub(crate) async fn process_token_range(
         all_results.sort_by_key(|r| (r.block_number, r.contract_address));
 
         let sub_dir = ctx.output_dir.join(&output_name).join(function_name);
-        std::fs::create_dir_all(&sub_dir)?;
+        tokio::fs::create_dir_all(&sub_dir).await?;
 
         let last_ts = filtered_blocks.last().map(|b| b.timestamp);
 

--- a/src/raw_data/historical/factories.rs
+++ b/src/raw_data/historical/factories.rs
@@ -291,6 +291,15 @@ pub(crate) async fn process_range(
     })
 }
 
+/// Async wrapper for `read_log_batches_from_parquet` that runs on the blocking threadpool.
+pub(crate) async fn read_log_batches_from_parquet_async(
+    file_path: PathBuf,
+) -> Result<Vec<RecordBatch>, FactoryCollectionError> {
+    tokio::task::spawn_blocking(move || read_log_batches_from_parquet(&file_path))
+        .await
+        .map_err(|e| FactoryCollectionError::JoinError(e.to_string()))?
+}
+
 /// Read log batches from a parquet file with column projection.
 /// Only reads block_number, block_timestamp, address, topics, data — skips transaction_hash and log_index.
 pub(crate) fn read_log_batches_from_parquet(
@@ -524,14 +533,9 @@ async fn write_factory_parquet_files(
 
         let record_count = collection_records.len();
         let sub_dir = output_dir.join(&collection_name);
-        std::fs::create_dir_all(&sub_dir)?;
+        tokio::fs::create_dir_all(&sub_dir).await?;
         let output_path = sub_dir.join(&file_name);
-        let output_path_clone = output_path.clone();
-        tokio::task::spawn_blocking(move || {
-            write_factory_records_to_parquet(&collection_records, &output_path_clone)
-        })
-        .await
-        .map_err(|e| FactoryCollectionError::JoinError(e.to_string()))??;
+        write_factory_records_to_parquet_async(collection_records, output_path.clone()).await?;
 
         tracing::info!(
             "Wrote {} factory addresses for {} to {}",
@@ -567,14 +571,9 @@ async fn write_factory_parquet_files(
                     .is_some_and(|m| m.has_factories(collection_name, range_start, range_end - 1))
             {
                 let sub_dir = output_dir.join(collection_name);
-                std::fs::create_dir_all(&sub_dir)?;
+                tokio::fs::create_dir_all(&sub_dir).await?;
                 let output_path = sub_dir.join(&file_name);
-                let output_path_clone = output_path.clone();
-                tokio::task::spawn_blocking(move || {
-                    write_empty_factory_parquet(&output_path_clone)
-                })
-                .await
-                .map_err(|e| FactoryCollectionError::JoinError(e.to_string()))??;
+                write_empty_factory_parquet_async(output_path.clone()).await?;
 
                 tracing::debug!(
                     "Wrote empty factory file for {} range {}-{}",
@@ -652,6 +651,17 @@ fn decode_address_from_data(
     }
 }
 
+pub(crate) async fn write_factory_records_to_parquet_async(
+    records: Vec<FactoryRecord>,
+    output_path: PathBuf,
+) -> Result<(), FactoryCollectionError> {
+    tokio::task::spawn_blocking(move || {
+        write_factory_records_to_parquet(&records, &output_path)
+    })
+    .await
+    .map_err(|e| FactoryCollectionError::JoinError(e.to_string()))?
+}
+
 fn write_factory_records_to_parquet(
     records: &[FactoryRecord],
     output_path: &Path,
@@ -696,6 +706,14 @@ fn write_factory_records_to_parquet(
 
 pub(crate) fn scan_existing_parquet_files(dir: &Path) -> HashSet<String> {
     scan_nested_parquet_files_1(dir)
+}
+
+pub(crate) async fn load_factory_addresses_from_parquet_async(
+    dir: PathBuf,
+) -> Result<Vec<FactoryAddressData>, FactoryCollectionError> {
+    tokio::task::spawn_blocking(move || load_factory_addresses_from_parquet(&dir))
+        .await
+        .map_err(|e| FactoryCollectionError::JoinError(e.to_string()))?
 }
 
 pub(crate) fn load_factory_addresses_from_parquet(
@@ -877,6 +895,14 @@ pub fn get_factory_collection_names(
     }
 
     names
+}
+
+pub(crate) async fn write_empty_factory_parquet_async(
+    output_path: PathBuf,
+) -> Result<(), FactoryCollectionError> {
+    tokio::task::spawn_blocking(move || write_empty_factory_parquet(&output_path))
+        .await
+        .map_err(|e| FactoryCollectionError::JoinError(e.to_string()))?
 }
 
 fn write_empty_factory_parquet(output_path: &Path) -> Result<(), FactoryCollectionError> {

--- a/src/raw_data/historical/logs.rs
+++ b/src/raw_data/historical/logs.rs
@@ -209,14 +209,14 @@ pub(crate) async fn process_range(
                     data: l.data,
                 })
                 .collect();
-            let schema_clone = schema.clone();
-            let fields_vec = fields.to_vec();
             let output_path = output_dir.join(range.file_name("logs"));
-            tokio::task::spawn_blocking(move || {
-                write_minimal_logs_to_parquet(&records, &schema_clone, &fields_vec, &output_path)
-            })
-            .await
-            .map_err(|e| LogCollectionError::JoinError(e.to_string()))??;
+            write_minimal_logs_to_parquet_async(
+                records,
+                schema.clone(),
+                fields.to_vec(),
+                output_path,
+            )
+            .await?;
         }
         None => {
             let records: Vec<FullLogRecord> = logs
@@ -231,13 +231,8 @@ pub(crate) async fn process_range(
                     data: l.data,
                 })
                 .collect();
-            let schema_clone = schema.clone();
             let output_path = output_dir.join(range.file_name("logs"));
-            tokio::task::spawn_blocking(move || {
-                write_full_logs_to_parquet(&records, &schema_clone, &output_path)
-            })
-            .await
-            .map_err(|e| LogCollectionError::JoinError(e.to_string()))??;
+            write_full_logs_to_parquet_async(records, schema.clone(), output_path).await?;
         }
     }
 
@@ -465,4 +460,29 @@ pub(crate) fn write_parquet(
     writer.close()?;
 
     Ok(())
+}
+
+pub(crate) async fn write_minimal_logs_to_parquet_async(
+    records: Vec<MinimalLogRecord>,
+    schema: Arc<Schema>,
+    fields: Vec<LogField>,
+    output_path: PathBuf,
+) -> Result<(), LogCollectionError> {
+    tokio::task::spawn_blocking(move || {
+        write_minimal_logs_to_parquet(&records, &schema, &fields, &output_path)
+    })
+    .await
+    .map_err(|e| LogCollectionError::JoinError(e.to_string()))?
+}
+
+pub(crate) async fn write_full_logs_to_parquet_async(
+    records: Vec<FullLogRecord>,
+    schema: Arc<Schema>,
+    output_path: PathBuf,
+) -> Result<(), LogCollectionError> {
+    tokio::task::spawn_blocking(move || {
+        write_full_logs_to_parquet(&records, &schema, &output_path)
+    })
+    .await
+    .map_err(|e| LogCollectionError::JoinError(e.to_string()))?
 }

--- a/src/raw_data/historical/receipts.rs
+++ b/src/raw_data/historical/receipts.rs
@@ -917,30 +917,23 @@ pub(crate) async fn process_range(
     let total_receipts = match receipt_fields {
         Some(fields) => {
             let count = all_minimal_records.len();
-            let schema_clone = schema.clone();
-            let fields_vec = fields.to_vec();
-            let output_path_clone = output_path.clone();
-            tokio::task::spawn_blocking(move || {
-                write_minimal_receipts_to_parquet(
-                    &all_minimal_records,
-                    &schema_clone,
-                    &fields_vec,
-                    &output_path_clone,
-                )
-            })
-            .await
-            .map_err(|e| ReceiptCollectionError::JoinError(e.to_string()))??;
+            write_minimal_receipts_to_parquet_async(
+                all_minimal_records,
+                schema.clone(),
+                fields.to_vec(),
+                output_path.clone(),
+            )
+            .await?;
             count
         }
         None => {
             let count = all_full_records.len();
-            let schema_clone = schema.clone();
-            let output_path_clone = output_path.clone();
-            tokio::task::spawn_blocking(move || {
-                write_full_receipts_to_parquet(&all_full_records, &schema_clone, &output_path_clone)
-            })
-            .await
-            .map_err(|e| ReceiptCollectionError::JoinError(e.to_string()))??;
+            write_full_receipts_to_parquet_async(
+                all_full_records,
+                schema.clone(),
+                output_path.clone(),
+            )
+            .await?;
             count
         }
     };
@@ -1098,6 +1091,22 @@ pub(crate) fn scan_existing_parquet_files(dir: &Path) -> HashSet<String> {
 
 pub(crate) fn scan_existing_logs_files(dir: &Path) -> HashSet<String> {
     scan_parquet_filenames(dir, "logs_")
+}
+
+pub(crate) async fn scan_existing_parquet_files_async(
+    dir: std::path::PathBuf,
+) -> Result<HashSet<String>, ReceiptCollectionError> {
+    tokio::task::spawn_blocking(move || scan_existing_parquet_files(&dir))
+        .await
+        .map_err(|e| ReceiptCollectionError::JoinError(e.to_string()))
+}
+
+pub(crate) async fn scan_existing_logs_files_async(
+    dir: std::path::PathBuf,
+) -> Result<HashSet<String>, ReceiptCollectionError> {
+    tokio::task::spawn_blocking(move || scan_existing_logs_files(&dir))
+        .await
+        .map_err(|e| ReceiptCollectionError::JoinError(e.to_string()))
 }
 
 pub(crate) fn build_receipt_schema(fields: &Option<Vec<ReceiptField>>) -> Arc<Schema> {
@@ -1282,4 +1291,29 @@ fn write_parquet(
     writer.close()?;
 
     Ok(())
+}
+
+pub(crate) async fn write_minimal_receipts_to_parquet_async(
+    records: Vec<MinimalReceiptRecord>,
+    schema: Arc<Schema>,
+    fields: Vec<ReceiptField>,
+    output_path: std::path::PathBuf,
+) -> Result<(), ReceiptCollectionError> {
+    tokio::task::spawn_blocking(move || {
+        write_minimal_receipts_to_parquet(&records, &schema, &fields, &output_path)
+    })
+    .await
+    .map_err(|e| ReceiptCollectionError::JoinError(e.to_string()))?
+}
+
+pub(crate) async fn write_full_receipts_to_parquet_async(
+    records: Vec<FullReceiptRecord>,
+    schema: Arc<Schema>,
+    output_path: std::path::PathBuf,
+) -> Result<(), ReceiptCollectionError> {
+    tokio::task::spawn_blocking(move || {
+        write_full_receipts_to_parquet(&records, &schema, &output_path)
+    })
+    .await
+    .map_err(|e| ReceiptCollectionError::JoinError(e.to_string()))?
 }


### PR DESCRIPTION
## Summary

Moves all synchronous `std::fs` operations off the tokio async runtime in `src/raw_data/historical/`, following the same patterns established in PR #66 for live mode.

Under load, blocking file I/O on the async runtime starves worker threads, causing latency spikes or deadlocks in concurrent async tasks (RPC calls, WebSocket handling, database queries, channel sends).

### What changed

**Async wrappers for parquet write functions** (18 files, ~40+ call sites):
- `blocks.rs`: `write_minimal_blocks_to_parquet_async`, `write_full_blocks_to_parquet_async`, `get_existing_block_ranges_async`, `read_block_info_from_parquet_async`
- `logs.rs`: `write_minimal_logs_to_parquet_async`, `write_full_logs_to_parquet_async`
- `receipts.rs`: `write_minimal_receipts_to_parquet_async`, `write_full_receipts_to_parquet_async`, `scan_existing_parquet_files_async`, `scan_existing_logs_files_async`
- `factories.rs`: `write_factory_records_to_parquet_async`, `write_empty_factory_parquet_async`, `load_factory_addresses_from_parquet_async`, `read_log_batches_from_parquet_async`
- `eth_calls/parquet_io.rs`: `write_results_to_parquet_async`, `write_once_results_to_parquet_async`, `write_record_batch_to_parquet_async`, `read_parquet_column_names_async`, `read_existing_once_parquet_async`, `load_or_build_once_column_index_async`, `read_once_column_index_async`, `write_once_column_index_async`, `find_null_entries_async`, `scan_existing_parquet_files_async`
- `eth_calls/event_triggers.rs`: `write_event_call_results_to_parquet_async`
- `eth_calls/factory.rs`: `get_existing_log_ranges_async`, `event_output_exists_async`, `read_logs_from_parquet_async`

**Simple fs ops replaced with tokio::fs**:
- All `std::fs::create_dir_all` → `tokio::fs::create_dir_all` in catchup/, current/, and eth_calls/ modules
- `std::fs::remove_file` → `tokio::fs::remove_file` in catchup/factories.rs

**Existing manual `spawn_blocking` simplified**:
- Call sites that previously did manual `spawn_blocking` + error mapping now call the async wrappers directly

### Design

Sync parquet functions remain as internal implementation details (the Arrow/parquet libraries are inherently synchronous). Each gets an async wrapper that takes owned data, moves it into a `spawn_blocking` closure, and maps `JoinError` through the existing `JoinError(String)` error variants. All error types already had this variant.

New shared helper `write_record_batch_to_parquet` consolidates the 4 inline `File::create + ArrowWriter` patterns in `once_calls.rs`.

### Why

Blocking file I/O on the tokio runtime is a correctness issue. When the runtime's thread pool is saturated with blocking operations, no async tasks can make progress — including RPC calls, WebSocket handling, database queries, and channel sends.