### PR TITLE
fix: use update_status_atomic for all status file mutations

### DIFF
--- a/docs/LIVE_MODE.md
+++ b/docs/LIVE_MODE.md
@@ -553,7 +553,7 @@ On startup, `ensure_dirs()` cleans up any leftover `.tmp` files from interrupted
 
 ### Atomic Status Updates
 
-Status files support atomic read-modify-write via `update_status_atomic()`, which uses a separate `.json.lock` file with exclusive file locking to prevent concurrent updates from overwriting each other:
+All status mutations (except the initial `write_status` that creates the file) go through `update_status_atomic()`, which uses a separate `.json.lock` file with exclusive file locking to prevent concurrent updates from overwriting each other:
 
 ```rust
 storage.update_status_atomic(block_number, |status| {

--- a/src/decoding/current/eth_calls/range_processor.rs
+++ b/src/decoding/current/eth_calls/range_processor.rs
@@ -108,15 +108,17 @@ pub(super) async fn handle_block_complete(
     complete_tx: Option<&Sender<RangeCompleteMessage>>,
     transform_retry_tx: Option<&Sender<TransformRetryRequest>>,
 ) {
-    if let Ok(mut status) = live_storage.read_status(range_start) {
+    match live_storage.update_status_atomic(range_start, |status| {
         status.eth_calls_decoded = true;
-        if let Err(e) = live_storage.write_status(range_start, &status) {
+    }) {
+        Ok(()) => {
+            tracing::debug!("Block {} eth_calls decoded", range_start);
+        }
+        Err(e) => {
             tracing::warn!(
                 "Failed to update block status after eth_call block completion: {}",
                 e
             );
-        } else {
-            tracing::debug!("Block {} eth_calls decoded", range_start);
         }
     }
 

--- a/src/decoding/logs.rs
+++ b/src/decoding/logs.rs
@@ -1227,18 +1227,18 @@ pub(crate) async fn process_logs_live(
     }
 
     // Update block status to mark log decoding complete
-    if let Ok(mut status) = storage.read_status(block_number) {
+    match storage.update_status_atomic(block_number, |status| {
         status.logs_decoded = true;
-        if let Err(e) = storage.write_status(block_number, &status) {
-            tracing::warn!("Failed to update block status after log decoding: {}", e);
-        } else {
+    }) {
+        Ok(()) => {
             tracing::info!("Block {} logs decoded", block_number);
         }
-    } else {
-        tracing::warn!(
-            "Block {} status file not found for log decode completion",
-            block_number
-        );
+        Err(e) => {
+            tracing::warn!(
+                "Failed to update block status after log decoding: {}",
+                e
+            );
+        }
     }
 
     // Signal that all events for this block have been sent

--- a/src/live/collector.rs
+++ b/src/live/collector.rs
@@ -372,9 +372,9 @@ impl LiveCollector {
         self.storage.write_block(&updated_block)?;
 
         // Update status
-        let mut status = self.storage.read_status(block_number)?;
-        status.block_fetched = true;
-        self.storage.write_status(block_number, &status)?;
+        self.storage.update_status_atomic(block_number, |status| {
+            status.block_fetched = true;
+        })?;
 
         tracing::info!(
             "Block {} collected: {} txs",
@@ -413,12 +413,12 @@ impl LiveCollector {
         }
 
         // Update status
-        let mut status = self.storage.read_status(block_number)?;
-        status.receipts_collected = true;
-        status.logs_collected = true;
-        // Factory extraction is always done at this point (even if no factories found)
-        status.factories_extracted = true;
-        self.storage.write_status(block_number, &status)?;
+        self.storage.update_status_atomic(block_number, |status| {
+            status.receipts_collected = true;
+            status.logs_collected = true;
+            // Factory extraction is always done at this point (even if no factories found)
+            status.factories_extracted = true;
+        })?;
 
         // Send to live message channel
         live_tx
@@ -491,9 +491,9 @@ impl LiveCollector {
 
         // If no log decoder is configured, mark logs as decoded
         if log_decoder_tx.is_none() {
-            let mut status = self.storage.read_status(block_number)?;
-            status.logs_decoded = true;
-            self.storage.write_status(block_number, &status)?;
+            self.storage.update_status_atomic(block_number, |status| {
+                status.logs_decoded = true;
+            })?;
         }
 
         // Collect eth_calls if configured
@@ -545,10 +545,10 @@ impl LiveCollector {
             }
         } else {
             // No eth_call collector configured - mark as collected and decoded
-            let mut status = self.storage.read_status(block_number)?;
-            status.eth_calls_collected = true;
-            status.eth_calls_decoded = true;
-            self.storage.write_status(block_number, &status)?;
+            self.storage.update_status_atomic(block_number, |status| {
+                status.eth_calls_collected = true;
+                status.eth_calls_decoded = true;
+            })?;
         };
 
         // If no handlers are registered, mark transformed=true
@@ -940,19 +940,20 @@ impl LiveCollector {
         self.storage.delete_snapshots(block_number)?;
         self.clear_persisted_progress(block_number).await?;
 
-        let mut status = self.storage.read_status(block_number)?;
-        status.block_fetched = false;
-        status.receipts_collected = false;
-        status.logs_collected = false;
-        status.factories_extracted = false;
-        status.eth_calls_collected = false;
-        status.logs_decoded = false;
-        status.eth_calls_decoded = false;
-        status.transformed = false;
-        status.completed_handlers.clear();
-        status.failed_handlers.clear();
-        status.apply_expectations(&self.expectations);
-        self.storage.write_status(block_number, &status)?;
+        let expectations = &self.expectations;
+        self.storage.update_status_atomic(block_number, |status| {
+            status.block_fetched = false;
+            status.receipts_collected = false;
+            status.logs_collected = false;
+            status.factories_extracted = false;
+            status.eth_calls_collected = false;
+            status.logs_decoded = false;
+            status.eth_calls_decoded = false;
+            status.transformed = false;
+            status.completed_handlers.clear();
+            status.failed_handlers.clear();
+            status.apply_expectations(expectations);
+        })?;
 
         Ok(())
     }
@@ -968,18 +969,19 @@ impl LiveCollector {
         self.storage.delete_snapshots(block_number)?;
         self.clear_persisted_progress(block_number).await?;
 
-        let mut status = self.storage.read_status(block_number)?;
-        status.receipts_collected = false;
-        status.logs_collected = false;
-        status.factories_extracted = false;
-        status.eth_calls_collected = false;
-        status.logs_decoded = false;
-        status.eth_calls_decoded = false;
-        status.transformed = false;
-        status.completed_handlers.clear();
-        status.failed_handlers.clear();
-        status.apply_expectations(&self.expectations);
-        self.storage.write_status(block_number, &status)?;
+        let expectations = &self.expectations;
+        self.storage.update_status_atomic(block_number, |status| {
+            status.receipts_collected = false;
+            status.logs_collected = false;
+            status.factories_extracted = false;
+            status.eth_calls_collected = false;
+            status.logs_decoded = false;
+            status.eth_calls_decoded = false;
+            status.transformed = false;
+            status.completed_handlers.clear();
+            status.failed_handlers.clear();
+            status.apply_expectations(expectations);
+        })?;
 
         Ok(())
     }
@@ -989,13 +991,14 @@ impl LiveCollector {
         self.storage.delete_all_decoded_calls(block_number)?;
         self.storage.delete_snapshots(block_number)?;
 
-        let mut status = self.storage.read_status(block_number)?;
-        status.eth_calls_collected = false;
-        status.eth_calls_decoded = false;
-        status.transformed = false;
-        status.failed_handlers.clear();
-        status.apply_expectations(&self.expectations);
-        self.storage.write_status(block_number, &status)?;
+        let expectations = &self.expectations;
+        self.storage.update_status_atomic(block_number, |status| {
+            status.eth_calls_collected = false;
+            status.eth_calls_decoded = false;
+            status.transformed = false;
+            status.failed_handlers.clear();
+            status.apply_expectations(expectations);
+        })?;
 
         Ok(())
     }
@@ -1040,11 +1043,12 @@ impl LiveCollector {
 
         self.storage.write_block(&full_block)?;
 
-        let mut status = self.storage.read_status(block_number)?;
-        status.collected = true;
-        status.block_fetched = true;
-        status.apply_expectations(&self.expectations);
-        self.storage.write_status(block_number, &status)?;
+        let expectations = &self.expectations;
+        self.storage.update_status_atomic(block_number, |status| {
+            status.collected = true;
+            status.block_fetched = true;
+            status.apply_expectations(expectations);
+        })?;
 
         self.resume_from_receipts_and_logs(block_number, log_decoder_tx, eth_call_decoder_tx)
             .await
@@ -1072,12 +1076,13 @@ impl LiveCollector {
                 .write_factories(block_number, &factory_addresses)?;
         }
 
-        let mut status = self.storage.read_status(block_number)?;
-        status.receipts_collected = true;
-        status.logs_collected = true;
-        status.factories_extracted = true;
-        status.apply_expectations(&self.expectations);
-        self.storage.write_status(block_number, &status)?;
+        let expectations = &self.expectations;
+        self.storage.update_status_atomic(block_number, |status| {
+            status.receipts_collected = true;
+            status.logs_collected = true;
+            status.factories_extracted = true;
+            status.apply_expectations(expectations);
+        })?;
 
         self.dispatch_logs_for_block(
             block_number,
@@ -1089,10 +1094,11 @@ impl LiveCollector {
         .await?;
 
         if log_decoder_tx.is_none() {
-            let mut status = self.storage.read_status(block_number)?;
-            status.logs_decoded = true;
-            status.apply_expectations(&self.expectations);
-            self.storage.write_status(block_number, &status)?;
+            let expectations = &self.expectations;
+            self.storage.update_status_atomic(block_number, |status| {
+                status.logs_decoded = true;
+                status.apply_expectations(expectations);
+            })?;
         }
 
         // retry_transform_after_decode=false: logs were re-dispatched through the
@@ -1178,21 +1184,28 @@ impl LiveCollector {
             self.reset_eth_call_state(block_number).await?;
         }
 
-        let mut status = self.storage.read_status(block_number)?;
-        status.eth_calls_collected = true;
-
-        if !batch.calls.is_empty() {
+        // Write data before updating status to preserve invariant:
+        // data exists before status says it's collected.
+        let empty_batch = batch.calls.is_empty();
+        if !empty_batch {
             self.storage.write_eth_calls(block_number, &batch.calls)?;
-        } else {
-            status.eth_calls_decoded = true;
         }
 
-        if eth_call_decoder_tx.is_none() {
-            status.eth_calls_decoded = true;
-        }
+        let no_decoder = eth_call_decoder_tx.is_none();
+        let expectations = &self.expectations;
+        self.storage.update_status_atomic(block_number, |status| {
+            status.eth_calls_collected = true;
 
-        status.apply_expectations(&self.expectations);
-        self.storage.write_status(block_number, &status)?;
+            if empty_batch {
+                status.eth_calls_decoded = true;
+            }
+
+            if no_decoder {
+                status.eth_calls_decoded = true;
+            }
+
+            status.apply_expectations(expectations);
+        })?;
 
         if let Some(ref mut eth_collector) = self.eth_call_collector {
             eth_collector.apply_collected_batch(&batch);
@@ -1284,11 +1297,12 @@ impl LiveCollector {
                 }
             }
         } else {
-            let mut status = self.storage.read_status(block_number)?;
-            status.eth_calls_collected = true;
-            status.eth_calls_decoded = true;
-            status.apply_expectations(&self.expectations);
-            self.storage.write_status(block_number, &status)?;
+            let expectations = &self.expectations;
+            self.storage.update_status_atomic(block_number, |status| {
+                status.eth_calls_collected = true;
+                status.eth_calls_decoded = true;
+                status.apply_expectations(expectations);
+            })?;
 
             if retry_transform_after_decode {
                 self.queue_transform_retry(block_number, None).await;

--- a/src/live/progress.rs
+++ b/src/live/progress.rs
@@ -149,11 +149,10 @@ impl LiveProgressTracker {
         }
 
         let storage = LiveStorage::new(&self.chain_name);
-        if let Ok(mut status) = storage.read_status(block_number) {
+        if let Err(e) = storage.update_status_atomic(block_number, |status| {
             status.transformed = true;
-            if let Err(e) = storage.write_status(block_number, &status) {
-                tracing::warn!("Failed to update block status (no handlers): {}", e);
-            }
+        }) {
+            tracing::warn!("Failed to update block status (no handlers): {}", e);
         }
     }
 


### PR DESCRIPTION
## Summary

Live mode has a read-modify-write race on block status JSON files. Multiple async tasks (collector, log decoder, eth_call decoder, progress tracker) update the same status file concurrently. When any task does `read_status → set flags → write_status`, it can overwrite flags that another task set between the read and write. This causes ~4% of blocks to end up with stale flags (e.g. `logs_decoded: false`), which prevents compaction from firing.

An `update_status_atomic()` method already existed with proper file locking (fs2 exclusive lock), but only a few call sites used it.

## What changed

- **`src/live/collector.rs`** — Converted 12 read-modify-write sites to `update_status_atomic()`. The initial `write_status` that creates the file (line 364) is unchanged since no other task can race against a nonexistent file.
  - `process_block`: block_fetched, receipts/logs/factories, logs_decoded (no decoder), eth_calls (no collector)
  - `reset_downstream_from_block_fetch`, `reset_downstream_from_logs`, `reset_eth_call_state`: reorg/reset paths that clear flags and handlers
  - `resume_from_block_fetch`, `resume_from_receipts_and_logs`: catchup paths
  - `commit_eth_call_batch`: restructured to write data before the atomic status update, preserving the invariant that data exists before status says it's collected
  - `resume_eth_call_collection`: no-collector fallback path

- **`src/decoding/logs.rs`** — Converted the `logs_decoded = true` site to `update_status_atomic()`

- **`src/decoding/current/eth_calls/range_processor.rs`** — Converted the `eth_calls_decoded = true` site to `update_status_atomic()`

- **`src/live/progress.rs`** — Converted `mark_transformed_if_no_handlers` to `update_status_atomic()`

- **`docs/LIVE_MODE.md`** — Updated docs to reflect that all status mutations (except initial creation) go through `update_status_atomic()`

## Why

The primary race was:
```
Collector:  write_status(logs_decoded=false, receipts_collected=true, ...)
Collector:  send logs to decoder channel
Decoder:    read_status → logs_decoded=true → write_status  ✓
Collector:  read_status (STALE: logs_decoded=false)
Collector:  write_status → OVERWRITES decoder's logs_decoded=true
```

After this fix, every status mutation holds an exclusive file lock for the entire read-modify-write cycle, eliminating the lost-update window.