### PR TITLE
feat: pool metrics foundation (phase 1)

### DIFF
--- a/docs/metrics_implementation_phases.md
+++ b/docs/metrics_implementation_phases.md
@@ -1,0 +1,312 @@
+# Pool Metrics Handlers — Implementation Roadmap
+
+## Context
+
+The old TypeScript indexer maintained only point-in-time pool state (reserves, price, market cap, etc.), updated on every event. The new Rust indexer produces **per-block time-series snapshots** alongside a hot-query **pool_state** table, enabling OHLC candles and historical protocol analytics at query time.
+
+This roadmap covers metrics handlers for all 9 pool type variants, shared abstractions, SQL migrations, and contract config changes. It is designed to be implemented across multiple sessions.
+
+---
+
+## Tables
+
+### pool_state — hot query target for dashboards
+
+Keyed by `(chain_id, pool_id, source, source_version)`. Contains latest tick, sqrt_price_x96, price, active_liquidity. Conditional upsert: only update if new `block_number > existing`. TVL and rolling 24h fields added in later phases.
+
+### pool_snapshots — per-block time series
+
+Keyed by `(chain_id, pool_id, block_number, source, source_version)`. OHLC prices, active_liquidity, volume0/1, swap_count. One row per (pool, block) with activity. INSERT ON CONFLICT updates all columns (idempotent).
+
+### liquidity_deltas — append-only recovery log
+
+Keyed by `(chain_id, pool_id, block_number, log_index)`. tick_lower, tick_upper, liquidity_delta. Simple INSERT. Used to rebuild in-memory tick maps for future TVL computation.
+
+---
+
+## Handler Matrix
+
+| Handler | Source | Swap Event | Liquidity Event | sqrtPriceX96 Source | Pool ID Source | Special |
+|---------|--------|-----------|-----------------|--------------------|----|---------|
+| V3MetricsHandler | DopplerV3Pool | V3 Swap (has sqrtPriceX96) | Mint/Burn | From event | contract_address (20 bytes) | — |
+| LockableV3MetricsHandler | DopplerLockableV3Pool | V3 Swap (has sqrtPriceX96) | Mint/Burn | From event | contract_address (20 bytes) | — |
+| V4BaseMetricsHandler | DopplerV4Hook | `Swap(int24, uint256, uint256)` | None (liquidity changes on swap) | Derived from tick via `tick_to_sqrt_price_x96()` | hook_address → pool_id via `v4_pool_configs` table | **Sequential**: in-memory proceeds tracker |
+| MulticurveMetricsHandler | UniswapV4MulticurveInitializerHook | V4 hook Swap (int128 amounts) | ModifyLiquidity (tuple PoolKey format) | getSlot0 on_event call | topics[3] (poolId) | — |
+| DecayMulticurveMetricsHandler | DecayMulticurveHook | V4 hook Swap (int128 amounts) | ModifyLiquidity (flat format, id in topics[1]) | getSlot0 on_event call | topics[3] (poolId) | — |
+| ScheduledMulticurveMetricsHandler | UniswapV4ScheduledMulticurveInitializerHook | V4 hook Swap (int128 amounts) | ModifyLiquidity (flat format, id in topics[1]) | getSlot0 on_event call | topics[3] (poolId) | — |
+| DhookMetricsHandler | DopplerHookInitializer | V4 hook Swap (int128 amounts) | ModifyLiquidity (tuple PoolKey format) | getSlot0 on_event call | topics[3] (poolId) | Initializer itself emits events |
+| MigrationPoolMetricsHandler | UniswapV4PoolManager + UniswapV4MigratorHook | PoolManager Swap (has sqrtPriceX96) | MigratorHook ModifyLiquidity | From event | topics[1] (id) | In-memory migration pool ID set for filtering |
+
+---
+
+## Event Signatures Reference
+
+**V3 Swap**: `Swap(address indexed sender, address indexed recipient, int256 amount0, int256 amount1, uint160 sqrtPriceX96, uint128 liquidity, int24 tick)`
+
+**V3 Mint**: `Mint(address sender, address indexed owner, int24 indexed tickLower, int24 indexed tickUpper, uint128 amount, uint256 amount0, uint256 amount1)`
+
+**V3 Burn**: `Burn(address indexed owner, int24 indexed tickLower, int24 indexed tickUpper, uint128 amount, uint256 amount0, uint256 amount1)`
+
+**V4 Base Swap**: `Swap(int24 currentTick, uint256 totalProceeds, uint256 totalTokensSold)`
+
+**V4 Hook Swap** (multicurve, decay, scheduled, dhook): `Swap(address indexed sender, (address currency0, address currency1, uint24 fee, int24 tickSpacing, address hooks) indexed poolKey, bytes32 indexed poolId, (bool zeroForOne, int256 amountSpecified, uint160 sqrtPriceLimitX96) params, int128 amount0, int128 amount1, bytes hookData)`
+
+**ModifyLiquidity (tuple format)** (multicurve, dhook): `ModifyLiquidity((address currency0, address currency1, uint24 fee, int24 tickSpacing, address hooks) key, (int24 tickLower, int24 tickUpper, int256 liquidityDelta, bytes32 salt) params)`
+
+**ModifyLiquidity (flat format)** (decay, scheduled): `ModifyLiquidity(bytes32 indexed id, address indexed sender, int24 tickLower, int24 tickUpper, int256 liquidityDelta, bytes32 salt)`
+
+**PoolManager Swap**: `Swap(bytes32 indexed id, address indexed sender, int128 amount0, int128 amount1, uint160 sqrtPriceX96, uint128 liquidity, int24 tick, uint24 fee)`
+
+**MigratorHook ModifyLiquidity**: `ModifyLiquidity((address currency0, address currency1, uint24 fee, int24 tickSpacing, address hooks) key, (int24 tickLower, int24 tickUpper, int256 liquidityDelta, bytes32 salt) params)`
+
+---
+
+## Processing Model
+
+| What | Ordering | Reason |
+|------|----------|--------|
+| Swap → pool_snapshots | Parallel OK | Per-block, idempotent upsert on conflict |
+| Swap → pool_state | Parallel OK | Conditional upsert (only if newer block) |
+| Mint/Burn/ModifyLiquidity → liquidity_deltas | Parallel OK | Append-only INSERT with PK |
+| V4 base Swap (proceeds) | Sequential | In-memory cumulative state |
+| TVL computation | Deferred | Separate future pass over liquidity_deltas |
+
+---
+
+## Shared Abstractions
+
+### File structure
+
+```
+src/transformations/
+├── util/
+│   ├── tick_math.rs             # NEW — tick_to_sqrt_price_x96(), port of TickMath.getSqrtRatioAtTick
+│   ├── pool_metadata.rs         # NEW — PoolMetadataCache (RwLock<HashMap>), quote_token_decimals()
+│   └── db/pool_metrics.rs       # NEW — upsert_pool_state(), insert_pool_snapshot(), insert_liquidity_delta()
+├── event/
+│   ├── metrics/                 # NEW — shared metrics types
+│   │   ├── mod.rs
+│   │   ├── accumulator.rs       # BlockAccumulator — per-pool per-block OHLC + volume aggregation
+│   │   └── swap_data.rs         # SwapInput, LiquidityInput, process_swaps(), process_liquidity_deltas()
+│   ├── v3/metrics.rs            # NEW
+│   ├── v4/metrics.rs            # NEW
+│   ├── multicurve/metrics.rs    # NEW
+│   ├── decay_multicurve/metrics.rs  # NEW
+│   ├── scheduled_multicurve/metrics.rs  # NEW
+│   ├── dhook/metrics.rs         # NEW
+│   └── migration_pool/          # NEW module
+│       ├── mod.rs
+│       └── metrics.rs
+```
+
+### Core types
+
+- **SwapInput**: Normalized swap data all pool types produce. Fields: pool_id, block_number, block_timestamp, log_index, amount0 (I256), amount1 (I256), sqrt_price_x96 (U256), tick (i32), liquidity (U256).
+- **LiquidityInput**: Normalized liquidity delta. Fields: pool_id, block_number, log_index, tick_lower, tick_upper, liquidity_delta (I256).
+- **BlockAccumulator**: Aggregates multiple swaps in one block into OHLC + volume. Has `record_swap()` method.
+- **PoolMetadataCache**: Thread-safe cache loaded from `pools` table on init. Maps pool_id → (base_token, quote_token, is_token_0, decimals).
+- **process_swaps()**: Takes `Vec<SwapInput>` → groups by (pool_id, block_number) → builds accumulators → emits `Vec<DbOperation>` for pool_snapshots + pool_state.
+- **process_liquidity_deltas()**: Takes `Vec<LiquidityInput>` → emits `Vec<DbOperation>` for liquidity_deltas INSERT.
+
+### Each handler's job
+
+Extract events from its source → normalize to SwapInput/LiquidityInput → call shared process functions. The per-handler code is thin: just event-specific field extraction.
+
+---
+
+## Config Changes Required
+
+### Add getSlot0 on_event calls (4 files)
+
+Target: `UniswapV4StateView`. Triggered by Swap events. Pool ID from topics[3].
+
+| Config File | Contract | Swap Event Source |
+|---|---|---|
+| `config/contracts/base/multicurve.json` | UniswapV4MulticurveInitializerHook | topics[3] |
+| `config/contracts/base/decay_multicurve.json` | DecayMulticurveHook | topics[3] |
+| `config/contracts/base/scheduled_multicurve.json` | UniswapV4ScheduledMulticurveInitializerHook | topics[3] |
+| `config/contracts/base/dhook.json` | DopplerHookInitializer | topics[3] |
+
+On_event call config pattern:
+```json
+{
+    "function": "getSlot0(bytes32)",
+    "output_type": "(uint160 sqrtPriceX96, int24 tick, uint24 protocolFee, uint24 lpFee)",
+    "frequency": { "on_events": {
+        "source": "<contract_name>",
+        "event": "Swap(address,(address,address,uint24,int24,address),bytes32,(bool,int256,uint160),int128,int128,bytes)"
+    }},
+    "target": "UniswapV4StateView",
+    "params": [{ "type": "bytes32", "from_event": "topics[3]" }]
+}
+```
+
+### Add DopplerHookInitializer events (dhook.json)
+
+Add to `DopplerHookInitializer.events[]`:
+```json
+{ "signature": "Swap(address indexed sender, (address currency0, address currency1, uint24 fee, int24 tickSpacing, address hooks) indexed poolKey, bytes32 indexed poolId, (bool zeroForOne, int256 amountSpecified, uint160 sqrtPriceLimitX96) params, int128 amount0, int128 amount1, bytes hookData)" },
+{ "signature": "ModifyLiquidity((address currency0, address currency1, uint24 fee, int24 tickSpacing, address hooks) key, (int24 tickLower, int24 tickUpper, int256 liquidityDelta, bytes32 salt) params)" }
+```
+
+### V4 base — no config change needed
+
+sqrtPriceX96 derived from currentTick via `tick_to_sqrt_price_x96()` in handler code.
+
+---
+
+## Phase 1: Foundation
+
+**Goal**: Build all shared infrastructure. No handlers yet.
+
+### Tasks
+1. Write SQL migrations: `pool_state.sql`, `pool_snapshots.sql`, populate `liquidity_deltas.sql`
+2. Implement `src/transformations/util/tick_math.rs` — port of Uniswap TickMath.getSqrtRatioAtTick()
+3. Implement `src/transformations/util/pool_metadata.rs` — PoolMetadataCache, quote_token_decimals()
+4. Implement `src/transformations/util/db/pool_metrics.rs` — DB operation builders
+5. Implement `src/transformations/event/metrics/` — accumulator.rs, swap_data.rs, mod.rs
+6. Wire new modules in util/mod.rs, util/db/mod.rs, event/mod.rs
+7. Unit tests for tick_math, accumulator, process_swaps
+
+### Key design decisions
+- `pool_state` uses `RawSql` for conditional upsert (`WHERE block_number < EXCLUDED.block_number`). Handler must include source/source_version manually since RawSql skips auto-injection.
+- `pool_snapshots` uses standard `Upsert` with all columns as update_columns (idempotent).
+- `liquidity_deltas` uses standard `Insert`.
+- Quote token decimals hardcoded: WETH=18, USDC=6, USDT=6, EURC=6. Extracted to a shared function from existing price handler pattern.
+
+---
+
+## Phase 2: V3 Handlers
+
+**Goal**: Validate the full pipeline end-to-end with the simplest pool type.
+
+### Tasks
+1. Implement `src/transformations/event/v3/metrics.rs` — V3MetricsHandler + LockableV3MetricsHandler
+2. Register in `v3/mod.rs` and `event/mod.rs`
+3. Test: run against a block range with known V3 swap/mint/burn events, verify pool_state + pool_snapshots + liquidity_deltas
+
+### Handler specifics
+- Source: `DopplerV3Pool` / `DopplerLockableV3Pool`
+- Pool ID = `event.contract_address` (20 bytes, stored as BYTEA)
+- Swap: sqrtPriceX96, tick, liquidity all in event params
+- Mint → LiquidityInput with positive liquidity_delta
+- Burn → LiquidityInput with negative liquidity_delta (negate the `amount`)
+- call_dependencies: none (all data in events)
+
+---
+
+## Phase 3: V4 Hook Handlers
+
+**Goal**: Add metrics for multicurve, decay, scheduled, and dhook pools.
+
+### Tasks
+1. Config changes: add getSlot0 on_event calls to multicurve.json, decay_multicurve.json, scheduled_multicurve.json, dhook.json
+2. Config change: add Swap + ModifyLiquidity events to DopplerHookInitializer in dhook.json
+3. Implement `multicurve/metrics.rs` — MulticurveMetricsHandler
+4. Implement `decay_multicurve/metrics.rs` — DecayMulticurveMetricsHandler
+5. Implement `scheduled_multicurve/metrics.rs` — ScheduledMulticurveMetricsHandler
+6. Implement `dhook/metrics.rs` — DhookMetricsHandler
+7. Register all handlers
+
+### Handler specifics
+- Swap event: `int128 amount0, amount1` (need I256 conversion), poolId from topics[3]
+- sqrtPriceX96 from getSlot0 call matched by `trigger_log_index == event.log_index`
+- ModifyLiquidity: two formats (tuple vs flat) — extract tick_lower/upper/liquidityDelta accordingly
+- Tuple format (multicurve, dhook): compute poolId from PoolKey via keccak hash
+- Flat format (decay, scheduled): poolId from topics[1] (`id`)
+- call_dependencies: `("UniswapV4StateView", "getSlot0")`
+
+### Verify on_event call format
+Test with one hook (e.g., DecayMulticurveHook) first. The `event` field in `frequency.on_events` is keccak-hashed and matched against log topic0. The ABI-canonical form (types only) is: `Swap(address,(address,address,uint24,int24,address),bytes32,(bool,int256,uint160),int128,int128,bytes)`
+
+---
+
+## Phase 4: V4 Base Handler
+
+**Goal**: Handle the unique cumulative-counter Swap event on DopplerV4Hook.
+
+### Tasks
+1. Implement `src/transformations/event/v4/metrics.rs` — V4BaseMetricsHandler
+2. Register in `v4/mod.rs`
+3. Test sequential processing with cumulative proceeds tracking
+
+### Handler specifics
+- Source: `DopplerV4Hook` (factory collection)
+- Swap event: `Swap(int24 currentTick, uint256 totalProceeds, uint256 totalTokensSold)`
+- **No poolId in event**: map hook contract_address → pool_id via `v4_pool_configs` table (loaded on init into `HashMap<[u8;20], [u8;32]>`)
+- **No sqrtPriceX96 in event**: derive from currentTick via `tick_to_sqrt_price_x96()`
+- **Cumulative counters**: in-memory `RwLock<HashMap<Vec<u8>, (U256, U256)>>` for (last_totalProceeds, last_totalTokensSold). Compute per-swap deltas. Rebuild from pool_snapshots or a dedicated column on init.
+- **Sequential processing required**: this handler cannot be parallelized across block ranges
+- No liquidity events (liquidity only changes via swaps or post-migration MigratorHook events)
+- amount0/amount1 derived from proceeds/tokens_sold deltas using is_token_0 orientation
+
+---
+
+## Phase 5: Migration Pool Handler
+
+**Goal**: Handle swaps and liquidity on graduated (migrated) V4 pools.
+
+### Tasks
+1. Create `src/transformations/event/migration_pool/` module
+2. Implement `migration_pool/metrics.rs` — MigrationPoolMetricsHandler
+3. Register in `event/mod.rs`
+
+### Handler specifics
+- Swap source: `UniswapV4PoolManager` — Swap event has sqrtPriceX96/tick/liquidity directly
+- Liquidity source: `UniswapV4MigratorHook` — ModifyLiquidity (tuple format)
+- **Must filter PoolManager Swaps**: PoolManager emits Swap for ALL V4 pools. Use in-memory `RwLock<HashSet<Vec<u8>>>` of migration pool IDs. Rebuild on init from `pools WHERE migrated_from IS NOT NULL`.
+- Also scan for Migrate events in current context to add newly graduated pools inline
+- call_dependencies: none (all data in events)
+
+---
+
+## Phase 6: USD Pricing & Rolling Metrics
+
+**Goal**: Add USD-denominated values to snapshots and rolling metrics to pool_state.
+
+### Tasks
+1. Read ChainlinkEthOracle latestAnswer from transformation context (calls_of_type)
+2. Read reference pool prices from `prices` table (written by existing PriceHandler)
+3. Resolve quote token → USD price (WETH via ETH/USD, USDC/USDT directly, others via reference pools)
+4. Add volume_usd to pool_snapshots
+5. Add rolling aggregation queries for pool_state: volume_24h_usd, price_change_1h, price_change_24h, swap_count_24h
+
+### Design notes
+- Price resolution: for each swap, look up quote token USD price. If quote is WETH, multiply by latest ETH/USD. If quote is USDC/USDT, use 1.0. If quote is another token, chain through reference pool prices.
+- Rolling metrics: query pool_snapshots for the relevant time window. This can be done as part of pool_state upsert or as a separate periodic handler.
+- Leave architecture open for future price graph traversal.
+
+---
+
+## Phase 7: TVL Computation (future)
+
+**Goal**: Compute TVL from in-memory tick maps and update pool_snapshots + pool_state.
+
+### Tasks
+1. Implement tick map store: `RwLock<HashMap<pool_id, BTreeMap<(tick_lower, tick_upper), i128>>>`
+2. Rebuild on startup from liquidity_deltas table (one GROUP BY query)
+3. Sequential pass: process liquidity_deltas in order, update tick maps, compute TVL per block
+4. TVL formula: iterate tick map positions, compute token amounts based on position vs current tick
+5. Add amount0, amount1, tvl_usd, market_cap_usd columns to pool_state and pool_snapshots
+6. Market cap = token price × total supply (total_supply from tokens table)
+
+### Design notes
+- This pass is sequential by nature (tick maps are cumulative state)
+- Could be a separate handler or a background task
+- Consider materialized views for protocol-wide TVL aggregation
+
+---
+
+## Resolved Design Decisions
+
+- **Separate handlers per pool type** with shared `process_swaps()`/`process_liquidity_deltas()` functions
+- **Per-block granularity** snapshots, candles built at query time
+- **Out-of-order safe**: pool_state conditional upsert, pool_snapshots idempotent, liquidity_deltas append-only
+- **V4 base sqrtPriceX96**: derived from tick in code, no extra RPC call
+- **V4 base pool_id**: hook_address → pool_id via `v4_pool_configs` table (has `hook_address` and `pool_id` columns from create handlers)
+- **DopplerHookInitializer events**: emitted by the initializer contract itself (not a separate hook)
+- **DopplerHookInitializer ModifyLiquidity**: tuple format `ModifyLiquidity((PoolKey) key, (ModifyLiquidityParams) params)`, same as multicurve
+- **Quote token decimals**: hardcoded lookup (WETH=18, USDC=6, USDT=6, EURC=6), extracted to shared util
+- **Indexed poolKey in Swap**: keccak hash of PoolKey = pool_id, so topics[2] = topics[3]
+- **getSlot0 on_event calls**: configured on hook contracts with `target: UniswapV4StateView`
+- **TVL deferred**: liquidity_deltas written in parallel, TVL computed in a separate sequential pass (Phase 7)

--- a/migrations/tables/liquidity_deltas.sql
+++ b/migrations/tables/liquidity_deltas.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS liquidity_deltas (
+    chain_id        BIGINT NOT NULL,
+    pool_id         BYTEA NOT NULL,
+    block_number    BIGINT NOT NULL,
+    log_index       INT NOT NULL,
+    tick_lower      INT NOT NULL,
+    tick_upper      INT NOT NULL,
+    liquidity_delta NUMERIC NOT NULL,
+    source          VARCHAR(255) NOT NULL,
+    source_version  INT NOT NULL,
+    PRIMARY KEY (chain_id, pool_id, block_number, log_index)
+);
+
+CREATE INDEX IF NOT EXISTS idx_liq_deltas_pool ON liquidity_deltas (pool_id);

--- a/migrations/tables/pool_snapshots.sql
+++ b/migrations/tables/pool_snapshots.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS pool_snapshots (
+    chain_id         BIGINT NOT NULL,
+    pool_id          BYTEA NOT NULL,
+    block_number     BIGINT NOT NULL,
+    block_timestamp  BIGINT NOT NULL,
+    price_open       NUMERIC NOT NULL,
+    price_close      NUMERIC NOT NULL,
+    price_high       NUMERIC NOT NULL,
+    price_low        NUMERIC NOT NULL,
+    active_liquidity NUMERIC NOT NULL,
+    volume0          NUMERIC NOT NULL DEFAULT 0,
+    volume1          NUMERIC NOT NULL DEFAULT 0,
+    swap_count       INT NOT NULL DEFAULT 0,
+    source           VARCHAR(255) NOT NULL,
+    source_version   INT NOT NULL,
+    UNIQUE (chain_id, pool_id, block_number, source, source_version)
+);
+
+CREATE INDEX IF NOT EXISTS idx_snapshots_time ON pool_snapshots (pool_id, block_timestamp);

--- a/migrations/tables/pool_state.sql
+++ b/migrations/tables/pool_state.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS pool_state (
+    chain_id         BIGINT NOT NULL,
+    pool_id          BYTEA NOT NULL,
+    block_number     BIGINT NOT NULL,
+    block_timestamp  BIGINT NOT NULL,
+    tick             INTEGER NOT NULL,
+    sqrt_price_x96   NUMERIC NOT NULL,
+    price            NUMERIC NOT NULL,
+    active_liquidity NUMERIC NOT NULL,
+    volume_24h_usd   NUMERIC,
+    price_change_1h  NUMERIC,
+    price_change_24h NUMERIC,
+    swap_count_24h   INTEGER,
+    source           VARCHAR(255) NOT NULL,
+    source_version   INT NOT NULL,
+    UNIQUE (chain_id, pool_id, source, source_version)
+);
+
+CREATE INDEX IF NOT EXISTS idx_pool_state_price ON pool_state (price DESC NULLS LAST);

--- a/src/transformations/event/metrics/accumulator.rs
+++ b/src/transformations/event/metrics/accumulator.rs
@@ -1,0 +1,140 @@
+//! Block-level swap accumulator for OHLC and volume aggregation.
+//!
+//! Each pool gets one BlockAccumulator per block. Multiple swap events
+//! in the same block are aggregated into a single snapshot row.
+
+use alloy_primitives::{I256, U256};
+
+/// Accumulates swap events within a single block for one pool.
+#[derive(Debug)]
+pub struct BlockAccumulator {
+    pub price_open: Option<f64>,
+    pub price_close: Option<f64>,
+    pub price_high: Option<f64>,
+    pub price_low: Option<f64>,
+    /// Raw absolute volume of token0 (sum of |amount0| across swaps).
+    pub volume0: U256,
+    /// Raw absolute volume of token1 (sum of |amount1| across swaps).
+    pub volume1: U256,
+    pub swap_count: u32,
+    pub last_tick: i32,
+    pub last_sqrt_price_x96: U256,
+    pub last_liquidity: U256,
+    pub block_timestamp: u64,
+}
+
+impl BlockAccumulator {
+    pub fn new(block_timestamp: u64) -> Self {
+        Self {
+            price_open: None,
+            price_close: None,
+            price_high: None,
+            price_low: None,
+            volume0: U256::ZERO,
+            volume1: U256::ZERO,
+            swap_count: 0,
+            last_tick: 0,
+            last_sqrt_price_x96: U256::ZERO,
+            last_liquidity: U256::ZERO,
+            block_timestamp,
+        }
+    }
+
+    /// Record a swap event into this accumulator.
+    pub fn record_swap(
+        &mut self,
+        price: f64,
+        amount0: I256,
+        amount1: I256,
+        tick: i32,
+        sqrt_price_x96: U256,
+        liquidity: U256,
+    ) {
+        // OHLC
+        if self.price_open.is_none() {
+            self.price_open = Some(price);
+        }
+        self.price_close = Some(price);
+        self.price_high = Some(
+            self.price_high
+                .map_or(price, |h| if price > h { price } else { h }),
+        );
+        self.price_low = Some(
+            self.price_low
+                .map_or(price, |l| if price < l { price } else { l }),
+        );
+
+        // Volume (absolute values)
+        self.volume0 += amount0.unsigned_abs();
+        self.volume1 += amount1.unsigned_abs();
+        self.swap_count += 1;
+
+        // Latest state
+        self.last_tick = tick;
+        self.last_sqrt_price_x96 = sqrt_price_x96;
+        self.last_liquidity = liquidity;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_single_swap() {
+        let mut acc = BlockAccumulator::new(1000);
+        acc.record_swap(
+            1.5,
+            I256::try_from(100i64).unwrap(),
+            I256::try_from(-150i64).unwrap(),
+            100,
+            U256::from(1u64) << 96,
+            U256::from(1000u64),
+        );
+        assert_eq!(acc.price_open, Some(1.5));
+        assert_eq!(acc.price_close, Some(1.5));
+        assert_eq!(acc.price_high, Some(1.5));
+        assert_eq!(acc.price_low, Some(1.5));
+        assert_eq!(acc.volume0, U256::from(100u64));
+        assert_eq!(acc.volume1, U256::from(150u64));
+        assert_eq!(acc.swap_count, 1);
+    }
+
+    #[test]
+    fn test_multiple_swaps_ohlc() {
+        let mut acc = BlockAccumulator::new(1000);
+        acc.record_swap(
+            2.0,
+            I256::try_from(10i64).unwrap(),
+            I256::try_from(-20i64).unwrap(),
+            100,
+            U256::from(1u64),
+            U256::from(1u64),
+        );
+        acc.record_swap(
+            3.0,
+            I256::try_from(5i64).unwrap(),
+            I256::try_from(-15i64).unwrap(),
+            200,
+            U256::from(2u64),
+            U256::from(2u64),
+        );
+        acc.record_swap(
+            1.0,
+            I256::try_from(20i64).unwrap(),
+            I256::try_from(-20i64).unwrap(),
+            50,
+            U256::from(3u64),
+            U256::from(3u64),
+        );
+
+        assert_eq!(acc.price_open, Some(2.0));
+        assert_eq!(acc.price_close, Some(1.0));
+        assert_eq!(acc.price_high, Some(3.0));
+        assert_eq!(acc.price_low, Some(1.0));
+        assert_eq!(acc.volume0, U256::from(35u64));
+        assert_eq!(acc.volume1, U256::from(55u64));
+        assert_eq!(acc.swap_count, 3);
+        assert_eq!(acc.last_tick, 50);
+    }
+}

--- a/src/transformations/event/metrics/mod.rs
+++ b/src/transformations/event/metrics/mod.rs
@@ -1,0 +1,7 @@
+//! Shared metrics types and processing logic for pool metrics handlers.
+//!
+//! All pool type handlers normalize events into SwapInput/LiquidityInput,
+//! then delegate to the shared process_swaps()/process_liquidity_deltas() functions.
+
+pub mod accumulator;
+pub mod swap_data;

--- a/src/transformations/event/metrics/swap_data.rs
+++ b/src/transformations/event/metrics/swap_data.rs
@@ -1,0 +1,188 @@
+//! Normalized swap and liquidity types with shared processing logic.
+//!
+//! All pool type handlers normalize their events into SwapInput/LiquidityInput,
+//! then call process_swaps()/process_liquidity_deltas() to produce DbOperations.
+
+use std::collections::BTreeMap;
+
+use alloy_primitives::{I256, U256};
+
+use crate::db::DbOperation;
+use crate::transformations::util::db::pool_metrics::{
+    insert_liquidity_delta, insert_pool_snapshot, upsert_pool_state, LiquidityDeltaData,
+    PoolStateData, SnapshotData,
+};
+use crate::transformations::util::pool_metadata::PoolMetadataCache;
+use crate::transformations::util::price::sqrt_price_x96_to_price;
+
+use super::accumulator::BlockAccumulator;
+
+/// Normalized swap input produced by all pool type handlers.
+#[derive(Debug, Clone)]
+pub struct SwapInput {
+    pub pool_id: Vec<u8>,
+    pub block_number: u64,
+    pub block_timestamp: u64,
+    pub log_index: u32,
+    pub amount0: I256,
+    pub amount1: I256,
+    pub sqrt_price_x96: U256,
+    pub tick: i32,
+    pub liquidity: U256,
+}
+
+/// Normalized liquidity delta from Mint/Burn/ModifyLiquidity events.
+#[derive(Debug, Clone)]
+pub struct LiquidityInput {
+    pub pool_id: Vec<u8>,
+    pub block_number: u64,
+    pub log_index: u32,
+    pub tick_lower: i32,
+    pub tick_upper: i32,
+    pub liquidity_delta: I256,
+}
+
+/// Process a batch of swap inputs into pool_snapshots + pool_state DbOperations.
+///
+/// Groups swaps by (pool_id, block_number), builds a BlockAccumulator for each group,
+/// then emits one snapshot row per group and one pool_state upsert per pool (latest block).
+pub fn process_swaps(
+    swaps: &[SwapInput],
+    metadata_cache: &PoolMetadataCache,
+    chain_id: u64,
+    handler_name: &str,
+    handler_version: u32,
+) -> Vec<DbOperation> {
+    if swaps.is_empty() {
+        return Vec::new();
+    }
+
+    // Group by (pool_id, block_number), preserving log_index order within each group.
+    // BTreeMap ensures deterministic ordering by block_number.
+    let mut grouped: BTreeMap<(Vec<u8>, u64), Vec<&SwapInput>> = BTreeMap::new();
+    for swap in swaps {
+        grouped
+            .entry((swap.pool_id.clone(), swap.block_number))
+            .or_default()
+            .push(swap);
+    }
+
+    let mut ops = Vec::new();
+    // Track the latest block per pool for pool_state upserts
+    let mut latest_per_pool: BTreeMap<Vec<u8>, (u64, &BlockAccumulator)> = BTreeMap::new();
+
+    // We need to collect accumulators first, then reference them
+    let mut accumulators: Vec<(Vec<u8>, u64, BlockAccumulator)> = Vec::new();
+
+    for ((pool_id, block_number), swap_group) in &grouped {
+        let meta = match metadata_cache.get(pool_id) {
+            Some(m) => m,
+            None => {
+                tracing::warn!(
+                    "No metadata for pool {} at block {}, skipping {} swaps",
+                    hex::encode(pool_id),
+                    block_number,
+                    swap_group.len()
+                );
+                continue;
+            }
+        };
+
+        let block_timestamp = swap_group[0].block_timestamp;
+        let mut acc = BlockAccumulator::new(block_timestamp);
+
+        // Sort by log_index within the block
+        let mut sorted_swaps: Vec<&&SwapInput> = swap_group.iter().collect();
+        sorted_swaps.sort_by_key(|s| s.log_index);
+
+        for swap in sorted_swaps {
+            let price = sqrt_price_x96_to_price(
+                &swap.sqrt_price_x96,
+                meta.base_decimals,
+                meta.quote_decimals,
+                meta.is_token_0,
+            );
+            acc.record_swap(
+                price,
+                swap.amount0,
+                swap.amount1,
+                swap.tick,
+                swap.sqrt_price_x96,
+                swap.liquidity,
+            );
+        }
+
+        accumulators.push((pool_id.clone(), *block_number, acc));
+    }
+
+    for (pool_id, block_number, acc) in &accumulators {
+        // Emit snapshot
+        let price_open = acc.price_open.unwrap_or(0.0);
+        let price_close = acc.price_close.unwrap_or(0.0);
+        let price_high = acc.price_high.unwrap_or(0.0);
+        let price_low = acc.price_low.unwrap_or(0.0);
+
+        ops.push(insert_pool_snapshot(&SnapshotData {
+            chain_id,
+            pool_id: pool_id.clone(),
+            block_number: *block_number,
+            block_timestamp: acc.block_timestamp,
+            price_open: format!("{:.18}", price_open),
+            price_close: format!("{:.18}", price_close),
+            price_high: format!("{:.18}", price_high),
+            price_low: format!("{:.18}", price_low),
+            active_liquidity: acc.last_liquidity.to_string(),
+            volume0: acc.volume0.to_string(),
+            volume1: acc.volume1.to_string(),
+            swap_count: acc.swap_count as i32,
+        }));
+
+        // Track latest block for pool_state
+        match latest_per_pool.get(pool_id) {
+            Some((prev_block, _)) if *prev_block >= *block_number => {}
+            _ => {
+                latest_per_pool.insert(pool_id.clone(), (*block_number, acc));
+            }
+        }
+    }
+
+    // Emit pool_state upserts for the latest block per pool
+    for (pool_id, (block_number, acc)) in &latest_per_pool {
+        let price_close = acc.price_close.unwrap_or(0.0);
+
+        ops.push(upsert_pool_state(
+            &PoolStateData {
+                chain_id,
+                pool_id: pool_id.clone(),
+                block_number: *block_number,
+                block_timestamp: acc.block_timestamp,
+                tick: acc.last_tick,
+                sqrt_price_x96: acc.last_sqrt_price_x96.to_string(),
+                price: format!("{:.18}", price_close),
+                active_liquidity: acc.last_liquidity.to_string(),
+            },
+            handler_name,
+            handler_version,
+        ));
+    }
+
+    ops
+}
+
+/// Process a batch of liquidity inputs into liquidity_deltas INSERT operations.
+pub fn process_liquidity_deltas(deltas: &[LiquidityInput], chain_id: u64) -> Vec<DbOperation> {
+    deltas
+        .iter()
+        .map(|d| {
+            insert_liquidity_delta(&LiquidityDeltaData {
+                chain_id,
+                pool_id: d.pool_id.clone(),
+                block_number: d.block_number,
+                log_index: d.log_index,
+                tick_lower: d.tick_lower,
+                tick_upper: d.tick_upper,
+                liquidity_delta: d.liquidity_delta.to_string(),
+            })
+        })
+        .collect()
+}

--- a/src/transformations/event/mod.rs
+++ b/src/transformations/event/mod.rs
@@ -5,6 +5,7 @@
 pub mod decay_multicurve;
 pub mod derc20_transfer;
 pub mod dhook;
+pub mod metrics;
 pub mod multicurve;
 pub mod scheduled_multicurve;
 pub mod v3;

--- a/src/transformations/util/db/mod.rs
+++ b/src/transformations/util/db/mod.rs
@@ -1,5 +1,6 @@
 pub mod dhook_pool_configs;
 pub mod pool;
+pub mod pool_metrics;
 pub mod token;
 pub mod transfers;
 pub mod users;

--- a/src/transformations/util/db/pool_metrics.rs
+++ b/src/transformations/util/db/pool_metrics.rs
@@ -1,0 +1,165 @@
+//! Database operation builders for pool metrics tables.
+//!
+//! Provides functions to construct DbOperations for pool_state, pool_snapshots,
+//! and liquidity_deltas tables. These are used by all metrics handlers.
+
+use crate::db::{DbOperation, DbValue};
+
+/// Data for a pool_state upsert.
+pub struct PoolStateData {
+    pub chain_id: u64,
+    pub pool_id: Vec<u8>,
+    pub block_number: u64,
+    pub block_timestamp: u64,
+    pub tick: i32,
+    pub sqrt_price_x96: String,
+    pub price: String,
+    pub active_liquidity: String,
+}
+
+/// Data for a pool_snapshots row.
+pub struct SnapshotData {
+    pub chain_id: u64,
+    pub pool_id: Vec<u8>,
+    pub block_number: u64,
+    pub block_timestamp: u64,
+    pub price_open: String,
+    pub price_close: String,
+    pub price_high: String,
+    pub price_low: String,
+    pub active_liquidity: String,
+    pub volume0: String,
+    pub volume1: String,
+    pub swap_count: i32,
+}
+
+/// Data for a liquidity_deltas row.
+pub struct LiquidityDeltaData {
+    pub chain_id: u64,
+    pub pool_id: Vec<u8>,
+    pub block_number: u64,
+    pub log_index: u32,
+    pub tick_lower: i32,
+    pub tick_upper: i32,
+    pub liquidity_delta: String,
+}
+
+/// Build a conditional pool_state upsert using RawSql.
+///
+/// Uses `INSERT ... ON CONFLICT DO UPDATE SET ... WHERE pool_state.block_number < EXCLUDED.block_number`
+/// so older blocks never overwrite newer state. RawSql is needed because the standard
+/// Upsert DbOperation doesn't support a WHERE clause on the DO UPDATE.
+///
+/// source/source_version are included manually since RawSql skips auto-injection.
+pub fn upsert_pool_state(
+    data: &PoolStateData,
+    handler_name: &str,
+    handler_version: u32,
+) -> DbOperation {
+    let query = "\
+        INSERT INTO pool_state (chain_id, pool_id, block_number, block_timestamp, \
+            tick, sqrt_price_x96, price, active_liquidity, source, source_version) \
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) \
+        ON CONFLICT (chain_id, pool_id, source, source_version) \
+        DO UPDATE SET \
+            block_number = EXCLUDED.block_number, \
+            block_timestamp = EXCLUDED.block_timestamp, \
+            tick = EXCLUDED.tick, \
+            sqrt_price_x96 = EXCLUDED.sqrt_price_x96, \
+            price = EXCLUDED.price, \
+            active_liquidity = EXCLUDED.active_liquidity \
+        WHERE pool_state.block_number < EXCLUDED.block_number"
+        .to_string();
+
+    DbOperation::RawSql {
+        query,
+        params: vec![
+            DbValue::Int64(data.chain_id as i64),
+            DbValue::Bytes(data.pool_id.clone()),
+            DbValue::Int64(data.block_number as i64),
+            DbValue::Int64(data.block_timestamp as i64),
+            DbValue::Int32(data.tick),
+            DbValue::Numeric(data.sqrt_price_x96.clone()),
+            DbValue::Numeric(data.price.clone()),
+            DbValue::Numeric(data.active_liquidity.clone()),
+            DbValue::Text(handler_name.to_string()),
+            DbValue::Int32(handler_version as i32),
+        ],
+    }
+}
+
+/// Build a pool_snapshots upsert (idempotent — updates all columns on conflict).
+pub fn insert_pool_snapshot(data: &SnapshotData) -> DbOperation {
+    DbOperation::Upsert {
+        table: "pool_snapshots".to_string(),
+        columns: vec![
+            "chain_id".into(),
+            "pool_id".into(),
+            "block_number".into(),
+            "block_timestamp".into(),
+            "price_open".into(),
+            "price_close".into(),
+            "price_high".into(),
+            "price_low".into(),
+            "active_liquidity".into(),
+            "volume0".into(),
+            "volume1".into(),
+            "swap_count".into(),
+        ],
+        values: vec![
+            DbValue::Int64(data.chain_id as i64),
+            DbValue::Bytes(data.pool_id.clone()),
+            DbValue::Int64(data.block_number as i64),
+            DbValue::Int64(data.block_timestamp as i64),
+            DbValue::Numeric(data.price_open.clone()),
+            DbValue::Numeric(data.price_close.clone()),
+            DbValue::Numeric(data.price_high.clone()),
+            DbValue::Numeric(data.price_low.clone()),
+            DbValue::Numeric(data.active_liquidity.clone()),
+            DbValue::Numeric(data.volume0.clone()),
+            DbValue::Numeric(data.volume1.clone()),
+            DbValue::Int32(data.swap_count),
+        ],
+        conflict_columns: vec![
+            "chain_id".into(),
+            "pool_id".into(),
+            "block_number".into(),
+        ],
+        update_columns: vec![
+            "block_timestamp".into(),
+            "price_open".into(),
+            "price_close".into(),
+            "price_high".into(),
+            "price_low".into(),
+            "active_liquidity".into(),
+            "volume0".into(),
+            "volume1".into(),
+            "swap_count".into(),
+        ],
+    }
+}
+
+/// Build a liquidity_deltas insert (append-only).
+pub fn insert_liquidity_delta(data: &LiquidityDeltaData) -> DbOperation {
+    DbOperation::Insert {
+        table: "liquidity_deltas".to_string(),
+        columns: vec![
+            "chain_id".into(),
+            "pool_id".into(),
+            "block_number".into(),
+            "log_index".into(),
+            "tick_lower".into(),
+            "tick_upper".into(),
+            "liquidity_delta".into(),
+        ],
+        values: vec![
+            DbValue::Int64(data.chain_id as i64),
+            DbValue::Bytes(data.pool_id.clone()),
+            DbValue::Int64(data.block_number as i64),
+            DbValue::Int32(data.log_index as i32),
+            DbValue::Int32(data.tick_lower),
+            DbValue::Int32(data.tick_upper),
+            DbValue::Numeric(data.liquidity_delta.clone()),
+        ],
+    }
+}

--- a/src/transformations/util/mod.rs
+++ b/src/transformations/util/mod.rs
@@ -5,5 +5,7 @@
 pub mod db;
 pub mod metadata;
 pub mod migration;
+pub mod pool_metadata;
 pub mod price;
 pub mod sanitize;
+pub mod tick_math;

--- a/src/transformations/util/pool_metadata.rs
+++ b/src/transformations/util/pool_metadata.rs
@@ -1,0 +1,177 @@
+//! Pool metadata cache for metrics handlers.
+//!
+//! Loads pool metadata from the `pools` table on handler initialization and
+//! provides fast lookups by pool_id during event processing.
+
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+use alloy_primitives::Address;
+
+use crate::db::DbPool;
+use crate::transformations::error::TransformationError;
+use crate::types::config::contract::{AddressOrAddresses, Contracts};
+
+/// Metadata for a single pool needed by metrics handlers.
+#[derive(Debug, Clone)]
+pub struct PoolMetadata {
+    pub pool_id: Vec<u8>,
+    pub base_token: [u8; 20],
+    pub quote_token: [u8; 20],
+    pub is_token_0: bool,
+    pub pool_type: String,
+    pub base_decimals: u8,
+    pub quote_decimals: u8,
+}
+
+/// Thread-safe cache of pool metadata keyed by pool_id bytes.
+pub struct PoolMetadataCache {
+    inner: RwLock<HashMap<Vec<u8>, PoolMetadata>>,
+}
+
+impl PoolMetadataCache {
+    /// Create an empty cache.
+    pub fn new() -> Self {
+        Self {
+            inner: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Load all pool metadata from the `pools` table for a given chain.
+    pub async fn load_from_db(
+        db_pool: &DbPool,
+        chain_id: u64,
+        contracts: &Contracts,
+    ) -> Result<Self, TransformationError> {
+        let client = db_pool
+            .inner()
+            .get()
+            .await
+            .map_err(|e| TransformationError::DatabaseError(e.into()))?;
+
+        let rows = client
+            .query(
+                "SELECT address, base_token, quote_token, is_token_0, type \
+                 FROM pools WHERE chain_id = $1",
+                &[&(chain_id as i64)],
+            )
+            .await
+            .map_err(|e| TransformationError::DatabaseError(e.into()))?;
+
+        let mut map = HashMap::with_capacity(rows.len());
+
+        for row in &rows {
+            let pool_id: Vec<u8> = row.get("address");
+            let base_token_bytes: Vec<u8> = row.get("base_token");
+            let quote_token_bytes: Vec<u8> = row.get("quote_token");
+            let is_token_0: bool = row.get("is_token_0");
+            let pool_type: String = row.get("type");
+
+            if base_token_bytes.len() != 20 || quote_token_bytes.len() != 20 {
+                continue;
+            }
+
+            let mut base_token = [0u8; 20];
+            let mut quote_token = [0u8; 20];
+            base_token.copy_from_slice(&base_token_bytes);
+            quote_token.copy_from_slice(&quote_token_bytes);
+
+            let base_decimals = 18; // all launched tokens are 18 decimals
+            let quote_decimals =
+                quote_token_decimals(&quote_token, contracts).unwrap_or(18);
+
+            map.insert(
+                pool_id.clone(),
+                PoolMetadata {
+                    pool_id,
+                    base_token,
+                    quote_token,
+                    is_token_0,
+                    pool_type,
+                    base_decimals,
+                    quote_decimals,
+                },
+            );
+        }
+
+        tracing::info!(
+            "PoolMetadataCache loaded {} pools for chain {}",
+            map.len(),
+            chain_id
+        );
+
+        Ok(Self {
+            inner: RwLock::new(map),
+        })
+    }
+
+    /// Look up metadata by pool_id.
+    pub fn get(&self, pool_id: &[u8]) -> Option<PoolMetadata> {
+        self.inner.read().unwrap().get(pool_id).cloned()
+    }
+
+    /// Insert or update metadata for a pool.
+    pub fn insert(&self, pool_id: Vec<u8>, meta: PoolMetadata) {
+        self.inner.write().unwrap().insert(pool_id, meta);
+    }
+
+    /// Number of cached entries.
+    pub fn len(&self) -> usize {
+        self.inner.read().unwrap().len()
+    }
+
+    /// Whether the cache is empty.
+    pub fn is_empty(&self) -> bool {
+        self.inner.read().unwrap().is_empty()
+    }
+}
+
+impl Default for PoolMetadataCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Known quote token decimals keyed by config name.
+struct QuoteTokenConfig {
+    config_name: &'static str,
+    decimals: u8,
+}
+
+const KNOWN_QUOTE_TOKENS: &[QuoteTokenConfig] = &[
+    QuoteTokenConfig {
+        config_name: "Weth",
+        decimals: 18,
+    },
+    QuoteTokenConfig {
+        config_name: "Usdc",
+        decimals: 6,
+    },
+    QuoteTokenConfig {
+        config_name: "Usdt",
+        decimals: 6,
+    },
+    QuoteTokenConfig {
+        config_name: "Eurc",
+        decimals: 6,
+    },
+];
+
+/// Resolve decimals for a known quote token address by checking against
+/// the contract configuration. Returns None if the address is not a known
+/// quote token.
+pub fn quote_token_decimals(address: &[u8; 20], contracts: &Contracts) -> Option<u8> {
+    let addr = Address::from(*address);
+    for qt in KNOWN_QUOTE_TOKENS {
+        if let Some(config) = contracts.get(qt.config_name) {
+            let matches = match &config.address {
+                AddressOrAddresses::Single(a) => *a == addr,
+                AddressOrAddresses::Multiple(addrs) => addrs.contains(&addr),
+            };
+            if matches {
+                return Some(qt.decimals);
+            }
+        }
+    }
+    None
+}

--- a/src/transformations/util/tick_math.rs
+++ b/src/transformations/util/tick_math.rs
@@ -1,0 +1,227 @@
+//! Tick math utilities ported from Uniswap v3's TickMath.sol.
+//!
+//! Provides precise conversion between ticks and sqrtPriceX96 values
+//! using the same algorithm as the on-chain contracts.
+
+use alloy_primitives::U256;
+
+/// Minimum tick that can be used on any pool.
+pub const MIN_TICK: i32 = -887272;
+/// Maximum tick that can be used on any pool.
+pub const MAX_TICK: i32 = 887272;
+
+/// Minimum sqrtPriceX96 (at MIN_TICK).
+pub const MIN_SQRT_RATIO: U256 = U256::from_limbs([4295128739, 0, 0, 0]);
+/// Maximum sqrtPriceX96 (at MAX_TICK).
+pub const MAX_SQRT_RATIO: U256 =
+    U256::from_limbs([6743328256752651558, 17280870778742802505, 4294805859, 0]);
+
+/// Convert a tick to its corresponding sqrtPriceX96 value.
+///
+/// Ports Uniswap v3's `TickMath.getSqrtRatioAtTick(int24 tick)`.
+/// The result is a Q64.96 fixed-point number representing sqrt(1.0001^tick) * 2^96.
+///
+/// # Panics
+/// Panics if tick is outside [MIN_TICK, MAX_TICK].
+pub fn tick_to_sqrt_price_x96(tick: i32) -> U256 {
+    assert!(
+        (MIN_TICK..=MAX_TICK).contains(&tick),
+        "tick {} out of range [{}, {}]",
+        tick,
+        MIN_TICK,
+        MAX_TICK
+    );
+
+    let abs_tick = tick.unsigned_abs();
+
+    // Start with the base ratio, matching Solidity's bit-by-bit multiplication.
+    // Each magic number corresponds to sqrt(1.0001^(2^i)) in Q128.128 format.
+    let mut ratio: U256 = if abs_tick & 0x1 != 0 {
+        U256::from_str_radix("fffcb933bd6fad37aa2d162d1a594001", 16).unwrap()
+    } else {
+        U256::from(1u64) << 128
+    };
+
+    // Bit 1: sqrt(1.0001^2)
+    if abs_tick & 0x2 != 0 {
+        ratio = (ratio * U256::from_str_radix("fff97272373d413259a46990580e213a", 16).unwrap())
+            >> 128;
+    }
+    // Bit 2: sqrt(1.0001^4)
+    if abs_tick & 0x4 != 0 {
+        ratio = (ratio * U256::from_str_radix("fff2e50f5f656932ef12357cf3c7fdcc", 16).unwrap())
+            >> 128;
+    }
+    // Bit 3: sqrt(1.0001^8)
+    if abs_tick & 0x8 != 0 {
+        ratio = (ratio * U256::from_str_radix("ffe5caca7e10e4e61c3624eaa0941cd0", 16).unwrap())
+            >> 128;
+    }
+    // Bit 4: sqrt(1.0001^16)
+    if abs_tick & 0x10 != 0 {
+        ratio = (ratio * U256::from_str_radix("ffcb9843d60f6159c9db58835c926644", 16).unwrap())
+            >> 128;
+    }
+    // Bit 5: sqrt(1.0001^32)
+    if abs_tick & 0x20 != 0 {
+        ratio = (ratio * U256::from_str_radix("ff973b41fa98c081472e6896dfb254c0", 16).unwrap())
+            >> 128;
+    }
+    // Bit 6: sqrt(1.0001^64)
+    if abs_tick & 0x40 != 0 {
+        ratio = (ratio * U256::from_str_radix("ff2ea16466c96a3843ec78b326b52861", 16).unwrap())
+            >> 128;
+    }
+    // Bit 7: sqrt(1.0001^128)
+    if abs_tick & 0x80 != 0 {
+        ratio = (ratio * U256::from_str_radix("fe5dee046a99a2a811c461f1969c3053", 16).unwrap())
+            >> 128;
+    }
+    // Bit 8: sqrt(1.0001^256)
+    if abs_tick & 0x100 != 0 {
+        ratio = (ratio * U256::from_str_radix("fcbe86c7900a88aedcffc83b479aa3a4", 16).unwrap())
+            >> 128;
+    }
+    // Bit 9: sqrt(1.0001^512)
+    if abs_tick & 0x200 != 0 {
+        ratio = (ratio * U256::from_str_radix("f987a7253ac413176f2b074cf7815e54", 16).unwrap())
+            >> 128;
+    }
+    // Bit 10: sqrt(1.0001^1024)
+    if abs_tick & 0x400 != 0 {
+        ratio = (ratio * U256::from_str_radix("f3392b0822b70005940c7a398e4b70f3", 16).unwrap())
+            >> 128;
+    }
+    // Bit 11: sqrt(1.0001^2048)
+    if abs_tick & 0x800 != 0 {
+        ratio = (ratio * U256::from_str_radix("e7159475a2c29b7443b29c7fa6e889d9", 16).unwrap())
+            >> 128;
+    }
+    // Bit 12: sqrt(1.0001^4096)
+    if abs_tick & 0x1000 != 0 {
+        ratio = (ratio * U256::from_str_radix("d097f3bdfd2022b8845ad8f792aa5825", 16).unwrap())
+            >> 128;
+    }
+    // Bit 13: sqrt(1.0001^8192)
+    if abs_tick & 0x2000 != 0 {
+        ratio = (ratio * U256::from_str_radix("a9f746462d870fdf8a65dc1f90e061e5", 16).unwrap())
+            >> 128;
+    }
+    // Bit 14: sqrt(1.0001^16384)
+    if abs_tick & 0x4000 != 0 {
+        ratio = (ratio * U256::from_str_radix("70d869a156d2a1b890bb3df62baf32f7", 16).unwrap())
+            >> 128;
+    }
+    // Bit 15: sqrt(1.0001^32768)
+    if abs_tick & 0x8000 != 0 {
+        ratio = (ratio * U256::from_str_radix("31be135f97d08fd981231505542fcfa6", 16).unwrap())
+            >> 128;
+    }
+    // Bit 16: sqrt(1.0001^65536)
+    if abs_tick & 0x10000 != 0 {
+        ratio = (ratio * U256::from_str_radix("9aa508b5b7a84e1c677de54f3e99bc9", 16).unwrap())
+            >> 128;
+    }
+    // Bit 17: sqrt(1.0001^131072)
+    if abs_tick & 0x20000 != 0 {
+        ratio = (ratio
+            * U256::from_str_radix("5d6af8dedb81196699c329225ee604", 16).unwrap())
+            >> 128;
+    }
+    // Bit 18: sqrt(1.0001^262144)
+    if abs_tick & 0x40000 != 0 {
+        ratio =
+            (ratio * U256::from_str_radix("2216e584f5fa1ea926041bedfe98", 16).unwrap()) >> 128;
+    }
+    // Bit 19: sqrt(1.0001^524288)
+    if abs_tick & 0x80000 != 0 {
+        ratio = (ratio * U256::from_str_radix("48a170391f7dc42444e8fa2", 16).unwrap()) >> 128;
+    }
+
+    // For positive ticks, invert the ratio
+    if tick > 0 {
+        ratio = U256::MAX / ratio;
+    }
+
+    // Shift from Q128.128 to Q64.96 and round up
+    let remainder = ratio % (U256::from(1u64) << 32);
+    let shift = if remainder > U256::ZERO {
+        U256::from(1u64)
+    } else {
+        U256::ZERO
+    };
+    (ratio >> 32) + shift
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tick_0() {
+        // tick 0 = price 1.0, sqrtPriceX96 = 2^96
+        let result = tick_to_sqrt_price_x96(0);
+        let expected = U256::from(1u64) << 96;
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_min_tick() {
+        let result = tick_to_sqrt_price_x96(MIN_TICK);
+        assert_eq!(result, MIN_SQRT_RATIO);
+    }
+
+    #[test]
+    fn test_max_tick() {
+        let result = tick_to_sqrt_price_x96(MAX_TICK);
+        assert_eq!(result, MAX_SQRT_RATIO);
+    }
+
+    #[test]
+    fn test_tick_1() {
+        // Known value from Uniswap: tick 1 = 79232123823359799118286999568
+        let result = tick_to_sqrt_price_x96(1);
+        let expected =
+            U256::from_str_radix("79232123823359799118286999568", 10).unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_tick_negative_1() {
+        // Known Uniswap value: tick -1 = 79224201403219477170569942574
+        let result = tick_to_sqrt_price_x96(-1);
+        let expected =
+            U256::from_str_radix("79224201403219477170569942574", 10).unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_positive_negative_symmetry() {
+        // sqrt(1.0001^tick) * sqrt(1.0001^(-tick)) ≈ 1
+        // So sqrtPrice(tick) * sqrtPrice(-tick) ≈ 2^192
+        let pos = tick_to_sqrt_price_x96(100);
+        let neg = tick_to_sqrt_price_x96(-100);
+        let product = pos * neg;
+        let one_q192 = U256::from(1u64) << 192;
+        // Allow small rounding error
+        let diff = if product > one_q192 {
+            product - one_q192
+        } else {
+            one_q192 - product
+        };
+        // Relative error should be tiny
+        assert!(diff < one_q192 / U256::from(1_000_000u64));
+    }
+
+    #[test]
+    #[should_panic(expected = "tick")]
+    fn test_tick_too_low() {
+        tick_to_sqrt_price_x96(MIN_TICK - 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "tick")]
+    fn test_tick_too_high() {
+        tick_to_sqrt_price_x96(MAX_TICK + 1);
+    }
+}


### PR DESCRIPTION
## Summary

- Add SQL migrations for `pool_state`, `pool_snapshots`, and `liquidity_deltas` tables
- Implement `tick_to_sqrt_price_x96()` — faithful port of Uniswap's TickMath.getSqrtRatioAtTick
- Add `PoolMetadataCache` for loading pool metadata from DB with `quote_token_decimals()` lookup
- Add DB operation builders: conditional `pool_state` upsert (RawSql), idempotent `pool_snapshots`, append-only `liquidity_deltas`
- Add shared `BlockAccumulator` for per-block OHLC + volume aggregation
- Add `process_swaps()` / `process_liquidity_deltas()` — normalized processing that all per-pool-type handlers will delegate to
- Add `docs/metrics_implementation_phases.md` roadmap covering all 7 phases

This is phase 1 of the pool metrics implementation. See `docs/metrics_implementation_phases.md` for the full roadmap. Phase 2 (V3 handlers) will be the first to wire up actual event processing through this foundation.