### PR TITLE
feat: add v3 and lockable v3 create handlers

### DIFF
--- a/config/contracts/base/v3.json
+++ b/config/contracts/base/v3.json
@@ -10,8 +10,11 @@
                 "factory_events": {
                     "name": "Create",
                     "topics_signature": "address,address,address",
-                    "factory_parameters": "topics[1]"                
+                    "factory_parameters": "topics[1]"
                 },
+                "calls": [
+                    { "function": "fee()", "output_type": "uint24", "frequency": "once" }
+                ],
                 "events": [
                     { "signature": "Mint(address sender, address indexed owner, int24 indexed tickLower, int24 indexed tickUpper, uint128 amount, uint256 amount0, uint256 amount1)" },
                     { "signature": "Burn(address indexed owner, int24 indexed tickLower, int24 indexed tickUpper, uint128 amount, uint256 amount0, uint256 amount1)" },
@@ -31,8 +34,11 @@
                 "factory_events": {
                     "name": "Create",
                     "topics_signature": "address,address,address",
-                    "factory_parameters": "topics[1]"                
+                    "factory_parameters": "topics[1]"
                 },
+                "calls": [
+                    { "function": "fee()", "output_type": "uint24", "frequency": "once" }
+                ],
                 "events": [
                     { "signature": "Mint(address sender, address indexed owner, int24 indexed tickLower, int24 indexed tickUpper, uint128 amount, uint256 amount0, uint256 amount1)" },
                     { "signature": "Burn(address indexed owner, int24 indexed tickLower, int24 indexed tickUpper, uint128 amount, uint256 amount0, uint256 amount1)" },

--- a/src/transformations/event/decay_multicurve/create.rs
+++ b/src/transformations/event/decay_multicurve/create.rs
@@ -14,6 +14,7 @@ use crate::transformations::util::db::pool::{
 use crate::transformations::util::db::token::{insert_token, TokenData};
 use crate::transformations::util::db::v4_pool_configs::{insert_pool_config, PoolConfigData};
 use crate::transformations::util::metadata::get_metadata;
+use crate::transformations::util::migration::resolve_migration_type;
 use crate::types::decoded::DecodedValue;
 use crate::types::uniswap::v4::{PoolAddressOrPoolId, PoolKey, V4PoolConfig};
 
@@ -347,24 +348,7 @@ impl TransformationHandler for V4DecayMulticurveCreateHandler {
                     _ => Vec::new(),
                 });
 
-            let migration_type = ctx
-                .match_contract_address(
-                    asset_metadata.migrator.into(),
-                    &[
-                        "UniswapV4Migrator",
-                        "UniswapV2Migrator",
-                        "NimCustomV2Migrator",
-                        "UniswapV3Migrator",
-                        "NimCustomV3Migrator",
-                    ],
-                )
-                .map(|contract_name| match contract_name {
-                    "UniswapV4Migrator" => "v4",
-                    "UniswapV2Migrator" | "NimCustomV2Migrator" => "v2",
-                    "UniswapV3Migrator" | "NimCustomV3Migrator" => "v3",
-                    _ => "unknown",
-                })
-                .unwrap_or("unknown");
+            let migration_type = resolve_migration_type(ctx, asset_metadata.migrator.into());
 
             ops.push(insert_pool(
                 &PoolData {
@@ -386,7 +370,7 @@ impl TransformationHandler for V4DecayMulticurveCreateHandler {
                     migration_type: migration_type.to_string(),
                     lock_duration: None,
                     beneficiaries,
-                    pool_key,
+                    pool_key: Some(pool_key),
                     starting_time: pool_config.starting_time,
                     ending_time: pool_config.ending_time,
                 },

--- a/src/transformations/event/dhook/create.rs
+++ b/src/transformations/event/dhook/create.rs
@@ -16,6 +16,7 @@ use crate::transformations::util::db::pool::{
 };
 use crate::transformations::util::db::token::{insert_token, TokenData};
 use crate::transformations::util::metadata::get_metadata;
+use crate::transformations::util::migration::resolve_migration_type;
 use crate::types::decoded::DecodedValue;
 use crate::types::uniswap::v4::{PoolAddressOrPoolId, PoolKey};
 
@@ -167,28 +168,7 @@ impl TransformationHandler for DopplerHookCreateHandler {
                     _ => Vec::new(),
                 });
 
-            let migration_type = ctx
-                .match_contract_address(
-                    asset_metadata.migrator.into(),
-                    &[
-                        "UniswapV4Migrator",
-                        "UniswapV2Migrator",
-                        "NimCustomV2Migrator",
-                        "UniswapV3Migrator",
-                        "NimCustomV3Migrator",
-                        "DopplerHookMigrator",
-                        "RehypeDopplerHookMigrator",
-                    ],
-                )
-                .map(|contract_name| match contract_name {
-                    "UniswapV4Migrator" => "v4",
-                    "UniswapV2Migrator" | "NimCustomV2Migrator" => "v2",
-                    "UniswapV3Migrator" | "NimCustomV3Migrator" => "v3",
-                    "DopplerHookMigrator" => "dhook",
-                    "RehypeDopplerHookMigrator" => "rehype",
-                    _ => "unknown",
-                })
-                .unwrap_or("unknown");
+            let migration_type = resolve_migration_type(ctx, asset_metadata.migrator.into());
 
             let pool_type = if ctx.match_contract_address(hook, &["RehypeHook"]).is_some() {
                 "rehype"
@@ -216,7 +196,7 @@ impl TransformationHandler for DopplerHookCreateHandler {
                     migration_type: migration_type.to_string(),
                     lock_duration: None,
                     beneficiaries,
-                    pool_key,
+                    pool_key: Some(pool_key),
                     starting_time: 0,
                     ending_time: 0,
                 },

--- a/src/transformations/event/mod.rs
+++ b/src/transformations/event/mod.rs
@@ -7,6 +7,7 @@ pub mod derc20_transfer;
 pub mod dhook;
 pub mod multicurve;
 pub mod scheduled_multicurve;
+pub mod v3;
 pub mod v4;
 
 use super::registry::TransformationRegistry;
@@ -19,4 +20,5 @@ pub fn register_handlers(registry: &mut TransformationRegistry) {
     scheduled_multicurve::create::register_handlers(registry);
     decay_multicurve::create::register_handlers(registry);
     dhook::create::register_handlers(registry);
+    v3::create::register_handlers(registry);
 }

--- a/src/transformations/event/multicurve/create.rs
+++ b/src/transformations/event/multicurve/create.rs
@@ -14,6 +14,7 @@ use crate::transformations::util::db::pool::{
 use crate::transformations::util::db::token::{insert_token, TokenData};
 use crate::transformations::util::db::v4_pool_configs::{insert_pool_config, PoolConfigData};
 use crate::transformations::util::metadata::get_metadata;
+use crate::transformations::util::migration::resolve_migration_type;
 use crate::types::decoded::DecodedValue;
 use crate::types::uniswap::v4::{PoolAddressOrPoolId, PoolKey, V4PoolConfig};
 
@@ -347,24 +348,7 @@ impl TransformationHandler for V4MulticurveCreateHandler {
                     _ => Vec::new(),
                 });
 
-            let migration_type = ctx
-                .match_contract_address(
-                    asset_metadata.migrator.into(),
-                    &[
-                        "UniswapV4Migrator",
-                        "UniswapV2Migrator",
-                        "NimCustomV2Migrator",
-                        "UniswapV3Migrator",
-                        "NimCustomV3Migrator",
-                    ],
-                )
-                .map(|contract_name| match contract_name {
-                    "UniswapV4Migrator" => "v4",
-                    "UniswapV2Migrator" | "NimCustomV2Migrator" => "v2",
-                    "UniswapV3Migrator" | "NimCustomV3Migrator" => "v3",
-                    _ => "unknown",
-                })
-                .unwrap_or("unknown");
+            let migration_type = resolve_migration_type(ctx, asset_metadata.migrator.into());
 
             ops.push(insert_pool(
                 &PoolData {
@@ -386,7 +370,7 @@ impl TransformationHandler for V4MulticurveCreateHandler {
                     migration_type: migration_type.to_string(),
                     lock_duration: None,
                     beneficiaries,
-                    pool_key,
+                    pool_key: Some(pool_key),
                     starting_time: pool_config.starting_time,
                     ending_time: pool_config.ending_time,
                 },

--- a/src/transformations/event/scheduled_multicurve/create.rs
+++ b/src/transformations/event/scheduled_multicurve/create.rs
@@ -15,6 +15,7 @@ use crate::transformations::util::db::pool::{
 use crate::transformations::util::db::token::{insert_token, TokenData};
 use crate::transformations::util::db::v4_pool_configs::{insert_pool_config, PoolConfigData};
 use crate::transformations::util::metadata::get_metadata;
+use crate::transformations::util::migration::resolve_migration_type;
 use crate::types::decoded::DecodedValue;
 use crate::types::uniswap::v4::{PoolAddressOrPoolId, PoolKey, V4PoolConfig};
 
@@ -378,24 +379,7 @@ impl TransformationHandler for V4ScheduledMulticurveCreateHandler {
                     _ => Vec::new(),
                 });
 
-            let migration_type = ctx
-                .match_contract_address(
-                    asset_metadata.migrator.into(),
-                    &[
-                        "UniswapV4Migrator",
-                        "UniswapV2Migrator",
-                        "NimCustomV2Migrator",
-                        "UniswapV3Migrator",
-                        "NimCustomV3Migrator",
-                    ],
-                )
-                .map(|contract_name| match contract_name {
-                    "UniswapV4Migrator" => "v4",
-                    "UniswapV2Migrator" | "NimCustomV2Migrator" => "v2",
-                    "UniswapV3Migrator" | "NimCustomV3Migrator" => "v3",
-                    _ => "unknown",
-                })
-                .unwrap_or("unknown");
+            let migration_type = resolve_migration_type(ctx, asset_metadata.migrator.into());
 
             ops.push(insert_pool(
                 &PoolData {
@@ -417,7 +401,7 @@ impl TransformationHandler for V4ScheduledMulticurveCreateHandler {
                     migration_type: migration_type.to_string(),
                     lock_duration: None,
                     beneficiaries,
-                    pool_key,
+                    pool_key: Some(pool_key),
                     starting_time: pool_config.starting_time,
                     ending_time: pool_config.ending_time,
                 },

--- a/src/transformations/event/v3/create.rs
+++ b/src/transformations/event/v3/create.rs
@@ -1,0 +1,339 @@
+use async_trait::async_trait;
+
+use alloy_primitives::{Address, B256, U256};
+
+use crate::db::{DbOperation, DbPool};
+use crate::transformations::context::{FieldExtractor, TransformationContext};
+use crate::transformations::error::TransformationError;
+use crate::transformations::registry::TransformationRegistry;
+use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
+
+use crate::transformations::util::db::pool::{insert_pool, PoolData};
+use crate::transformations::util::db::token::{insert_token, TokenData};
+use crate::transformations::util::metadata::get_metadata;
+use crate::transformations::util::migration::resolve_migration_type;
+
+use crate::types::uniswap::v4::PoolAddressOrPoolId;
+
+pub struct V3CreateHandler;
+
+#[async_trait]
+impl TransformationHandler for V3CreateHandler {
+    fn name(&self) -> &'static str {
+        "V3CreateHandler"
+    }
+
+    fn version(&self) -> u32 {
+        1
+    }
+
+    fn migration_paths(&self) -> Vec<&'static str> {
+        vec![
+            "migrations/tables/tokens.sql",
+            "migrations/tables/pools.sql",
+        ]
+    }
+
+    fn reorg_tables(&self) -> Vec<&'static str> {
+        vec!["tokens", "pools"]
+    }
+
+    async fn handle(
+        &self,
+        ctx: &TransformationContext,
+    ) -> Result<Vec<DbOperation>, TransformationError> {
+        let mut ops = Vec::new();
+
+        for event in ctx.events_of_type("UniswapV3Initializer", "Create") {
+            let asset = event.extract_address("asset")?;
+            let numeraire = event.extract_address("numeraire")?;
+            let pool_or_hook = event.extract_address("poolOrHook")?;
+
+            let (asset_metadata, numeraire_metadata) =
+                get_metadata(&asset, &numeraire, event, ctx)?;
+
+            let pool_call = ctx
+                .calls_for_address(pool_or_hook)
+                .find(|call| call.function_name == "once")
+                .ok_or_else(|| {
+                    let available_calls: Vec<_> = ctx
+                        .calls_for_address(pool_or_hook)
+                        .map(|c| format!("{}:{}", c.source_name, c.function_name))
+                        .collect();
+                    TransformationError::MissingData(format!(
+                        "No 'once' call found for pool {} at block {} tx {}. Available calls: {:?}",
+                        Address::from(pool_or_hook),
+                        event.block_number,
+                        B256::from(event.transaction_hash),
+                        available_calls
+                    ))
+                })?;
+
+            let fee = pool_call.extract_u32("fee")?;
+            let is_token_0 = asset < numeraire;
+
+            ops.push(insert_token(
+                &TokenData {
+                    block_number: event.block_number,
+                    block_timestamp: event.block_timestamp,
+                    tx_hash: &event.transaction_hash,
+                    creator_address: ctx.tx_from(&event.transaction_hash),
+                    integrator: Some(&asset_metadata.integrator.into()),
+                    token_address: &asset,
+                    pool: Some(&PoolAddressOrPoolId::Address(pool_or_hook)),
+                    name: &asset_metadata.name,
+                    symbol: &asset_metadata.symbol,
+                    decimals: asset_metadata.decimals,
+                    total_supply: Some(&asset_metadata.total_supply),
+                    token_uri: Some(&asset_metadata.token_uri),
+                    is_derc20: true,
+                    is_creator_coin: false,
+                    is_content_coin: false,
+                    creator_coin_pool: None,
+                    governance: Some(&asset_metadata.governance),
+                },
+                ctx,
+            ));
+
+            ops.push(insert_token(
+                &TokenData {
+                    block_number: event.block_number,
+                    block_timestamp: event.block_timestamp,
+                    tx_hash: &event.transaction_hash,
+                    creator_address: None,
+                    integrator: None,
+                    token_address: &numeraire,
+                    pool: None,
+                    name: &numeraire_metadata.name,
+                    symbol: &numeraire_metadata.symbol,
+                    decimals: numeraire_metadata.decimals,
+                    total_supply: None,
+                    token_uri: None,
+                    is_derc20: false,
+                    is_creator_coin: false,
+                    is_content_coin: false,
+                    creator_coin_pool: None,
+                    governance: None,
+                },
+                ctx,
+            ));
+
+            let migration_type = resolve_migration_type(ctx, asset_metadata.migrator.into());
+
+            ops.push(insert_pool(
+                &PoolData {
+                    block_number: event.block_number,
+                    block_timestamp: event.block_timestamp,
+                    address: PoolAddressOrPoolId::Address(pool_or_hook),
+                    base_token: asset,
+                    quote_token: numeraire,
+                    is_token_0,
+                    pool_type: "v3".to_string(),
+                    integrator: asset_metadata.integrator.into(),
+                    initializer: asset_metadata.initializer.into(),
+                    fee,
+                    min_threshold: U256::ZERO,
+                    max_threshold: U256::ZERO,
+                    migrator: asset_metadata.migrator.into(),
+                    migrated_at: None,
+                    migration_pool: asset_metadata.migration_pool,
+                    migration_type: migration_type.to_string(),
+                    lock_duration: None,
+                    beneficiaries: None,
+                    pool_key: None,
+                    starting_time: 0,
+                    ending_time: 0,
+                },
+                ctx,
+            ));
+        }
+
+        Ok(ops)
+    }
+
+    async fn initialize(&self, _db_pool: &DbPool) -> Result<(), TransformationError> {
+        tracing::info!("V3CreateHandler initialized");
+        Ok(())
+    }
+}
+
+impl EventHandler for V3CreateHandler {
+    fn triggers(&self) -> Vec<EventTrigger> {
+        vec![EventTrigger::new(
+            "UniswapV3Initializer",
+            "Create(address,address,address)",
+        )]
+    }
+
+    fn call_dependencies(&self) -> Vec<(String, String)> {
+        vec![
+            ("DERC20".to_string(), "once".to_string()),
+            ("Numeraires".to_string(), "once".to_string()),
+            ("DopplerV3Pool".to_string(), "once".to_string()),
+        ]
+    }
+}
+
+pub struct LockableV3CreateHandler;
+
+#[async_trait]
+impl TransformationHandler for LockableV3CreateHandler {
+    fn name(&self) -> &'static str {
+        "LockableV3CreateHandler"
+    }
+
+    fn version(&self) -> u32 {
+        1
+    }
+
+    fn migration_paths(&self) -> Vec<&'static str> {
+        vec![
+            "migrations/tables/tokens.sql",
+            "migrations/tables/pools.sql",
+        ]
+    }
+
+    fn reorg_tables(&self) -> Vec<&'static str> {
+        vec!["tokens", "pools"]
+    }
+
+    async fn handle(
+        &self,
+        ctx: &TransformationContext,
+    ) -> Result<Vec<DbOperation>, TransformationError> {
+        let mut ops = Vec::new();
+
+        for event in ctx.events_of_type("LockableUniswapV3Initializer", "Create") {
+            let asset = event.extract_address("asset")?;
+            let numeraire = event.extract_address("numeraire")?;
+            let pool_or_hook = event.extract_address("poolOrHook")?;
+
+            let (asset_metadata, numeraire_metadata) =
+                get_metadata(&asset, &numeraire, event, ctx)?;
+
+            let pool_call = ctx
+                .calls_for_address(pool_or_hook)
+                .find(|call| call.function_name == "once")
+                .ok_or_else(|| {
+                    let available_calls: Vec<_> = ctx
+                        .calls_for_address(pool_or_hook)
+                        .map(|c| format!("{}:{}", c.source_name, c.function_name))
+                        .collect();
+                    TransformationError::MissingData(format!(
+                        "No 'once' call found for pool {} at block {} tx {}. Available calls: {:?}",
+                        Address::from(pool_or_hook),
+                        event.block_number,
+                        B256::from(event.transaction_hash),
+                        available_calls
+                    ))
+                })?;
+
+            let fee = pool_call.extract_u32("fee")?;
+            let is_token_0 = asset < numeraire;
+
+            ops.push(insert_token(
+                &TokenData {
+                    block_number: event.block_number,
+                    block_timestamp: event.block_timestamp,
+                    tx_hash: &event.transaction_hash,
+                    creator_address: ctx.tx_from(&event.transaction_hash),
+                    integrator: Some(&asset_metadata.integrator.into()),
+                    token_address: &asset,
+                    pool: Some(&PoolAddressOrPoolId::Address(pool_or_hook)),
+                    name: &asset_metadata.name,
+                    symbol: &asset_metadata.symbol,
+                    decimals: asset_metadata.decimals,
+                    total_supply: Some(&asset_metadata.total_supply),
+                    token_uri: Some(&asset_metadata.token_uri),
+                    is_derc20: true,
+                    is_creator_coin: false,
+                    is_content_coin: false,
+                    creator_coin_pool: None,
+                    governance: Some(&asset_metadata.governance),
+                },
+                ctx,
+            ));
+
+            ops.push(insert_token(
+                &TokenData {
+                    block_number: event.block_number,
+                    block_timestamp: event.block_timestamp,
+                    tx_hash: &event.transaction_hash,
+                    creator_address: None,
+                    integrator: None,
+                    token_address: &numeraire,
+                    pool: None,
+                    name: &numeraire_metadata.name,
+                    symbol: &numeraire_metadata.symbol,
+                    decimals: numeraire_metadata.decimals,
+                    total_supply: None,
+                    token_uri: None,
+                    is_derc20: false,
+                    is_creator_coin: false,
+                    is_content_coin: false,
+                    creator_coin_pool: None,
+                    governance: None,
+                },
+                ctx,
+            ));
+
+            let migration_type = resolve_migration_type(ctx, asset_metadata.migrator.into());
+
+            ops.push(insert_pool(
+                &PoolData {
+                    block_number: event.block_number,
+                    block_timestamp: event.block_timestamp,
+                    address: PoolAddressOrPoolId::Address(pool_or_hook),
+                    base_token: asset,
+                    quote_token: numeraire,
+                    is_token_0,
+                    pool_type: "lockable_v3".to_string(),
+                    integrator: asset_metadata.integrator.into(),
+                    initializer: asset_metadata.initializer.into(),
+                    fee,
+                    min_threshold: U256::ZERO,
+                    max_threshold: U256::ZERO,
+                    migrator: asset_metadata.migrator.into(),
+                    migrated_at: None,
+                    migration_pool: asset_metadata.migration_pool,
+                    migration_type: migration_type.to_string(),
+                    lock_duration: None,
+                    beneficiaries: None,
+                    pool_key: None,
+                    starting_time: 0,
+                    ending_time: 0,
+                },
+                ctx,
+            ));
+        }
+
+        Ok(ops)
+    }
+
+    async fn initialize(&self, _db_pool: &DbPool) -> Result<(), TransformationError> {
+        tracing::info!("LockableV3CreateHandler initialized");
+        Ok(())
+    }
+}
+
+impl EventHandler for LockableV3CreateHandler {
+    fn triggers(&self) -> Vec<EventTrigger> {
+        vec![EventTrigger::new(
+            "LockableUniswapV3Initializer",
+            "Create(address,address,address)",
+        )]
+    }
+
+    fn call_dependencies(&self) -> Vec<(String, String)> {
+        vec![
+            ("DERC20".to_string(), "once".to_string()),
+            ("Numeraires".to_string(), "once".to_string()),
+            ("DopplerLockableV3Pool".to_string(), "once".to_string()),
+        ]
+    }
+}
+
+pub fn register_handlers(registry: &mut TransformationRegistry) {
+    registry.register_event_handler(V3CreateHandler);
+    registry.register_event_handler(LockableV3CreateHandler);
+}

--- a/src/transformations/event/v3/mod.rs
+++ b/src/transformations/event/v3/mod.rs
@@ -1,0 +1,1 @@
+pub mod create;

--- a/src/transformations/event/v4/create.rs
+++ b/src/transformations/event/v4/create.rs
@@ -12,6 +12,7 @@ use crate::transformations::util::db::pool::{insert_pool, PoolData};
 use crate::transformations::util::db::token::{insert_token, TokenData};
 use crate::transformations::util::db::v4_pool_configs::{insert_pool_config, PoolConfigData};
 use crate::transformations::util::metadata::get_metadata;
+use crate::transformations::util::migration::resolve_migration_type;
 
 use crate::types::uniswap::v4::{PoolAddressOrPoolId, PoolKey, V4PoolConfig};
 
@@ -170,24 +171,7 @@ impl TransformationHandler for V4CreateHandler {
                 ctx,
             ));
 
-            let migration_type = ctx
-                .match_contract_address(
-                    asset_metadata.migrator.into(),
-                    &[
-                        "UniswapV4Migrator",
-                        "UniswapV2Migrator",
-                        "NimCustomV2Migrator",
-                        "UniswapV3Migrator",
-                        "NimCustomV3Migrator",
-                    ],
-                )
-                .map(|contract_name| match contract_name {
-                    "UniswapV4Migrator" => "v4",
-                    "UniswapV2Migrator" | "NimCustomV2Migrator" => "v2",
-                    "UniswapV3Migrator" | "NimCustomV3Migrator" => "v3",
-                    _ => "unknown",
-                })
-                .unwrap_or("unknown");
+            let migration_type = resolve_migration_type(ctx, asset_metadata.migrator.into());
 
             ops.push(insert_pool(
                 &PoolData {
@@ -209,7 +193,7 @@ impl TransformationHandler for V4CreateHandler {
                     migration_type: migration_type.to_string(),
                     lock_duration: None,
                     beneficiaries: None,
-                    pool_key,
+                    pool_key: Some(pool_key),
                     starting_time: pool_config.starting_time,
                     ending_time: pool_config.ending_time,
                 },

--- a/src/transformations/util/db/pool.rs
+++ b/src/transformations/util/db/pool.rs
@@ -51,7 +51,7 @@ pub struct PoolData {
     pub migration_type: String,
     pub lock_duration: Option<u32>,
     pub beneficiaries: Option<BeneficiariesData>,
-    pub pool_key: PoolKey,
+    pub pool_key: Option<PoolKey>,
     pub starting_time: u64,
     pub ending_time: u64,
 }
@@ -120,7 +120,10 @@ pub fn insert_pool(data: &PoolData, ctx: &TransformationContext) -> DbOperation 
                 Some(beneficiaries_data) => DbValue::jsonb(beneficiaries_data),
                 None => DbValue::Null,
             },
-            DbValue::jsonb(&data.pool_key),
+            match &data.pool_key {
+                Some(pk) => DbValue::jsonb(pk),
+                None => DbValue::Null,
+            },
             DbValue::Timestamp(data.starting_time as i64),
             DbValue::Timestamp(data.ending_time as i64),
         ],

--- a/src/transformations/util/migration.rs
+++ b/src/transformations/util/migration.rs
@@ -1,0 +1,32 @@
+use crate::transformations::context::TransformationContext;
+
+/// Resolve the migration type string from a migrator contract address.
+///
+/// Matches the address against all known migrator contracts and returns
+/// the corresponding migration type identifier.
+pub fn resolve_migration_type(
+    ctx: &TransformationContext,
+    migrator_address: [u8; 20],
+) -> &'static str {
+    ctx.match_contract_address(
+        migrator_address,
+        &[
+            "UniswapV4Migrator",
+            "UniswapV2Migrator",
+            "NimCustomV2Migrator",
+            "UniswapV3Migrator",
+            "NimCustomV3Migrator",
+            "DopplerHookMigrator",
+            "RehypeDopplerHookMigrator",
+        ],
+    )
+    .map(|contract_name| match contract_name {
+        "UniswapV4Migrator" => "v4",
+        "UniswapV2Migrator" | "NimCustomV2Migrator" => "v2",
+        "UniswapV3Migrator" | "NimCustomV3Migrator" => "v3",
+        "DopplerHookMigrator" => "dhook",
+        "RehypeDopplerHookMigrator" => "rehype",
+        _ => "unknown",
+    })
+    .unwrap_or("unknown")
+}

--- a/src/transformations/util/mod.rs
+++ b/src/transformations/util/mod.rs
@@ -4,5 +4,6 @@
 
 pub mod db;
 pub mod metadata;
+pub mod migration;
 pub mod price;
 pub mod sanitize;


### PR DESCRIPTION
## Summary

- Add `V3CreateHandler` and `LockableV3CreateHandler` for processing `UniswapV3Initializer:Create` and `LockableUniswapV3Initializer:Create` events
- Extract `resolve_migration_type()` into a shared utility (`src/transformations/util/migration.rs`), replacing duplicated inline matching across all 5 existing create handlers
- Make `pool_key` optional in `PoolData` — V3 pools use contract addresses rather than V4 pool IDs, so they have no pool key
- Add `fee()` once call to `DopplerV3Pool` and `DopplerLockableV3Pool` factory collections in config