### PR TITLE
perf: pipeline parquet writes behind RPC in eth_call catchup

### DIFF
--- a/src/raw_data/historical/catchup/eth_calls.rs
+++ b/src/raw_data/historical/catchup/eth_calls.rs
@@ -10,16 +10,14 @@ use crate::decoding::DecoderMessage;
 use crate::raw_data::historical::blocks::{
     get_existing_block_ranges_async, read_block_info_from_parquet_async,
 };
-use tokio::task::JoinHandle;
-
 use crate::raw_data::historical::eth_calls::{
     build_call_configs, build_event_triggered_call_configs, build_factory_once_call_configs,
     build_once_call_configs, event_output_exists_async, get_existing_log_ranges_async,
     process_event_triggers, process_event_triggers_multicall, process_factory_once_calls,
     process_once_calls_multicall, process_once_calls_regular, process_range,
     process_range_multicall, read_logs_from_parquet_async, scan_existing_parquet_files_async,
-    BlockInfo, BlockRange, EthCallCatchupState, EthCallCollectionError, EthCallContext,
-    FrequencyState,
+    AbortOnDropHandles, BlockInfo, BlockRange, EthCallCatchupState, EthCallCollectionError,
+    EthCallContext, FrequencyState,
 };
 use crate::raw_data::historical::eth_calls::parquet_io::{
     load_or_build_once_column_index_async, read_once_column_index_async,
@@ -182,17 +180,13 @@ pub async fn collect_eth_calls(
 
         let mut catchup_count = 0;
         let total_ranges = block_ranges.len();
-        let mut pending_writes: Vec<JoinHandle<Result<(), EthCallCollectionError>>> = Vec::new();
+        let mut pending_writes = AbortOnDropHandles::new();
 
         for (idx, block_range) in block_ranges.iter().enumerate() {
             // Drain writes from the previous range before starting the next one.
             // This ensures writes from range N complete before range N+1 finishes
             // its RPC work, overlapping I/O with RPC for maximum throughput.
-            for handle in pending_writes.drain(..) {
-                handle
-                    .await
-                    .map_err(|e| EthCallCollectionError::JoinError(e.to_string()))??;
-            }
+            pending_writes.drain_all().await?;
             let range = BlockRange {
                 start: block_range.start,
                 end: block_range.end,
@@ -430,11 +424,7 @@ pub async fn collect_eth_calls(
         }
 
         // Drain any remaining writes from the final range
-        for handle in pending_writes {
-            handle
-                .await
-                .map_err(|e| EthCallCollectionError::JoinError(e.to_string()))??;
-        }
+        pending_writes.drain_all().await?;
 
         if catchup_count > 0 {
             tracing::info!(

--- a/src/raw_data/historical/catchup/eth_calls.rs
+++ b/src/raw_data/historical/catchup/eth_calls.rs
@@ -10,6 +10,8 @@ use crate::decoding::DecoderMessage;
 use crate::raw_data::historical::blocks::{
     get_existing_block_ranges_async, read_block_info_from_parquet_async,
 };
+use tokio::task::JoinHandle;
+
 use crate::raw_data::historical::eth_calls::{
     build_call_configs, build_event_triggered_call_configs, build_factory_once_call_configs,
     build_once_call_configs, event_output_exists_async, get_existing_log_ranges_async,
@@ -180,8 +182,17 @@ pub async fn collect_eth_calls(
 
         let mut catchup_count = 0;
         let total_ranges = block_ranges.len();
+        let mut pending_writes: Vec<JoinHandle<Result<(), EthCallCollectionError>>> = Vec::new();
 
         for (idx, block_range) in block_ranges.iter().enumerate() {
+            // Drain writes from the previous range before starting the next one.
+            // This ensures writes from range N complete before range N+1 finishes
+            // its RPC work, overlapping I/O with RPC for maximum throughput.
+            for handle in pending_writes.drain(..) {
+                handle
+                    .await
+                    .map_err(|e| EthCallCollectionError::JoinError(e.to_string()))??;
+            }
             let range = BlockRange {
                 start: block_range.start,
                 end: block_range.end,
@@ -374,6 +385,7 @@ pub async fn collect_eth_calls(
                         max_params,
                         &mut frequency_state,
                         multicall_addr,
+                        Some(&mut pending_writes),
                     )
                     .await?;
                 } else {
@@ -384,6 +396,7 @@ pub async fn collect_eth_calls(
                         &call_configs,
                         max_params,
                         &mut frequency_state,
+                        Some(&mut pending_writes),
                     )
                     .await?;
                 }
@@ -414,6 +427,13 @@ pub async fn collect_eth_calls(
 
             range_regular_done.insert(range.start);
             catchup_count += 1;
+        }
+
+        // Drain any remaining writes from the final range
+        for handle in pending_writes {
+            handle
+                .await
+                .map_err(|e| EthCallCollectionError::JoinError(e.to_string()))??;
         }
 
         if catchup_count > 0 {

--- a/src/raw_data/historical/current/eth_calls/factory.rs
+++ b/src/raw_data/historical/current/eth_calls/factory.rs
@@ -172,6 +172,7 @@ pub(super) async fn handle_factory_message(
                                 state.factory_max_params,
                                 &mut state.frequency_state,
                                 multicall_addr,
+                                None,
                             )
                             .await?;
                         } else {
@@ -183,6 +184,7 @@ pub(super) async fn handle_factory_message(
                                 &state.factory_call_configs,
                                 state.factory_max_params,
                                 &mut state.frequency_state,
+                                None,
                             )
                             .await?;
                         }

--- a/src/raw_data/historical/current/eth_calls/range_processor.rs
+++ b/src/raw_data/historical/current/eth_calls/range_processor.rs
@@ -59,6 +59,7 @@ pub(super) async fn process_complete_range(
                 state.max_params,
                 &mut state.frequency_state,
                 multicall_addr,
+                None,
             )
             .await?;
         } else {
@@ -69,6 +70,7 @@ pub(super) async fn process_complete_range(
                 &state.call_configs,
                 state.max_params,
                 &mut state.frequency_state,
+                None,
             )
             .await?;
         }
@@ -104,6 +106,7 @@ pub(super) async fn process_complete_range(
                     state.factory_max_params,
                     &mut state.frequency_state,
                     multicall_addr,
+                    None,
                 )
                 .await?;
             } else {
@@ -115,6 +118,7 @@ pub(super) async fn process_complete_range(
                     &state.factory_call_configs,
                     state.factory_max_params,
                     &mut state.frequency_state,
+                    None,
                 )
                 .await?;
             }
@@ -205,6 +209,7 @@ pub(super) async fn process_incomplete_range(
                 state.max_params,
                 &mut state.frequency_state,
                 multicall_addr,
+                None,
             )
             .await?;
         } else {
@@ -215,6 +220,7 @@ pub(super) async fn process_incomplete_range(
                 &state.call_configs,
                 state.max_params,
                 &mut state.frequency_state,
+                None,
             )
             .await?;
         }
@@ -256,6 +262,7 @@ pub(super) async fn process_incomplete_range(
                         state.factory_max_params,
                         &mut state.frequency_state,
                         multicall_addr,
+                        None,
                     )
                     .await?;
                 } else {
@@ -267,6 +274,7 @@ pub(super) async fn process_incomplete_range(
                         &state.factory_call_configs,
                         state.factory_max_params,
                         &mut state.frequency_state,
+                        None,
                     )
                     .await?;
                 }

--- a/src/raw_data/historical/eth_calls/postprocessing.rs
+++ b/src/raw_data/historical/eth_calls/postprocessing.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use tokio::sync::mpsc::Sender;
+use tokio::task::JoinHandle;
 
 use super::parquet_io::write_results_to_parquet_async;
 use super::types::{CallResult, EthCallCollectionError, FrequencyState};
@@ -163,5 +164,134 @@ pub(crate) async fn finalize_regular_results(
     }
 
     Ok(())
+}
+
+/// Deferred version of [`finalize_regular_results`].
+///
+/// Performs the frequency state update synchronously (needed for correct
+/// frequency filtering on subsequent ranges), but spawns the I/O work
+/// (parquet write, S3 upload, decoder notification) as a background tokio
+/// task. Returns the `JoinHandle` so the caller can await it later (e.g.
+/// at the start of the next range iteration) to pipeline writes behind RPC.
+pub(crate) async fn finalize_regular_results_deferred(
+    params: FinalizeRegularParams<'_>,
+) -> Result<JoinHandle<Result<(), EthCallCollectionError>>, EthCallCollectionError> {
+    let result_count = params.results.len();
+    let output_path = params.sub_dir.join(&params.file_name);
+
+    // Build decoder results before moving results into the spawned task
+    let decoder_results: Option<Vec<DecoderEthCallResult>> = if params.decoder_tx.is_some() {
+        Some(
+            params
+                .results
+                .iter()
+                .map(|r| DecoderEthCallResult {
+                    block_number: r.block_number,
+                    block_timestamp: r.block_timestamp,
+                    contract_address: r.contract_address,
+                    value: r.value_bytes.clone(),
+                })
+                .collect(),
+        )
+    } else {
+        None
+    };
+
+    // Clone owned copies of everything the background task needs
+    let results = params.results;
+    let max_params = params.max_params;
+    let log_label = params.log_label;
+    let s3_data_type = params.s3_data_type;
+    let chain_name = params.chain_name.to_string();
+    let range_start = params.range_start;
+    let range_end = params.range_end;
+    let storage_manager = params.storage_manager.cloned();
+    let decoder_tx = params.decoder_tx.clone();
+    let contract_name = params.contract_name;
+    let function_name = params.function_name;
+    let file_name = params.file_name;
+    let sub_dir = params.sub_dir;
+
+    #[cfg(feature = "bench")]
+    let bench = params.bench;
+
+    // Frequency state update happens synchronously (before spawn) so the
+    // next range sees the updated state.
+    if let Frequency::Duration(_) = params.frequency {
+        if let Some(ts) = params.last_block_timestamp {
+            params
+                .frequency_state
+                .last_call_times
+                .insert((contract_name.clone(), function_name.clone()), ts);
+        }
+    }
+
+    let handle = tokio::spawn(async move {
+        // 1. Parquet write
+        #[cfg(feature = "bench")]
+        let write_start = std::time::Instant::now();
+        write_results_to_parquet_async(results, output_path.clone(), max_params).await?;
+
+        // 2. Bench recording
+        #[cfg(feature = "bench")]
+        {
+            let write_time = write_start.elapsed();
+            if let Some((bench_label, rpc_time, process_time)) = bench {
+                crate::bench::record(
+                    &bench_label,
+                    range_start,
+                    range_end,
+                    result_count,
+                    rpc_time,
+                    process_time,
+                    write_time,
+                );
+            }
+        }
+
+        // 3. Log
+        let output_path_for_upload = sub_dir.join(&file_name);
+        tracing::info!(
+            "Wrote {} {} results to {}",
+            result_count,
+            log_label,
+            output_path_for_upload.display()
+        );
+
+        // 4. S3 upload
+        if let Some(sm) = &storage_manager {
+            upload_parquet_to_s3(
+                sm,
+                &output_path_for_upload,
+                &chain_name,
+                &s3_data_type,
+                range_start,
+                range_end - 1,
+            )
+            .await
+            .map_err(|e| EthCallCollectionError::Io(std::io::Error::other(e.to_string())))?;
+        }
+
+        // 5. Decoder notification
+        if let Some(tx) = &decoder_tx {
+            if let Some(results) = decoder_results {
+                let _ = tx
+                    .send(DecoderMessage::EthCallsReady {
+                        range_start,
+                        range_end,
+                        contract_name: contract_name.clone(),
+                        function_name: function_name.clone(),
+                        results,
+                        live_mode: false,
+                        retry_transform_after_decode: false,
+                    })
+                    .await;
+            }
+        }
+
+        Ok(())
+    });
+
+    Ok(handle)
 }
 

--- a/src/raw_data/historical/eth_calls/regular_calls.rs
+++ b/src/raw_data/historical/eth_calls/regular_calls.rs
@@ -9,13 +9,17 @@ use alloy::dyn_abi::DynSolValue;
 use alloy::primitives::Address;
 use alloy::rpc::types::{BlockId, BlockNumberOrTag, TransactionRequest};
 
+use tokio::task::JoinHandle;
+
 use super::config::{compute_function_selector, generate_param_combinations};
 use super::frequency::filter_blocks_for_frequency;
 use super::multicall::{
     execute_multicalls_generic, BlockMulticall, FactoryCallMeta, FactoryGroupInfo,
     MulticallSlotGeneric, RegularCallMeta, RegularGroupInfo,
 };
-use super::postprocessing::{finalize_regular_results, FinalizeRegularParams};
+use super::postprocessing::{
+    finalize_regular_results, finalize_regular_results_deferred, FinalizeRegularParams,
+};
 use super::types::{
     BlockInfo, BlockRange, CallConfig, CallResult, EthCallCollectionError, EthCallContext,
     EncodedParam, FrequencyState,
@@ -31,6 +35,7 @@ pub(crate) async fn process_factory_range(
     factory_call_configs: &HashMap<String, Vec<EthCallConfig>>,
     max_params: usize,
     frequency_state: &mut FrequencyState,
+    mut pending_writes: Option<&mut Vec<JoinHandle<Result<(), EthCallCollectionError>>>>,
 ) -> Result<(), EthCallCollectionError> {
     let mut addresses_by_collection: HashMap<String, HashSet<Address>> = HashMap::new();
     for addrs in factory_data.addresses_by_block.values() {
@@ -220,7 +225,7 @@ pub(crate) async fn process_factory_range(
 
             let last_ts = filtered_blocks.last().map(|b| b.timestamp);
 
-            finalize_regular_results(FinalizeRegularParams {
+            let finalize_params = FinalizeRegularParams {
                 results: all_results,
                 max_params,
                 sub_dir,
@@ -243,8 +248,13 @@ pub(crate) async fn process_factory_range(
                     rpc_time,
                     process_time,
                 )),
-            })
-            .await?;
+            };
+            if let Some(ref mut writes) = pending_writes {
+                let handle = finalize_regular_results_deferred(finalize_params).await?;
+                writes.push(handle);
+            } else {
+                finalize_regular_results(finalize_params).await?;
+            }
         }
     }
 
@@ -262,6 +272,7 @@ pub(crate) async fn process_factory_range_multicall(
     max_params: usize,
     frequency_state: &mut FrequencyState,
     multicall3_address: Address,
+    mut pending_writes: Option<&mut Vec<JoinHandle<Result<(), EthCallCollectionError>>>>,
 ) -> Result<(), EthCallCollectionError> {
     // Collect factory addresses by collection
     let mut addresses_by_collection: HashMap<String, HashSet<Address>> = HashMap::new();
@@ -479,7 +490,7 @@ pub(crate) async fn process_factory_range_multicall(
 
             let last_ts = group.filtered_blocks.last().map(|b| b.timestamp);
 
-            finalize_regular_results(FinalizeRegularParams {
+            let finalize_params = FinalizeRegularParams {
                 results: std::mem::take(results),
                 max_params,
                 sub_dir,
@@ -501,8 +512,13 @@ pub(crate) async fn process_factory_range_multicall(
                 last_block_timestamp: last_ts,
                 #[cfg(feature = "bench")]
                 bench: None,
-            })
-            .await?;
+            };
+            if let Some(ref mut writes) = pending_writes {
+                let handle = finalize_regular_results_deferred(finalize_params).await?;
+                writes.push(handle);
+            } else {
+                finalize_regular_results(finalize_params).await?;
+            }
         }
     }
 
@@ -516,6 +532,7 @@ pub(crate) async fn process_range(
     call_configs: &[CallConfig],
     max_params: usize,
     frequency_state: &mut FrequencyState,
+    mut pending_writes: Option<&mut Vec<JoinHandle<Result<(), EthCallCollectionError>>>>,
 ) -> Result<(), EthCallCollectionError> {
     let mut grouped_configs: HashMap<(String, String), Vec<&CallConfig>> = HashMap::new();
     for config in call_configs {
@@ -661,7 +678,7 @@ pub(crate) async fn process_range(
 
         let last_ts = filtered_blocks.last().map(|b| b.timestamp);
 
-        finalize_regular_results(FinalizeRegularParams {
+        let finalize_params = FinalizeRegularParams {
             results: all_results,
             max_params,
             sub_dir,
@@ -684,8 +701,13 @@ pub(crate) async fn process_range(
                 rpc_time,
                 process_time,
             )),
-        })
-        .await?;
+        };
+        if let Some(ref mut writes) = pending_writes {
+            let handle = finalize_regular_results_deferred(finalize_params).await?;
+            writes.push(handle);
+        } else {
+            finalize_regular_results(finalize_params).await?;
+        }
     }
 
     Ok(())
@@ -700,6 +722,7 @@ pub(crate) async fn process_range_multicall(
     max_params: usize,
     frequency_state: &mut FrequencyState,
     multicall3_address: Address,
+    mut pending_writes: Option<&mut Vec<JoinHandle<Result<(), EthCallCollectionError>>>>,
 ) -> Result<(), EthCallCollectionError> {
     // Group configs by (contract_name, function_name)
     let mut grouped_configs: HashMap<(String, String), Vec<&CallConfig>> = HashMap::new();
@@ -878,7 +901,7 @@ pub(crate) async fn process_range_multicall(
 
             let last_ts = group.filtered_blocks.last().map(|b| b.timestamp);
 
-            finalize_regular_results(FinalizeRegularParams {
+            let finalize_params = FinalizeRegularParams {
                 results: std::mem::take(results),
                 max_params,
                 sub_dir,
@@ -900,8 +923,13 @@ pub(crate) async fn process_range_multicall(
                 last_block_timestamp: last_ts,
                 #[cfg(feature = "bench")]
                 bench: None,
-            })
-            .await?;
+            };
+            if let Some(ref mut writes) = pending_writes {
+                let handle = finalize_regular_results_deferred(finalize_params).await?;
+                writes.push(handle);
+            } else {
+                finalize_regular_results(finalize_params).await?;
+            }
         }
     }
 

--- a/src/raw_data/historical/eth_calls/regular_calls.rs
+++ b/src/raw_data/historical/eth_calls/regular_calls.rs
@@ -9,8 +9,6 @@ use alloy::dyn_abi::DynSolValue;
 use alloy::primitives::Address;
 use alloy::rpc::types::{BlockId, BlockNumberOrTag, TransactionRequest};
 
-use tokio::task::JoinHandle;
-
 use super::config::{compute_function_selector, generate_param_combinations};
 use super::frequency::filter_blocks_for_frequency;
 use super::multicall::{
@@ -21,8 +19,8 @@ use super::postprocessing::{
     finalize_regular_results, finalize_regular_results_deferred, FinalizeRegularParams,
 };
 use super::types::{
-    BlockInfo, BlockRange, CallConfig, CallResult, EthCallCollectionError, EthCallContext,
-    EncodedParam, FrequencyState,
+    AbortOnDropHandles, BlockInfo, BlockRange, CallConfig, CallResult, EthCallCollectionError,
+    EthCallContext, EncodedParam, FrequencyState,
 };
 use crate::raw_data::historical::factories::FactoryAddressData;
 use crate::types::config::eth_call::{encode_call_with_params, EthCallConfig};
@@ -35,7 +33,7 @@ pub(crate) async fn process_factory_range(
     factory_call_configs: &HashMap<String, Vec<EthCallConfig>>,
     max_params: usize,
     frequency_state: &mut FrequencyState,
-    mut pending_writes: Option<&mut Vec<JoinHandle<Result<(), EthCallCollectionError>>>>,
+    mut pending_writes: Option<&mut AbortOnDropHandles>,
 ) -> Result<(), EthCallCollectionError> {
     let mut addresses_by_collection: HashMap<String, HashSet<Address>> = HashMap::new();
     for addrs in factory_data.addresses_by_block.values() {
@@ -272,7 +270,7 @@ pub(crate) async fn process_factory_range_multicall(
     max_params: usize,
     frequency_state: &mut FrequencyState,
     multicall3_address: Address,
-    mut pending_writes: Option<&mut Vec<JoinHandle<Result<(), EthCallCollectionError>>>>,
+    mut pending_writes: Option<&mut AbortOnDropHandles>,
 ) -> Result<(), EthCallCollectionError> {
     // Collect factory addresses by collection
     let mut addresses_by_collection: HashMap<String, HashSet<Address>> = HashMap::new();
@@ -532,7 +530,7 @@ pub(crate) async fn process_range(
     call_configs: &[CallConfig],
     max_params: usize,
     frequency_state: &mut FrequencyState,
-    mut pending_writes: Option<&mut Vec<JoinHandle<Result<(), EthCallCollectionError>>>>,
+    mut pending_writes: Option<&mut AbortOnDropHandles>,
 ) -> Result<(), EthCallCollectionError> {
     let mut grouped_configs: HashMap<(String, String), Vec<&CallConfig>> = HashMap::new();
     for config in call_configs {
@@ -722,7 +720,7 @@ pub(crate) async fn process_range_multicall(
     max_params: usize,
     frequency_state: &mut FrequencyState,
     multicall3_address: Address,
-    mut pending_writes: Option<&mut Vec<JoinHandle<Result<(), EthCallCollectionError>>>>,
+    mut pending_writes: Option<&mut AbortOnDropHandles>,
 ) -> Result<(), EthCallCollectionError> {
     // Group configs by (contract_name, function_name)
     let mut grouped_configs: HashMap<(String, String), Vec<&CallConfig>> = HashMap::new();

--- a/src/raw_data/historical/eth_calls/types.rs
+++ b/src/raw_data/historical/eth_calls/types.rs
@@ -1,12 +1,13 @@
 //! Types for eth_call collection: error types, config structs, result structs, and state.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use alloy::primitives::Address;
 use thiserror::Error;
 use tokio::sync::mpsc::Sender;
+use tokio::task::JoinHandle;
 
 use crate::decoding::DecoderMessage;
 use crate::raw_data::historical::eth_calls::event_triggers::SkippedFactoryTrigger;
@@ -43,6 +44,43 @@ pub enum EthCallCollectionError {
 
     #[error("Event parameter extraction error: {0}")]
     EventParamExtraction(String),
+}
+
+/// A collection of spawned write-task handles that aborts all remaining
+/// tasks when dropped. Prevents silent detached writes on error paths.
+pub(crate) struct AbortOnDropHandles {
+    handles: VecDeque<JoinHandle<Result<(), EthCallCollectionError>>>,
+}
+
+impl AbortOnDropHandles {
+    pub fn new() -> Self {
+        Self {
+            handles: VecDeque::new(),
+        }
+    }
+
+    pub fn push(&mut self, handle: JoinHandle<Result<(), EthCallCollectionError>>) {
+        self.handles.push_back(handle);
+    }
+
+    /// Await all handles front-to-back. On error, remaining handles stay in
+    /// `self` and are aborted by `Drop`.
+    pub async fn drain_all(&mut self) -> Result<(), EthCallCollectionError> {
+        while let Some(handle) = self.handles.pop_front() {
+            handle
+                .await
+                .map_err(|e| EthCallCollectionError::JoinError(e.to_string()))??;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for AbortOnDropHandles {
+    fn drop(&mut self) {
+        for handle in &self.handles {
+            handle.abort();
+        }
+    }
 }
 
 pub use crate::storage::BlockRange;


### PR DESCRIPTION
## Summary

- During eth_call catchup, parquet writes (+ S3 upload + decoder notification) for one range now run concurrently with RPC work for the next range, eliminating rate limiter idle gaps between ranges.
- Added `finalize_regular_results_deferred` in `postprocessing.rs` that spawns the I/O work as a background tokio task (frequency state updates still happen synchronously to preserve correctness).
- `process_range`, `process_range_multicall`, `process_factory_range`, and `process_factory_range_multicall` accept an optional `pending_writes` Vec to collect deferred write handles; when `None` (current/live callers), behavior is unchanged.
- The catchup loop in `catchup/eth_calls.rs` drains pending write handles at the start of each range iteration and after the final range.