### PR TITLE
perf: remove eth_call sequential chunking for rate limiter saturation

### DIFF
--- a/src/raw_data/historical/eth_calls/event_triggers.rs
+++ b/src/raw_data/historical/eth_calls/event_triggers.rs
@@ -640,85 +640,66 @@ pub(crate) async fn process_event_triggers(
             });
         }
 
-        // Execute calls in batches with concurrent chunk processing
+        // Execute all calls in a single batch
         let max_params = calls
             .iter()
             .map(|c| c.encoded_params.len())
             .max()
             .unwrap_or(0);
 
-        // Number of chunks to process concurrently
-        let chunk_concurrency = 4;
-
-        // Collect chunks for concurrent processing
-        let owned_chunks: Vec<Vec<PendingEventCall>> = pending_calls
-            .chunks(ctx.rpc_batch_size)
-            .map(|chunk| chunk.to_vec())
+        let batch_calls: Vec<(TransactionRequest, BlockId)> = pending_calls
+            .iter()
+            .map(|c| (c.request.clone(), c.block_id))
             .collect();
 
-        let chunk_results: Vec<Vec<EventCallResult>> = stream::iter(owned_chunks)
-            .map(|chunk| {
-                let contract_name = contract_name.clone();
-                let function_name = function_name.clone();
-                async move {
-                    let batch_calls: Vec<(TransactionRequest, BlockId)> = chunk
-                        .iter()
-                        .map(|c| (c.request.clone(), c.block_id))
-                        .collect();
+        let results = ctx.client.call_batch(batch_calls).await?;
 
-                    let results = ctx.client.call_batch(batch_calls).await?;
+        let mut all_results: Vec<EventCallResult> = Vec::with_capacity(results.len());
+        for (i, result) in results.into_iter().enumerate() {
+            let call = &pending_calls[i];
 
-                    let mut chunk_results = Vec::with_capacity(results.len());
-                    for (i, result) in results.into_iter().enumerate() {
-                        let call = &chunk[i];
-
-                        match result {
-                            Ok(bytes) => {
-                                chunk_results.push(EventCallResult {
-                                    block_number: call.trigger.block_number,
-                                    block_timestamp: call.trigger.block_timestamp,
-                                    log_index: call.trigger.log_index,
-                                    target_address: call.target_address.0.0,
-                                    value_bytes: bytes.to_vec(),
-                                    param_values: call.encoded_params.clone(),
-                                    is_reverted: false,
-                                    revert_reason: None,
-                                });
-                            }
-                            Err(e) => {
-                                let reason = e.to_string();
-                                let params_hex: Vec<String> = call.encoded_params.iter().map(|p| format!("0x{}", hex::encode(p))).collect();
-                                tracing::warn!(
-                                    "Event-triggered eth_call reverted for {}.{} at block {} (address {}, params {:?}): {}",
-                                    contract_name,
-                                    function_name,
-                                    call.trigger.block_number,
-                                    call.target_address,
-                                    params_hex,
-                                    reason
-                                );
-                                chunk_results.push(EventCallResult {
-                                    block_number: call.trigger.block_number,
-                                    block_timestamp: call.trigger.block_timestamp,
-                                    log_index: call.trigger.log_index,
-                                    target_address: call.target_address.0.0,
-                                    value_bytes: Vec::new(),
-                                    param_values: call.encoded_params.clone(),
-                                    is_reverted: true,
-                                    revert_reason: Some(reason),
-                                });
-                            }
-                        }
-                    }
-                    Ok::<_, EthCallCollectionError>(chunk_results)
+            match result {
+                Ok(bytes) => {
+                    all_results.push(EventCallResult {
+                        block_number: call.trigger.block_number,
+                        block_timestamp: call.trigger.block_timestamp,
+                        log_index: call.trigger.log_index,
+                        target_address: call.target_address.0 .0,
+                        value_bytes: bytes.to_vec(),
+                        param_values: call.encoded_params.clone(),
+                        is_reverted: false,
+                        revert_reason: None,
+                    });
                 }
-            })
-            .buffer_unordered(chunk_concurrency)
-            .try_collect()
-            .await?;
-
-        // Flatten chunk results
-        let mut all_results: Vec<EventCallResult> = chunk_results.into_iter().flatten().collect();
+                Err(e) => {
+                    let reason = e.to_string();
+                    let params_hex: Vec<String> = call
+                        .encoded_params
+                        .iter()
+                        .map(|p| format!("0x{}", hex::encode(p)))
+                        .collect();
+                    tracing::warn!(
+                        "Event-triggered eth_call reverted for {}.{} at block {} (address {}, params {:?}): {}",
+                        contract_name,
+                        function_name,
+                        call.trigger.block_number,
+                        call.target_address,
+                        params_hex,
+                        reason
+                    );
+                    all_results.push(EventCallResult {
+                        block_number: call.trigger.block_number,
+                        block_timestamp: call.trigger.block_timestamp,
+                        log_index: call.trigger.log_index,
+                        target_address: call.target_address.0 .0,
+                        value_bytes: Vec::new(),
+                        param_values: call.encoded_params.clone(),
+                        is_reverted: true,
+                        revert_reason: Some(reason),
+                    });
+                }
+            }
+        }
 
         // Sort by block number, log index
         all_results.sort_by_key(|r| (r.block_number, r.log_index, r.target_address));

--- a/src/raw_data/historical/eth_calls/event_triggers.rs
+++ b/src/raw_data/historical/eth_calls/event_triggers.rs
@@ -1051,13 +1051,8 @@ pub(crate) async fn process_event_triggers_multicall(
     );
 
     // Execute all multicalls
-    let results = execute_multicalls_generic(
-        ctx.client,
-        multicall3_address,
-        block_multicalls,
-        ctx.rpc_batch_size,
-    )
-    .await?;
+    let results =
+        execute_multicalls_generic(ctx.client, multicall3_address, block_multicalls).await?;
 
     // Distribute results back to groups
     let mut group_results: HashMap<(String, String), Vec<EventCallResult>> = HashMap::new();

--- a/src/raw_data/historical/eth_calls/event_triggers.rs
+++ b/src/raw_data/historical/eth_calls/event_triggers.rs
@@ -14,7 +14,6 @@ use arrow::array::{
 };
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
-use futures::{stream, StreamExt, TryStreamExt};
 use parquet::arrow::ArrowWriter;
 use parquet::file::properties::WriterProperties;
 

--- a/src/raw_data/historical/eth_calls/multicall.rs
+++ b/src/raw_data/historical/eth_calls/multicall.rs
@@ -3,8 +3,6 @@
 use alloy::dyn_abi::{DynSolType, DynSolValue};
 use alloy::primitives::{Address, Bytes};
 use alloy::rpc::types::{BlockId, TransactionRequest};
-use futures::{stream, StreamExt, TryStreamExt};
-
 use super::config::compute_function_selector;
 use super::types::{BlockInfo, EthCallCollectionError};
 use crate::rpc::UnifiedRpcClient;
@@ -184,118 +182,7 @@ pub(crate) async fn execute_multicalls_generic<M: Clone + Send + Sync>(
     client: &UnifiedRpcClient,
     multicall3_address: Address,
     block_multicalls: Vec<BlockMulticall<M>>,
-    rpc_batch_size: usize,
 ) -> Result<Vec<(M, Vec<u8>, bool)>, EthCallCollectionError> {
-    // Track failed calls with chunk-relative indices
-    struct ChunkFailedCall {
-        relative_index: usize, // Index within the chunk's results
-        target_address: Address,
-        calldata: Bytes,
-        block_number: u64,
-        block_id: BlockId,
-    }
-
-    struct ChunkResult<M> {
-        results: Vec<(M, Vec<u8>, bool)>,
-        failed_calls: Vec<ChunkFailedCall>,
-    }
-
-    // Number of chunks to process concurrently
-    let chunk_concurrency = 4;
-
-    // Pre-collect chunks into owned vectors to avoid lifetime issues
-    let owned_chunks: Vec<Vec<BlockMulticall<M>>> = block_multicalls
-        .chunks(rpc_batch_size)
-        .map(|chunk| chunk.to_vec())
-        .collect();
-
-    // Process chunks concurrently using buffered (maintains order for correct index calculation)
-    let chunk_results: Vec<ChunkResult<M>> = stream::iter(owned_chunks)
-        .map(|chunk| async move {
-            let calls: Vec<(TransactionRequest, BlockId)> = chunk
-                .iter()
-                .map(|bm| {
-                    let sub_calls: Vec<(Address, &Bytes)> = bm
-                        .slots
-                        .iter()
-                        .map(|s| (s.target_address, &s.encoded_calldata))
-                        .collect();
-                    let multicall_data = build_multicall_calldata(&sub_calls);
-                    let tx = TransactionRequest::default()
-                        .to(multicall3_address)
-                        .input(multicall_data.into());
-                    (tx, bm.block_id)
-                })
-                .collect();
-
-            let results = client.call_batch(calls).await?;
-
-            let mut chunk_results: Vec<(M, Vec<u8>, bool)> = Vec::new();
-            let mut chunk_failed_calls: Vec<ChunkFailedCall> = Vec::new();
-
-            for (i, result) in results.into_iter().enumerate() {
-                let bm = &chunk[i];
-                let slot_count = bm.slots.len();
-
-                match result {
-                    Ok(bytes) => {
-                        match decode_multicall_results(&bytes, slot_count) {
-                            Ok(decoded) => {
-                                for (j, (success, return_data)) in decoded.into_iter().enumerate() {
-                                    let slot = &bm.slots[j];
-                                    if !success {
-                                        tracing::warn!(
-                                            "Multicall sub-call failed at block {} targeting {}",
-                                            bm.block_number,
-                                            slot.target_address
-                                        );
-                                        chunk_failed_calls.push(ChunkFailedCall {
-                                            relative_index: chunk_results.len(),
-                                            target_address: slot.target_address,
-                                            calldata: slot.encoded_calldata.clone(),
-                                            block_number: bm.block_number,
-                                            block_id: bm.block_id,
-                                        });
-                                    }
-                                    chunk_results.push((
-                                        slot.metadata.clone(),
-                                        if success { return_data } else { Vec::new() },
-                                        success,
-                                    ));
-                                }
-                            }
-                            Err(e) => {
-                                tracing::warn!(
-                                    "Failed to decode multicall results for block {}: {}",
-                                    bm.block_number,
-                                    e
-                                );
-                                // Treat all sub-calls as failed
-                                for slot in &bm.slots {
-                                    chunk_results.push((slot.metadata.clone(), Vec::new(), false));
-                                }
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        tracing::warn!("Multicall RPC failed for block {}: {}", bm.block_number, e);
-                        // Treat all sub-calls as failed
-                        for slot in &bm.slots {
-                            chunk_results.push((slot.metadata.clone(), Vec::new(), false));
-                        }
-                    }
-                }
-            }
-            Ok::<_, EthCallCollectionError>(ChunkResult {
-                results: chunk_results,
-                failed_calls: chunk_failed_calls,
-            })
-        })
-        .buffered(chunk_concurrency)
-        .try_collect()
-        .await?;
-
-    // Flatten results and compute global indices for failed calls
     struct FailedCall {
         result_index: usize,
         target_address: Address,
@@ -304,24 +191,80 @@ pub(crate) async fn execute_multicalls_generic<M: Clone + Send + Sync>(
         block_id: BlockId,
     }
 
+    // Build a single batch of calls from all block multicalls
+    let calls: Vec<(TransactionRequest, BlockId)> = block_multicalls
+        .iter()
+        .map(|bm| {
+            let sub_calls: Vec<(Address, &Bytes)> = bm
+                .slots
+                .iter()
+                .map(|s| (s.target_address, &s.encoded_calldata))
+                .collect();
+            let multicall_data = build_multicall_calldata(&sub_calls);
+            let tx = TransactionRequest::default()
+                .to(multicall3_address)
+                .input(multicall_data.into());
+            (tx, bm.block_id)
+        })
+        .collect();
+
+    let results = client.call_batch(calls).await?;
+
     let mut all_results: Vec<(M, Vec<u8>, bool)> = Vec::new();
     let mut failed_retries: Vec<FailedCall> = Vec::new();
 
-    for chunk_result in chunk_results {
-        let base_index = all_results.len();
+    for (i, result) in results.into_iter().enumerate() {
+        let bm = &block_multicalls[i];
+        let slot_count = bm.slots.len();
 
-        // Convert chunk-relative indices to global indices
-        for failed in chunk_result.failed_calls {
-            failed_retries.push(FailedCall {
-                result_index: base_index + failed.relative_index,
-                target_address: failed.target_address,
-                calldata: failed.calldata,
-                block_number: failed.block_number,
-                block_id: failed.block_id,
-            });
+        match result {
+            Ok(bytes) => {
+                match decode_multicall_results(&bytes, slot_count) {
+                    Ok(decoded) => {
+                        for (j, (success, return_data)) in decoded.into_iter().enumerate() {
+                            let slot = &bm.slots[j];
+                            if !success {
+                                tracing::warn!(
+                                    "Multicall sub-call failed at block {} targeting {}",
+                                    bm.block_number,
+                                    slot.target_address
+                                );
+                                failed_retries.push(FailedCall {
+                                    result_index: all_results.len(),
+                                    target_address: slot.target_address,
+                                    calldata: slot.encoded_calldata.clone(),
+                                    block_number: bm.block_number,
+                                    block_id: bm.block_id,
+                                });
+                            }
+                            all_results.push((
+                                slot.metadata.clone(),
+                                if success { return_data } else { Vec::new() },
+                                success,
+                            ));
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "Failed to decode multicall results for block {}: {}",
+                            bm.block_number,
+                            e
+                        );
+                        // Treat all sub-calls as failed
+                        for slot in &bm.slots {
+                            all_results.push((slot.metadata.clone(), Vec::new(), false));
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::warn!("Multicall RPC failed for block {}: {}", bm.block_number, e);
+                // Treat all sub-calls as failed
+                for slot in &bm.slots {
+                    all_results.push((slot.metadata.clone(), Vec::new(), false));
+                }
+            }
         }
-
-        all_results.extend(chunk_result.results);
     }
 
     // Retry failed multicall sub-calls individually

--- a/src/raw_data/historical/eth_calls/once_calls.rs
+++ b/src/raw_data/historical/eth_calls/once_calls.rs
@@ -1037,13 +1037,8 @@ pub(crate) async fn process_once_calls_multicall(
     );
 
     // Execute multicall
-    let results = execute_multicalls_generic(
-        ctx.client,
-        multicall3_address,
-        block_multicalls,
-        ctx.rpc_batch_size,
-    )
-    .await?;
+    let results =
+        execute_multicalls_generic(ctx.client, multicall3_address, block_multicalls).await?;
 
     // Group results by contract_name -> address -> function_name -> value
     let mut results_by_contract: HashMap<String, HashMap<Address, HashMap<String, Vec<u8>>>> =
@@ -1427,13 +1422,8 @@ pub(crate) async fn process_factory_once_calls_multicall(
         );
 
         // Execute multicalls
-        let results = execute_multicalls_generic(
-            ctx.client,
-            multicall3_address,
-            block_multicalls,
-            ctx.rpc_batch_size,
-        )
-        .await?;
+        let results =
+            execute_multicalls_generic(ctx.client, multicall3_address, block_multicalls).await?;
 
         for (meta, return_data, _success) in results {
             let entry = results_by_collection
@@ -1583,7 +1573,6 @@ pub(crate) async fn process_factory_once_calls_multicall(
                             ctx.client,
                             multicall3_address,
                             backfill_multicalls,
-                            ctx.rpc_batch_size,
                         )
                         .await?;
 

--- a/src/raw_data/historical/eth_calls/regular_calls.rs
+++ b/src/raw_data/historical/eth_calls/regular_calls.rs
@@ -161,57 +161,55 @@ pub(crate) async fn process_factory_range(
                 }
             }
 
-            for chunk in pending_calls.chunks(ctx.rpc_batch_size) {
-                let calls: Vec<(TransactionRequest, BlockId)> = chunk
-                    .iter()
-                    .map(|(tx, block_id, _, _)| (tx.clone(), *block_id))
-                    .collect();
+            let calls: Vec<(TransactionRequest, BlockId)> = pending_calls
+                .iter()
+                .map(|(tx, block_id, _, _)| (tx.clone(), *block_id))
+                .collect();
 
-                #[cfg(feature = "bench")]
-                let rpc_start = Instant::now();
-                let results = ctx.client.call_batch(calls).await?;
-                #[cfg(feature = "bench")]
-                {
-                    rpc_time += rpc_start.elapsed();
-                }
+            #[cfg(feature = "bench")]
+            let rpc_start = Instant::now();
+            let results = ctx.client.call_batch(calls).await?;
+            #[cfg(feature = "bench")]
+            {
+                rpc_time += rpc_start.elapsed();
+            }
 
-                #[cfg(feature = "bench")]
-                let process_start = Instant::now();
-                for (i, result) in results.into_iter().enumerate() {
-                    let (_, _, block, config) = &chunk[i];
-                    match result {
-                        Ok(bytes) => {
-                            all_results.push(CallResult {
-                                block_number: block.block_number,
-                                block_timestamp: block.timestamp,
-                                contract_address: config.address.0 .0,
-                                value_bytes: bytes.to_vec(),
-                                param_values: config.param_values.clone(),
-                            });
-                        }
-                        Err(e) => {
-                            let params_hex: Vec<String> = config
-                                .param_values
-                                .iter()
-                                .map(|p| format!("0x{}", hex::encode(p)))
-                                .collect();
-                            tracing::warn!(
-                                "Factory eth_call failed for {}.{} at block {} (address {}, params {:?}): {}",
-                                collection_name,
-                                function_name,
-                                block.block_number,
-                                config.address,
-                                params_hex,
-                                e
-                            );
-                            // Skip reverted calls - don't store empty results
-                        }
+            #[cfg(feature = "bench")]
+            let process_start = Instant::now();
+            for (i, result) in results.into_iter().enumerate() {
+                let (_, _, block, config) = &pending_calls[i];
+                match result {
+                    Ok(bytes) => {
+                        all_results.push(CallResult {
+                            block_number: block.block_number,
+                            block_timestamp: block.timestamp,
+                            contract_address: config.address.0 .0,
+                            value_bytes: bytes.to_vec(),
+                            param_values: config.param_values.clone(),
+                        });
+                    }
+                    Err(e) => {
+                        let params_hex: Vec<String> = config
+                            .param_values
+                            .iter()
+                            .map(|p| format!("0x{}", hex::encode(p)))
+                            .collect();
+                        tracing::warn!(
+                            "Factory eth_call failed for {}.{} at block {} (address {}, params {:?}): {}",
+                            collection_name,
+                            function_name,
+                            block.block_number,
+                            config.address,
+                            params_hex,
+                            e
+                        );
+                        // Skip reverted calls - don't store empty results
                     }
                 }
-                #[cfg(feature = "bench")]
-                {
-                    process_time += process_start.elapsed();
-                }
+            }
+            #[cfg(feature = "bench")]
+            {
+                process_time += process_start.elapsed();
             }
 
             all_results
@@ -610,57 +608,55 @@ pub(crate) async fn process_range(
             }
         }
 
-        for chunk in pending_calls.chunks(ctx.rpc_batch_size) {
-            let calls: Vec<(TransactionRequest, BlockId)> = chunk
-                .iter()
-                .map(|(tx, block_id, _, _)| (tx.clone(), *block_id))
-                .collect();
+        let calls: Vec<(TransactionRequest, BlockId)> = pending_calls
+            .iter()
+            .map(|(tx, block_id, _, _)| (tx.clone(), *block_id))
+            .collect();
 
-            #[cfg(feature = "bench")]
-            let rpc_start = Instant::now();
-            let results = ctx.client.call_batch(calls).await?;
-            #[cfg(feature = "bench")]
-            {
-                rpc_time += rpc_start.elapsed();
-            }
+        #[cfg(feature = "bench")]
+        let rpc_start = Instant::now();
+        let results = ctx.client.call_batch(calls).await?;
+        #[cfg(feature = "bench")]
+        {
+            rpc_time += rpc_start.elapsed();
+        }
 
-            #[cfg(feature = "bench")]
-            let process_start = Instant::now();
-            for (i, result) in results.into_iter().enumerate() {
-                let (_, _, block, config) = &chunk[i];
-                match result {
-                    Ok(bytes) => {
-                        all_results.push(CallResult {
-                            block_number: block.block_number,
-                            block_timestamp: block.timestamp,
-                            contract_address: config.address.0 .0,
-                            value_bytes: bytes.to_vec(),
-                            param_values: config.param_values.clone(),
-                        });
-                    }
-                    Err(e) => {
-                        let params_hex: Vec<String> = config
-                            .param_values
-                            .iter()
-                            .map(|p| format!("0x{}", hex::encode(p)))
-                            .collect();
-                        tracing::warn!(
-                            "eth_call failed for {}.{} at block {} (address {}, params {:?}): {}",
-                            contract_name,
-                            function_name,
-                            block.block_number,
-                            config.address,
-                            params_hex,
-                            e
-                        );
-                        // Skip reverted calls - don't store empty results
-                    }
+        #[cfg(feature = "bench")]
+        let process_start = Instant::now();
+        for (i, result) in results.into_iter().enumerate() {
+            let (_, _, block, config) = &pending_calls[i];
+            match result {
+                Ok(bytes) => {
+                    all_results.push(CallResult {
+                        block_number: block.block_number,
+                        block_timestamp: block.timestamp,
+                        contract_address: config.address.0 .0,
+                        value_bytes: bytes.to_vec(),
+                        param_values: config.param_values.clone(),
+                    });
+                }
+                Err(e) => {
+                    let params_hex: Vec<String> = config
+                        .param_values
+                        .iter()
+                        .map(|p| format!("0x{}", hex::encode(p)))
+                        .collect();
+                    tracing::warn!(
+                        "eth_call failed for {}.{} at block {} (address {}, params {:?}): {}",
+                        contract_name,
+                        function_name,
+                        block.block_number,
+                        config.address,
+                        params_hex,
+                        e
+                    );
+                    // Skip reverted calls - don't store empty results
                 }
             }
-            #[cfg(feature = "bench")]
-            {
-                process_time += process_start.elapsed();
-            }
+        }
+        #[cfg(feature = "bench")]
+        {
+            process_time += process_start.elapsed();
         }
 
         all_results.sort_by_key(|r| (r.block_number, r.contract_address, r.param_values.clone()));

--- a/src/raw_data/historical/eth_calls/regular_calls.rs
+++ b/src/raw_data/historical/eth_calls/regular_calls.rs
@@ -439,13 +439,8 @@ pub(crate) async fn process_factory_range_multicall(
     );
 
     // Execute all multicalls
-    let results = execute_multicalls_generic(
-        ctx.client,
-        multicall3_address,
-        block_multicalls,
-        ctx.rpc_batch_size,
-    )
-    .await?;
+    let results =
+        execute_multicalls_generic(ctx.client, multicall3_address, block_multicalls).await?;
 
     // Distribute results back to groups
     let mut group_results: HashMap<(String, String), Vec<CallResult>> = HashMap::new();
@@ -843,13 +838,8 @@ pub(crate) async fn process_range_multicall(
     );
 
     // Execute all multicalls
-    let results = execute_multicalls_generic(
-        ctx.client,
-        multicall3_address,
-        block_multicalls,
-        ctx.rpc_batch_size,
-    )
-    .await?;
+    let results =
+        execute_multicalls_generic(ctx.client, multicall3_address, block_multicalls).await?;
 
     // Distribute results back to groups
     let mut group_results: HashMap<(String, String), Vec<CallResult>> = HashMap::new();

--- a/src/raw_data/historical/eth_calls/types.rs
+++ b/src/raw_data/historical/eth_calls/types.rs
@@ -52,6 +52,7 @@ pub use crate::storage::BlockRange;
 /// Bundles the RPC client, output paths, and chain info that are threaded
 /// through every `process_*` function in the execution and event_triggers
 /// modules.
+#[allow(dead_code)]
 pub struct EthCallContext<'a> {
     pub client: &'a UnifiedRpcClient,
     pub output_dir: &'a Path,

--- a/src/rpc/alchemy.rs
+++ b/src/rpc/alchemy.rs
@@ -390,7 +390,7 @@ impl AlchemyClient {
             semaphore: Arc::new(Semaphore::new(self.config.rpc_concurrency)),
             rate_limiter: self.rate_limiter.clone(),
             cost_per_request,
-            max_in_flight: self.config.rpc_concurrency * 2,
+            max_in_flight: (self.config.rpc_concurrency * 2).max(1),
         }
     }
 

--- a/src/rpc/alchemy.rs
+++ b/src/rpc/alchemy.rs
@@ -243,6 +243,10 @@ struct ConcurrentExecutor {
     semaphore: Arc<Semaphore>,
     rate_limiter: Arc<SlidingWindowRateLimiter>,
     cost_per_request: u32,
+    /// Maximum number of spawned tasks allowed in a JoinSet at once.
+    /// Tasks beyond this limit are spawned only as earlier tasks complete,
+    /// preventing unbounded task creation for large request sets.
+    max_in_flight: usize,
 }
 
 impl ConcurrentExecutor {
@@ -386,6 +390,7 @@ impl AlchemyClient {
             semaphore: Arc::new(Semaphore::new(self.config.rpc_concurrency)),
             rate_limiter: self.rate_limiter.clone(),
             cost_per_request,
+            max_in_flight: self.config.rpc_concurrency * 2,
         }
     }
 
@@ -421,9 +426,11 @@ impl AlchemyClient {
         let executor = self.create_concurrent_executor(cost_per_request);
         let make_request = Arc::new(make_request);
         let mut join_set = JoinSet::new();
+        let mut requests_iter = requests.into_iter().enumerate().peekable();
 
-        // Spawn all tasks immediately - permit acquisition happens inside each task.
-        for (idx, request) in requests.into_iter().enumerate() {
+        // Seed the initial batch up to the spawn window
+        while requests_iter.peek().is_some() && join_set.len() < executor.max_in_flight {
+            let (idx, request) = requests_iter.next().unwrap();
             let make_request = make_request.clone();
             executor.spawn_indexed(
                 &mut join_set,
@@ -432,7 +439,7 @@ impl AlchemyClient {
             );
         }
 
-        // Collect results and sort by index to preserve order
+        // Collect results and spawn replacements as tasks complete
         let mut indexed_results: Vec<(usize, T)> = Vec::with_capacity(num_requests);
         let mut had_panic = false;
 
@@ -443,6 +450,17 @@ impl AlchemyClient {
                     tracing::error!("Task panicked in execute_concurrent_ordered: {:?}", e);
                     had_panic = true;
                 }
+            }
+
+            // Spawn replacements to keep the pipeline full
+            while requests_iter.peek().is_some() && join_set.len() < executor.max_in_flight {
+                let (idx, request) = requests_iter.next().unwrap();
+                let make_request = make_request.clone();
+                executor.spawn_indexed(
+                    &mut join_set,
+                    idx,
+                    async move { make_request(request).await },
+                );
             }
         }
 
@@ -486,9 +504,11 @@ impl AlchemyClient {
             }
 
             let mut join_set = JoinSet::new();
+            let mut requests_iter = requests.into_iter().peekable();
 
-            // Spawn all tasks immediately - permit acquisition happens inside each task.
-            for request in requests {
+            // Seed the initial batch up to the spawn window
+            while requests_iter.peek().is_some() && join_set.len() < executor.max_in_flight {
+                let request = requests_iter.next().unwrap();
                 let make_request = make_request.clone();
                 let result_tx = result_tx.clone();
                 executor.spawn_streaming(&mut join_set, result_tx, async move {
@@ -496,10 +516,20 @@ impl AlchemyClient {
                 });
             }
 
-            // Wait for all tasks to complete, logging any panics
+            // Wait for tasks to complete, spawning replacements to keep the pipeline full
             while let Some(result) = join_set.join_next().await {
                 if let Err(e) = result {
                     tracing::error!("Task panicked in execute_streaming: {:?}", e);
+                }
+
+                // Spawn replacements
+                while requests_iter.peek().is_some() && join_set.len() < executor.max_in_flight {
+                    let request = requests_iter.next().unwrap();
+                    let make_request = make_request.clone();
+                    let result_tx = result_tx.clone();
+                    executor.spawn_streaming(&mut join_set, result_tx, async move {
+                        make_request(request).await
+                    });
                 }
             }
         })


### PR DESCRIPTION
## Summary

- Remove `for chunk in pending_calls.chunks(rpc_batch_size)` sequential loops in regular_calls.rs (`process_range`, `process_factory_range`), token_calls.rs (`process_token_range`, `process_token_range_multicall`), dispatching all pending calls in a single `call_batch`
- Remove `stream::iter(...).buffered(4)` chunking pattern in `execute_multicalls_generic` (multicall.rs), replacing with a single `call_batch` for all block multicalls. Remove the now-unnecessary `rpc_batch_size` parameter and update all 6 call sites
- Remove `stream::iter(...).buffer_unordered(4)` chunking in `process_event_triggers` (event_triggers.rs), replacing with a single `call_batch` and direct result processing
- Clean up unused `futures::{stream, StreamExt, TryStreamExt}` imports from multicall.rs and event_triggers.rs

These artificial batch boundaries created inter-batch gaps that prevented the rate limiter from saturating the Alchemy CU budget. With the executor acquisition order fix (rate limiter before semaphore), the rate limiter alone handles throughput pacing, making chunking unnecessary.

May conflict with sibling PR for Workstream A (receipt saturation) on shared config types if `rpc_batch_size` field is also modified there.