### PR TITLE
feat: handler dependency graph and topological sort

### DIFF
--- a/src/transformations/registry.rs
+++ b/src/transformations/registry.rs
@@ -2,7 +2,7 @@
 //!
 //! The registry maintains a mapping from event/call triggers to their handlers.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 
 use super::traits::{
@@ -57,6 +57,10 @@ pub struct TransformationRegistry {
     call_handlers: HashMap<(String, String), Vec<Arc<dyn EthCallHandler>>>,
     /// All handlers for initialization (de-duplicated)
     all_handlers: Vec<Arc<dyn TransformationHandler>>,
+    /// Maps handler name() to its declared handler dependency names
+    handler_dependency_graph: HashMap<String, Vec<String>>,
+    /// Topological ordering of handler names (computed after all handlers registered)
+    handler_topological_order: Vec<String>,
 }
 
 impl TransformationRegistry {
@@ -66,6 +70,8 @@ impl TransformationRegistry {
             event_handlers: HashMap::new(),
             call_handlers: HashMap::new(),
             all_handlers: Vec::new(),
+            handler_dependency_graph: HashMap::new(),
+            handler_topological_order: Vec::new(),
         }
     }
 
@@ -85,6 +91,16 @@ impl TransformationRegistry {
                 .entry(key)
                 .or_default()
                 .push(handler.clone());
+        }
+
+        let deps: Vec<String> = handler
+            .handler_dependencies()
+            .iter()
+            .map(|d| d.to_string())
+            .collect();
+        if !deps.is_empty() {
+            self.handler_dependency_graph
+                .insert(handler.name().to_string(), deps);
         }
 
         self.all_handlers.push(handler);
@@ -161,6 +177,129 @@ impl TransformationRegistry {
         .collect()
     }
 
+    /// Get the topological ordering of handler names.
+    /// Available after `validate_and_sort_handler_dependencies()` has been called.
+    pub fn handler_topological_order(&self) -> &[String] {
+        &self.handler_topological_order
+    }
+
+    /// Get the dependency graph (handler name -> dependency names).
+    pub fn handler_dependency_graph(&self) -> &HashMap<String, Vec<String>> {
+        &self.handler_dependency_graph
+    }
+
+    /// Validate handler dependencies and compute topological ordering.
+    ///
+    /// Panics if:
+    /// - A handler declares a dependency on a name that isn't registered
+    /// - The dependency graph contains a cycle
+    pub fn validate_and_sort_handler_dependencies(&mut self) {
+        // Collect all registered handler names (use name(), not handler_key())
+        let registered_names: HashSet<String> = self
+            .all_handlers
+            .iter()
+            .map(|h| h.name().to_string())
+            .collect();
+
+        // Validate all dependency references exist
+        let mut missing: Vec<(String, Vec<String>)> = Vec::new();
+        for (handler_name, deps) in &self.handler_dependency_graph {
+            let unresolved: Vec<String> = deps
+                .iter()
+                .filter(|dep| !registered_names.contains(*dep))
+                .cloned()
+                .collect();
+            if !unresolved.is_empty() {
+                missing.push((handler_name.clone(), unresolved));
+            }
+        }
+
+        if !missing.is_empty() {
+            let mut msg = String::from(
+                "missing handler dependency: one or more handlers declare handler_dependencies \
+                 that do not match any registered handler name:\n",
+            );
+            for (handler_name, unresolved) in &missing {
+                msg.push_str(&format!("\n  Handler '{}':\n", handler_name));
+                for dep in unresolved {
+                    msg.push_str(&format!("    - \"{}\"\n", dep));
+                }
+            }
+            msg.push_str("\nRegistered handler names:\n");
+            let mut sorted_names: Vec<_> = registered_names.iter().collect();
+            sorted_names.sort();
+            for name in &sorted_names {
+                msg.push_str(&format!("    - \"{}\"\n", name));
+            }
+            panic!("{}", msg);
+        }
+
+        // Kahn's algorithm for topological sort
+        // Build adjacency: dependency -> set of dependents
+        let mut in_degree: HashMap<String, usize> = HashMap::new();
+        let mut dependents: HashMap<String, Vec<String>> = HashMap::new();
+
+        // Initialize all handlers with 0 in-degree
+        for name in &registered_names {
+            in_degree.insert(name.clone(), 0);
+        }
+
+        // Build edges from the dependency graph
+        for (handler_name, deps) in &self.handler_dependency_graph {
+            *in_degree.get_mut(handler_name).unwrap() += deps.len();
+            for dep in deps {
+                dependents
+                    .entry(dep.clone())
+                    .or_default()
+                    .push(handler_name.clone());
+            }
+        }
+
+        // Seed queue with zero-in-degree handlers, sorted alphabetically for determinism
+        let mut queue: VecDeque<String> = {
+            let mut zeros: Vec<String> = in_degree
+                .iter()
+                .filter(|(_, &deg)| deg == 0)
+                .map(|(name, _)| name.clone())
+                .collect();
+            zeros.sort();
+            zeros.into_iter().collect()
+        };
+
+        let mut order: Vec<String> = Vec::with_capacity(registered_names.len());
+
+        while let Some(name) = queue.pop_front() {
+            order.push(name.clone());
+            if let Some(deps) = dependents.get(&name) {
+                // Collect newly freed handlers, sort for determinism
+                let mut newly_free: Vec<String> = Vec::new();
+                for dependent in deps {
+                    let deg = in_degree.get_mut(dependent).unwrap();
+                    *deg -= 1;
+                    if *deg == 0 {
+                        newly_free.push(dependent.clone());
+                    }
+                }
+                newly_free.sort();
+                for freed in newly_free {
+                    queue.push_back(freed);
+                }
+            }
+        }
+
+        if order.len() != registered_names.len() {
+            // Cycle detected — find and report it
+            let cycle = trace_cycle(&self.handler_dependency_graph, &in_degree);
+            panic!(
+                "handler dependency cycle detected: {}\n\
+                 Handler dependencies must form a directed acyclic graph (DAG).",
+                cycle
+            );
+        }
+
+        self.handler_topological_order = order;
+    }
+
     /// Get all unique call handlers with their triggers grouped.
     /// Each handler appears exactly once, deduplicated by `handler_key()`.
     pub fn unique_call_handlers(&self) -> Vec<CallHandlerInfo> {
@@ -183,6 +322,47 @@ impl Default for TransformationRegistry {
 /// e.g., "Swap(bytes32,address,int128)" -> "Swap"
 pub fn extract_event_name(signature: &str) -> String {
     signature.split('(').next().unwrap_or(signature).to_string()
+}
+
+/// Trace a cycle in the dependency graph for error reporting.
+/// Returns a string like "A -> B -> C -> A".
+fn trace_cycle(
+    graph: &HashMap<String, Vec<String>>,
+    in_degree: &HashMap<String, usize>,
+) -> String {
+    // Start from any node still with non-zero in-degree (part of a cycle)
+    let start = in_degree
+        .iter()
+        .find(|(_, &deg)| deg > 0)
+        .map(|(name, _)| name.clone())
+        .unwrap_or_default();
+
+    let mut path = vec![start.clone()];
+    let mut current = start.clone();
+
+    // Follow dependency edges to trace the cycle
+    for _ in 0..in_degree.len() {
+        if let Some(deps) = graph.get(&current) {
+            // Follow the first dependency that's part of the cycle (non-zero in-degree)
+            if let Some(next) = deps
+                .iter()
+                .find(|d| in_degree.get(*d).copied().unwrap_or(0) > 0)
+            {
+                if *next == start {
+                    path.push(next.clone());
+                    break;
+                }
+                path.push(next.clone());
+                current = next.clone();
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+
+    path.join(" -> ")
 }
 
 /// Validate that all handler call_dependencies are satisfied by the eth_call configs.
@@ -292,6 +472,8 @@ pub fn build_registry() -> TransformationRegistry {
 
     // Register eth_call handlers
     super::eth_call::register_handlers(&mut registry);
+
+    registry.validate_and_sort_handler_dependencies();
 
     tracing::info!(
         "Built transformation registry with {} handlers ({} event triggers, {} call triggers)",

--- a/src/transformations/traits.rs
+++ b/src/transformations/traits.rs
@@ -136,6 +136,12 @@ pub trait EventHandler: TransformationHandler {
     fn call_dependencies(&self) -> Vec<(String, String)> {
         vec![]
     }
+
+    /// Handler names (via `TransformationHandler::name()`) that must complete
+    /// before this handler can execute for a given block range.
+    fn handler_dependencies(&self) -> Vec<&'static str> {
+        vec![]
+    }
 }
 
 /// Marker trait for handlers that respond to eth_call results.


### PR DESCRIPTION
## Summary

- Adds `handler_dependencies()` method to the `EventHandler` trait, allowing handlers to declare other handler names that must complete before they can execute for a given block range. Default implementation returns empty vec (no dependencies).
- Builds a dependency graph in `TransformationRegistry` during handler registration, recording each handler's declared dependencies.
- Validates all dependency references resolve to registered handler names and detects cycles at startup via Kahn's topological sort algorithm. Panics with descriptive error messages on missing deps or cycles.
- Stores the computed topological ordering for use in catchup mode scheduling.
- Wires validation into `build_registry()` so it runs automatically at startup after all handlers are registered.

## Notes

- Expected merge conflict with sibling test PR in `src/transformations/registry.rs` (both add code to the same file).