### PR TITLE
feat: handler dependency chains for ordered handler execution

### DIFF
--- a/docs/designs/handler-dependency-chains.md
+++ b/docs/designs/handler-dependency-chains.md
@@ -133,6 +133,8 @@ The database transaction model is unchanged: each handler commits independently.
 4. Independent dependency chains execute concurrently. A handler blocks only on its own declared dependencies.
 5. Catchup mode processes handlers in topological order. Live mode dispatches handlers as soon as their dependencies complete.
 6. When a handler fails, all transitive dependents are immediately failed for that range — they are not left pending.
+7. A handler is not marked completed (in-memory or persisted) while it still has pending entries for the range. This prevents a handler with multiple batches (e.g., from multiple triggers or split call-dep arrivals) from prematurely unblocking its dependents or being skipped on crash recovery.
+8. Multi-trigger handler success is not persisted to `_handler_progress` or `_live_progress` until the corresponding completion signal (`RangeCompleteKind::Logs` for event handlers) confirms all batches have been dispatched. Single-trigger handlers persist immediately for crash-recovery efficiency. `finalize_range()` handles deferred persistence for multi-trigger handlers.
 
 ## Files to Modify
 

--- a/docs/designs/handler-dependency-chains.md
+++ b/docs/designs/handler-dependency-chains.md
@@ -43,16 +43,17 @@ Live mode processes single-block ranges. Events arrive as `DecodedEventsMessage`
 #### New State
 
 ```rust
-// In LiveProcessingState:
+// In PendingEventData (extended, not a new struct):
+pub required_handlers: Vec<String>,  // handler name() strings
 
-/// Handlers that have completed for a given range.
-/// Key: (range_start, range_end), Value: set of handler names (from name(), not handler_key())
+// In LiveProcessingState:
 pub completed_handlers: HashMap<(u64, u64), HashSet<String>>,
 
-/// Events buffered because handler dependencies are not yet met.
-/// Key: handler_key, Value: pending event data (similar to existing call-dep pending)
-pub pending_handler_dep_events: HashMap<String, Vec<PendingEventData>>,
+// In HandlerOutcome (extended):
+pub handler_name: String,  // handler name() for completion tracking
 ```
+
+Handler deps are tracked in the **same** `pending_events` map as call deps (via the extended `PendingEventData`), not a separate map. This avoids the "which map does a handler with both dep types go in?" problem.
 
 #### Dispatch Flow
 
@@ -63,13 +64,14 @@ When `process_events_message` receives events for a block:
    - **Call deps**: all `(source, function)` pairs present in `received_calls` for this range.
    - **Handler deps**: all dependency handler `name()`s present in `completed_handlers` for this range.
 3. If both are satisfied, the handler is ready — add to the execution batch.
-4. If either is unsatisfied, buffer in the appropriate pending structure.
+4. If either is unsatisfied, buffer in `pending_events` with both `required_calls` and `required_handlers` populated.
 
 When a handler completes execution:
 
 1. Insert its `name()` into `completed_handlers` for the range.
-2. Scan `pending_handler_dep_events` for handlers whose dependencies are now fully met.
-3. Dispatch any newly-unblocked handlers (they may still need call-dep checks).
+2. Call `try_process_pending_events` which scans the unified `pending_events` map for handlers whose call deps AND handler deps are now all met.
+3. Dispatch any newly-unblocked handlers.
+4. Cascade: loop steps 1-3 until no more handlers are unblocked (handles A→B→C chains).
 
 This means independent chains and dependency-free handlers run concurrently, while dependent handlers wait only for their specific dependencies — not an entire "level."
 
@@ -91,11 +93,11 @@ A handler is ready to execute when ALL of the following are true:
 - All `call_dependencies()` are available for the range
 - All `handler_dependencies()` are completed (or no-op'd) for the range
 
-The pending state can be unified or kept as two separate maps checked together. Two separate maps is cleaner since the unblocking triggers are different (call arrival vs. handler completion), but the dispatch check gates on both.
+Both dep types are stored on the same `PendingEventData` and checked in the same filter in `try_process_pending_events`. The check runs on two triggers: call arrival (existing) and handler completion (new).
 
 #### Finalization
 
-The existing finalization flow is unchanged. `check_finalization_readiness` already gates on "no pending events." Handler-dep pending events are an additional set of pending events that must drain before finalization. The 5-minute timeout applies to handler-dep pending events as well, as a safety net.
+The existing finalization flow is unchanged. `check_finalization_readiness` already gates on "no pending events." Since handler-dep pending events use the same `pending_events` map, they are automatically included in the finalization gate and the 5-minute timeout.
 
 ### Catchup / Historical Mode
 
@@ -126,8 +128,9 @@ The database transaction model is unchanged: each handler commits independently.
 |------|--------|
 | `src/transformations/traits.rs` | Add `handler_dependencies()` to `EventHandler` trait |
 | `src/transformations/registry.rs` | Dependency graph construction, topological sort, cycle detection, missing-dep validation |
-| `src/transformations/live_state.rs` | Add `completed_handlers` and `pending_handler_dep_events` to `LiveProcessingState`, handler-dep readiness check |
-| `src/transformations/engine.rs` | Extend `process_events_message` to check handler deps, add handler-completion dispatch, integrate no-op completion into `process_range_complete` flow |
+| `src/transformations/live_state.rs` | Add `completed_handlers` to `LiveProcessingState`, extend `PendingEventData` with `required_handlers`, extend cleanup methods |
+| `src/transformations/executor.rs` | Add `handler_name` to `HandlerOutcome` |
+| `src/transformations/engine.rs` | Unified dep check in `process_events_message`, handler-completion recording, cascading dispatch in `try_process_pending_events`, integrate no-op completion into `process_range_complete` flow |
 | `src/transformations/finalizer.rs` | Extend `process_range_complete` to trigger no-op marking before finalization check |
 | `src/transformations/event/v3/create.rs` | No change (this is the dependency target) |
 | Swap/metrics handlers | Add `handler_dependencies()` returning `vec!["V3CreateHandler"]` |
@@ -150,20 +153,44 @@ The database transaction model is unchanged: each handler commits independently.
 - Only applies to `HandlerKind::Event` — call handlers have no dependency ordering.
 - Committed directly to `feat/handler-dependency-chains`.
 
-### Phase 3: Live Mode Dispatch
+### Phase 3: Live Mode Dispatch (COMPLETE)
 
-- Add `completed_handlers` and `pending_handler_dep_events` to `LiveProcessingState`.
-- Extend `process_events_message` to check handler dependencies alongside call dependencies when categorizing handlers as ready vs. pending.
-- On handler completion, insert into `completed_handlers` and scan pending handlers for newly-unblocked ones.
-- Dispatch unblocked handlers through the existing executor path.
-- Cleanup `completed_handlers` and `pending_handler_dep_events` in `cleanup_after_finalize`.
+- Extended `PendingEventData` with `required_handlers` field (unified pending map, not a second map).
+- Added `completed_handlers` to `LiveProcessingState` for tracking handler completions per range.
+- Added `handler_name` to `HandlerOutcome` for completion tracking without reverse-lookup.
+- Extended `process_events_message` with unified call+handler dep check.
+- Record handler completions after execution, then cascade via `try_process_pending_events`.
+- `try_process_pending_events` now checks both `required_calls` and `required_handlers`, wrapped in a loop for cascading (A→B→C chains).
+- Extended all cleanup methods (`cleanup_after_finalize`, `cleanup_for_orphaned_blocks`, `cleanup_for_retry`) to clear `completed_handlers`.
+- Timeout logging now shows both `waiting_for_calls` and `waiting_for_handlers`.
+- PRs: #82 (state), #83 (dispatch)
 
-### Phase 4: No-op Completion and Finalization
+### Phase 4: No-op Completion for Untriggered Handlers
 
-- On `RangeCompleteKind::Logs`, compute untriggered dependency handlers and mark them completed-no-op.
-- Unblock any pending handlers that were waiting on the no-op'd handlers.
-- Extend `check_finalization_readiness` to also gate on handler-dep pending events being drained.
-- Apply the existing 5-minute timeout to handler-dep pending events.
+- On `RangeCompleteKind::Logs`, compute untriggered dependency handlers and mark them completed-no-op in `completed_handlers`.
+- Unblock any pending handlers that were waiting on the no-op'd handlers via `try_process_pending_events`.
+- Without this phase, a handler depending on an untriggered handler will timeout after 5 minutes (the existing timeout safety net).
+
+**Key details for implementation:**
+
+**File:** `src/transformations/engine.rs` or `src/transformations/finalizer.rs`
+
+**Trigger:** `process_range_complete()` in `finalizer.rs` (line 92) is called when `RangeCompleteKind::Logs` arrives. After marking `logs_complete`, but before calling `maybe_finalize_range`, insert the no-op logic.
+
+**Logic:**
+1. Get the set of all handler names that are declared as dependencies (from `registry.handler_dependency_graph()` — values are the dep names).
+2. Lock `live_state`, get `completed_handlers[range_key]` (what has already completed).
+3. For each dependency handler name not in the completed set, insert it as completed-no-op.
+4. Call `try_process_pending_events(range_key)` to unblock any waiting handlers.
+5. Then proceed to `maybe_finalize_range`.
+
+**Registry helper needed:** A method like `all_dependency_handler_names() -> HashSet<String>` that returns the union of all values in `handler_dependency_graph`. This can be precomputed during `validate_and_sort_handler_dependencies()` and stored as a field. Or computed on the fly from `handler_dependency_graph()`.
+
+**Interaction with `process_range_complete`:** Currently `process_range_complete` just marks completion and calls `maybe_finalize_range`. The no-op + unblock step goes between. Since `process_range_complete` is on `RangeFinalizer` (not the engine), it doesn't have access to `try_process_pending_events`. Options:
+- Move the no-op logic to the engine's `run()` loop where `complete_rx` messages are handled (the engine has access to both finalizer and live_state)
+- Pass a callback or the engine ref to the finalizer
+
+The cleanest approach is to handle it in the engine's `run()` loop: when receiving a `RangeCompleteKind::Logs` message, do the no-op marking and pending dispatch BEFORE calling `finalizer.process_range_complete`.
 
 ### Phase 5: Wire Up Handlers
 

--- a/docs/designs/handler-dependency-chains.md
+++ b/docs/designs/handler-dependency-chains.md
@@ -1,0 +1,171 @@
+# Handler Dependency Chains
+
+## Problem
+
+Handlers currently execute concurrently with no ordering guarantees relative to each other. Some handlers produce data that downstream handlers depend on — for example, a pool creation handler must populate a shared metadata cache before a swap handler can look up pool metadata for the same block. Today there is no way to express or enforce this relationship.
+
+## Design
+
+### Trait Change
+
+Add a `handler_dependencies()` method to `EventHandler` with a default empty implementation:
+
+```rust
+pub trait EventHandler: TransformationHandler {
+    fn triggers(&self) -> Vec<EventTrigger>;
+
+    fn call_dependencies(&self) -> Vec<(String, String)> {
+        vec![]
+    }
+
+    /// Handler names (via `TransformationHandler::name()`) that must complete
+    /// before this handler can execute for a given block range.
+    fn handler_dependencies(&self) -> Vec<&'static str> {
+        vec![]
+    }
+}
+```
+
+Dependencies reference the `name()` of other handlers (e.g., `"V3CreateHandler"`), not the versioned `handler_key()`. This means bumping a dependency's version doesn't require updating dependents.
+
+### Startup Validation
+
+During registry construction, validate the dependency graph:
+
+1. **Missing dependency check** — if a handler declares a dependency on a name that isn't registered, panic with a descriptive error. Same pattern as the existing `validate_call_dependencies()`.
+2. **Cycle detection** — perform a topological sort of the handler dependency graph. If a cycle is detected, panic with the cycle path. This catches `A -> B -> A` and longer cycles.
+3. **Store the resolved dependency graph** — the registry holds a mapping from each handler name to its resolved dependency handler names, plus a precomputed topological ordering for use in catchup mode.
+
+### Live Mode Execution
+
+Live mode processes single-block ranges. Events arrive as `DecodedEventsMessage` batches per `(source, event_name)`. The existing call-dependency buffering pattern in `LiveProcessingState` is extended to also track handler dependencies.
+
+#### New State
+
+```rust
+// In LiveProcessingState:
+
+/// Handlers that have completed for a given range.
+/// Key: (range_start, range_end), Value: set of handler names (from name(), not handler_key())
+pub completed_handlers: HashMap<(u64, u64), HashSet<String>>,
+
+/// Events buffered because handler dependencies are not yet met.
+/// Key: handler_key, Value: pending event data (similar to existing call-dep pending)
+pub pending_handler_dep_events: HashMap<String, Vec<PendingEventData>>,
+```
+
+#### Dispatch Flow
+
+When `process_events_message` receives events for a block:
+
+1. Find all handlers registered for the event.
+2. For each handler, check **both** call dependencies (existing) and handler dependencies (new):
+   - **Call deps**: all `(source, function)` pairs present in `received_calls` for this range.
+   - **Handler deps**: all dependency handler `name()`s present in `completed_handlers` for this range.
+3. If both are satisfied, the handler is ready — add to the execution batch.
+4. If either is unsatisfied, buffer in the appropriate pending structure.
+
+When a handler completes execution:
+
+1. Insert its `name()` into `completed_handlers` for the range.
+2. Scan `pending_handler_dep_events` for handlers whose dependencies are now fully met.
+3. Dispatch any newly-unblocked handlers (they may still need call-dep checks).
+
+This means independent chains and dependency-free handlers run concurrently, while dependent handlers wait only for their specific dependencies — not an entire "level."
+
+#### No-op Completion for Untriggered Handlers
+
+If Handler A is declared as a dependency but has no events in a block, it is never dispatched and never completes — blocking dependent handlers forever.
+
+**Resolution:** When `RangeCompleteKind::Logs` arrives for a range, the engine knows all event messages for that block have been sent. At this point:
+
+1. Compute the set of all handlers that are declared as dependencies by any other handler (from the registry's dependency graph).
+2. For each such handler that was **not** triggered for this range (not in `completed_handlers` and not currently executing), mark it as completed-no-op in `completed_handlers`.
+3. Run the standard pending-handler-dep check to unblock any waiting handlers.
+
+This integrates into the existing `process_range_complete` flow, between marking `logs_complete` and calling `maybe_finalize_range`.
+
+#### Unified Readiness Check
+
+A handler is ready to execute when ALL of the following are true:
+- All `call_dependencies()` are available for the range
+- All `handler_dependencies()` are completed (or no-op'd) for the range
+
+The pending state can be unified or kept as two separate maps checked together. Two separate maps is cleaner since the unblocking triggers are different (call arrival vs. handler completion), but the dispatch check gates on both.
+
+#### Finalization
+
+The existing finalization flow is unchanged. `check_finalization_readiness` already gates on "no pending events." Handler-dep pending events are an additional set of pending events that must drain before finalization. The 5-minute timeout applies to handler-dep pending events as well, as a safety net.
+
+### Catchup / Historical Mode
+
+In catchup mode, handlers already run sequentially in `run_handler_catchup` (a `for ch in &handlers` loop). The change is:
+
+1. **Order handlers by topological sort** — process handlers in dependency order instead of registration order.
+2. **No per-event interleaving** — each handler processes its entire range before the next handler starts. This is correct because catchup is throughput-sensitive, not latency-sensitive.
+
+Independent handlers (no dependency relationship between them) can remain in any relative order since they don't interact. The topological sort just ensures that if B depends on A, A runs before B.
+
+### Cross-Handler Data Visibility
+
+Handler dependencies enforce **execution ordering only**. Cross-handler data sharing is handled via an in-memory shared cache (implemented separately). The dependency system guarantees that when Handler B runs, Handler A has already populated the cache for events up to and including B's block range.
+
+The database transaction model is unchanged: each handler commits independently. Handler B does not need to read Handler A's committed rows — it reads from the shared cache.
+
+## Invariants
+
+1. A handler never executes for a range until all of its declared dependencies have completed (or been marked no-op) for that range.
+2. The dependency graph is a DAG — cycles are detected and rejected at startup.
+3. All handler names referenced in `handler_dependencies()` must correspond to a registered handler — missing references are rejected at startup.
+4. Independent dependency chains execute concurrently. A handler blocks only on its own declared dependencies.
+5. Catchup mode processes handlers in topological order. Live mode dispatches handlers as soon as their dependencies complete.
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `src/transformations/traits.rs` | Add `handler_dependencies()` to `EventHandler` trait |
+| `src/transformations/registry.rs` | Dependency graph construction, topological sort, cycle detection, missing-dep validation |
+| `src/transformations/live_state.rs` | Add `completed_handlers` and `pending_handler_dep_events` to `LiveProcessingState`, handler-dep readiness check |
+| `src/transformations/engine.rs` | Extend `process_events_message` to check handler deps, add handler-completion dispatch, integrate no-op completion into `process_range_complete` flow |
+| `src/transformations/finalizer.rs` | Extend `process_range_complete` to trigger no-op marking before finalization check |
+| `src/transformations/event/v3/create.rs` | No change (this is the dependency target) |
+| Swap/metrics handlers | Add `handler_dependencies()` returning `vec!["V3CreateHandler"]` |
+
+## Roadmap
+
+### Phase 1: Trait and Registry (COMPLETE)
+
+- Added `handler_dependencies()` to `EventHandler` with default empty vec.
+- Built dependency graph in `TransformationRegistry` during handler registration.
+- Implemented topological sort with cycle detection — panic on cycles.
+- Validated all declared dependency names resolve to registered handlers — panic on missing.
+- Stored topological ordering for catchup mode.
+- Unit tests: cycle detection, missing dep detection, topological sort correctness, diamond dependencies.
+- PRs: #80 (impl), #81 (tests)
+
+### Phase 2: Catchup Mode (COMPLETE)
+
+- Sorted event handlers by topological order in `run_handler_catchup()` before the processing loop.
+- Only applies to `HandlerKind::Event` — call handlers have no dependency ordering.
+- Committed directly to `feat/handler-dependency-chains`.
+
+### Phase 3: Live Mode Dispatch
+
+- Add `completed_handlers` and `pending_handler_dep_events` to `LiveProcessingState`.
+- Extend `process_events_message` to check handler dependencies alongside call dependencies when categorizing handlers as ready vs. pending.
+- On handler completion, insert into `completed_handlers` and scan pending handlers for newly-unblocked ones.
+- Dispatch unblocked handlers through the existing executor path.
+- Cleanup `completed_handlers` and `pending_handler_dep_events` in `cleanup_after_finalize`.
+
+### Phase 4: No-op Completion and Finalization
+
+- On `RangeCompleteKind::Logs`, compute untriggered dependency handlers and mark them completed-no-op.
+- Unblock any pending handlers that were waiting on the no-op'd handlers.
+- Extend `check_finalization_readiness` to also gate on handler-dep pending events being drained.
+- Apply the existing 5-minute timeout to handler-dep pending events.
+
+### Phase 5: Wire Up Handlers
+
+- Add `handler_dependencies()` to swap/metrics handlers that depend on create handlers.
+- Integration test: block with pool creation and swap in same block, verify create handler runs before swap handler.

--- a/docs/designs/handler-dependency-chains.md
+++ b/docs/designs/handler-dependency-chains.md
@@ -95,6 +95,17 @@ A handler is ready to execute when ALL of the following are true:
 
 Both dep types are stored on the same `PendingEventData` and checked in the same filter in `try_process_pending_events`. The check runs on two triggers: call arrival (existing) and handler completion (new).
 
+#### Failure Cascading
+
+When a handler fails, all of its transitive dependents are immediately failed as well (they can never satisfy their `required_handlers`). The cascade:
+
+1. Computes transitive dependents via `registry.transitive_dependents_of(failed_name)`.
+2. Marks each dependent as failed in `state.failed_handlers` for the range.
+3. Removes their pending events from `state.pending_events` so they don't sit waiting for a 5-minute timeout.
+4. Persists the cascaded failures to the status file so the block is retryable.
+
+This replaces the previous behavior where dependents of a failed handler would eventually time out after 5 minutes. Failure cascading is immediate.
+
 #### Finalization
 
 The existing finalization flow is unchanged. `check_finalization_readiness` already gates on "no pending events." Since handler-dep pending events use the same `pending_events` map, they are automatically included in the finalization gate and the 5-minute timeout.
@@ -121,6 +132,7 @@ The database transaction model is unchanged: each handler commits independently.
 3. All handler names referenced in `handler_dependencies()` must correspond to a registered handler — missing references are rejected at startup.
 4. Independent dependency chains execute concurrently. A handler blocks only on its own declared dependencies.
 5. Catchup mode processes handlers in topological order. Live mode dispatches handlers as soon as their dependencies complete.
+6. When a handler fails, all transitive dependents are immediately failed for that range — they are not left pending.
 
 ## Files to Modify
 

--- a/src/transformations/engine.rs
+++ b/src/transformations/engine.rs
@@ -1235,12 +1235,15 @@ impl TransformationEngine {
             let mut state = self.live_state.lock().await;
             for handler in &handlers {
                 let call_deps = handler.call_dependencies();
+                let handler_deps: Vec<String> = handler
+                    .handler_dependencies()
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect();
                 let handler_key = handler.handler_key();
 
-                if call_deps.is_empty() {
-                    ready_handlers.push((handler.clone(), Arc::new(Vec::new())));
-                } else {
-                    let deps_ready = call_deps.iter().all(|dep| {
+                let call_deps_ready = call_deps.is_empty()
+                    || call_deps.iter().all(|dep| {
                         state
                             .received_calls
                             .get(dep)
@@ -1248,7 +1251,20 @@ impl TransformationEngine {
                             .unwrap_or(false)
                     });
 
-                    if deps_ready {
+                let handler_deps_ready = handler_deps.is_empty()
+                    || handler_deps.iter().all(|dep| {
+                        state
+                            .completed_handlers
+                            .get(&range_key)
+                            .map(|completed| completed.contains(dep))
+                            .unwrap_or(false)
+                    });
+
+                if call_deps_ready && handler_deps_ready {
+                    // Ready to execute
+                    if call_deps.is_empty() {
+                        ready_handlers.push((handler.clone(), Arc::new(Vec::new())));
+                    } else {
                         let calls = state.get_buffered_calls(range_key);
                         let calls: Vec<_> = calls
                             .into_iter()
@@ -1267,32 +1283,44 @@ impl TransformationEngine {
                             calls.len()
                         );
                         ready_handlers.push((handler.clone(), Arc::new(calls)));
-                    } else {
-                        tracing::warn!(
-                            "Handler {} buffering block {}: waiting for eth_call deps {:?}",
-                            handler_key,
-                            msg.range_start,
-                            call_deps
-                        );
-                        let pending = PendingEventData {
-                            range_start: msg.range_start,
-                            range_end: msg.range_end,
-                            source_name: msg.source_name.clone(),
-                            event_name: msg.event_name.clone(),
-                            events: filtered_events.clone(),
-                            required_calls: call_deps.clone(),
-                        };
-                        let timestamp_key = (msg.range_start, msg.range_end, handler_key.clone());
-                        state
-                            .pending_event_timestamps
-                            .entry(timestamp_key)
-                            .or_insert_with(Instant::now);
-                        state
-                            .pending_events
-                            .entry(handler_key)
-                            .or_default()
-                            .push(pending);
                     }
+                } else {
+                    // Buffer — needs either call deps or handler deps (or both)
+                    let waiting_for = if !call_deps_ready && !handler_deps_ready {
+                        format!(
+                            "eth_call deps {:?} and handler deps {:?}",
+                            call_deps, handler_deps
+                        )
+                    } else if !call_deps_ready {
+                        format!("eth_call deps {:?}", call_deps)
+                    } else {
+                        format!("handler deps {:?}", handler_deps)
+                    };
+                    tracing::warn!(
+                        "Handler {} buffering block {}: waiting for {}",
+                        handler_key,
+                        msg.range_start,
+                        waiting_for
+                    );
+                    let pending = PendingEventData {
+                        range_start: msg.range_start,
+                        range_end: msg.range_end,
+                        source_name: msg.source_name.clone(),
+                        event_name: msg.event_name.clone(),
+                        events: filtered_events.clone(),
+                        required_calls: call_deps.clone(),
+                        required_handlers: handler_deps,
+                    };
+                    let timestamp_key = (msg.range_start, msg.range_end, handler_key.clone());
+                    state
+                        .pending_event_timestamps
+                        .entry(timestamp_key)
+                        .or_insert_with(Instant::now);
+                    state
+                        .pending_events
+                        .entry(handler_key)
+                        .or_default()
+                        .push(pending);
                 }
             }
         } // lock released
@@ -1342,6 +1370,21 @@ impl TransformationEngine {
             &outcomes,
         )
         .await;
+
+        // Record handler completions for dependency tracking
+        {
+            let mut state = self.live_state.lock().await;
+            for outcome in &outcomes {
+                state
+                    .completed_handlers
+                    .entry(range_key)
+                    .or_default()
+                    .insert(outcome.handler_name.clone());
+            }
+        }
+
+        // Try to unblock handlers waiting on these completions
+        self.try_process_pending_events(range_key).await?;
 
         Ok(())
     }
@@ -1512,133 +1555,159 @@ impl TransformationEngine {
         Ok(())
     }
 
-    /// Try to process pending events for a range now that new calls arrived.
+    /// Try to process pending events for a range now that new calls or handler
+    /// completions arrived. Uses a cascading loop: after executing newly-ready
+    /// handlers, their completions may unblock further handlers in the chain.
     async fn try_process_pending_events(
         &self,
         range_key: (u64, u64),
     ) -> Result<(), TransformationError> {
-        let ready_events: Vec<(
-            String,
-            PendingEventData,
-            Arc<dyn super::traits::TransformationHandler>,
-        )> = {
-            let mut state = self.live_state.lock().await;
-            let mut ready = Vec::new();
+        loop {
+            let ready_events: Vec<(
+                String,
+                PendingEventData,
+                Arc<dyn super::traits::TransformationHandler>,
+            )> = {
+                let mut state = self.live_state.lock().await;
+                let mut ready = Vec::new();
 
-            let handler_keys: Vec<_> = state.pending_events.keys().cloned().collect();
+                let handler_keys: Vec<_> = state.pending_events.keys().cloned().collect();
 
-            for handler_key in handler_keys {
-                let ready_indices: Vec<usize> = {
-                    let pending = state.pending_events.get(&handler_key).unwrap();
+                for handler_key in handler_keys {
+                    let ready_indices: Vec<usize> = {
+                        let pending = state.pending_events.get(&handler_key).unwrap();
 
-                    pending
-                        .iter()
-                        .enumerate()
-                        .filter(|(_, event_data)| {
-                            (event_data.range_start, event_data.range_end) == range_key
-                        })
-                        .filter(|(_, event_data)| {
-                            event_data.required_calls.iter().all(|dep| {
-                                state
-                                    .received_calls
-                                    .get(dep)
-                                    .map(|ranges| ranges.contains(&range_key))
-                                    .unwrap_or(false)
+                        pending
+                            .iter()
+                            .enumerate()
+                            .filter(|(_, event_data)| {
+                                (event_data.range_start, event_data.range_end) == range_key
                             })
-                        })
-                        .map(|(i, _)| i)
-                        .collect()
-                };
+                            .filter(|(_, event_data)| {
+                                let calls_ready = event_data.required_calls.iter().all(|dep| {
+                                    state
+                                        .received_calls
+                                        .get(dep)
+                                        .map(|ranges| ranges.contains(&range_key))
+                                        .unwrap_or(false)
+                                });
+                                let handlers_ready =
+                                    event_data.required_handlers.iter().all(|dep| {
+                                        state
+                                            .completed_handlers
+                                            .get(&range_key)
+                                            .map(|completed| completed.contains(dep))
+                                            .unwrap_or(false)
+                                    });
+                                calls_ready && handlers_ready
+                            })
+                            .map(|(i, _)| i)
+                            .collect()
+                    };
 
-                if !ready_indices.is_empty() {
-                    tracing::info!(
-                        "Handler {} unblocked for block {}: call deps now available",
-                        handler_key,
-                        range_key.0
-                    );
-                    let pending = state.pending_events.get_mut(&handler_key).unwrap();
-                    for i in ready_indices.into_iter().rev() {
-                        let event_data = pending.remove(i);
-                        let handlers = self
-                            .registry
-                            .handlers_for_event(&event_data.source_name, &event_data.event_name);
-                        if let Some(handler) = handlers
-                            .into_iter()
-                            .find(|h| h.handler_key() == handler_key)
-                        {
-                            let handler: Arc<dyn super::traits::TransformationHandler> = handler;
-                            ready.push((handler_key.clone(), event_data, handler));
+                    if !ready_indices.is_empty() {
+                        tracing::info!(
+                            "Handler {} unblocked for block {}: deps now available",
+                            handler_key,
+                            range_key.0
+                        );
+                        let pending = state.pending_events.get_mut(&handler_key).unwrap();
+                        for i in ready_indices.into_iter().rev() {
+                            let event_data = pending.remove(i);
+                            let handlers = self.registry.handlers_for_event(
+                                &event_data.source_name,
+                                &event_data.event_name,
+                            );
+                            if let Some(handler) = handlers
+                                .into_iter()
+                                .find(|h| h.handler_key() == handler_key)
+                            {
+                                let handler: Arc<dyn super::traits::TransformationHandler> =
+                                    handler;
+                                ready.push((handler_key.clone(), event_data, handler));
+                            }
                         }
+                    }
+
+                    if state
+                        .pending_events
+                        .get(&handler_key)
+                        .map(|p| p.is_empty())
+                        .unwrap_or(true)
+                    {
+                        state.pending_events.remove(&handler_key);
                     }
                 }
 
-                if state
-                    .pending_events
-                    .get(&handler_key)
-                    .map(|p| p.is_empty())
-                    .unwrap_or(true)
-                {
-                    state.pending_events.remove(&handler_key);
-                }
+                ready
+            };
+
+            if ready_events.is_empty() {
+                return Ok(());
             }
 
-            ready
-        };
+            let calls = {
+                let state = self.live_state.lock().await;
+                let calls = state.get_buffered_calls(range_key);
+                Arc::new(filter_calls_by_start_block(&self.contracts, calls))
+            };
 
-        if ready_events.is_empty() {
-            return Ok(());
-        }
+            // Build HandlerTasks and use executor
+            let mut tasks = Vec::new();
+            for (_handler_key, event_data, handler) in ready_events {
+                let tx_addresses =
+                    self.read_receipt_addresses(event_data.range_start, event_data.range_end);
+                tasks.push(HandlerTask {
+                    handler,
+                    events: Arc::new(event_data.events),
+                    calls: calls.clone(),
+                    tx_addresses,
+                });
+            }
 
-        let calls = {
-            let state = self.live_state.lock().await;
-            let calls = state.get_buffered_calls(range_key);
-            Arc::new(filter_calls_by_start_block(&self.contracts, calls))
-        };
+            let submitted_keys: HashSet<String> =
+                tasks.iter().map(|t| t.handler.handler_key()).collect();
 
-        // Build HandlerTasks and use executor
-        let mut tasks = Vec::new();
-        for (_handler_key, event_data, handler) in ready_events {
-            let tx_addresses =
-                self.read_receipt_addresses(event_data.range_start, event_data.range_end);
-            tasks.push(HandlerTask {
-                handler,
-                events: Arc::new(event_data.events),
-                calls: calls.clone(),
-                tx_addresses,
-            });
-        }
+            let outcomes = self
+                .executor
+                .execute_handlers(tasks, range_key.0, range_key.1, &DbExecMode::Direct)
+                .await;
 
-        let submitted_keys: HashSet<String> =
-            tasks.iter().map(|t| t.handler.handler_key()).collect();
+            let succeeded_keys: HashSet<String> =
+                outcomes.iter().map(|o| o.handler_key.clone()).collect();
 
-        let outcomes = self
-            .executor
-            .execute_handlers(tasks, range_key.0, range_key.1, &DbExecMode::Direct)
+            for outcome in &outcomes {
+                self.finalizer
+                    .record_completed_range_for_handler(
+                        &outcome.handler_key,
+                        outcome.range_start,
+                        outcome.range_end,
+                    )
+                    .await?;
+            }
+
+            self.record_handler_outcomes(
+                range_key.0,
+                range_key.1,
+                &submitted_keys,
+                &succeeded_keys,
+                &outcomes,
+            )
             .await;
 
-        let succeeded_keys: HashSet<String> =
-            outcomes.iter().map(|o| o.handler_key.clone()).collect();
-
-        for outcome in &outcomes {
-            self.finalizer
-                .record_completed_range_for_handler(
-                    &outcome.handler_key,
-                    outcome.range_start,
-                    outcome.range_end,
-                )
-                .await?;
+            // Record handler completions for cascading
+            {
+                let mut state = self.live_state.lock().await;
+                for outcome in &outcomes {
+                    state
+                        .completed_handlers
+                        .entry(range_key)
+                        .or_default()
+                        .insert(outcome.handler_name.clone());
+                }
+            }
+            // Loop to check if more handlers are now unblocked
         }
-
-        self.record_handler_outcomes(
-            range_key.0,
-            range_key.1,
-            &submitted_keys,
-            &succeeded_keys,
-            &outcomes,
-        )
-        .await;
-
-        Ok(())
     }
 
     /// Build handler tasks for all event and call triggers in a block range.

--- a/src/transformations/engine.rs
+++ b/src/transformations/engine.rs
@@ -1226,13 +1226,24 @@ impl TransformationEngine {
                 Some(msg) = complete_rx.recv() => {
                     let range_key = (msg.range_start, msg.range_end);
 
-                    // When all log events have been sent, mark untriggered dependency
-                    // handlers as completed-no-op so dependent handlers can proceed.
+                    // When all log events have been sent, mark logs complete and
+                    // mark untriggered dependency handlers as completed-no-op so
+                    // dependent handlers can proceed.
                     if msg.kind == RangeCompleteKind::Logs {
                         let dep_names = self.registry.dependency_handler_names();
-                        if !dep_names.is_empty() {
-                            let mut state = self.live_state.lock().await;
 
+                        // Mark logs complete before processing pending events so
+                        // that handlers unblocked below are properly recorded in
+                        // completed_handlers (the recording logic gates dep-handler
+                        // completion on logs_complete being true).
+                        let mut state = self.live_state.lock().await;
+                        state
+                            .completion
+                            .entry(range_key)
+                            .or_default()
+                            .mark(RangeCompleteKind::Logs);
+
+                        if !dep_names.is_empty() {
                             // Compute handler names that are pending (triggered
                             // but waiting on their own deps). These must NOT be
                             // marked as no-op — they still need to execute.
@@ -1271,6 +1282,8 @@ impl TransformationEngine {
                                 }
                             }
                         }
+                        drop(state);
+
                         self.try_process_pending_events(range_key).await?;
                     }
 
@@ -1530,13 +1543,19 @@ impl TransformationEngine {
         let succeeded_keys: HashSet<String> =
             outcomes.iter().map(|o| o.handler_key.clone()).collect();
 
-        for outcome in &outcomes {
+        // Only persist success for single-trigger handlers.  Multi-trigger
+        // handlers are deferred to finalize_range() because this method runs
+        // once per (source, event_name) batch and a multi-trigger handler
+        // would be marked complete before all its batches are dispatched.
+        let persistable_success_keys: HashSet<String> = succeeded_keys
+            .iter()
+            .filter(|k| !self.registry.is_multi_trigger(k))
+            .cloned()
+            .collect();
+
+        for key in &persistable_success_keys {
             self.finalizer
-                .record_completed_range_for_handler(
-                    &outcome.handler_key,
-                    outcome.range_start,
-                    outcome.range_end,
-                )
+                .record_completed_range_for_handler(key, msg.range_start, msg.range_end)
                 .await?;
         }
 
@@ -1545,6 +1564,7 @@ impl TransformationEngine {
             msg.range_end,
             &submitted_keys,
             &succeeded_keys,
+            &persistable_success_keys,
             &outcomes,
         )
         .await;
@@ -1647,16 +1667,23 @@ impl TransformationEngine {
     /// Record progress and persist failures for handler outcomes from a single
     /// block range execution.  For single-block (live) ranges this records
     /// per-handler live progress and writes failures to the status file.
+    ///
+    /// `persistable_success_keys` controls which handlers get their success
+    /// written to `_live_progress` and the status file.  This is a subset of
+    /// `succeeded_keys` that excludes multi-trigger handlers whose remaining
+    /// batches have not yet been dispatched.  Failure persistence always uses
+    /// the real `submitted_keys` / `succeeded_keys` to avoid false positives.
     async fn record_handler_outcomes(
         &self,
         range_start: u64,
         range_end: u64,
         submitted_keys: &HashSet<String>,
         succeeded_keys: &HashSet<String>,
+        persistable_success_keys: &HashSet<String>,
         _outcomes: &[super::executor::HandlerOutcome],
     ) {
         if range_end - range_start == 1 {
-            // Only record live progress for fully succeeded handlers.
+            // Only record live progress for handlers in persistable_success_keys.
             // Skip handlers that already failed for this block to prevent
             // re-completing them outside explicit retry.
             let failed_for_block: HashSet<String> = {
@@ -1667,7 +1694,7 @@ impl TransformationEngine {
                     .cloned()
                     .unwrap_or_default()
             };
-            for key in succeeded_keys {
+            for key in persistable_success_keys {
                 let is_already_failed = self
                     .registry
                     .handler_name_for_key(key)
@@ -1922,8 +1949,42 @@ impl TransformationEngine {
                 .map(|(k, _)| k.clone())
                 .collect();
 
-            // Only write _handler_progress for fully succeeded handlers
-            for key in &succeeded_keys {
+            // Compute which succeeded keys are safe to persist now.
+            // A handler's success is persistable only when:
+            //  - it is not multi-trigger, OR logs_complete is true (all
+            //    event batches dispatched), AND
+            //  - it has no remaining pending entries for this range.
+            let (persistable_success_keys, logs_complete) = {
+                let state = self.live_state.lock().await;
+                let logs_complete = state
+                    .completion
+                    .get(&range_key)
+                    .map(|c| c.logs_complete)
+                    .unwrap_or(false);
+                let keys: HashSet<String> = succeeded_keys
+                    .iter()
+                    .filter(|key| {
+                        let is_multi = self.registry.is_multi_trigger(key);
+                        if is_multi && !logs_complete {
+                            return false;
+                        }
+                        let has_remaining_pending = state
+                            .pending_events
+                            .get(*key)
+                            .map(|entries| {
+                                entries
+                                    .iter()
+                                    .any(|e| (e.range_start, e.range_end) == range_key)
+                            })
+                            .unwrap_or(false);
+                        !has_remaining_pending
+                    })
+                    .cloned()
+                    .collect();
+                (keys, logs_complete)
+            };
+
+            for key in &persistable_success_keys {
                 self.finalizer
                     .record_completed_range_for_handler(key, range_key.0, range_key.1)
                     .await?;
@@ -1934,31 +1995,38 @@ impl TransformationEngine {
                 range_key.1,
                 &submitted_keys,
                 &succeeded_keys,
+                &persistable_success_keys,
                 &outcomes,
             )
             .await;
 
             // Record handler completions and failures for cascading.
-            // Dep handlers are only completed post-Logs (all batches dispatched);
-            // pre-Logs they are deferred to avoid premature dependent unblocking.
-            // Only fully-succeeded handlers are marked as completed.
-            // Handlers already in failed_handlers are never re-completed.
+            // A handler is only marked completed in-memory when:
+            //  - it succeeded (all batches in this execution round)
+            //  - for dep handlers: logs_complete is true (all event batches dispatched)
+            //  - it has no remaining pending entries for this range
+            //  - it is not already failed
             let newly_failed_names: Vec<String> = {
                 let dep_names = self.registry.dependency_handler_names();
                 let mut state = self.live_state.lock().await;
-                let logs_complete = state
-                    .completion
-                    .get(&range_key)
-                    .map(|c| c.logs_complete)
-                    .unwrap_or(false);
                 let failed_names: HashSet<String> = state
                     .failed_handlers
                     .get(&range_key)
                     .cloned()
                     .unwrap_or_default();
                 for outcome in &outcomes {
+                    let has_remaining_pending = state
+                        .pending_events
+                        .get(&outcome.handler_key)
+                        .map(|entries| {
+                            entries
+                                .iter()
+                                .any(|e| (e.range_start, e.range_end) == range_key)
+                        })
+                        .unwrap_or(false);
                     if succeeded_keys.contains(&outcome.handler_key)
                         && (logs_complete || !dep_names.contains(&outcome.handler_name))
+                        && !has_remaining_pending
                         && !failed_names.contains(&outcome.handler_name)
                     {
                         state
@@ -2196,8 +2264,17 @@ impl TransformationEngine {
             .map(|(k, _)| k.clone())
             .collect();
 
-        // Only write _handler_progress for fully succeeded handlers
-        for key in &succeeded_keys {
+        // Only persist success for single-trigger handlers.  Multi-trigger
+        // call handlers (e.g. PriceHandler) are deferred to finalize_range()
+        // because process_calls_message dispatches one call-trigger batch at
+        // a time.
+        let persistable_success_keys: HashSet<String> = succeeded_keys
+            .iter()
+            .filter(|k| !self.registry.is_multi_trigger(k))
+            .cloned()
+            .collect();
+
+        for key in &persistable_success_keys {
             self.finalizer
                 .record_completed_range_for_handler(key, range_start, range_end)
                 .await?;
@@ -2208,6 +2285,7 @@ impl TransformationEngine {
             range_end,
             &submitted_keys,
             &succeeded_keys,
+            &persistable_success_keys,
             &outcomes,
         )
         .await;

--- a/src/transformations/engine.rs
+++ b/src/transformations/engine.rs
@@ -640,7 +640,10 @@ impl TransformationEngine {
                 .map(|(i, name)| (name.as_str(), i))
                 .collect();
             handlers.sort_by_key(|ch| {
-                position.get(ch.handler.name()).copied().unwrap_or(usize::MAX)
+                position
+                    .get(ch.handler.name())
+                    .copied()
+                    .unwrap_or(usize::MAX)
             });
         }
 
@@ -658,11 +661,7 @@ impl TransformationEngine {
                         .await?;
                     dep_completed.insert(name.clone(), completed);
                 } else {
-                    debug_assert!(
-                        false,
-                        "dep target {} not found in catchup handlers",
-                        name
-                    );
+                    debug_assert!(false, "dep target {} not found in catchup handlers", name);
                     tracing::error!(
                         "Dependency target handler {} not found in catchup handlers",
                         name
@@ -700,6 +699,29 @@ impl TransformationEngine {
                 .collect();
 
             if to_process.is_empty() {
+                if !ch.handler_deps.is_empty() {
+                    let blocked_count = available
+                        .iter()
+                        .filter(|(start, _)| !completed.contains(start))
+                        .filter(|(start, _)| {
+                            ch.handler_deps.iter().any(|dep_name| {
+                                !dep_completed
+                                    .get(dep_name)
+                                    .map(|c| c.contains(start))
+                                    .unwrap_or(false)
+                            })
+                        })
+                        .count();
+                    if blocked_count > 0 {
+                        tracing::warn!(
+                            "Handler {} catchup: {} range(s) blocked by incomplete dependencies ({:?})",
+                            handler_key,
+                            blocked_count,
+                            ch.handler_deps,
+                        );
+                        continue;
+                    }
+                }
                 tracing::info!("Handler {} catchup: already up to date", handler_key);
                 continue;
             }
@@ -1370,6 +1392,7 @@ impl TransformationEngine {
                     .map(|s| s.to_string())
                     .collect();
                 let handler_key = handler.handler_key();
+                let handler_name = handler.name().to_string();
 
                 let call_deps_ready = call_deps.is_empty()
                     || call_deps.iter().all(|dep| {
@@ -1389,6 +1412,20 @@ impl TransformationEngine {
                             .unwrap_or(false)
                     });
 
+                let self_already_failed = state
+                    .failed_handlers
+                    .get(&range_key)
+                    .map(|failed| failed.contains(&handler_name))
+                    .unwrap_or(false);
+                if self_already_failed {
+                    tracing::debug!(
+                        "Handler {} skipped for block {}: already failed for this range",
+                        handler_key,
+                        msg.range_start,
+                    );
+                    continue;
+                }
+
                 // If any handler dependency has already failed for this
                 // range, this handler can never run — skip it immediately.
                 let dep_already_failed = if handler_deps.is_empty() {
@@ -1400,7 +1437,6 @@ impl TransformationEngine {
                         .map(|f| handler_deps.iter().any(|dep| f.contains(dep)))
                         .unwrap_or(false);
                     if failed {
-                        let handler_name = handler.name().to_string();
                         tracing::warn!(
                             "Handler {} skipped for block {}: upstream handler dep already failed",
                             handler_key,
@@ -1828,6 +1864,36 @@ impl TransformationEngine {
                 let handler_keys: Vec<_> = state.pending_events.keys().cloned().collect();
 
                 for handler_key in handler_keys {
+                    let handler_failed = self
+                        .registry
+                        .handler_name_for_key(&handler_key)
+                        .map(|name| {
+                            state
+                                .failed_handlers
+                                .get(&range_key)
+                                .map(|failed| failed.contains(name))
+                                .unwrap_or(false)
+                        })
+                        .unwrap_or(false);
+                    if handler_failed {
+                        let remove_entry =
+                            if let Some(pending) = state.pending_events.get_mut(&handler_key) {
+                                pending.retain(|p| (p.range_start, p.range_end) != range_key);
+                                pending.is_empty()
+                            } else {
+                                false
+                            };
+                        if remove_entry {
+                            state.pending_events.remove(&handler_key);
+                        }
+                        state.pending_event_timestamps.remove(&(
+                            range_key.0,
+                            range_key.1,
+                            handler_key.clone(),
+                        ));
+                        continue;
+                    }
+
                     let ready_indices: Vec<usize> = {
                         let pending = state.pending_events.get(&handler_key).unwrap();
 
@@ -1923,9 +1989,7 @@ impl TransformationEngine {
             // A handler is "fully succeeded" only if ALL its batches succeeded.
             let mut submitted_counts: HashMap<String, usize> = HashMap::new();
             for t in &tasks {
-                *submitted_counts
-                    .entry(t.handler.handler_key())
-                    .or_default() += 1;
+                *submitted_counts.entry(t.handler.handler_key()).or_default() += 1;
             }
 
             let outcomes = self
@@ -1935,17 +1999,12 @@ impl TransformationEngine {
 
             let mut succeeded_counts: HashMap<String, usize> = HashMap::new();
             for o in &outcomes {
-                *succeeded_counts
-                    .entry(o.handler_key.clone())
-                    .or_default() += 1;
+                *succeeded_counts.entry(o.handler_key.clone()).or_default() += 1;
             }
-            let submitted_keys: HashSet<String> =
-                submitted_counts.keys().cloned().collect();
+            let submitted_keys: HashSet<String> = submitted_counts.keys().cloned().collect();
             let succeeded_keys: HashSet<String> = submitted_counts
                 .iter()
-                .filter(|(k, &count)| {
-                    succeeded_counts.get(*k).copied().unwrap_or(0) == count
-                })
+                .filter(|(k, &count)| succeeded_counts.get(*k).copied().unwrap_or(0) == count)
                 .map(|(k, _)| k.clone())
                 .collect();
 
@@ -2066,11 +2125,7 @@ impl TransformationEngine {
     /// just failed — **not** handler keys.
     ///
     /// Must be called while the caller does **not** hold the `live_state` lock.
-    async fn cascade_handler_failures(
-        &self,
-        newly_failed_names: &[String],
-        range_key: (u64, u64),
-    ) {
+    async fn cascade_handler_failures(&self, newly_failed_names: &[String], range_key: (u64, u64)) {
         if newly_failed_names.is_empty() {
             return;
         }
@@ -2081,10 +2136,11 @@ impl TransformationEngine {
                 cascaded.insert(dep_name);
             }
         }
-        if cascaded.is_empty() {
-            return;
-        }
 
+        let newly_failed_keys: Vec<String> = newly_failed_names
+            .iter()
+            .filter_map(|name| self.registry.handler_key_for_name(name).map(str::to_string))
+            .collect();
         let cascaded_keys: Vec<String> = cascaded
             .iter()
             .filter_map(|name| {
@@ -2096,6 +2152,21 @@ impl TransformationEngine {
 
         {
             let mut state = self.live_state.lock().await;
+            for key in &newly_failed_keys {
+                let remove_entry = if let Some(pending) = state.pending_events.get_mut(key) {
+                    pending.retain(|p| (p.range_start, p.range_end) != range_key);
+                    pending.is_empty()
+                } else {
+                    false
+                };
+                if remove_entry {
+                    state.pending_events.remove(key);
+                }
+                state
+                    .pending_event_timestamps
+                    .remove(&(range_key.0, range_key.1, key.clone()));
+            }
+
             for name in &cascaded {
                 state
                     .failed_handlers
@@ -2118,6 +2189,10 @@ impl TransformationEngine {
                     .pending_event_timestamps
                     .remove(&(range_key.0, range_key.1, key.clone()));
             }
+        }
+
+        if cascaded.is_empty() {
+            return;
         }
 
         tracing::warn!(
@@ -2238,9 +2313,7 @@ impl TransformationEngine {
         // Count submissions per handler to detect partial failures.
         let mut submitted_counts: HashMap<String, usize> = HashMap::new();
         for t in &tasks {
-            *submitted_counts
-                .entry(t.handler.handler_key())
-                .or_default() += 1;
+            *submitted_counts.entry(t.handler.handler_key()).or_default() += 1;
         }
 
         let outcomes = self
@@ -2250,17 +2323,12 @@ impl TransformationEngine {
 
         let mut succeeded_counts: HashMap<String, usize> = HashMap::new();
         for o in &outcomes {
-            *succeeded_counts
-                .entry(o.handler_key.clone())
-                .or_default() += 1;
+            *succeeded_counts.entry(o.handler_key.clone()).or_default() += 1;
         }
-        let submitted_keys: HashSet<String> =
-            submitted_counts.keys().cloned().collect();
+        let submitted_keys: HashSet<String> = submitted_counts.keys().cloned().collect();
         let succeeded_keys: HashSet<String> = submitted_counts
             .iter()
-            .filter(|(k, &count)| {
-                succeeded_counts.get(*k).copied().unwrap_or(0) == count
-            })
+            .filter(|(k, &count)| succeeded_counts.get(*k).copied().unwrap_or(0) == count)
             .map(|(k, _)| k.clone())
             .collect();
 

--- a/src/transformations/engine.rs
+++ b/src/transformations/engine.rs
@@ -581,7 +581,7 @@ impl TransformationEngine {
         }
 
         // Collect handler descriptors uniformly across both kinds.
-        let handlers: Vec<CatchupHandler> = match kind {
+        let mut handlers: Vec<CatchupHandler> = match kind {
             HandlerKind::Event => self
                 .registry
                 .unique_event_handlers()
@@ -620,6 +620,19 @@ impl TransformationEngine {
                 })
                 .collect(),
         };
+
+        // Sort event handlers by topological order so dependencies are processed first
+        if kind == HandlerKind::Event {
+            let topo_order = self.registry.handler_topological_order();
+            let position: HashMap<&str, usize> = topo_order
+                .iter()
+                .enumerate()
+                .map(|(i, name)| (name.as_str(), i))
+                .collect();
+            handlers.sort_by_key(|ch| {
+                position.get(ch.handler.name()).copied().unwrap_or(usize::MAX)
+            });
+        }
 
         let mut failed_handlers: Vec<(String, String)> = vec![];
 

--- a/src/transformations/engine.rs
+++ b/src/transformations/engine.rs
@@ -1176,11 +1176,30 @@ impl TransformationEngine {
                         let dep_names = self.registry.dependency_handler_names();
                         if !dep_names.is_empty() {
                             let mut state = self.live_state.lock().await;
+
+                            // Compute handler names that are pending (triggered
+                            // but waiting on their own deps). These must NOT be
+                            // marked as no-op — they still need to execute.
+                            let pending_names: HashSet<&str> = state
+                                .pending_events
+                                .iter()
+                                .filter(|(_, entries)| {
+                                    entries.iter().any(|e| {
+                                        (e.range_start, e.range_end) == range_key
+                                    })
+                                })
+                                .filter_map(|(handler_key, _)| {
+                                    self.registry.handler_name_for_key(handler_key)
+                                })
+                                .collect();
+
                             let completed = state.completed_handlers
                                 .entry(range_key)
                                 .or_default();
                             for name in dep_names {
-                                if !completed.contains(name) {
+                                if !completed.contains(name)
+                                    && !pending_names.contains(name.as_str())
+                                {
                                     tracing::debug!(
                                         "Marking handler {} as completed-no-op for block {} (not triggered)",
                                         name, range_key.0

--- a/src/transformations/engine.rs
+++ b/src/transformations/engine.rs
@@ -1294,6 +1294,7 @@ impl TransformationEngine {
                             event_name: msg.event_name.clone(),
                             events: filtered_events.clone(),
                             required_calls: call_deps.clone(),
+                            required_handlers: vec![],
                         };
                         let timestamp_key = (msg.range_start, msg.range_end, handler_key.clone());
                         state

--- a/src/transformations/engine.rs
+++ b/src/transformations/engine.rs
@@ -1168,12 +1168,32 @@ impl TransformationEngine {
                 }
 
                 Some(msg) = complete_rx.recv() => {
+                    let range_key = (msg.range_start, msg.range_end);
+
+                    // When all log events have been sent, mark untriggered dependency
+                    // handlers as completed-no-op so dependent handlers can proceed.
+                    if msg.kind == RangeCompleteKind::Logs {
+                        let dep_names = self.registry.dependency_handler_names();
+                        if !dep_names.is_empty() {
+                            let mut state = self.live_state.lock().await;
+                            let completed = state.completed_handlers
+                                .entry(range_key)
+                                .or_default();
+                            for name in dep_names {
+                                if !completed.contains(name) {
+                                    tracing::debug!(
+                                        "Marking handler {} as completed-no-op for block {} (not triggered)",
+                                        name, range_key.0
+                                    );
+                                    completed.insert(name.clone());
+                                }
+                            }
+                        }
+                        self.try_process_pending_events(range_key).await?;
+                    }
+
                     self.finalizer
-                        .process_range_complete(
-                            (msg.range_start, msg.range_end),
-                            msg.kind,
-                            &self.live_state,
-                        )
+                        .process_range_complete(range_key, msg.kind, &self.live_state)
                         .await?;
                 }
 

--- a/src/transformations/engine.rs
+++ b/src/transformations/engine.rs
@@ -1346,6 +1346,7 @@ impl TransformationEngine {
         // Categorize handlers: ready to run vs needs buffering
         let range_key = (msg.range_start, msg.range_end);
         let mut ready_handlers: Vec<ReadyHandler> = Vec::new();
+        let mut dep_failed_names: Vec<String> = Vec::new();
         {
             let mut state = self.live_state.lock().await;
             for handler in &handlers {
@@ -1375,7 +1376,36 @@ impl TransformationEngine {
                             .unwrap_or(false)
                     });
 
-                if call_deps_ready && handler_deps_ready {
+                // If any handler dependency has already failed for this
+                // range, this handler can never run — skip it immediately.
+                let dep_already_failed = if handler_deps.is_empty() {
+                    false
+                } else {
+                    let failed = state
+                        .failed_handlers
+                        .get(&range_key)
+                        .map(|f| handler_deps.iter().any(|dep| f.contains(dep)))
+                        .unwrap_or(false);
+                    if failed {
+                        let handler_name = handler.name().to_string();
+                        tracing::warn!(
+                            "Handler {} skipped for block {}: upstream handler dep already failed",
+                            handler_key,
+                            msg.range_start,
+                        );
+                        state
+                            .failed_handlers
+                            .entry(range_key)
+                            .or_default()
+                            .insert(handler_name.clone());
+                        dep_failed_names.push(handler_name);
+                    }
+                    failed
+                };
+
+                if dep_already_failed {
+                    // Don't buffer — handler is already doomed for this range
+                } else if call_deps_ready && handler_deps_ready {
                     // Ready to execute
                     if call_deps.is_empty() {
                         ready_handlers.push((handler.clone(), Arc::new(Vec::new())));
@@ -1440,6 +1470,39 @@ impl TransformationEngine {
             }
         } // lock released
 
+        // Handlers skipped because an upstream dep already failed: persist
+        // and cascade so their own dependents are also failed immediately.
+        if !dep_failed_names.is_empty() {
+            if range_key.1 - range_key.0 == 1 {
+                let failed_keys: HashSet<String> = dep_failed_names
+                    .iter()
+                    .filter_map(|name| {
+                        self.registry
+                            .handler_key_for_name(name)
+                            .map(|k| k.to_string())
+                    })
+                    .collect();
+                let storage = LiveStorage::new(&self.chain_name);
+                if let Err(e) = storage.update_status_atomic(range_key.0, |status| {
+                    status.failed_handlers.extend(failed_keys.iter().cloned());
+                    for k in &failed_keys {
+                        status.completed_handlers.remove(k);
+                    }
+                    status.transformed = false;
+                }) {
+                    if !matches!(e, StorageError::NotFound(_)) {
+                        tracing::warn!(
+                            "Failed to persist dep-failed handlers for block {}: {}",
+                            range_key.0,
+                            e
+                        );
+                    }
+                }
+            }
+            self.cascade_handler_failures(&dep_failed_names, range_key)
+                .await;
+        }
+
         if ready_handlers.is_empty() {
             return Ok(());
         }
@@ -1492,7 +1555,7 @@ impl TransformationEngine {
         // handler would prematurely unblock dependents after its first batch.
         // Dep handlers are completed at RangeCompleteKind::Logs time when all
         // event batches for the block have been dispatched.
-        {
+        let newly_failed_names: Vec<String> = {
             let dep_names = self.registry.dependency_handler_names();
             let mut state = self.live_state.lock().await;
             let failed_names: HashSet<String> = state
@@ -1511,6 +1574,7 @@ impl TransformationEngine {
                         .insert(outcome.handler_name.clone());
                 }
             }
+            let mut newly_failed = Vec::new();
             for key in submitted_keys.difference(&succeeded_keys) {
                 if let Some(name) = self.registry.handler_name_for_key(key) {
                     state
@@ -1518,9 +1582,14 @@ impl TransformationEngine {
                         .entry(range_key)
                         .or_default()
                         .insert(name.to_string());
+                    newly_failed.push(name.to_string());
                 }
             }
-        }
+            newly_failed
+        };
+
+        self.cascade_handler_failures(&newly_failed_names, range_key)
+            .await;
 
         // Try to unblock handlers waiting on call deps (handler dep
         // unblocking for dep handlers is deferred until Logs fires).
@@ -1874,7 +1943,7 @@ impl TransformationEngine {
             // pre-Logs they are deferred to avoid premature dependent unblocking.
             // Only fully-succeeded handlers are marked as completed.
             // Handlers already in failed_handlers are never re-completed.
-            {
+            let newly_failed_names: Vec<String> = {
                 let dep_names = self.registry.dependency_handler_names();
                 let mut state = self.live_state.lock().await;
                 let logs_complete = state
@@ -1899,6 +1968,7 @@ impl TransformationEngine {
                             .insert(outcome.handler_name.clone());
                     }
                 }
+                let mut newly_failed_names: Vec<String> = Vec::new();
                 for key in submitted_keys.difference(&succeeded_keys) {
                     if let Some(name) = self.registry.handler_name_for_key(key) {
                         state
@@ -1906,10 +1976,110 @@ impl TransformationEngine {
                             .entry(range_key)
                             .or_default()
                             .insert(name.to_string());
+                        newly_failed_names.push(name.to_string());
                     }
                 }
-            }
+                newly_failed_names
+            };
+
+            self.cascade_handler_failures(&newly_failed_names, range_key)
+                .await;
+
             // Loop to check if more handlers are now unblocked
+        }
+    }
+
+    /// Cascade failures from newly-failed handlers to all their transitive
+    /// dependents.  Marks dependents as failed in `state`, removes their
+    /// pending events, and persists the cascaded failures to the status file
+    /// for single-block (live) ranges.
+    ///
+    /// `newly_failed_names` should contain the handler `name()` strings that
+    /// just failed — **not** handler keys.
+    ///
+    /// Must be called while the caller does **not** hold the `live_state` lock.
+    async fn cascade_handler_failures(
+        &self,
+        newly_failed_names: &[String],
+        range_key: (u64, u64),
+    ) {
+        if newly_failed_names.is_empty() {
+            return;
+        }
+
+        let mut cascaded: HashSet<String> = HashSet::new();
+        for failed_name in newly_failed_names {
+            for dep_name in self.registry.transitive_dependents_of(failed_name) {
+                cascaded.insert(dep_name);
+            }
+        }
+        if cascaded.is_empty() {
+            return;
+        }
+
+        let cascaded_keys: Vec<String> = cascaded
+            .iter()
+            .filter_map(|name| {
+                self.registry
+                    .handler_key_for_name(name)
+                    .map(|k| k.to_string())
+            })
+            .collect();
+
+        {
+            let mut state = self.live_state.lock().await;
+            for name in &cascaded {
+                state
+                    .failed_handlers
+                    .entry(range_key)
+                    .or_default()
+                    .insert(name.clone());
+                if let Some(completed) = state.completed_handlers.get_mut(&range_key) {
+                    completed.remove(name);
+                }
+            }
+
+            for key in &cascaded_keys {
+                if let Some(pending) = state.pending_events.get_mut(key) {
+                    pending.retain(|p| (p.range_start, p.range_end) != range_key);
+                    if pending.is_empty() {
+                        state.pending_events.remove(key);
+                    }
+                }
+                state
+                    .pending_event_timestamps
+                    .remove(&(range_key.0, range_key.1, key.clone()));
+            }
+        }
+
+        tracing::warn!(
+            "Cascaded failure to {} dependent handler(s) for block {}: {:?}",
+            cascaded.len(),
+            range_key.0,
+            cascaded
+        );
+
+        // Persist cascaded failures to status file for single-block (live) ranges.
+        if range_key.1 - range_key.0 == 1 {
+            let cascaded_key_set: HashSet<String> = cascaded_keys.into_iter().collect();
+            let storage = LiveStorage::new(&self.chain_name);
+            if let Err(e) = storage.update_status_atomic(range_key.0, |status| {
+                status
+                    .failed_handlers
+                    .extend(cascaded_key_set.iter().cloned());
+                for k in &cascaded_key_set {
+                    status.completed_handlers.remove(k);
+                }
+                status.transformed = false;
+            }) {
+                if !matches!(e, StorageError::NotFound(_)) {
+                    tracing::warn!(
+                        "Failed to persist cascaded failures for block {}: {}",
+                        range_key.0,
+                        e
+                    );
+                }
+            }
         }
     }
 

--- a/src/transformations/engine.rs
+++ b/src/transformations/engine.rs
@@ -133,6 +133,8 @@ struct CatchupHandler {
     triggers: Vec<(String, String)>,
     /// Call dependencies (Event handlers only; empty for Call handlers).
     call_deps: Vec<(String, String)>,
+    /// Handler dependencies: handler name() values that must complete first.
+    handler_deps: Vec<String>,
     kind: HandlerKind,
 }
 
@@ -593,10 +595,17 @@ impl TransformationEngine {
                         .map(|t| (t.source.clone(), extract_event_name(&t.event_signature)))
                         .collect();
                     let call_deps = info.handler.call_dependencies();
+                    let handler_deps: Vec<String> = info
+                        .handler
+                        .handler_dependencies()
+                        .iter()
+                        .map(|s| s.to_string())
+                        .collect();
                     CatchupHandler {
                         handler: info.handler as Arc<dyn super::traits::TransformationHandler>,
                         triggers,
                         call_deps,
+                        handler_deps,
                         kind: HandlerKind::Event,
                     }
                 })
@@ -615,6 +624,7 @@ impl TransformationEngine {
                         handler: info.handler as Arc<dyn super::traits::TransformationHandler>,
                         triggers,
                         call_deps: Vec::new(),
+                        handler_deps: Vec::new(),
                         kind: HandlerKind::Call,
                     }
                 })
@@ -634,6 +644,34 @@ impl TransformationEngine {
             });
         }
 
+        // Preload completed ranges for dependency target handlers so downstream
+        // handlers can be gated on upstream completion per range.
+        let mut dep_completed: HashMap<String, HashSet<u64>> = HashMap::new();
+        if kind == HandlerKind::Event {
+            let dep_names = self.registry.dependency_handler_names();
+            for name in dep_names {
+                if let Some(ch) = handlers.iter().find(|ch| ch.handler.name() == name) {
+                    let dep_key = ch.handler.handler_key();
+                    let completed = self
+                        .finalizer
+                        .get_completed_ranges_for_handler(&dep_key)
+                        .await?;
+                    dep_completed.insert(name.clone(), completed);
+                } else {
+                    debug_assert!(
+                        false,
+                        "dep target {} not found in catchup handlers",
+                        name
+                    );
+                    tracing::error!(
+                        "Dependency target handler {} not found in catchup handlers",
+                        name
+                    );
+                    dep_completed.insert(name.clone(), HashSet::new());
+                }
+            }
+        }
+
         let mut failed_handlers: Vec<(String, String)> = vec![];
 
         for ch in &handlers {
@@ -650,6 +688,14 @@ impl TransformationEngine {
             let to_process: Vec<_> = available
                 .iter()
                 .filter(|(start, _)| !completed.contains(start))
+                .filter(|(start, _)| {
+                    ch.handler_deps.iter().all(|dep_name| {
+                        dep_completed
+                            .get(dep_name)
+                            .map(|c| c.contains(start))
+                            .unwrap_or(false)
+                    })
+                })
                 .cloned()
                 .collect();
 
@@ -853,6 +899,16 @@ impl TransformationEngine {
                     handler_errored = true;
                     break;
                 }
+            }
+
+            // Refresh dep completed ranges so downstream handlers see current state
+            let handler_name = handler.name().to_string();
+            if dep_completed.contains_key(&handler_name) {
+                let refreshed = self
+                    .finalizer
+                    .get_completed_ranges_for_handler(&handler_key)
+                    .await?;
+                dep_completed.insert(handler_name, refreshed);
             }
 
             if handler_errored {
@@ -1439,8 +1495,15 @@ impl TransformationEngine {
         {
             let dep_names = self.registry.dependency_handler_names();
             let mut state = self.live_state.lock().await;
+            let failed_names: HashSet<String> = state
+                .failed_handlers
+                .get(&range_key)
+                .cloned()
+                .unwrap_or_default();
             for outcome in &outcomes {
-                if !dep_names.contains(&outcome.handler_name) {
+                if !dep_names.contains(&outcome.handler_name)
+                    && !failed_names.contains(&outcome.handler_name)
+                {
                     state
                         .completed_handlers
                         .entry(range_key)
@@ -1499,6 +1562,7 @@ impl TransformationEngine {
                 for h in &failed_keys {
                     status.completed_handlers.remove(h);
                 }
+                status.transformed = false;
             }) {
                 if !matches!(e, StorageError::NotFound(_)) {
                     tracing::warn!(
@@ -1520,12 +1584,29 @@ impl TransformationEngine {
         range_end: u64,
         submitted_keys: &HashSet<String>,
         succeeded_keys: &HashSet<String>,
-        outcomes: &[super::executor::HandlerOutcome],
+        _outcomes: &[super::executor::HandlerOutcome],
     ) {
         if range_end - range_start == 1 {
-            for outcome in outcomes {
-                self.record_live_progress(outcome.range_start, &outcome.handler_key)
-                    .await;
+            // Only record live progress for fully succeeded handlers.
+            // Skip handlers that already failed for this block to prevent
+            // re-completing them outside explicit retry.
+            let failed_for_block: HashSet<String> = {
+                let state = self.live_state.lock().await;
+                state
+                    .failed_handlers
+                    .get(&(range_start, range_end))
+                    .cloned()
+                    .unwrap_or_default()
+            };
+            for key in succeeded_keys {
+                let is_already_failed = self
+                    .registry
+                    .handler_name_for_key(key)
+                    .map(|n| failed_for_block.contains(n))
+                    .unwrap_or(false);
+                if !is_already_failed {
+                    self.record_live_progress(range_start, key).await;
+                }
             }
             self.persist_failed_handlers(range_start, submitted_keys, succeeded_keys)
                 .await;
@@ -1742,24 +1823,40 @@ impl TransformationEngine {
                 });
             }
 
-            let submitted_keys: HashSet<String> =
-                tasks.iter().map(|t| t.handler.handler_key()).collect();
+            // Count submissions per handler to detect partial failures.
+            // A handler is "fully succeeded" only if ALL its batches succeeded.
+            let mut submitted_counts: HashMap<String, usize> = HashMap::new();
+            for t in &tasks {
+                *submitted_counts
+                    .entry(t.handler.handler_key())
+                    .or_default() += 1;
+            }
 
             let outcomes = self
                 .executor
                 .execute_handlers(tasks, range_key.0, range_key.1, &DbExecMode::Direct)
                 .await;
 
-            let succeeded_keys: HashSet<String> =
-                outcomes.iter().map(|o| o.handler_key.clone()).collect();
+            let mut succeeded_counts: HashMap<String, usize> = HashMap::new();
+            for o in &outcomes {
+                *succeeded_counts
+                    .entry(o.handler_key.clone())
+                    .or_default() += 1;
+            }
+            let submitted_keys: HashSet<String> =
+                submitted_counts.keys().cloned().collect();
+            let succeeded_keys: HashSet<String> = submitted_counts
+                .iter()
+                .filter(|(k, &count)| {
+                    succeeded_counts.get(*k).copied().unwrap_or(0) == count
+                })
+                .map(|(k, _)| k.clone())
+                .collect();
 
-            for outcome in &outcomes {
+            // Only write _handler_progress for fully succeeded handlers
+            for key in &succeeded_keys {
                 self.finalizer
-                    .record_completed_range_for_handler(
-                        &outcome.handler_key,
-                        outcome.range_start,
-                        outcome.range_end,
-                    )
+                    .record_completed_range_for_handler(key, range_key.0, range_key.1)
                     .await?;
             }
 
@@ -1775,6 +1872,8 @@ impl TransformationEngine {
             // Record handler completions and failures for cascading.
             // Dep handlers are only completed post-Logs (all batches dispatched);
             // pre-Logs they are deferred to avoid premature dependent unblocking.
+            // Only fully-succeeded handlers are marked as completed.
+            // Handlers already in failed_handlers are never re-completed.
             {
                 let dep_names = self.registry.dependency_handler_names();
                 let mut state = self.live_state.lock().await;
@@ -1783,8 +1882,16 @@ impl TransformationEngine {
                     .get(&range_key)
                     .map(|c| c.logs_complete)
                     .unwrap_or(false);
+                let failed_names: HashSet<String> = state
+                    .failed_handlers
+                    .get(&range_key)
+                    .cloned()
+                    .unwrap_or_default();
                 for outcome in &outcomes {
-                    if logs_complete || !dep_names.contains(&outcome.handler_name) {
+                    if succeeded_keys.contains(&outcome.handler_key)
+                        && (logs_complete || !dep_names.contains(&outcome.handler_name))
+                        && !failed_names.contains(&outcome.handler_name)
+                    {
                         state
                             .completed_handlers
                             .entry(range_key)
@@ -1890,24 +1997,39 @@ impl TransformationEngine {
             tx_addresses,
         );
 
-        let submitted_keys: HashSet<String> =
-            tasks.iter().map(|t| t.handler.handler_key()).collect();
+        // Count submissions per handler to detect partial failures.
+        let mut submitted_counts: HashMap<String, usize> = HashMap::new();
+        for t in &tasks {
+            *submitted_counts
+                .entry(t.handler.handler_key())
+                .or_default() += 1;
+        }
 
         let outcomes = self
             .executor
             .execute_handlers(tasks, range_start, range_end, &db_exec_mode)
             .await;
 
-        let succeeded_keys: HashSet<String> =
-            outcomes.iter().map(|o| o.handler_key.clone()).collect();
+        let mut succeeded_counts: HashMap<String, usize> = HashMap::new();
+        for o in &outcomes {
+            *succeeded_counts
+                .entry(o.handler_key.clone())
+                .or_default() += 1;
+        }
+        let submitted_keys: HashSet<String> =
+            submitted_counts.keys().cloned().collect();
+        let succeeded_keys: HashSet<String> = submitted_counts
+            .iter()
+            .filter(|(k, &count)| {
+                succeeded_counts.get(*k).copied().unwrap_or(0) == count
+            })
+            .map(|(k, _)| k.clone())
+            .collect();
 
-        for outcome in &outcomes {
+        // Only write _handler_progress for fully succeeded handlers
+        for key in &succeeded_keys {
             self.finalizer
-                .record_completed_range_for_handler(
-                    &outcome.handler_key,
-                    outcome.range_start,
-                    outcome.range_end,
-                )
+                .record_completed_range_for_handler(key, range_start, range_end)
                 .await?;
         }
 

--- a/src/transformations/engine.rs
+++ b/src/transformations/engine.rs
@@ -1248,12 +1248,15 @@ impl TransformationEngine {
             let mut state = self.live_state.lock().await;
             for handler in &handlers {
                 let call_deps = handler.call_dependencies();
+                let handler_deps: Vec<String> = handler
+                    .handler_dependencies()
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect();
                 let handler_key = handler.handler_key();
 
-                if call_deps.is_empty() {
-                    ready_handlers.push((handler.clone(), Arc::new(Vec::new())));
-                } else {
-                    let deps_ready = call_deps.iter().all(|dep| {
+                let call_deps_ready = call_deps.is_empty()
+                    || call_deps.iter().all(|dep| {
                         state
                             .received_calls
                             .get(dep)
@@ -1261,7 +1264,20 @@ impl TransformationEngine {
                             .unwrap_or(false)
                     });
 
-                    if deps_ready {
+                let handler_deps_ready = handler_deps.is_empty()
+                    || handler_deps.iter().all(|dep| {
+                        state
+                            .completed_handlers
+                            .get(&range_key)
+                            .map(|completed| completed.contains(dep))
+                            .unwrap_or(false)
+                    });
+
+                if call_deps_ready && handler_deps_ready {
+                    // Ready to execute
+                    if call_deps.is_empty() {
+                        ready_handlers.push((handler.clone(), Arc::new(Vec::new())));
+                    } else {
                         let calls = state.get_buffered_calls(range_key);
                         let calls: Vec<_> = calls
                             .into_iter()
@@ -1280,33 +1296,44 @@ impl TransformationEngine {
                             calls.len()
                         );
                         ready_handlers.push((handler.clone(), Arc::new(calls)));
-                    } else {
-                        tracing::warn!(
-                            "Handler {} buffering block {}: waiting for eth_call deps {:?}",
-                            handler_key,
-                            msg.range_start,
-                            call_deps
-                        );
-                        let pending = PendingEventData {
-                            range_start: msg.range_start,
-                            range_end: msg.range_end,
-                            source_name: msg.source_name.clone(),
-                            event_name: msg.event_name.clone(),
-                            events: filtered_events.clone(),
-                            required_calls: call_deps.clone(),
-                            required_handlers: vec![],
-                        };
-                        let timestamp_key = (msg.range_start, msg.range_end, handler_key.clone());
-                        state
-                            .pending_event_timestamps
-                            .entry(timestamp_key)
-                            .or_insert_with(Instant::now);
-                        state
-                            .pending_events
-                            .entry(handler_key)
-                            .or_default()
-                            .push(pending);
                     }
+                } else {
+                    // Buffer — needs either call deps or handler deps (or both)
+                    let waiting_for = if !call_deps_ready && !handler_deps_ready {
+                        format!(
+                            "eth_call deps {:?} and handler deps {:?}",
+                            call_deps, handler_deps
+                        )
+                    } else if !call_deps_ready {
+                        format!("eth_call deps {:?}", call_deps)
+                    } else {
+                        format!("handler deps {:?}", handler_deps)
+                    };
+                    tracing::warn!(
+                        "Handler {} buffering block {}: waiting for {}",
+                        handler_key,
+                        msg.range_start,
+                        waiting_for
+                    );
+                    let pending = PendingEventData {
+                        range_start: msg.range_start,
+                        range_end: msg.range_end,
+                        source_name: msg.source_name.clone(),
+                        event_name: msg.event_name.clone(),
+                        events: filtered_events.clone(),
+                        required_calls: call_deps.clone(),
+                        required_handlers: handler_deps,
+                    };
+                    let timestamp_key = (msg.range_start, msg.range_end, handler_key.clone());
+                    state
+                        .pending_event_timestamps
+                        .entry(timestamp_key)
+                        .or_insert_with(Instant::now);
+                    state
+                        .pending_events
+                        .entry(handler_key)
+                        .or_default()
+                        .push(pending);
                 }
             }
         } // lock released
@@ -1356,6 +1383,21 @@ impl TransformationEngine {
             &outcomes,
         )
         .await;
+
+        // Record handler completions for dependency tracking
+        {
+            let mut state = self.live_state.lock().await;
+            for outcome in &outcomes {
+                state
+                    .completed_handlers
+                    .entry(range_key)
+                    .or_default()
+                    .insert(outcome.handler_name.clone());
+            }
+        }
+
+        // Try to unblock handlers waiting on these completions
+        self.try_process_pending_events(range_key).await?;
 
         Ok(())
     }
@@ -1526,133 +1568,159 @@ impl TransformationEngine {
         Ok(())
     }
 
-    /// Try to process pending events for a range now that new calls arrived.
+    /// Try to process pending events for a range now that new calls or handler
+    /// completions arrived. Uses a cascading loop: after executing newly-ready
+    /// handlers, their completions may unblock further handlers in the chain.
     async fn try_process_pending_events(
         &self,
         range_key: (u64, u64),
     ) -> Result<(), TransformationError> {
-        let ready_events: Vec<(
-            String,
-            PendingEventData,
-            Arc<dyn super::traits::TransformationHandler>,
-        )> = {
-            let mut state = self.live_state.lock().await;
-            let mut ready = Vec::new();
+        loop {
+            let ready_events: Vec<(
+                String,
+                PendingEventData,
+                Arc<dyn super::traits::TransformationHandler>,
+            )> = {
+                let mut state = self.live_state.lock().await;
+                let mut ready = Vec::new();
 
-            let handler_keys: Vec<_> = state.pending_events.keys().cloned().collect();
+                let handler_keys: Vec<_> = state.pending_events.keys().cloned().collect();
 
-            for handler_key in handler_keys {
-                let ready_indices: Vec<usize> = {
-                    let pending = state.pending_events.get(&handler_key).unwrap();
+                for handler_key in handler_keys {
+                    let ready_indices: Vec<usize> = {
+                        let pending = state.pending_events.get(&handler_key).unwrap();
 
-                    pending
-                        .iter()
-                        .enumerate()
-                        .filter(|(_, event_data)| {
-                            (event_data.range_start, event_data.range_end) == range_key
-                        })
-                        .filter(|(_, event_data)| {
-                            event_data.required_calls.iter().all(|dep| {
-                                state
-                                    .received_calls
-                                    .get(dep)
-                                    .map(|ranges| ranges.contains(&range_key))
-                                    .unwrap_or(false)
+                        pending
+                            .iter()
+                            .enumerate()
+                            .filter(|(_, event_data)| {
+                                (event_data.range_start, event_data.range_end) == range_key
                             })
-                        })
-                        .map(|(i, _)| i)
-                        .collect()
-                };
+                            .filter(|(_, event_data)| {
+                                let calls_ready = event_data.required_calls.iter().all(|dep| {
+                                    state
+                                        .received_calls
+                                        .get(dep)
+                                        .map(|ranges| ranges.contains(&range_key))
+                                        .unwrap_or(false)
+                                });
+                                let handlers_ready =
+                                    event_data.required_handlers.iter().all(|dep| {
+                                        state
+                                            .completed_handlers
+                                            .get(&range_key)
+                                            .map(|completed| completed.contains(dep))
+                                            .unwrap_or(false)
+                                    });
+                                calls_ready && handlers_ready
+                            })
+                            .map(|(i, _)| i)
+                            .collect()
+                    };
 
-                if !ready_indices.is_empty() {
-                    tracing::info!(
-                        "Handler {} unblocked for block {}: call deps now available",
-                        handler_key,
-                        range_key.0
-                    );
-                    let pending = state.pending_events.get_mut(&handler_key).unwrap();
-                    for i in ready_indices.into_iter().rev() {
-                        let event_data = pending.remove(i);
-                        let handlers = self
-                            .registry
-                            .handlers_for_event(&event_data.source_name, &event_data.event_name);
-                        if let Some(handler) = handlers
-                            .into_iter()
-                            .find(|h| h.handler_key() == handler_key)
-                        {
-                            let handler: Arc<dyn super::traits::TransformationHandler> = handler;
-                            ready.push((handler_key.clone(), event_data, handler));
+                    if !ready_indices.is_empty() {
+                        tracing::info!(
+                            "Handler {} unblocked for block {}: deps now available",
+                            handler_key,
+                            range_key.0
+                        );
+                        let pending = state.pending_events.get_mut(&handler_key).unwrap();
+                        for i in ready_indices.into_iter().rev() {
+                            let event_data = pending.remove(i);
+                            let handlers = self.registry.handlers_for_event(
+                                &event_data.source_name,
+                                &event_data.event_name,
+                            );
+                            if let Some(handler) = handlers
+                                .into_iter()
+                                .find(|h| h.handler_key() == handler_key)
+                            {
+                                let handler: Arc<dyn super::traits::TransformationHandler> =
+                                    handler;
+                                ready.push((handler_key.clone(), event_data, handler));
+                            }
                         }
+                    }
+
+                    if state
+                        .pending_events
+                        .get(&handler_key)
+                        .map(|p| p.is_empty())
+                        .unwrap_or(true)
+                    {
+                        state.pending_events.remove(&handler_key);
                     }
                 }
 
-                if state
-                    .pending_events
-                    .get(&handler_key)
-                    .map(|p| p.is_empty())
-                    .unwrap_or(true)
-                {
-                    state.pending_events.remove(&handler_key);
-                }
+                ready
+            };
+
+            if ready_events.is_empty() {
+                return Ok(());
             }
 
-            ready
-        };
+            let calls = {
+                let state = self.live_state.lock().await;
+                let calls = state.get_buffered_calls(range_key);
+                Arc::new(filter_calls_by_start_block(&self.contracts, calls))
+            };
 
-        if ready_events.is_empty() {
-            return Ok(());
-        }
+            // Build HandlerTasks and use executor
+            let mut tasks = Vec::new();
+            for (_handler_key, event_data, handler) in ready_events {
+                let tx_addresses =
+                    self.read_receipt_addresses(event_data.range_start, event_data.range_end);
+                tasks.push(HandlerTask {
+                    handler,
+                    events: Arc::new(event_data.events),
+                    calls: calls.clone(),
+                    tx_addresses,
+                });
+            }
 
-        let calls = {
-            let state = self.live_state.lock().await;
-            let calls = state.get_buffered_calls(range_key);
-            Arc::new(filter_calls_by_start_block(&self.contracts, calls))
-        };
+            let submitted_keys: HashSet<String> =
+                tasks.iter().map(|t| t.handler.handler_key()).collect();
 
-        // Build HandlerTasks and use executor
-        let mut tasks = Vec::new();
-        for (_handler_key, event_data, handler) in ready_events {
-            let tx_addresses =
-                self.read_receipt_addresses(event_data.range_start, event_data.range_end);
-            tasks.push(HandlerTask {
-                handler,
-                events: Arc::new(event_data.events),
-                calls: calls.clone(),
-                tx_addresses,
-            });
-        }
+            let outcomes = self
+                .executor
+                .execute_handlers(tasks, range_key.0, range_key.1, &DbExecMode::Direct)
+                .await;
 
-        let submitted_keys: HashSet<String> =
-            tasks.iter().map(|t| t.handler.handler_key()).collect();
+            let succeeded_keys: HashSet<String> =
+                outcomes.iter().map(|o| o.handler_key.clone()).collect();
 
-        let outcomes = self
-            .executor
-            .execute_handlers(tasks, range_key.0, range_key.1, &DbExecMode::Direct)
+            for outcome in &outcomes {
+                self.finalizer
+                    .record_completed_range_for_handler(
+                        &outcome.handler_key,
+                        outcome.range_start,
+                        outcome.range_end,
+                    )
+                    .await?;
+            }
+
+            self.record_handler_outcomes(
+                range_key.0,
+                range_key.1,
+                &submitted_keys,
+                &succeeded_keys,
+                &outcomes,
+            )
             .await;
 
-        let succeeded_keys: HashSet<String> =
-            outcomes.iter().map(|o| o.handler_key.clone()).collect();
-
-        for outcome in &outcomes {
-            self.finalizer
-                .record_completed_range_for_handler(
-                    &outcome.handler_key,
-                    outcome.range_start,
-                    outcome.range_end,
-                )
-                .await?;
+            // Record handler completions for cascading
+            {
+                let mut state = self.live_state.lock().await;
+                for outcome in &outcomes {
+                    state
+                        .completed_handlers
+                        .entry(range_key)
+                        .or_default()
+                        .insert(outcome.handler_name.clone());
+                }
+            }
+            // Loop to check if more handlers are now unblocked
         }
-
-        self.record_handler_outcomes(
-            range_key.0,
-            range_key.1,
-            &submitted_keys,
-            &succeeded_keys,
-            &outcomes,
-        )
-        .await;
-
-        Ok(())
     }
 
     /// Build handler tasks for all event and call triggers in a block range.

--- a/src/transformations/engine.rs
+++ b/src/transformations/engine.rs
@@ -1193,12 +1193,19 @@ impl TransformationEngine {
                                 })
                                 .collect();
 
+                            let failed_names: HashSet<String> = state
+                                .failed_handlers
+                                .get(&range_key)
+                                .cloned()
+                                .unwrap_or_default();
+
                             let completed = state.completed_handlers
                                 .entry(range_key)
                                 .or_default();
                             for name in dep_names {
                                 if !completed.contains(name)
                                     && !pending_names.contains(name.as_str())
+                                    && !failed_names.contains(name)
                                 {
                                     tracing::debug!(
                                         "Marking handler {} as completed-no-op for block {} (not triggered)",
@@ -1423,7 +1430,7 @@ impl TransformationEngine {
         )
         .await;
 
-        // Record handler completions for dependency tracking
+        // Record handler completions and failures for dependency tracking
         {
             let mut state = self.live_state.lock().await;
             for outcome in &outcomes {
@@ -1432,6 +1439,15 @@ impl TransformationEngine {
                     .entry(range_key)
                     .or_default()
                     .insert(outcome.handler_name.clone());
+            }
+            for key in submitted_keys.difference(&succeeded_keys) {
+                if let Some(name) = self.registry.handler_name_for_key(key) {
+                    state
+                        .failed_handlers
+                        .entry(range_key)
+                        .or_default()
+                        .insert(name.to_string());
+                }
             }
         }
 
@@ -1747,7 +1763,7 @@ impl TransformationEngine {
             )
             .await;
 
-            // Record handler completions for cascading
+            // Record handler completions and failures for cascading
             {
                 let mut state = self.live_state.lock().await;
                 for outcome in &outcomes {
@@ -1756,6 +1772,15 @@ impl TransformationEngine {
                         .entry(range_key)
                         .or_default()
                         .insert(outcome.handler_name.clone());
+                }
+                for key in submitted_keys.difference(&succeeded_keys) {
+                    if let Some(name) = self.registry.handler_name_for_key(key) {
+                        state
+                            .failed_handlers
+                            .entry(range_key)
+                            .or_default()
+                            .insert(name.to_string());
+                    }
                 }
             }
             // Loop to check if more handlers are now unblocked

--- a/src/transformations/engine.rs
+++ b/src/transformations/engine.rs
@@ -1208,7 +1208,7 @@ impl TransformationEngine {
                                     && !failed_names.contains(name)
                                 {
                                     tracing::debug!(
-                                        "Marking handler {} as completed-no-op for block {} (not triggered)",
+                                        "Marking dep handler {} as completed for block {} (all batches dispatched)",
                                         name, range_key.0
                                     );
                                     completed.insert(name.clone());
@@ -1430,15 +1430,23 @@ impl TransformationEngine {
         )
         .await;
 
-        // Record handler completions and failures for dependency tracking
+        // Record handler completions and failures for dependency tracking.
+        // Dependency handlers are NOT marked as completed here because this
+        // method runs per (source, event_name) batch — a multi-trigger dep
+        // handler would prematurely unblock dependents after its first batch.
+        // Dep handlers are completed at RangeCompleteKind::Logs time when all
+        // event batches for the block have been dispatched.
         {
+            let dep_names = self.registry.dependency_handler_names();
             let mut state = self.live_state.lock().await;
             for outcome in &outcomes {
-                state
-                    .completed_handlers
-                    .entry(range_key)
-                    .or_default()
-                    .insert(outcome.handler_name.clone());
+                if !dep_names.contains(&outcome.handler_name) {
+                    state
+                        .completed_handlers
+                        .entry(range_key)
+                        .or_default()
+                        .insert(outcome.handler_name.clone());
+                }
             }
             for key in submitted_keys.difference(&succeeded_keys) {
                 if let Some(name) = self.registry.handler_name_for_key(key) {
@@ -1451,7 +1459,8 @@ impl TransformationEngine {
             }
         }
 
-        // Try to unblock handlers waiting on these completions
+        // Try to unblock handlers waiting on call deps (handler dep
+        // unblocking for dep handlers is deferred until Logs fires).
         self.try_process_pending_events(range_key).await?;
 
         Ok(())
@@ -1763,15 +1772,25 @@ impl TransformationEngine {
             )
             .await;
 
-            // Record handler completions and failures for cascading
+            // Record handler completions and failures for cascading.
+            // Dep handlers are only completed post-Logs (all batches dispatched);
+            // pre-Logs they are deferred to avoid premature dependent unblocking.
             {
+                let dep_names = self.registry.dependency_handler_names();
                 let mut state = self.live_state.lock().await;
+                let logs_complete = state
+                    .completion
+                    .get(&range_key)
+                    .map(|c| c.logs_complete)
+                    .unwrap_or(false);
                 for outcome in &outcomes {
-                    state
-                        .completed_handlers
-                        .entry(range_key)
-                        .or_default()
-                        .insert(outcome.handler_name.clone());
+                    if logs_complete || !dep_names.contains(&outcome.handler_name) {
+                        state
+                            .completed_handlers
+                            .entry(range_key)
+                            .or_default()
+                            .insert(outcome.handler_name.clone());
+                    }
                 }
                 for key in submitted_keys.difference(&succeeded_keys) {
                     if let Some(name) = self.registry.handler_name_for_key(key) {

--- a/src/transformations/executor.rs
+++ b/src/transformations/executor.rs
@@ -22,6 +22,7 @@ use crate::types::config::contract::Contracts;
 /// Outcome of a successful handler execution.
 pub(crate) struct HandlerOutcome {
     pub handler_key: String,
+    pub handler_name: String,
     pub range_start: u64,
     pub range_end: u64,
 }
@@ -142,6 +143,7 @@ impl HandlerExecutor {
                         }
                         Ok(Some(HandlerOutcome {
                             handler_key,
+                            handler_name: handler_name.to_string(),
                             range_start,
                             range_end,
                         }))

--- a/src/transformations/finalizer.rs
+++ b/src/transformations/finalizer.rs
@@ -125,6 +125,44 @@ impl RangeFinalizer {
                 range_key,
                 timed_out_handlers
             );
+
+            // Persist timed-out handlers as failures so they remain retryable
+            let is_single_block = range_key.1 - range_key.0 == 1;
+            if is_single_block {
+                let storage = LiveStorage::new(&self.chain_name);
+                if let Err(e) = storage.update_status_atomic(range_key.0, |status| {
+                    for key in &timed_out_handlers {
+                        status.failed_handlers.insert(key.clone());
+                        status.completed_handlers.remove(key);
+                    }
+                    status.transformed = false;
+                }) {
+                    if !matches!(e, StorageError::NotFound(_)) {
+                        tracing::warn!(
+                            "Failed to persist timed-out handlers for block {}: {}",
+                            range_key.0,
+                            e
+                        );
+                    }
+                }
+            }
+
+            // Update in-memory state: mark failed, remove from completed
+            {
+                let mut state = live_state.lock().await;
+                for key in &timed_out_handlers {
+                    if let Some(name) = self.registry.handler_name_for_key(key) {
+                        state
+                            .failed_handlers
+                            .entry(range_key)
+                            .or_default()
+                            .insert(name.to_string());
+                        if let Some(completed) = state.completed_handlers.get_mut(&range_key) {
+                            completed.remove(name);
+                        }
+                    }
+                }
+            }
         }
 
         if !should_finalize {

--- a/src/transformations/live_state.rs
+++ b/src/transformations/live_state.rs
@@ -67,7 +67,6 @@ impl LiveProcessingState {
 
             // Remove from finalized_ranges to allow re-finalization if block is re-processed
             self.finalized_ranges.remove(&range_key);
-            self.completed_handlers.remove(&range_key);
 
             // Remove from received_calls
             for ranges in self.received_calls.values_mut() {
@@ -222,6 +221,10 @@ impl LiveProcessingState {
         for ranges in self.received_calls.values_mut() {
             ranges.remove(&range_key);
         }
+        for pending in self.pending_events.values_mut() {
+            pending.retain(|entry| (entry.range_start, entry.range_end) != range_key);
+        }
+        self.pending_events.retain(|_, entries| !entries.is_empty());
         self.pending_event_timestamps
             .retain(|(rs, re, _), _| (*rs, *re) != range_key);
     }

--- a/src/transformations/live_state.rs
+++ b/src/transformations/live_state.rs
@@ -289,4 +289,268 @@ mod tests {
         state.mark(RangeCompleteKind::EthCalls);
         assert!(state.is_ready(false, true));
     }
+
+    /// Helper: check whether a handler has remaining pending entries for a range.
+    /// This mirrors the `has_remaining_pending` check in
+    /// `TransformationEngine::try_process_pending_events`.
+    fn has_remaining_pending(
+        state: &LiveProcessingState,
+        handler_key: &str,
+        range_key: (u64, u64),
+    ) -> bool {
+        state
+            .pending_events
+            .get(handler_key)
+            .map(|entries| {
+                entries
+                    .iter()
+                    .any(|e| (e.range_start, e.range_end) == range_key)
+            })
+            .unwrap_or(false)
+    }
+
+    /// Simulates the in-memory completion condition in try_process_pending_events:
+    /// a handler is only marked complete when it succeeded, logs_complete (for
+    /// dep handlers), has NO remaining pending entries, and is not already failed.
+    fn should_mark_complete_in_memory(
+        state: &LiveProcessingState,
+        handler_key: &str,
+        handler_name: &str,
+        range_key: (u64, u64),
+        succeeded: bool,
+        is_dep_handler: bool,
+    ) -> bool {
+        let logs_complete = state
+            .completion
+            .get(&range_key)
+            .map(|c| c.logs_complete)
+            .unwrap_or(false);
+        let is_failed = state
+            .failed_handlers
+            .get(&range_key)
+            .map(|f| f.contains(handler_name))
+            .unwrap_or(false);
+        let remaining = has_remaining_pending(state, handler_key, range_key);
+
+        succeeded
+            && (logs_complete || !is_dep_handler)
+            && !remaining
+            && !is_failed
+    }
+
+    /// Simulates the persistable_success_keys computation in
+    /// try_process_pending_events: multi-trigger handlers require logs_complete,
+    /// and all handlers require no remaining pending entries.
+    fn should_persist_success(
+        state: &LiveProcessingState,
+        handler_key: &str,
+        range_key: (u64, u64),
+        succeeded: bool,
+        is_multi_trigger: bool,
+    ) -> bool {
+        let logs_complete = state
+            .completion
+            .get(&range_key)
+            .map(|c| c.logs_complete)
+            .unwrap_or(false);
+        let remaining = has_remaining_pending(state, handler_key, range_key);
+
+        succeeded && !(is_multi_trigger && !logs_complete) && !remaining
+    }
+
+    fn make_pending(
+        range_key: (u64, u64),
+        required_calls: Vec<(String, String)>,
+        required_handlers: Vec<String>,
+    ) -> PendingEventData {
+        PendingEventData {
+            range_start: range_key.0,
+            range_end: range_key.1,
+            source_name: "Test".to_string(),
+            event_name: "Event".to_string(),
+            events: vec![],
+            required_calls,
+            required_handlers,
+        }
+    }
+
+    // ── Regression: dep handler with two pending batches ──────────────
+
+    #[test]
+    fn dep_handler_not_completed_while_pending_entries_remain() {
+        let range_key = (100u64, 101u64);
+        let mut state = LiveProcessingState::default();
+
+        // Handler B is a dep handler with two pending batches.
+        // Batch 1 needs call C; batch 2 needs call D.
+        state.pending_events.insert(
+            "B_v1".to_string(),
+            vec![
+                make_pending(
+                    range_key,
+                    vec![("Pool".into(), "callC".into())],
+                    vec![],
+                ),
+                make_pending(
+                    range_key,
+                    vec![("Pool".into(), "callD".into())],
+                    vec![],
+                ),
+            ],
+        );
+
+        // Mark logs_complete (all event batches dispatched).
+        state
+            .completion
+            .entry(range_key)
+            .or_default()
+            .mark(RangeCompleteKind::Logs);
+
+        // Simulate: call C arrives, batch 1 becomes ready, is removed from
+        // pending_events.  Batch 2 still waiting for call D.
+        let pending = state.pending_events.get_mut("B_v1").unwrap();
+        pending.remove(0); // batch 1 removed (ready & executed)
+
+        // After batch 1 succeeds: B must NOT be marked complete because
+        // batch 2 is still pending.
+        assert!(
+            has_remaining_pending(&state, "B_v1", range_key),
+            "B still has a pending entry for the range"
+        );
+        assert!(
+            !should_mark_complete_in_memory(&state, "B_v1", "B", range_key, true, true),
+            "dep handler B must NOT be marked complete while a batch is pending"
+        );
+        assert!(
+            !should_persist_success(&state, "B_v1", range_key, true, false),
+            "B's success must NOT be persisted while a batch is pending"
+        );
+
+        // Now call D arrives, batch 2 removed (ready & executed).
+        let pending = state.pending_events.get_mut("B_v1").unwrap();
+        pending.remove(0);
+        // Entry is now empty; clean up like the engine does.
+        state.pending_events.remove("B_v1");
+
+        // Now B should be completable.
+        assert!(
+            !has_remaining_pending(&state, "B_v1", range_key),
+            "B has no more pending entries"
+        );
+        assert!(
+            should_mark_complete_in_memory(&state, "B_v1", "B", range_key, true, true),
+            "dep handler B should be completable now"
+        );
+        assert!(
+            should_persist_success(&state, "B_v1", range_key, true, false),
+            "B's success should be persistable now"
+        );
+    }
+
+    #[test]
+    fn dep_handler_not_completed_before_logs_complete() {
+        let range_key = (100u64, 101u64);
+        let state = LiveProcessingState::default();
+        // logs_complete is false (default)
+
+        // Handler B succeeded and has no pending entries, but logs_complete
+        // is false — must NOT be marked complete (more event batches could arrive).
+        assert!(
+            !should_mark_complete_in_memory(&state, "B_v1", "B", range_key, true, true),
+            "dep handler must wait for logs_complete"
+        );
+
+        // Non-dep handler is fine without logs_complete.
+        assert!(
+            should_mark_complete_in_memory(&state, "X_v1", "X", range_key, true, false),
+            "non-dep handler can complete without logs_complete"
+        );
+    }
+
+    // ── Regression: multi-trigger call handler ────────────────────────
+
+    #[test]
+    fn multi_trigger_handler_not_persisted_before_logs_complete() {
+        let range_key = (100u64, 101u64);
+        let state = LiveProcessingState::default();
+        // logs_complete is false
+
+        // Multi-trigger handler succeeded with no pending entries, but
+        // logs_complete is false — persistence must be deferred.
+        assert!(
+            !should_persist_success(&state, "price_v1", range_key, true, true),
+            "multi-trigger handler must defer persistence until logs_complete"
+        );
+
+        // Single-trigger handler in the same situation should persist.
+        assert!(
+            should_persist_success(&state, "single_v1", range_key, true, false),
+            "single-trigger handler can persist immediately"
+        );
+    }
+
+    #[test]
+    fn multi_trigger_handler_persisted_after_logs_complete() {
+        let range_key = (100u64, 101u64);
+        let mut state = LiveProcessingState::default();
+        state
+            .completion
+            .entry(range_key)
+            .or_default()
+            .mark(RangeCompleteKind::Logs);
+
+        // Multi-trigger handler with logs_complete and no pending entries.
+        assert!(
+            should_persist_success(&state, "price_v1", range_key, true, true),
+            "multi-trigger handler should persist after logs_complete"
+        );
+    }
+
+    #[test]
+    fn multi_trigger_handler_not_persisted_while_pending() {
+        let range_key = (100u64, 101u64);
+        let mut state = LiveProcessingState::default();
+        state
+            .completion
+            .entry(range_key)
+            .or_default()
+            .mark(RangeCompleteKind::Logs);
+
+        // Even with logs_complete, if pending entries remain, don't persist.
+        state.pending_events.insert(
+            "price_v1".to_string(),
+            vec![make_pending(
+                range_key,
+                vec![("Pool".into(), "slot0".into())],
+                vec![],
+            )],
+        );
+        assert!(
+            !should_persist_success(&state, "price_v1", range_key, true, true),
+            "must not persist while pending entries remain, even with logs_complete"
+        );
+    }
+
+    #[test]
+    fn failed_handler_never_marked_complete() {
+        let range_key = (100u64, 101u64);
+        let mut state = LiveProcessingState::default();
+        state
+            .completion
+            .entry(range_key)
+            .or_default()
+            .mark(RangeCompleteKind::Logs);
+
+        // Mark handler as failed.
+        state
+            .failed_handlers
+            .entry(range_key)
+            .or_default()
+            .insert("B".to_string());
+
+        assert!(
+            !should_mark_complete_in_memory(&state, "B_v1", "B", range_key, true, true),
+            "failed handler must never be marked complete"
+        );
+    }
 }

--- a/src/transformations/live_state.rs
+++ b/src/transformations/live_state.rs
@@ -19,6 +19,8 @@ pub(crate) struct PendingEventData {
     pub events: Vec<DecodedEvent>,
     /// Call dependencies needed: (source, function_name)
     pub required_calls: Vec<(String, String)>,
+    /// Handler dependencies needed: handler name() strings
+    pub required_handlers: Vec<String>,
 }
 
 /// Default timeout for stuck pending events (5 minutes).
@@ -42,6 +44,9 @@ pub(crate) struct LiveProcessingState {
     pub pending_event_timestamps: HashMap<(u64, u64, String), Instant>,
     /// Ranges that have been finalized (to prevent double finalization).
     pub finalized_ranges: HashSet<(u64, u64)>,
+    /// Handlers that have completed for a given range.
+    /// Key: (range_start, range_end), Value: set of handler names (from name(), not handler_key())
+    pub completed_handlers: HashMap<(u64, u64), HashSet<String>>,
 }
 
 impl LiveProcessingState {
@@ -61,6 +66,7 @@ impl LiveProcessingState {
 
             // Remove from finalized_ranges to allow re-finalization if block is re-processed
             self.finalized_ranges.remove(&range_key);
+            self.completed_handlers.remove(&range_key);
 
             // Remove from received_calls
             for ranges in self.received_calls.values_mut() {
@@ -100,6 +106,7 @@ impl LiveProcessingState {
         self.calls_buffer.remove(&range_key);
         self.completion.remove(&range_key);
         self.finalized_ranges.remove(&range_key);
+        self.completed_handlers.remove(&range_key);
         self.pending_event_timestamps
             .retain(|(rs, re, _), _| (*rs, *re) != range_key);
         for ranges in self.received_calls.values_mut() {
@@ -133,7 +140,7 @@ impl LiveProcessingState {
                     if let Some(&first_seen) = self.pending_event_timestamps.get(&timestamp_key) {
                         if now.duration_since(first_seen) >= timeout {
                             tracing::error!(
-                                "Pending event TIMED OUT after {:?}: handler={} range={}-{} event={}/{} waiting_for={:?}. \
+                                "Pending event TIMED OUT after {:?}: handler={} range={}-{} event={}/{} waiting_for_calls={:?} waiting_for_handlers={:?}. \
                                  Force-finalizing range to unblock progress.",
                                 now.duration_since(first_seen),
                                 handler_key,
@@ -141,7 +148,8 @@ impl LiveProcessingState {
                                 pending.range_end,
                                 pending.source_name,
                                 pending.event_name,
-                                pending.required_calls
+                                pending.required_calls,
+                                pending.required_handlers
                             );
                             timed_out.push(handler_key.clone());
                         }
@@ -172,14 +180,15 @@ impl LiveProcessingState {
                 for pending in pending_list {
                     if (pending.range_start, pending.range_end) == range_key {
                         tracing::warn!(
-                            "Stuck pending event detected: handler={} range={}-{} event={}/{} waiting_for={:?}. \
-                             This may indicate missing eth_call configuration or RPC failure.",
+                            "Stuck pending event detected: handler={} range={}-{} event={}/{} waiting_for_calls={:?} waiting_for_handlers={:?}. \
+                             This may indicate missing eth_call configuration, handler dependency issue, or RPC failure.",
                             handler_key,
                             pending.range_start,
                             pending.range_end,
                             pending.source_name,
                             pending.event_name,
-                            pending.required_calls
+                            pending.required_calls,
+                            pending.required_handlers
                         );
                     }
                 }
@@ -208,6 +217,7 @@ impl LiveProcessingState {
     pub fn cleanup_after_finalize(&mut self, range_key: (u64, u64)) {
         self.calls_buffer.remove(&range_key);
         self.completion.remove(&range_key);
+        self.completed_handlers.remove(&range_key);
         for ranges in self.received_calls.values_mut() {
             ranges.remove(&range_key);
         }

--- a/src/transformations/live_state.rs
+++ b/src/transformations/live_state.rs
@@ -332,10 +332,7 @@ mod tests {
             .unwrap_or(false);
         let remaining = has_remaining_pending(state, handler_key, range_key);
 
-        succeeded
-            && (logs_complete || !is_dep_handler)
-            && !remaining
-            && !is_failed
+        succeeded && (logs_complete || !is_dep_handler) && !remaining && !is_failed
     }
 
     /// Simulates the persistable_success_keys computation in
@@ -386,16 +383,8 @@ mod tests {
         state.pending_events.insert(
             "B_v1".to_string(),
             vec![
-                make_pending(
-                    range_key,
-                    vec![("Pool".into(), "callC".into())],
-                    vec![],
-                ),
-                make_pending(
-                    range_key,
-                    vec![("Pool".into(), "callD".into())],
-                    vec![],
-                ),
+                make_pending(range_key, vec![("Pool".into(), "callC".into())], vec![]),
+                make_pending(range_key, vec![("Pool".into(), "callD".into())], vec![]),
             ],
         );
 

--- a/src/transformations/live_state.rs
+++ b/src/transformations/live_state.rs
@@ -47,6 +47,9 @@ pub(crate) struct LiveProcessingState {
     /// Handlers that have completed for a given range.
     /// Key: (range_start, range_end), Value: set of handler names (from name(), not handler_key())
     pub completed_handlers: HashMap<(u64, u64), HashSet<String>>,
+    /// Handlers that were dispatched and failed for a given range.
+    /// Key: (range_start, range_end), Value: set of handler names (from name(), not handler_key())
+    pub failed_handlers: HashMap<(u64, u64), HashSet<String>>,
 }
 
 impl LiveProcessingState {
@@ -64,6 +67,7 @@ impl LiveProcessingState {
             }
             self.completion.remove(&range_key);
             self.completed_handlers.remove(&range_key);
+            self.failed_handlers.remove(&range_key);
 
             // Remove from finalized_ranges to allow re-finalization if block is re-processed
             self.finalized_ranges.remove(&range_key);
@@ -107,6 +111,7 @@ impl LiveProcessingState {
         self.completion.remove(&range_key);
         self.finalized_ranges.remove(&range_key);
         self.completed_handlers.remove(&range_key);
+        self.failed_handlers.remove(&range_key);
         self.pending_event_timestamps
             .retain(|(rs, re, _), _| (*rs, *re) != range_key);
         for ranges in self.received_calls.values_mut() {
@@ -218,6 +223,7 @@ impl LiveProcessingState {
         self.calls_buffer.remove(&range_key);
         self.completion.remove(&range_key);
         self.completed_handlers.remove(&range_key);
+        self.failed_handlers.remove(&range_key);
         for ranges in self.received_calls.values_mut() {
             ranges.remove(&range_key);
         }

--- a/src/transformations/live_state.rs
+++ b/src/transformations/live_state.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 use super::context::{DecodedCall, DecodedEvent};
 use super::engine::RangeCompleteKind;
 
-/// Buffered event data waiting for call dependencies.
+/// Buffered event data waiting for call dependencies and/or handler dependencies.
 #[derive(Debug)]
 pub(crate) struct PendingEventData {
     pub range_start: u64,
@@ -19,12 +19,14 @@ pub(crate) struct PendingEventData {
     pub events: Vec<DecodedEvent>,
     /// Call dependencies needed: (source, function_name)
     pub required_calls: Vec<(String, String)>,
+    /// Handler dependencies needed: handler keys that must complete first
+    pub required_handlers: Vec<String>,
 }
 
 /// Default timeout for stuck pending events (5 minutes).
 pub(crate) const PENDING_EVENT_TIMEOUT_SECS: u64 = 300;
 
-/// Live processing state for buffering events with call dependencies.
+/// Live processing state for buffering events with call and handler dependencies.
 #[derive(Default)]
 pub(crate) struct LiveProcessingState {
     /// Track which (source, function) calls have arrived for which ranges.
@@ -42,6 +44,9 @@ pub(crate) struct LiveProcessingState {
     pub pending_event_timestamps: HashMap<(u64, u64, String), Instant>,
     /// Ranges that have been finalized (to prevent double finalization).
     pub finalized_ranges: HashSet<(u64, u64)>,
+    /// Track which handlers have completed for each range (for handler dependency chains).
+    /// Key: (range_start, range_end), Value: set of completed handler keys
+    pub completed_handlers: HashMap<(u64, u64), HashSet<String>>,
 }
 
 impl LiveProcessingState {
@@ -58,6 +63,7 @@ impl LiveProcessingState {
                 tracing::debug!("Removed calls buffer for orphaned range {:?}", range_key);
             }
             self.completion.remove(&range_key);
+            self.completed_handlers.remove(&range_key);
 
             // Remove from finalized_ranges to allow re-finalization if block is re-processed
             self.finalized_ranges.remove(&range_key);
@@ -100,6 +106,7 @@ impl LiveProcessingState {
         self.calls_buffer.remove(&range_key);
         self.completion.remove(&range_key);
         self.finalized_ranges.remove(&range_key);
+        self.completed_handlers.remove(&range_key);
         self.pending_event_timestamps
             .retain(|(rs, re, _), _| (*rs, *re) != range_key);
         for ranges in self.received_calls.values_mut() {
@@ -208,6 +215,7 @@ impl LiveProcessingState {
     pub fn cleanup_after_finalize(&mut self, range_key: (u64, u64)) {
         self.calls_buffer.remove(&range_key);
         self.completion.remove(&range_key);
+        self.completed_handlers.remove(&range_key);
         for ranges in self.received_calls.values_mut() {
             ranges.remove(&range_key);
         }

--- a/src/transformations/live_state.rs
+++ b/src/transformations/live_state.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 use super::context::{DecodedCall, DecodedEvent};
 use super::engine::RangeCompleteKind;
 
-/// Buffered event data waiting for call dependencies.
+/// Buffered event data waiting for call dependencies and/or handler dependencies.
 #[derive(Debug)]
 pub(crate) struct PendingEventData {
     pub range_start: u64,
@@ -26,7 +26,7 @@ pub(crate) struct PendingEventData {
 /// Default timeout for stuck pending events (5 minutes).
 pub(crate) const PENDING_EVENT_TIMEOUT_SECS: u64 = 300;
 
-/// Live processing state for buffering events with call dependencies.
+/// Live processing state for buffering events with call and handler dependencies.
 #[derive(Default)]
 pub(crate) struct LiveProcessingState {
     /// Track which (source, function) calls have arrived for which ranges.
@@ -63,6 +63,7 @@ impl LiveProcessingState {
                 tracing::debug!("Removed calls buffer for orphaned range {:?}", range_key);
             }
             self.completion.remove(&range_key);
+            self.completed_handlers.remove(&range_key);
 
             // Remove from finalized_ranges to allow re-finalization if block is re-processed
             self.finalized_ranges.remove(&range_key);

--- a/src/transformations/registry.rs
+++ b/src/transformations/registry.rs
@@ -65,6 +65,8 @@ pub struct TransformationRegistry {
     dependency_handler_names: HashSet<String>,
     /// Maps handler_key() to handler name() for reverse lookup
     handler_key_to_name: HashMap<String, String>,
+    /// Set of handler names registered as event handlers (for dep validation)
+    event_handler_names: HashSet<String>,
 }
 
 impl TransformationRegistry {
@@ -78,6 +80,7 @@ impl TransformationRegistry {
             handler_topological_order: Vec::new(),
             dependency_handler_names: HashSet::new(),
             handler_key_to_name: HashMap::new(),
+            event_handler_names: HashSet::new(),
         }
     }
 
@@ -111,6 +114,8 @@ impl TransformationRegistry {
 
         self.handler_key_to_name
             .insert(handler.handler_key(), handler.name().to_string());
+        self.event_handler_names
+            .insert(handler.name().to_string());
 
         self.all_handlers.push(handler);
     }
@@ -238,6 +243,39 @@ impl TransformationRegistry {
             let mut sorted_names: Vec<_> = registered_names.iter().collect();
             sorted_names.sort();
             for name in &sorted_names {
+                msg.push_str(&format!("    - \"{}\"\n", name));
+            }
+            panic!("{}", msg);
+        }
+
+        // Validate all dependencies reference event handlers (not call handlers)
+        let mut non_event_deps: Vec<(String, Vec<String>)> = Vec::new();
+        for (handler_name, deps) in &self.handler_dependency_graph {
+            let bad: Vec<String> = deps
+                .iter()
+                .filter(|dep| !self.event_handler_names.contains(*dep))
+                .cloned()
+                .collect();
+            if !bad.is_empty() {
+                non_event_deps.push((handler_name.clone(), bad));
+            }
+        }
+
+        if !non_event_deps.is_empty() {
+            let mut msg = String::from(
+                "invalid handler dependency: handler_dependencies can only reference event \
+                 handler names, not call handler names:\n",
+            );
+            for (handler_name, bad) in &non_event_deps {
+                msg.push_str(&format!("\n  Handler '{}':\n", handler_name));
+                for dep in bad {
+                    msg.push_str(&format!("    - \"{}\" (not an event handler)\n", dep));
+                }
+            }
+            msg.push_str("\nRegistered event handler names:\n");
+            let mut sorted: Vec<_> = self.event_handler_names.iter().collect();
+            sorted.sort();
+            for name in &sorted {
                 msg.push_str(&format!("    - \"{}\"\n", name));
             }
             panic!("{}", msg);
@@ -843,5 +881,56 @@ mod tests {
             let order = registry.handler_topological_order();
             assert_eq!(order, &["A", "B", "C"]);
         }
+    }
+
+    // ─── Call handler dep validation tests ──────────────────────────────
+
+    use crate::transformations::traits::{EthCallHandler, EthCallTrigger};
+
+    struct MockCallHandler {
+        name: &'static str,
+    }
+
+    #[async_trait]
+    impl TransformationHandler for MockCallHandler {
+        fn name(&self) -> &'static str {
+            self.name
+        }
+
+        async fn handle(
+            &self,
+            _ctx: &TransformationContext,
+        ) -> Result<Vec<DbOperation>, TransformationError> {
+            Ok(vec![])
+        }
+    }
+
+    impl EthCallHandler for MockCallHandler {
+        fn triggers(&self) -> Vec<EthCallTrigger> {
+            vec![EthCallTrigger::new("Test", self.name)]
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "not an event handler")]
+    fn handler_deps_referencing_call_handler_panics() {
+        let mut registry = TransformationRegistry::new();
+        registry.register_event_handler(mock_handler("A", vec![]));
+        registry.register_call_handler(MockCallHandler { name: "B" });
+        registry.register_event_handler(mock_handler("C", vec!["B"]));
+        registry.validate_and_sort_handler_dependencies();
+    }
+
+    #[test]
+    fn handler_deps_with_call_handlers_and_valid_event_deps_passes() {
+        let mut registry = TransformationRegistry::new();
+        registry.register_event_handler(mock_handler("A", vec![]));
+        registry.register_call_handler(MockCallHandler { name: "B" });
+        registry.register_event_handler(mock_handler("C", vec!["A"]));
+        registry.validate_and_sort_handler_dependencies();
+        let order = registry.handler_topological_order();
+        let pos_a = order.iter().position(|n| n == "A").unwrap();
+        let pos_c = order.iter().position(|n| n == "C").unwrap();
+        assert!(pos_a < pos_c, "A must come before C");
     }
 }

--- a/src/transformations/registry.rs
+++ b/src/transformations/registry.rs
@@ -499,6 +499,7 @@ mod tests {
         name: &'static str,
         triggers: Vec<EventTrigger>,
         call_deps: Vec<(String, String)>,
+        handler_deps: Vec<&'static str>,
     }
 
     #[async_trait]
@@ -523,6 +524,10 @@ mod tests {
         fn call_dependencies(&self) -> Vec<(String, String)> {
             self.call_deps.clone()
         }
+
+        fn handler_dependencies(&self) -> Vec<&'static str> {
+            self.handler_deps.clone()
+        }
     }
 
     fn empty_contracts() -> Contracts {
@@ -531,6 +536,15 @@ mod tests {
 
     fn empty_factory_collections() -> FactoryCollections {
         FactoryCollections::new()
+    }
+
+    fn mock_handler(name: &'static str, handler_deps: Vec<&'static str>) -> MockEventHandler {
+        MockEventHandler {
+            name,
+            triggers: vec![EventTrigger::new("Test", format!("{}()", name))],
+            call_deps: vec![],
+            handler_deps,
+        }
     }
 
     #[test]
@@ -553,6 +567,7 @@ mod tests {
                 "Transfer(address,address,uint256)",
             )],
             call_deps: vec![],
+            handler_deps: vec![],
         });
 
         let contracts = empty_contracts();
@@ -574,6 +589,7 @@ mod tests {
             name: "test_handler",
             triggers: vec![EventTrigger::new("TestContract", "Swap(address,uint256)")],
             call_deps: vec![("TestContract".to_string(), "getState".to_string())],
+            handler_deps: vec![],
         });
 
         let mut contracts = Contracts::new();
@@ -608,6 +624,7 @@ mod tests {
             name: "test_handler",
             triggers: vec![EventTrigger::new("TestContract", "Swap(address,uint256)")],
             call_deps: vec![("MissingContract".to_string(), "getState".to_string())],
+            handler_deps: vec![],
         });
 
         let contracts = empty_contracts();
@@ -630,6 +647,7 @@ mod tests {
             name: "test_handler",
             triggers: vec![EventTrigger::new("TestContract", "Swap(address,uint256)")],
             call_deps: vec![("TestContract".to_string(), "wrongFunction".to_string())],
+            handler_deps: vec![],
         });
 
         let mut contracts = Contracts::new();
@@ -668,6 +686,7 @@ mod tests {
             name: "test_handler",
             triggers: vec![EventTrigger::new("TestContract", "Swap(address,uint256)")],
             call_deps: vec![("TestContract".to_string(), "once".to_string())],
+            handler_deps: vec![],
         });
 
         let mut contracts = Contracts::new();
@@ -692,5 +711,108 @@ mod tests {
 
         // Should not panic — once dependency is satisfied
         validate_call_dependencies(&registry, &contracts, &factory_collections);
+    }
+
+    #[test]
+    fn handler_deps_empty_registry_passes() {
+        let mut registry = TransformationRegistry::new();
+        // Should not panic — no handlers, no deps
+        registry.validate_and_sort_handler_dependencies();
+        assert!(registry.handler_topological_order().is_empty());
+    }
+
+    #[test]
+    fn handler_deps_no_deps_passes() {
+        let mut registry = TransformationRegistry::new();
+        registry.register_event_handler(mock_handler("A", vec![]));
+        registry.register_event_handler(mock_handler("B", vec![]));
+        registry.validate_and_sort_handler_dependencies();
+        assert_eq!(registry.handler_topological_order().len(), 2);
+    }
+
+    #[test]
+    fn handler_deps_linear_chain() {
+        let mut registry = TransformationRegistry::new();
+        // C depends on B, B depends on A
+        registry.register_event_handler(mock_handler("C", vec!["B"]));
+        registry.register_event_handler(mock_handler("A", vec![]));
+        registry.register_event_handler(mock_handler("B", vec!["A"]));
+        registry.validate_and_sort_handler_dependencies();
+        let order = registry.handler_topological_order();
+        let pos_a = order.iter().position(|n| n == "A").unwrap();
+        let pos_b = order.iter().position(|n| n == "B").unwrap();
+        let pos_c = order.iter().position(|n| n == "C").unwrap();
+        assert!(pos_a < pos_b, "A must come before B");
+        assert!(pos_b < pos_c, "B must come before C");
+    }
+
+    #[test]
+    fn handler_deps_diamond() {
+        let mut registry = TransformationRegistry::new();
+        // Diamond: A -> B, A -> C, B -> D, C -> D
+        registry.register_event_handler(mock_handler("D", vec!["B", "C"]));
+        registry.register_event_handler(mock_handler("B", vec!["A"]));
+        registry.register_event_handler(mock_handler("C", vec!["A"]));
+        registry.register_event_handler(mock_handler("A", vec![]));
+        registry.validate_and_sort_handler_dependencies();
+        let order = registry.handler_topological_order();
+        let pos_a = order.iter().position(|n| n == "A").unwrap();
+        let pos_b = order.iter().position(|n| n == "B").unwrap();
+        let pos_c = order.iter().position(|n| n == "C").unwrap();
+        let pos_d = order.iter().position(|n| n == "D").unwrap();
+        assert!(pos_a < pos_b, "A must come before B");
+        assert!(pos_a < pos_c, "A must come before C");
+        assert!(pos_b < pos_d, "B must come before D");
+        assert!(pos_c < pos_d, "C must come before D");
+    }
+
+    #[test]
+    #[should_panic(expected = "cycle")]
+    fn handler_deps_two_node_cycle_panics() {
+        let mut registry = TransformationRegistry::new();
+        registry.register_event_handler(mock_handler("A", vec!["B"]));
+        registry.register_event_handler(mock_handler("B", vec!["A"]));
+        registry.validate_and_sort_handler_dependencies();
+    }
+
+    #[test]
+    #[should_panic(expected = "cycle")]
+    fn handler_deps_three_node_cycle_panics() {
+        let mut registry = TransformationRegistry::new();
+        registry.register_event_handler(mock_handler("A", vec!["C"]));
+        registry.register_event_handler(mock_handler("B", vec!["A"]));
+        registry.register_event_handler(mock_handler("C", vec!["B"]));
+        registry.validate_and_sort_handler_dependencies();
+    }
+
+    #[test]
+    #[should_panic(expected = "cycle")]
+    fn handler_deps_self_cycle_panics() {
+        let mut registry = TransformationRegistry::new();
+        registry.register_event_handler(mock_handler("A", vec!["A"]));
+        registry.validate_and_sort_handler_dependencies();
+    }
+
+    #[test]
+    #[should_panic(expected = "missing handler dependency")]
+    fn handler_deps_missing_dep_panics() {
+        let mut registry = TransformationRegistry::new();
+        registry.register_event_handler(mock_handler("A", vec!["NonExistent"]));
+        registry.validate_and_sort_handler_dependencies();
+    }
+
+    #[test]
+    fn handler_deps_deterministic_ordering() {
+        // Run twice to verify determinism
+        for _ in 0..2 {
+            let mut registry = TransformationRegistry::new();
+            // All independent — should sort alphabetically
+            registry.register_event_handler(mock_handler("C", vec![]));
+            registry.register_event_handler(mock_handler("A", vec![]));
+            registry.register_event_handler(mock_handler("B", vec![]));
+            registry.validate_and_sort_handler_dependencies();
+            let order = registry.handler_topological_order();
+            assert_eq!(order, &["A", "B", "C"]);
+        }
     }
 }

--- a/src/transformations/registry.rs
+++ b/src/transformations/registry.rs
@@ -69,6 +69,10 @@ pub struct TransformationRegistry {
     handler_name_to_key: HashMap<String, String>,
     /// Set of handler names registered as event handlers (for dep validation)
     event_handler_names: HashSet<String>,
+    /// Handler keys whose handler declares more than one trigger.
+    /// Multi-trigger handlers must not have their success persisted until
+    /// all batches for the block have been dispatched.
+    multi_trigger_handler_keys: HashSet<String>,
 }
 
 impl TransformationRegistry {
@@ -84,6 +88,7 @@ impl TransformationRegistry {
             handler_key_to_name: HashMap::new(),
             handler_name_to_key: HashMap::new(),
             event_handler_names: HashSet::new(),
+            multi_trigger_handler_keys: HashSet::new(),
         }
     }
 
@@ -92,7 +97,24 @@ impl TransformationRegistry {
     /// The handler will be invoked for all events matching its triggers.
     pub fn register_event_handler<H: EventHandler + 'static>(&mut self, handler: H) {
         let handler = Arc::new(handler);
+        let name = handler.name().to_string();
+
+        if let Some(existing_key) = self.handler_name_to_key.get(&name) {
+            panic!(
+                "duplicate handler name '{}': already registered with key '{}', \
+                 cannot register again with key '{}'",
+                name,
+                existing_key,
+                handler.handler_key()
+            );
+        }
+
         let triggers = handler.triggers();
+
+        if triggers.len() > 1 {
+            self.multi_trigger_handler_keys
+                .insert(handler.handler_key());
+        }
 
         for trigger in triggers {
             let key = (
@@ -131,7 +153,24 @@ impl TransformationRegistry {
     #[allow(dead_code)]
     pub fn register_call_handler<H: EthCallHandler + 'static>(&mut self, handler: H) {
         let handler = Arc::new(handler);
+        let name = handler.name().to_string();
+
+        if let Some(existing_key) = self.handler_name_to_key.get(&name) {
+            panic!(
+                "duplicate handler name '{}': already registered with key '{}', \
+                 cannot register again with key '{}'",
+                name,
+                existing_key,
+                handler.handler_key()
+            );
+        }
+
         let triggers = handler.triggers();
+
+        if triggers.len() > 1 {
+            self.multi_trigger_handler_keys
+                .insert(handler.handler_key());
+        }
 
         for trigger in triggers {
             let key = (trigger.source.clone(), trigger.function_name.clone());
@@ -140,6 +179,11 @@ impl TransformationRegistry {
                 .or_default()
                 .push(handler.clone());
         }
+
+        self.handler_key_to_name
+            .insert(handler.handler_key(), name.clone());
+        self.handler_name_to_key
+            .insert(name, handler.handler_key());
 
         self.all_handlers.push(handler);
     }
@@ -371,6 +415,32 @@ impl TransformationRegistry {
     /// Look up a handler's handler_key() from its name().
     pub fn handler_key_for_name(&self, name: &str) -> Option<&str> {
         self.handler_name_to_key.get(name).map(|s| s.as_str())
+    }
+
+    /// Whether a handler was registered with more than one trigger.
+    pub fn is_multi_trigger(&self, handler_key: &str) -> bool {
+        self.multi_trigger_handler_keys.contains(handler_key)
+    }
+
+    /// Get handler keys for all dependency handler names.
+    ///
+    /// Panics if any dependency name cannot be resolved to a handler key,
+    /// which would indicate a registry inconsistency.
+    pub fn dependency_handler_keys(&self) -> HashSet<String> {
+        self.dependency_handler_names
+            .iter()
+            .map(|name| {
+                self.handler_name_to_key
+                    .get(name)
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "dependency handler name '{}' has no registered handler_key",
+                            name
+                        )
+                    })
+                    .clone()
+            })
+            .collect()
     }
 
     /// Return the transitive set of handler names that depend on `name`.
@@ -1023,5 +1093,95 @@ mod tests {
         registry.register_event_handler(mock_handler("A", vec![]));
         assert!(registry.handler_key_for_name("A").is_some());
         assert!(registry.handler_key_for_name("nonexistent").is_none());
+    }
+
+    #[test]
+    fn single_trigger_handler_is_not_multi_trigger() {
+        let mut registry = TransformationRegistry::new();
+        registry.register_event_handler(mock_handler("A", vec![]));
+        assert!(!registry.is_multi_trigger(&"A_v1".to_string()));
+    }
+
+    #[test]
+    fn multi_trigger_event_handler_detected() {
+        let mut registry = TransformationRegistry::new();
+        registry.register_event_handler(MockEventHandler {
+            name: "multi",
+            triggers: vec![
+                EventTrigger::new("Source1", "Event1()"),
+                EventTrigger::new("Source2", "Event2()"),
+            ],
+            call_deps: vec![],
+            handler_deps: vec![],
+        });
+        assert!(registry.is_multi_trigger("multi_v1"));
+    }
+
+    #[test]
+    fn multi_trigger_call_handler_detected() {
+        use crate::transformations::traits::{EthCallHandler, EthCallTrigger};
+
+        struct MockCallHandler;
+
+        #[async_trait]
+        impl TransformationHandler for MockCallHandler {
+            fn name(&self) -> &'static str {
+                "multi_call"
+            }
+            async fn handle(
+                &self,
+                _ctx: &TransformationContext,
+            ) -> Result<Vec<DbOperation>, TransformationError> {
+                Ok(vec![])
+            }
+        }
+
+        impl EthCallHandler for MockCallHandler {
+            fn triggers(&self) -> Vec<EthCallTrigger> {
+                vec![
+                    EthCallTrigger::new("Pool1", "slot0"),
+                    EthCallTrigger::new("Pool2", "slot0"),
+                ]
+            }
+        }
+
+        let mut registry = TransformationRegistry::new();
+        registry.register_call_handler(MockCallHandler);
+        assert!(registry.is_multi_trigger("multi_call_v1"));
+    }
+
+    #[test]
+    fn dependency_handler_keys_resolves_all_names() {
+        let mut registry = TransformationRegistry::new();
+        registry.register_event_handler(mock_handler("A", vec![]));
+        registry.register_event_handler(mock_handler("B", vec!["A"]));
+        registry.validate_and_sort_handler_dependencies();
+        let dep_keys = registry.dependency_handler_keys();
+        assert_eq!(dep_keys.len(), 1);
+        assert!(dep_keys.contains("A_v1"));
+    }
+
+    #[test]
+    #[should_panic(expected = "duplicate handler name 'A'")]
+    fn duplicate_event_handler_name_panics() {
+        let mut registry = TransformationRegistry::new();
+        registry.register_event_handler(mock_handler("A", vec![]));
+        registry.register_event_handler(mock_handler("A", vec![]));
+    }
+
+    #[test]
+    #[should_panic(expected = "duplicate handler name 'B'")]
+    fn duplicate_call_handler_name_panics() {
+        let mut registry = TransformationRegistry::new();
+        registry.register_call_handler(MockCallHandler { name: "B" });
+        registry.register_call_handler(MockCallHandler { name: "B" });
+    }
+
+    #[test]
+    #[should_panic(expected = "duplicate handler name 'X'")]
+    fn duplicate_name_across_event_and_call_panics() {
+        let mut registry = TransformationRegistry::new();
+        registry.register_event_handler(mock_handler("X", vec![]));
+        registry.register_call_handler(MockCallHandler { name: "X" });
     }
 }

--- a/src/transformations/registry.rs
+++ b/src/transformations/registry.rs
@@ -330,12 +330,16 @@ fn trace_cycle(
     graph: &HashMap<String, Vec<String>>,
     in_degree: &HashMap<String, usize>,
 ) -> String {
-    // Start from any node still with non-zero in-degree (part of a cycle)
-    let start = in_degree
-        .iter()
-        .find(|(_, &deg)| deg > 0)
-        .map(|(name, _)| name.clone())
-        .unwrap_or_default();
+    // Start from the alphabetically first node with non-zero in-degree (deterministic)
+    let start = {
+        let mut candidates: Vec<_> = in_degree
+            .iter()
+            .filter(|(_, &deg)| deg > 0)
+            .map(|(name, _)| name.clone())
+            .collect();
+        candidates.sort();
+        candidates.into_iter().next().unwrap_or_default()
+    };
 
     let mut path = vec![start.clone()];
     let mut current = start.clone();

--- a/src/transformations/registry.rs
+++ b/src/transformations/registry.rs
@@ -61,6 +61,8 @@ pub struct TransformationRegistry {
     handler_dependency_graph: HashMap<String, Vec<String>>,
     /// Topological ordering of handler names (computed after all handlers registered)
     handler_topological_order: Vec<String>,
+    /// Set of all handler names that appear as a dependency of another handler
+    dependency_handler_names: HashSet<String>,
 }
 
 impl TransformationRegistry {
@@ -72,6 +74,7 @@ impl TransformationRegistry {
             all_handlers: Vec::new(),
             handler_dependency_graph: HashMap::new(),
             handler_topological_order: Vec::new(),
+            dependency_handler_names: HashSet::new(),
         }
     }
 
@@ -298,6 +301,17 @@ impl TransformationRegistry {
         }
 
         self.handler_topological_order = order;
+        self.dependency_handler_names = self
+            .handler_dependency_graph
+            .values()
+            .flatten()
+            .cloned()
+            .collect();
+    }
+
+    /// Get the set of all handler names that are declared as a dependency by another handler.
+    pub fn dependency_handler_names(&self) -> &HashSet<String> {
+        &self.dependency_handler_names
     }
 
     /// Get all unique call handlers with their triggers grouped.

--- a/src/transformations/registry.rs
+++ b/src/transformations/registry.rs
@@ -141,8 +141,7 @@ impl TransformationRegistry {
             .insert(handler.handler_key(), handler.name().to_string());
         self.handler_name_to_key
             .insert(handler.name().to_string(), handler.handler_key());
-        self.event_handler_names
-            .insert(handler.name().to_string());
+        self.event_handler_names.insert(handler.name().to_string());
 
         self.all_handlers.push(handler);
     }
@@ -182,8 +181,7 @@ impl TransformationRegistry {
 
         self.handler_key_to_name
             .insert(handler.handler_key(), name.clone());
-        self.handler_name_to_key
-            .insert(name, handler.handler_key());
+        self.handler_name_to_key.insert(name, handler.handler_key());
 
         self.all_handlers.push(handler);
     }
@@ -409,7 +407,9 @@ impl TransformationRegistry {
 
     /// Look up a handler's name() from its handler_key().
     pub fn handler_name_for_key(&self, handler_key: &str) -> Option<&str> {
-        self.handler_key_to_name.get(handler_key).map(|s| s.as_str())
+        self.handler_key_to_name
+            .get(handler_key)
+            .map(|s| s.as_str())
     }
 
     /// Look up a handler's handler_key() from its name().
@@ -452,7 +452,10 @@ impl TransformationRegistry {
         let mut reverse: HashMap<&str, Vec<&str>> = HashMap::new();
         for (handler, deps) in &self.handler_dependency_graph {
             for dep in deps {
-                reverse.entry(dep.as_str()).or_default().push(handler.as_str());
+                reverse
+                    .entry(dep.as_str())
+                    .or_default()
+                    .push(handler.as_str());
             }
         }
 
@@ -501,10 +504,7 @@ pub fn extract_event_name(signature: &str) -> String {
 
 /// Trace a cycle in the dependency graph for error reporting.
 /// Returns a string like "A -> B -> C -> A".
-fn trace_cycle(
-    graph: &HashMap<String, Vec<String>>,
-    in_degree: &HashMap<String, usize>,
-) -> String {
+fn trace_cycle(graph: &HashMap<String, Vec<String>>, in_degree: &HashMap<String, usize>) -> String {
     // Start from the alphabetically first node with non-zero in-degree (deterministic)
     let start = {
         let mut candidates: Vec<_> = in_degree

--- a/src/transformations/registry.rs
+++ b/src/transformations/registry.rs
@@ -63,6 +63,8 @@ pub struct TransformationRegistry {
     handler_topological_order: Vec<String>,
     /// Set of all handler names that appear as a dependency of another handler
     dependency_handler_names: HashSet<String>,
+    /// Maps handler_key() to handler name() for reverse lookup
+    handler_key_to_name: HashMap<String, String>,
 }
 
 impl TransformationRegistry {
@@ -75,6 +77,7 @@ impl TransformationRegistry {
             handler_dependency_graph: HashMap::new(),
             handler_topological_order: Vec::new(),
             dependency_handler_names: HashSet::new(),
+            handler_key_to_name: HashMap::new(),
         }
     }
 
@@ -105,6 +108,9 @@ impl TransformationRegistry {
             self.handler_dependency_graph
                 .insert(handler.name().to_string(), deps);
         }
+
+        self.handler_key_to_name
+            .insert(handler.handler_key(), handler.name().to_string());
 
         self.all_handlers.push(handler);
     }
@@ -312,6 +318,11 @@ impl TransformationRegistry {
     /// Get the set of all handler names that are declared as a dependency by another handler.
     pub fn dependency_handler_names(&self) -> &HashSet<String> {
         &self.dependency_handler_names
+    }
+
+    /// Look up a handler's name() from its handler_key().
+    pub fn handler_name_for_key(&self, handler_key: &str) -> Option<&str> {
+        self.handler_key_to_name.get(handler_key).map(|s| s.as_str())
     }
 
     /// Get all unique call handlers with their triggers grouped.

--- a/src/transformations/registry.rs
+++ b/src/transformations/registry.rs
@@ -65,6 +65,8 @@ pub struct TransformationRegistry {
     dependency_handler_names: HashSet<String>,
     /// Maps handler_key() to handler name() for reverse lookup
     handler_key_to_name: HashMap<String, String>,
+    /// Maps handler name() to handler_key() for reverse lookup
+    handler_name_to_key: HashMap<String, String>,
     /// Set of handler names registered as event handlers (for dep validation)
     event_handler_names: HashSet<String>,
 }
@@ -80,6 +82,7 @@ impl TransformationRegistry {
             handler_topological_order: Vec::new(),
             dependency_handler_names: HashSet::new(),
             handler_key_to_name: HashMap::new(),
+            handler_name_to_key: HashMap::new(),
             event_handler_names: HashSet::new(),
         }
     }
@@ -114,6 +117,8 @@ impl TransformationRegistry {
 
         self.handler_key_to_name
             .insert(handler.handler_key(), handler.name().to_string());
+        self.handler_name_to_key
+            .insert(handler.name().to_string(), handler.handler_key());
         self.event_handler_names
             .insert(handler.name().to_string());
 
@@ -361,6 +366,43 @@ impl TransformationRegistry {
     /// Look up a handler's name() from its handler_key().
     pub fn handler_name_for_key(&self, handler_key: &str) -> Option<&str> {
         self.handler_key_to_name.get(handler_key).map(|s| s.as_str())
+    }
+
+    /// Look up a handler's handler_key() from its name().
+    pub fn handler_key_for_name(&self, name: &str) -> Option<&str> {
+        self.handler_name_to_key.get(name).map(|s| s.as_str())
+    }
+
+    /// Return the transitive set of handler names that depend on `name`.
+    ///
+    /// Given handler A with dependent B and B with dependent C,
+    /// `transitive_dependents_of("A")` returns {"B", "C"}.
+    pub fn transitive_dependents_of(&self, name: &str) -> HashSet<String> {
+        // Build reverse adjacency: dep -> set of handlers that list it as a dependency
+        let mut reverse: HashMap<&str, Vec<&str>> = HashMap::new();
+        for (handler, deps) in &self.handler_dependency_graph {
+            for dep in deps {
+                reverse.entry(dep.as_str()).or_default().push(handler.as_str());
+            }
+        }
+
+        let mut result = HashSet::new();
+        let mut queue = VecDeque::new();
+        if let Some(direct) = reverse.get(name) {
+            for d in direct {
+                queue.push_back(*d);
+            }
+        }
+        while let Some(current) = queue.pop_front() {
+            if result.insert(current.to_string()) {
+                if let Some(further) = reverse.get(current) {
+                    for d in further {
+                        queue.push_back(*d);
+                    }
+                }
+            }
+        }
+        result
     }
 
     /// Get all unique call handlers with their triggers grouped.
@@ -932,5 +974,54 @@ mod tests {
         let pos_a = order.iter().position(|n| n == "A").unwrap();
         let pos_c = order.iter().position(|n| n == "C").unwrap();
         assert!(pos_a < pos_c, "A must come before C");
+    }
+
+    #[test]
+    fn transitive_dependents_no_deps() {
+        let mut registry = TransformationRegistry::new();
+        registry.register_event_handler(mock_handler("A", vec![]));
+        registry.register_event_handler(mock_handler("B", vec![]));
+        registry.validate_and_sort_handler_dependencies();
+        assert!(registry.transitive_dependents_of("A").is_empty());
+    }
+
+    #[test]
+    fn transitive_dependents_linear_chain() {
+        let mut registry = TransformationRegistry::new();
+        registry.register_event_handler(mock_handler("A", vec![]));
+        registry.register_event_handler(mock_handler("B", vec!["A"]));
+        registry.register_event_handler(mock_handler("C", vec!["B"]));
+        registry.validate_and_sort_handler_dependencies();
+        let deps_of_a = registry.transitive_dependents_of("A");
+        assert_eq!(deps_of_a.len(), 2);
+        assert!(deps_of_a.contains("B"));
+        assert!(deps_of_a.contains("C"));
+        let deps_of_b = registry.transitive_dependents_of("B");
+        assert_eq!(deps_of_b.len(), 1);
+        assert!(deps_of_b.contains("C"));
+        assert!(registry.transitive_dependents_of("C").is_empty());
+    }
+
+    #[test]
+    fn transitive_dependents_diamond() {
+        let mut registry = TransformationRegistry::new();
+        registry.register_event_handler(mock_handler("A", vec![]));
+        registry.register_event_handler(mock_handler("B", vec!["A"]));
+        registry.register_event_handler(mock_handler("C", vec!["A"]));
+        registry.register_event_handler(mock_handler("D", vec!["B", "C"]));
+        registry.validate_and_sort_handler_dependencies();
+        let deps_of_a = registry.transitive_dependents_of("A");
+        assert_eq!(deps_of_a.len(), 3);
+        assert!(deps_of_a.contains("B"));
+        assert!(deps_of_a.contains("C"));
+        assert!(deps_of_a.contains("D"));
+    }
+
+    #[test]
+    fn handler_key_for_name_lookup() {
+        let mut registry = TransformationRegistry::new();
+        registry.register_event_handler(mock_handler("A", vec![]));
+        assert!(registry.handler_key_for_name("A").is_some());
+        assert!(registry.handler_key_for_name("nonexistent").is_none());
     }
 }

--- a/src/transformations/registry.rs
+++ b/src/transformations/registry.rs
@@ -2,7 +2,7 @@
 //!
 //! The registry maintains a mapping from event/call triggers to their handlers.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 
 use super::traits::{
@@ -57,6 +57,10 @@ pub struct TransformationRegistry {
     call_handlers: HashMap<(String, String), Vec<Arc<dyn EthCallHandler>>>,
     /// All handlers for initialization (de-duplicated)
     all_handlers: Vec<Arc<dyn TransformationHandler>>,
+    /// Maps handler name() to its declared handler dependency names
+    handler_dependency_graph: HashMap<String, Vec<String>>,
+    /// Topological ordering of handler names (computed after all handlers registered)
+    handler_topological_order: Vec<String>,
 }
 
 impl TransformationRegistry {
@@ -66,6 +70,8 @@ impl TransformationRegistry {
             event_handlers: HashMap::new(),
             call_handlers: HashMap::new(),
             all_handlers: Vec::new(),
+            handler_dependency_graph: HashMap::new(),
+            handler_topological_order: Vec::new(),
         }
     }
 
@@ -85,6 +91,16 @@ impl TransformationRegistry {
                 .entry(key)
                 .or_default()
                 .push(handler.clone());
+        }
+
+        let deps: Vec<String> = handler
+            .handler_dependencies()
+            .iter()
+            .map(|d| d.to_string())
+            .collect();
+        if !deps.is_empty() {
+            self.handler_dependency_graph
+                .insert(handler.name().to_string(), deps);
         }
 
         self.all_handlers.push(handler);
@@ -161,6 +177,129 @@ impl TransformationRegistry {
         .collect()
     }
 
+    /// Get the topological ordering of handler names.
+    /// Available after `validate_and_sort_handler_dependencies()` has been called.
+    pub fn handler_topological_order(&self) -> &[String] {
+        &self.handler_topological_order
+    }
+
+    /// Get the dependency graph (handler name -> dependency names).
+    pub fn handler_dependency_graph(&self) -> &HashMap<String, Vec<String>> {
+        &self.handler_dependency_graph
+    }
+
+    /// Validate handler dependencies and compute topological ordering.
+    ///
+    /// Panics if:
+    /// - A handler declares a dependency on a name that isn't registered
+    /// - The dependency graph contains a cycle
+    pub fn validate_and_sort_handler_dependencies(&mut self) {
+        // Collect all registered handler names (use name(), not handler_key())
+        let registered_names: HashSet<String> = self
+            .all_handlers
+            .iter()
+            .map(|h| h.name().to_string())
+            .collect();
+
+        // Validate all dependency references exist
+        let mut missing: Vec<(String, Vec<String>)> = Vec::new();
+        for (handler_name, deps) in &self.handler_dependency_graph {
+            let unresolved: Vec<String> = deps
+                .iter()
+                .filter(|dep| !registered_names.contains(*dep))
+                .cloned()
+                .collect();
+            if !unresolved.is_empty() {
+                missing.push((handler_name.clone(), unresolved));
+            }
+        }
+
+        if !missing.is_empty() {
+            let mut msg = String::from(
+                "missing handler dependency: one or more handlers declare handler_dependencies \
+                 that do not match any registered handler name:\n",
+            );
+            for (handler_name, unresolved) in &missing {
+                msg.push_str(&format!("\n  Handler '{}':\n", handler_name));
+                for dep in unresolved {
+                    msg.push_str(&format!("    - \"{}\"\n", dep));
+                }
+            }
+            msg.push_str("\nRegistered handler names:\n");
+            let mut sorted_names: Vec<_> = registered_names.iter().collect();
+            sorted_names.sort();
+            for name in &sorted_names {
+                msg.push_str(&format!("    - \"{}\"\n", name));
+            }
+            panic!("{}", msg);
+        }
+
+        // Kahn's algorithm for topological sort
+        // Build adjacency: dependency -> set of dependents
+        let mut in_degree: HashMap<String, usize> = HashMap::new();
+        let mut dependents: HashMap<String, Vec<String>> = HashMap::new();
+
+        // Initialize all handlers with 0 in-degree
+        for name in &registered_names {
+            in_degree.insert(name.clone(), 0);
+        }
+
+        // Build edges from the dependency graph
+        for (handler_name, deps) in &self.handler_dependency_graph {
+            *in_degree.get_mut(handler_name).unwrap() += deps.len();
+            for dep in deps {
+                dependents
+                    .entry(dep.clone())
+                    .or_default()
+                    .push(handler_name.clone());
+            }
+        }
+
+        // Seed queue with zero-in-degree handlers, sorted alphabetically for determinism
+        let mut queue: VecDeque<String> = {
+            let mut zeros: Vec<String> = in_degree
+                .iter()
+                .filter(|(_, &deg)| deg == 0)
+                .map(|(name, _)| name.clone())
+                .collect();
+            zeros.sort();
+            zeros.into_iter().collect()
+        };
+
+        let mut order: Vec<String> = Vec::with_capacity(registered_names.len());
+
+        while let Some(name) = queue.pop_front() {
+            order.push(name.clone());
+            if let Some(deps) = dependents.get(&name) {
+                // Collect newly freed handlers, sort for determinism
+                let mut newly_free: Vec<String> = Vec::new();
+                for dependent in deps {
+                    let deg = in_degree.get_mut(dependent).unwrap();
+                    *deg -= 1;
+                    if *deg == 0 {
+                        newly_free.push(dependent.clone());
+                    }
+                }
+                newly_free.sort();
+                for freed in newly_free {
+                    queue.push_back(freed);
+                }
+            }
+        }
+
+        if order.len() != registered_names.len() {
+            // Cycle detected — find and report it
+            let cycle = trace_cycle(&self.handler_dependency_graph, &in_degree);
+            panic!(
+                "handler dependency cycle detected: {}\n\
+                 Handler dependencies must form a directed acyclic graph (DAG).",
+                cycle
+            );
+        }
+
+        self.handler_topological_order = order;
+    }
+
     /// Get all unique call handlers with their triggers grouped.
     /// Each handler appears exactly once, deduplicated by `handler_key()`.
     pub fn unique_call_handlers(&self) -> Vec<CallHandlerInfo> {
@@ -183,6 +322,47 @@ impl Default for TransformationRegistry {
 /// e.g., "Swap(bytes32,address,int128)" -> "Swap"
 pub fn extract_event_name(signature: &str) -> String {
     signature.split('(').next().unwrap_or(signature).to_string()
+}
+
+/// Trace a cycle in the dependency graph for error reporting.
+/// Returns a string like "A -> B -> C -> A".
+fn trace_cycle(
+    graph: &HashMap<String, Vec<String>>,
+    in_degree: &HashMap<String, usize>,
+) -> String {
+    // Start from any node still with non-zero in-degree (part of a cycle)
+    let start = in_degree
+        .iter()
+        .find(|(_, &deg)| deg > 0)
+        .map(|(name, _)| name.clone())
+        .unwrap_or_default();
+
+    let mut path = vec![start.clone()];
+    let mut current = start.clone();
+
+    // Follow dependency edges to trace the cycle
+    for _ in 0..in_degree.len() {
+        if let Some(deps) = graph.get(&current) {
+            // Follow the first dependency that's part of the cycle (non-zero in-degree)
+            if let Some(next) = deps
+                .iter()
+                .find(|d| in_degree.get(*d).copied().unwrap_or(0) > 0)
+            {
+                if *next == start {
+                    path.push(next.clone());
+                    break;
+                }
+                path.push(next.clone());
+                current = next.clone();
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+
+    path.join(" -> ")
 }
 
 /// Validate that all handler call_dependencies are satisfied by the eth_call configs.
@@ -292,6 +472,8 @@ pub fn build_registry() -> TransformationRegistry {
 
     // Register eth_call handlers
     super::eth_call::register_handlers(&mut registry);
+
+    registry.validate_and_sort_handler_dependencies();
 
     tracing::info!(
         "Built transformation registry with {} handlers ({} event triggers, {} call triggers)",

--- a/src/transformations/retry.rs
+++ b/src/transformations/retry.rs
@@ -43,6 +43,8 @@ struct RetryHandler {
     triggers: HashSet<(String, String)>,
     /// Call dependencies (Event handlers only; empty for Call handlers).
     call_deps: HashSet<(String, String)>,
+    /// Handler dependencies: handler name() values that must complete first.
+    handler_deps: Vec<String>,
     kind: HandlerKind,
 }
 
@@ -363,6 +365,18 @@ impl RetryProcessor {
         let mut blocked_handlers = HashSet::new();
         let mut attempted_keys = HashSet::new();
         let mut succeeded_keys = HashSet::new();
+        let mut succeeded_names: HashSet<String> = HashSet::new();
+
+        // Precompute handler names that are being retried (in missing_handlers)
+        // so we can check handler deps efficiently.
+        let missing_names: HashSet<String> = missing_handlers
+            .iter()
+            .filter_map(|mk| {
+                self.registry
+                    .handler_name_for_key(mk)
+                    .map(|n| n.to_string())
+            })
+            .collect();
 
         // Build a uniform list of retry handler descriptors, sorted by
         // topological order so dependencies execute before dependents.
@@ -381,6 +395,28 @@ impl RetryProcessor {
             let handler_key = rh.handler.handler_key();
             if !missing_handlers.contains(&handler_key) {
                 continue;
+            }
+
+            // Check handler dependencies: a dep blocks only if it is itself
+            // being retried (in missing_names) and hasn't succeeded yet.
+            // Deps not in missing_names already completed in a prior run.
+            if !rh.handler_deps.is_empty() {
+                let unmet: Vec<&str> = rh
+                    .handler_deps
+                    .iter()
+                    .filter(|dep| missing_names.contains(*dep) && !succeeded_names.contains(*dep))
+                    .map(|s| s.as_str())
+                    .collect();
+                if !unmet.is_empty() {
+                    tracing::warn!(
+                        "Skipping live retry for handler {} on block {}: handler deps not met {:?}",
+                        handler_key,
+                        block_number,
+                        unmet
+                    );
+                    blocked_handlers.insert(handler_key);
+                    continue;
+                }
             }
 
             // Filter primary data by trigger match
@@ -482,6 +518,7 @@ impl RetryProcessor {
                     }
 
                     succeeded_keys.insert(handler_key.clone());
+                    succeeded_names.insert(handler_name.to_string());
 
                     if let Err(e) = self
                         .db_pool
@@ -572,10 +609,17 @@ impl RetryProcessor {
                 .collect();
             let call_deps: HashSet<(String, String)> =
                 info.handler.call_dependencies().into_iter().collect();
+            let handler_deps: Vec<String> = info
+                .handler
+                .handler_dependencies()
+                .iter()
+                .map(|s| s.to_string())
+                .collect();
             handlers.push(RetryHandler {
                 handler: info.handler as Arc<dyn super::traits::TransformationHandler>,
                 triggers,
                 call_deps,
+                handler_deps,
                 kind: HandlerKind::Event,
             });
         }
@@ -590,6 +634,7 @@ impl RetryProcessor {
                 handler: info.handler as Arc<dyn super::traits::TransformationHandler>,
                 triggers,
                 call_deps: HashSet::new(),
+                handler_deps: Vec::new(),
                 kind: HandlerKind::Call,
             });
         }

--- a/src/transformations/retry.rs
+++ b/src/transformations/retry.rs
@@ -432,6 +432,24 @@ impl RetryProcessor {
                         .collect();
 
                     if handler_events.is_empty() {
+                        // No matching events — treat as no-op success so
+                        // dependent handlers aren't blocked on this one.
+                        attempted_keys.insert(handler_key.clone());
+                        succeeded_keys.insert(handler_key.clone());
+                        succeeded_names.insert(rh.handler.name().to_string());
+                        if let Some(ref tracker) = self.progress_tracker {
+                            if let Err(e) = tracker
+                                .lock()
+                                .await
+                                .mark_complete(block_number, &handler_key)
+                                .await
+                            {
+                                tracing::warn!(
+                                    "Failed to mark no-op retry progress for block {} handler {}: {}",
+                                    block_number, handler_key, e
+                                );
+                            }
+                        }
                         continue;
                     }
 
@@ -470,6 +488,24 @@ impl RetryProcessor {
                         .collect();
 
                     if handler_calls.is_empty() {
+                        // No matching calls — treat as no-op success so
+                        // dependent handlers aren't blocked on this one.
+                        attempted_keys.insert(handler_key.clone());
+                        succeeded_keys.insert(handler_key.clone());
+                        succeeded_names.insert(rh.handler.name().to_string());
+                        if let Some(ref tracker) = self.progress_tracker {
+                            if let Err(e) = tracker
+                                .lock()
+                                .await
+                                .mark_complete(block_number, &handler_key)
+                                .await
+                            {
+                                tracing::warn!(
+                                    "Failed to mark no-op retry progress for block {} handler {}: {}",
+                                    block_number, handler_key, e
+                                );
+                            }
+                        }
                         continue;
                     }
 
@@ -982,5 +1018,39 @@ mod tests {
         assert!(s.failed_handlers.is_empty());
         assert!(s.completed_handlers.contains("handler_a"));
         assert!(s.completed_handlers.contains("handler_b"));
+    }
+
+    /// Regression: a no-op handler (no matching events) that was previously in
+    /// `failed_handlers` must be moved to `completed_handlers` when retried as
+    /// a no-op success, so dependents can proceed and the handler isn't retried
+    /// indefinitely.
+    #[test]
+    fn retry_noop_handler_clears_prior_failure() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let storage = LiveStorage::with_base_dir(tmp.path().to_path_buf());
+        storage.ensure_dirs().unwrap();
+
+        let mut status = LiveBlockStatus::default();
+        status.logs_decoded = true;
+        status.eth_calls_decoded = true;
+        // Simulate a prior failure for handler_a
+        status.failed_handlers.insert("handler_a".to_string());
+        storage.write_status(100, &status).unwrap();
+
+        // Retry treats handler_a as no-op success (no matching events)
+        let attempted = HashSet::from(["handler_a".to_string()]);
+        let succeeded = HashSet::from(["handler_a".to_string()]);
+        let blocked = HashSet::new();
+        update_retry_status(&storage, 100, &attempted, &succeeded, &blocked).unwrap();
+
+        let s = storage.read_status(100).unwrap();
+        assert!(
+            s.completed_handlers.contains("handler_a"),
+            "no-op succeeded handler must be in completed_handlers"
+        );
+        assert!(
+            !s.failed_handlers.contains("handler_a"),
+            "no-op succeeded handler must be cleared from failed_handlers"
+        );
     }
 }

--- a/src/transformations/retry.rs
+++ b/src/transformations/retry.rs
@@ -405,7 +405,10 @@ impl RetryProcessor {
             .map(|(i, name)| (name.as_str(), i))
             .collect();
         retry_handlers.sort_by_key(|rh| {
-            position.get(rh.handler.name()).copied().unwrap_or(usize::MAX)
+            position
+                .get(rh.handler.name())
+                .copied()
+                .unwrap_or(usize::MAX)
         });
 
         for rh in &retry_handlers {
@@ -931,10 +934,7 @@ mod tests {
     #[test]
     fn retry_missing_handlers_tracker_only() {
         let tracker = Some(HashSet::from(["handler_b_v1".to_string()]));
-        let all_handlers = HashSet::from([
-            "handler_a_v1".to_string(),
-            "handler_b_v1".to_string(),
-        ]);
+        let all_handlers = HashSet::from(["handler_a_v1".to_string(), "handler_b_v1".to_string()]);
 
         let resolved = resolve_retry_missing_handlers(None, tracker, all_handlers);
         assert_eq!(resolved, HashSet::from(["handler_b_v1".to_string()]));

--- a/src/transformations/retry.rs
+++ b/src/transformations/retry.rs
@@ -7,8 +7,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use tokio::sync::{Mutex, Semaphore};
-use tokio::task::JoinSet;
+use tokio::sync::Mutex;
 
 use super::context::{DecodedCall, DecodedEvent, TransactionAddresses, TransformationContext};
 use super::engine::HandlerKind;
@@ -360,14 +359,23 @@ impl RetryProcessor {
     ) -> Result<HashSet<String>, TransformationError> {
         let range_start = block_number;
         let range_end = block_number + 1;
-        let tx_addresses = Arc::new(read_live_receipt_addresses(&self.chain_name, block_number)?);
-        let semaphore = Arc::new(Semaphore::new(self.handler_concurrency));
-        let mut join_set: JoinSet<Result<Option<String>, TransformationError>> = JoinSet::new();
+        let tx_addresses = read_live_receipt_addresses(&self.chain_name, block_number)?;
         let mut blocked_handlers = HashSet::new();
         let mut attempted_keys = HashSet::new();
+        let mut succeeded_keys = HashSet::new();
 
-        // Build a uniform list of retry handler descriptors from both kinds.
-        let retry_handlers = self.build_retry_handler_list();
+        // Build a uniform list of retry handler descriptors, sorted by
+        // topological order so dependencies execute before dependents.
+        let mut retry_handlers = self.build_retry_handler_list();
+        let topo_order = self.registry.handler_topological_order();
+        let position: HashMap<&str, usize> = topo_order
+            .iter()
+            .enumerate()
+            .map(|(i, name)| (name.as_str(), i))
+            .collect();
+        retry_handlers.sort_by_key(|rh| {
+            position.get(rh.handler.name()).copied().unwrap_or(usize::MAX)
+        });
 
         for rh in &retry_handlers {
             let handler_key = rh.handler.handler_key();
@@ -435,64 +443,44 @@ impl RetryProcessor {
 
             attempted_keys.insert(handler_key.clone());
 
-            let permit = semaphore.clone().acquire_owned().await.unwrap();
-            let db_pool = self.db_pool.clone();
-            let chain_name = self.chain_name.clone();
-            let chain_id = self.chain_id;
-            let historical = self.historical_reader.clone();
-            let rpc = self.rpc_client.clone();
-            let contracts = self.contracts.clone();
-            let handler = rh.handler.clone();
-            let handler_name = handler.name();
-            let handler_version = handler.version();
+            let handler_name = rh.handler.name();
+            let handler_version = rh.handler.version();
 
             // Event handlers get tx_addresses; call handlers pass empty map
             let task_tx_addresses = match rh.kind {
-                HandlerKind::Event => (*tx_addresses).clone(),
+                HandlerKind::Event => tx_addresses.clone(),
                 HandlerKind::Call => HashMap::new(),
             };
 
-            join_set.spawn(async move {
-                let _permit = permit;
-                let live_storage = LiveStorage::new(&chain_name);
-                let ctx = TransformationContext::new(
-                    chain_name,
-                    chain_id,
-                    range_start,
-                    range_end,
-                    Arc::new(handler_events),
-                    Arc::new(handler_calls),
-                    task_tx_addresses,
-                    historical,
-                    rpc,
-                    contracts,
-                );
+            let live_storage = LiveStorage::new(&self.chain_name);
+            let ctx = TransformationContext::new(
+                self.chain_name.clone(),
+                self.chain_id,
+                range_start,
+                range_end,
+                Arc::new(handler_events),
+                Arc::new(handler_calls),
+                task_tx_addresses,
+                self.historical_reader.clone(),
+                self.rpc_client.clone(),
+                self.contracts.clone(),
+            );
 
-                match handler.handle(&ctx).await {
-                    Ok(ops) => {
-                        if !ops.is_empty() {
-                            let ops = inject_source_version(ops, handler_name, handler_version);
-                            execute_with_snapshot_capture(
-                                ops,
-                                &db_pool,
-                                Some(&live_storage),
-                                range_start,
-                                handler_name,
-                                handler_version,
-                            )
-                            .await?;
-                        }
-                        Ok(Some(handler_key))
+            match rh.handler.handle(&ctx).await {
+                Ok(ops) => {
+                    if !ops.is_empty() {
+                        let ops = inject_source_version(ops, handler_name, handler_version);
+                        execute_with_snapshot_capture(
+                            ops,
+                            &self.db_pool,
+                            Some(&live_storage),
+                            range_start,
+                            handler_name,
+                            handler_version,
+                        )
+                        .await?;
                     }
-                    Err(e) => Err(e),
-                }
-            });
-        }
 
-        let mut succeeded_keys = HashSet::new();
-        while let Some(result) = join_set.join_next().await {
-            match result {
-                Ok(Ok(Some(handler_key))) => {
                     succeeded_keys.insert(handler_key.clone());
 
                     if let Err(e) = self
@@ -540,17 +528,10 @@ impl RetryProcessor {
                         }
                     }
                 }
-                Ok(Ok(None)) => {}
-                Ok(Err(e)) => {
-                    tracing::error!(
-                        "Handler failed during live retry for block {}: {}",
-                        block_number,
-                        e
-                    );
-                }
                 Err(e) => {
                     tracing::error!(
-                        "Handler task panicked during live retry for block {}: {}",
+                        "Handler {} failed during live retry for block {}: {}",
+                        handler_key,
                         block_number,
                         e
                     );

--- a/src/transformations/retry.rs
+++ b/src/transformations/retry.rs
@@ -569,7 +569,7 @@ impl RetryProcessor {
                 Ok(ops) => {
                     if !ops.is_empty() {
                         let ops = inject_source_version(ops, handler_name, handler_version);
-                        execute_with_snapshot_capture(
+                        if let Err(e) = execute_with_snapshot_capture(
                             ops,
                             &self.db_pool,
                             Some(&live_storage),
@@ -577,7 +577,16 @@ impl RetryProcessor {
                             handler_name,
                             handler_version,
                         )
-                        .await?;
+                        .await
+                        {
+                            tracing::error!(
+                                "Handler {} DB write failed during live retry for block {}: {}",
+                                handler_key,
+                                block_number,
+                                e
+                            );
+                            continue;
+                        }
                     }
 
                     succeeded_keys.insert(handler_key.clone());

--- a/src/transformations/retry.rs
+++ b/src/transformations/retry.rs
@@ -397,30 +397,11 @@ impl RetryProcessor {
                 continue;
             }
 
-            // Check handler dependencies: a dep blocks only if it is itself
-            // being retried (in missing_names) and hasn't succeeded yet.
-            // Deps not in missing_names already completed in a prior run.
-            if !rh.handler_deps.is_empty() {
-                let unmet: Vec<&str> = rh
-                    .handler_deps
-                    .iter()
-                    .filter(|dep| missing_names.contains(*dep) && !succeeded_names.contains(*dep))
-                    .map(|s| s.as_str())
-                    .collect();
-                if !unmet.is_empty() {
-                    tracing::warn!(
-                        "Skipping live retry for handler {} on block {}: handler deps not met {:?}",
-                        handler_key,
-                        block_number,
-                        unmet
-                    );
-                    blocked_handlers.insert(handler_key);
-                    continue;
-                }
-            }
-
-            // Filter primary data by trigger match
-            let (handler_events, handler_calls) = match rh.kind {
+            // Filter primary data by trigger match BEFORE checking handler
+            // deps. If the handler has no matching events/calls, it's a no-op
+            // regardless of whether its deps are met — blocking it would
+            // prevent finalization for no reason.
+            let trigger_data = match rh.kind {
                 HandlerKind::Event => {
                     let handler_events: Vec<DecodedEvent> = events
                         .iter()
@@ -453,29 +434,7 @@ impl RetryProcessor {
                         continue;
                     }
 
-                    // Check call dependencies
-                    let missing_deps = missing_retry_call_dependencies(&rh.call_deps, &calls);
-                    if !missing_deps.is_empty() {
-                        tracing::warn!(
-                            "Skipping live retry for handler {} on block {}: missing call dependencies {:?}",
-                            handler_key,
-                            block_number,
-                            missing_deps
-                        );
-                        blocked_handlers.insert(handler_key);
-                        continue;
-                    }
-
-                    let handler_calls: Vec<DecodedCall> = calls
-                        .iter()
-                        .filter(|call| {
-                            rh.call_deps
-                                .contains(&(call.source_name.clone(), call.function_name.clone()))
-                        })
-                        .cloned()
-                        .collect();
-
-                    (handler_events, handler_calls)
+                    Some((handler_events, Vec::new()))
                 }
                 HandlerKind::Call => {
                     let handler_calls: Vec<DecodedCall> = calls
@@ -509,9 +468,60 @@ impl RetryProcessor {
                         continue;
                     }
 
-                    (Vec::new(), handler_calls)
+                    Some((Vec::new(), handler_calls))
                 }
             };
+
+            // Unwrap trigger data (both no-match branches continue above)
+            let (handler_events, mut handler_calls) = trigger_data.unwrap();
+
+            // Check handler dependencies: a dep blocks only if it is itself
+            // being retried (in missing_names) and hasn't succeeded yet.
+            // Deps not in missing_names already completed in a prior run.
+            if !rh.handler_deps.is_empty() {
+                let unmet: Vec<&str> = rh
+                    .handler_deps
+                    .iter()
+                    .filter(|dep| missing_names.contains(*dep) && !succeeded_names.contains(*dep))
+                    .map(|s| s.as_str())
+                    .collect();
+                if !unmet.is_empty() {
+                    tracing::warn!(
+                        "Skipping live retry for handler {} on block {}: handler deps not met {:?}",
+                        handler_key,
+                        block_number,
+                        unmet
+                    );
+                    blocked_handlers.insert(handler_key);
+                    continue;
+                }
+            }
+
+            // For event handlers: check call dependencies and filter calls
+            if rh.kind == HandlerKind::Event {
+                let missing_deps = missing_retry_call_dependencies(&rh.call_deps, &calls);
+                if !missing_deps.is_empty() {
+                    tracing::warn!(
+                        "Skipping live retry for handler {} on block {}: missing call dependencies {:?}",
+                        handler_key,
+                        block_number,
+                        missing_deps
+                    );
+                    blocked_handlers.insert(handler_key);
+                    continue;
+                }
+
+                handler_calls = calls
+                    .iter()
+                    .filter(|call| {
+                        rh.call_deps
+                            .contains(&(call.source_name.clone(), call.function_name.clone()))
+                    })
+                    .cloned()
+                    .collect();
+            }
+
+            // handler_events and handler_calls are now ready for execution
 
             attempted_keys.insert(handler_key.clone());
 

--- a/src/transformations/retry.rs
+++ b/src/transformations/retry.rs
@@ -53,7 +53,12 @@ pub(crate) fn resolve_retry_missing_handlers(
     tracker_missing: Option<HashSet<String>>,
     all_handlers: HashSet<String>,
 ) -> HashSet<String> {
-    tracker_missing.unwrap_or_else(|| request_missing.unwrap_or(all_handlers))
+    match (tracker_missing, request_missing) {
+        (Some(tracker), Some(request)) => tracker.union(&request).cloned().collect(),
+        (Some(tracker), None) => tracker,
+        (None, Some(request)) => request,
+        (None, None) => all_handlers,
+    }
 }
 
 pub(crate) fn missing_retry_call_dependencies(
@@ -144,8 +149,20 @@ impl RetryProcessor {
             .iter()
             .map(|handler| handler.handler_key())
             .collect();
-        let missing_handlers =
+        let mut missing_handlers =
             resolve_retry_missing_handlers(request.missing_handlers, tracker_missing, all_handlers);
+
+        // Union in persisted failed_handlers so stale tracker state can't hide
+        // known failures. This must happen BEFORE the empty check.
+        let storage = LiveStorage::new(&self.chain_name);
+        if let Ok(status) = storage.read_status(block_number) {
+            if !status.failed_handlers.is_empty() {
+                missing_handlers = missing_handlers
+                    .union(&status.failed_handlers)
+                    .cloned()
+                    .collect();
+            }
+        }
 
         if missing_handlers.is_empty() {
             return record_and_finalize
@@ -717,6 +734,9 @@ pub(crate) fn update_retry_status(
             status.failed_handlers.insert(key.clone());
             status.completed_handlers.remove(key);
         }
+        if !failed_keys.is_empty() {
+            status.transformed = false;
+        }
         // Don't set transformed=true here — finalize_range() handles that
         // after recording _handler_progress for all handlers.
     })
@@ -861,7 +881,7 @@ mod tests {
     use crate::transformations::context::DecodedValue;
 
     #[test]
-    fn retry_missing_handlers_prefers_current_tracker_state() {
+    fn retry_missing_handlers_unions_tracker_and_request() {
         let requested = Some(HashSet::from([
             "handler_a_v1".to_string(),
             "handler_b_v1".to_string(),
@@ -874,6 +894,22 @@ mod tests {
         ]);
 
         let resolved = resolve_retry_missing_handlers(requested, tracker, all_handlers);
+        // Union: tracker {b} ∪ request {a, b} = {a, b}
+        assert_eq!(
+            resolved,
+            HashSet::from(["handler_a_v1".to_string(), "handler_b_v1".to_string()])
+        );
+    }
+
+    #[test]
+    fn retry_missing_handlers_tracker_only() {
+        let tracker = Some(HashSet::from(["handler_b_v1".to_string()]));
+        let all_handlers = HashSet::from([
+            "handler_a_v1".to_string(),
+            "handler_b_v1".to_string(),
+        ]);
+
+        let resolved = resolve_retry_missing_handlers(None, tracker, all_handlers);
         assert_eq!(resolved, HashSet::from(["handler_b_v1".to_string()]));
     }
 
@@ -1062,5 +1098,32 @@ mod tests {
             !s.failed_handlers.contains("handler_a"),
             "no-op succeeded handler must be cleared from failed_handlers"
         );
+    }
+
+    /// Regression: when update_retry_status records failed handlers, it must
+    /// also clear `transformed` so the block remains retryable on restart.
+    #[test]
+    fn retry_status_clears_transformed_on_failure() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let storage = LiveStorage::with_base_dir(tmp.path().to_path_buf());
+        storage.ensure_dirs().unwrap();
+
+        let mut status = LiveBlockStatus::default();
+        status.logs_decoded = true;
+        status.eth_calls_decoded = true;
+        status.transformed = true;
+        storage.write_status(100, &status).unwrap();
+
+        let attempted = HashSet::from(["handler_a".to_string()]);
+        let succeeded = HashSet::new();
+        let blocked = HashSet::new();
+        update_retry_status(&storage, 100, &attempted, &succeeded, &blocked).unwrap();
+
+        let s = storage.read_status(100).unwrap();
+        assert!(
+            !s.transformed,
+            "transformed must be cleared when failures are recorded"
+        );
+        assert!(s.failed_handlers.contains("handler_a"));
     }
 }

--- a/src/transformations/retry.rs
+++ b/src/transformations/retry.rs
@@ -433,21 +433,16 @@ impl RetryProcessor {
                         // No matching events — treat as no-op success so
                         // dependent handlers aren't blocked on this one.
                         attempted_keys.insert(handler_key.clone());
-                        succeeded_keys.insert(handler_key.clone());
-                        succeeded_names.insert(rh.handler.name().to_string());
-                        if let Some(ref tracker) = self.progress_tracker {
-                            if let Err(e) = tracker
-                                .lock()
-                                .await
-                                .mark_complete(block_number, &handler_key)
-                                .await
-                            {
-                                tracing::warn!(
-                                    "Failed to mark no-op retry progress for block {} handler {}: {}",
-                                    block_number, handler_key, e
-                                );
-                            }
-                        }
+                        self.record_handler_retry_success(
+                            &handler_key,
+                            rh.handler.name(),
+                            range_start,
+                            range_end,
+                            block_number,
+                            &mut succeeded_keys,
+                            &mut succeeded_names,
+                        )
+                        .await;
                         continue;
                     }
 
@@ -467,21 +462,16 @@ impl RetryProcessor {
                         // No matching calls — treat as no-op success so
                         // dependent handlers aren't blocked on this one.
                         attempted_keys.insert(handler_key.clone());
-                        succeeded_keys.insert(handler_key.clone());
-                        succeeded_names.insert(rh.handler.name().to_string());
-                        if let Some(ref tracker) = self.progress_tracker {
-                            if let Err(e) = tracker
-                                .lock()
-                                .await
-                                .mark_complete(block_number, &handler_key)
-                                .await
-                            {
-                                tracing::warn!(
-                                    "Failed to mark no-op retry progress for block {} handler {}: {}",
-                                    block_number, handler_key, e
-                                );
-                            }
-                        }
+                        self.record_handler_retry_success(
+                            &handler_key,
+                            rh.handler.name(),
+                            range_start,
+                            range_end,
+                            block_number,
+                            &mut succeeded_keys,
+                            &mut succeeded_names,
+                        )
+                        .await;
                         continue;
                     }
 
@@ -589,53 +579,16 @@ impl RetryProcessor {
                         }
                     }
 
-                    succeeded_keys.insert(handler_key.clone());
-                    succeeded_names.insert(handler_name.to_string());
-
-                    if let Err(e) = self
-                        .db_pool
-                        .execute_transaction(vec![crate::db::DbOperation::Upsert {
-                            table: "_handler_progress".to_string(),
-                            columns: vec![
-                                "chain_id".to_string(),
-                                "handler_key".to_string(),
-                                "range_start".to_string(),
-                                "range_end".to_string(),
-                            ],
-                            values: vec![
-                                crate::db::DbValue::Int64(self.chain_id as i64),
-                                crate::db::DbValue::Text(handler_key.clone()),
-                                crate::db::DbValue::Int64(range_start as i64),
-                                crate::db::DbValue::Int64(range_end as i64),
-                            ],
-                            conflict_columns: vec![
-                                "chain_id".to_string(),
-                                "handler_key".to_string(),
-                                "range_start".to_string(),
-                            ],
-                            update_columns: vec!["range_end".to_string()],
-                        }])
-                        .await
-                    {
-                        tracing::warn!(
-                            "Failed to record completed range for handler {} on block {}: {}",
-                            handler_key,
-                            block_number,
-                            e
-                        );
-                    }
-
-                    if let Some(ref tracker) = self.progress_tracker {
-                        let mut tracker = tracker.lock().await;
-                        if let Err(e) = tracker.mark_complete(block_number, &handler_key).await {
-                            tracing::warn!(
-                                "Failed to mark retry progress for block {} handler {}: {}",
-                                block_number,
-                                handler_key,
-                                e
-                            );
-                        }
-                    }
+                    self.record_handler_retry_success(
+                        &handler_key,
+                        handler_name,
+                        range_start,
+                        range_end,
+                        block_number,
+                        &mut succeeded_keys,
+                        &mut succeeded_names,
+                    )
+                    .await;
                 }
                 Err(e) => {
                     tracing::error!(
@@ -667,6 +620,71 @@ impl RetryProcessor {
         }
 
         Ok(blocked_handlers)
+    }
+
+    /// Record shared bookkeeping for a successfully retried handler (no-op or real).
+    ///
+    /// Operations in order (matching the normal success path):
+    /// 1. Insert into succeeded_keys / succeeded_names
+    /// 2. Upsert `_handler_progress` so catchup won't re-run this range
+    /// 3. Mark complete in progress_tracker (`_live_progress`)
+    async fn record_handler_retry_success(
+        &self,
+        handler_key: &str,
+        handler_name: &str,
+        range_start: u64,
+        range_end: u64,
+        block_number: u64,
+        succeeded_keys: &mut HashSet<String>,
+        succeeded_names: &mut HashSet<String>,
+    ) {
+        succeeded_keys.insert(handler_key.to_string());
+        succeeded_names.insert(handler_name.to_string());
+
+        if let Err(e) = self
+            .db_pool
+            .execute_transaction(vec![crate::db::DbOperation::Upsert {
+                table: "_handler_progress".to_string(),
+                columns: vec![
+                    "chain_id".to_string(),
+                    "handler_key".to_string(),
+                    "range_start".to_string(),
+                    "range_end".to_string(),
+                ],
+                values: vec![
+                    crate::db::DbValue::Int64(self.chain_id as i64),
+                    crate::db::DbValue::Text(handler_key.to_string()),
+                    crate::db::DbValue::Int64(range_start as i64),
+                    crate::db::DbValue::Int64(range_end as i64),
+                ],
+                conflict_columns: vec![
+                    "chain_id".to_string(),
+                    "handler_key".to_string(),
+                    "range_start".to_string(),
+                ],
+                update_columns: vec!["range_end".to_string()],
+            }])
+            .await
+        {
+            tracing::warn!(
+                "Failed to record completed range for handler {} on block {}: {}",
+                handler_key,
+                block_number,
+                e
+            );
+        }
+
+        if let Some(ref tracker) = self.progress_tracker {
+            let mut tracker = tracker.lock().await;
+            if let Err(e) = tracker.mark_complete(block_number, handler_key).await {
+                tracing::warn!(
+                    "Failed to mark retry progress for block {} handler {}: {}",
+                    block_number,
+                    handler_key,
+                    e
+                );
+            }
+        }
     }
 
     /// Build a uniform list of retry handler descriptors from both event and call handlers.
@@ -1134,5 +1152,57 @@ mod tests {
             "transformed must be cleared when failures are recorded"
         );
         assert!(s.failed_handlers.contains("handler_a"));
+    }
+
+    /// Regression: a no-op retry (no matching events/calls) that clears a prior
+    /// failure must flow through to finalization successfully — the handler ends
+    /// up in `completed_handlers`, failures are empty, and `transformed` is set.
+    ///
+    /// This exercises the status-file chain that the `record_handler_retry_success`
+    /// helper feeds into. Direct `_handler_progress` DB verification requires a
+    /// test harness that doesn't exist yet (tracked as follow-up).
+    #[test]
+    fn noop_retry_success_flows_through_to_finalization() {
+        use super::super::finalizer::update_finalization_status;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let storage = LiveStorage::with_base_dir(tmp.path().to_path_buf());
+        storage.ensure_dirs().unwrap();
+
+        let mut status = LiveBlockStatus::default();
+        status.logs_decoded = true;
+        status.eth_calls_decoded = true;
+        // handler_a previously failed (will be retried as no-op)
+        status.failed_handlers.insert("handler_a".to_string());
+        storage.write_status(100, &status).unwrap();
+
+        let registered_keys = HashSet::from(["handler_a".to_string(), "handler_b".to_string()]);
+
+        // Phase 1: No-op retry succeeds for handler_a, handler_b was never
+        // attempted (already completed in a prior run)
+        let attempted = HashSet::from(["handler_a".to_string()]);
+        let succeeded = HashSet::from(["handler_a".to_string()]);
+        let blocked = HashSet::new();
+        update_retry_status(&storage, 100, &attempted, &succeeded, &blocked).unwrap();
+
+        let s = storage.read_status(100).unwrap();
+        assert!(
+            s.completed_handlers.contains("handler_a"),
+            "no-op retry must move handler into completed_handlers"
+        );
+        assert!(
+            s.failed_handlers.is_empty(),
+            "no failures should remain after successful retry"
+        );
+
+        // Phase 2: Finalization runs — no failures remain, so transformed is set
+        update_finalization_status(&storage, 100, &registered_keys).unwrap();
+
+        let s = storage.read_status(100).unwrap();
+        assert!(
+            s.transformed,
+            "finalization must set transformed once all failures are cleared by retry"
+        );
+        assert!(s.completed_handlers.contains("handler_a"));
     }
 }

--- a/src/transformations/traits.rs
+++ b/src/transformations/traits.rs
@@ -136,6 +136,12 @@ pub trait EventHandler: TransformationHandler {
     fn call_dependencies(&self) -> Vec<(String, String)> {
         vec![]
     }
+
+    /// Handler names (via `TransformationHandler::name()`) that must complete
+    /// before this handler can execute for a given block range.
+    fn handler_dependencies(&self) -> Vec<&'static str> {
+        vec![]
+    }
 }
 
 /// Marker trait for handlers that respond to eth_call results.

--- a/src/transformations/traits.rs
+++ b/src/transformations/traits.rs
@@ -136,6 +136,13 @@ pub trait EventHandler: TransformationHandler {
     fn call_dependencies(&self) -> Vec<(String, String)> {
         vec![]
     }
+
+    /// Declare other handlers that must complete before this handler runs.
+    /// Returns handler keys (e.g., "pool_create_v1") that must have finished
+    /// processing the same block range before this handler can execute.
+    fn handler_dependencies(&self) -> Vec<String> {
+        vec![]
+    }
 }
 
 /// Marker trait for handlers that respond to eth_call results.

--- a/src/transformations/util/db/pool_metrics.rs
+++ b/src/transformations/util/db/pool_metrics.rs
@@ -120,11 +120,7 @@ pub fn insert_pool_snapshot(data: &SnapshotData) -> DbOperation {
             DbValue::Numeric(data.volume1.clone()),
             DbValue::Int32(data.swap_count),
         ],
-        conflict_columns: vec![
-            "chain_id".into(),
-            "pool_id".into(),
-            "block_number".into(),
-        ],
+        conflict_columns: vec!["chain_id".into(), "pool_id".into(), "block_number".into()],
         update_columns: vec![
             "block_timestamp".into(),
             "price_open".into(),

--- a/src/transformations/util/pool_metadata.rs
+++ b/src/transformations/util/pool_metadata.rs
@@ -77,8 +77,7 @@ impl PoolMetadataCache {
             quote_token.copy_from_slice(&quote_token_bytes);
 
             let base_decimals = 18; // all launched tokens are 18 decimals
-            let quote_decimals =
-                quote_token_decimals(&quote_token, contracts).unwrap_or(18);
+            let quote_decimals = quote_token_decimals(&quote_token, contracts).unwrap_or(18);
 
             map.insert(
                 pool_id.clone(),

--- a/src/transformations/util/tick_math.rs
+++ b/src/transformations/util/tick_math.rs
@@ -44,94 +44,92 @@ pub fn tick_to_sqrt_price_x96(tick: i32) -> U256 {
 
     // Bit 1: sqrt(1.0001^2)
     if abs_tick & 0x2 != 0 {
-        ratio = (ratio * U256::from_str_radix("fff97272373d413259a46990580e213a", 16).unwrap())
-            >> 128;
+        ratio =
+            (ratio * U256::from_str_radix("fff97272373d413259a46990580e213a", 16).unwrap()) >> 128;
     }
     // Bit 2: sqrt(1.0001^4)
     if abs_tick & 0x4 != 0 {
-        ratio = (ratio * U256::from_str_radix("fff2e50f5f656932ef12357cf3c7fdcc", 16).unwrap())
-            >> 128;
+        ratio =
+            (ratio * U256::from_str_radix("fff2e50f5f656932ef12357cf3c7fdcc", 16).unwrap()) >> 128;
     }
     // Bit 3: sqrt(1.0001^8)
     if abs_tick & 0x8 != 0 {
-        ratio = (ratio * U256::from_str_radix("ffe5caca7e10e4e61c3624eaa0941cd0", 16).unwrap())
-            >> 128;
+        ratio =
+            (ratio * U256::from_str_radix("ffe5caca7e10e4e61c3624eaa0941cd0", 16).unwrap()) >> 128;
     }
     // Bit 4: sqrt(1.0001^16)
     if abs_tick & 0x10 != 0 {
-        ratio = (ratio * U256::from_str_radix("ffcb9843d60f6159c9db58835c926644", 16).unwrap())
-            >> 128;
+        ratio =
+            (ratio * U256::from_str_radix("ffcb9843d60f6159c9db58835c926644", 16).unwrap()) >> 128;
     }
     // Bit 5: sqrt(1.0001^32)
     if abs_tick & 0x20 != 0 {
-        ratio = (ratio * U256::from_str_radix("ff973b41fa98c081472e6896dfb254c0", 16).unwrap())
-            >> 128;
+        ratio =
+            (ratio * U256::from_str_radix("ff973b41fa98c081472e6896dfb254c0", 16).unwrap()) >> 128;
     }
     // Bit 6: sqrt(1.0001^64)
     if abs_tick & 0x40 != 0 {
-        ratio = (ratio * U256::from_str_radix("ff2ea16466c96a3843ec78b326b52861", 16).unwrap())
-            >> 128;
+        ratio =
+            (ratio * U256::from_str_radix("ff2ea16466c96a3843ec78b326b52861", 16).unwrap()) >> 128;
     }
     // Bit 7: sqrt(1.0001^128)
     if abs_tick & 0x80 != 0 {
-        ratio = (ratio * U256::from_str_radix("fe5dee046a99a2a811c461f1969c3053", 16).unwrap())
-            >> 128;
+        ratio =
+            (ratio * U256::from_str_radix("fe5dee046a99a2a811c461f1969c3053", 16).unwrap()) >> 128;
     }
     // Bit 8: sqrt(1.0001^256)
     if abs_tick & 0x100 != 0 {
-        ratio = (ratio * U256::from_str_radix("fcbe86c7900a88aedcffc83b479aa3a4", 16).unwrap())
-            >> 128;
+        ratio =
+            (ratio * U256::from_str_radix("fcbe86c7900a88aedcffc83b479aa3a4", 16).unwrap()) >> 128;
     }
     // Bit 9: sqrt(1.0001^512)
     if abs_tick & 0x200 != 0 {
-        ratio = (ratio * U256::from_str_radix("f987a7253ac413176f2b074cf7815e54", 16).unwrap())
-            >> 128;
+        ratio =
+            (ratio * U256::from_str_radix("f987a7253ac413176f2b074cf7815e54", 16).unwrap()) >> 128;
     }
     // Bit 10: sqrt(1.0001^1024)
     if abs_tick & 0x400 != 0 {
-        ratio = (ratio * U256::from_str_radix("f3392b0822b70005940c7a398e4b70f3", 16).unwrap())
-            >> 128;
+        ratio =
+            (ratio * U256::from_str_radix("f3392b0822b70005940c7a398e4b70f3", 16).unwrap()) >> 128;
     }
     // Bit 11: sqrt(1.0001^2048)
     if abs_tick & 0x800 != 0 {
-        ratio = (ratio * U256::from_str_radix("e7159475a2c29b7443b29c7fa6e889d9", 16).unwrap())
-            >> 128;
+        ratio =
+            (ratio * U256::from_str_radix("e7159475a2c29b7443b29c7fa6e889d9", 16).unwrap()) >> 128;
     }
     // Bit 12: sqrt(1.0001^4096)
     if abs_tick & 0x1000 != 0 {
-        ratio = (ratio * U256::from_str_radix("d097f3bdfd2022b8845ad8f792aa5825", 16).unwrap())
-            >> 128;
+        ratio =
+            (ratio * U256::from_str_radix("d097f3bdfd2022b8845ad8f792aa5825", 16).unwrap()) >> 128;
     }
     // Bit 13: sqrt(1.0001^8192)
     if abs_tick & 0x2000 != 0 {
-        ratio = (ratio * U256::from_str_radix("a9f746462d870fdf8a65dc1f90e061e5", 16).unwrap())
-            >> 128;
+        ratio =
+            (ratio * U256::from_str_radix("a9f746462d870fdf8a65dc1f90e061e5", 16).unwrap()) >> 128;
     }
     // Bit 14: sqrt(1.0001^16384)
     if abs_tick & 0x4000 != 0 {
-        ratio = (ratio * U256::from_str_radix("70d869a156d2a1b890bb3df62baf32f7", 16).unwrap())
-            >> 128;
+        ratio =
+            (ratio * U256::from_str_radix("70d869a156d2a1b890bb3df62baf32f7", 16).unwrap()) >> 128;
     }
     // Bit 15: sqrt(1.0001^32768)
     if abs_tick & 0x8000 != 0 {
-        ratio = (ratio * U256::from_str_radix("31be135f97d08fd981231505542fcfa6", 16).unwrap())
-            >> 128;
+        ratio =
+            (ratio * U256::from_str_radix("31be135f97d08fd981231505542fcfa6", 16).unwrap()) >> 128;
     }
     // Bit 16: sqrt(1.0001^65536)
     if abs_tick & 0x10000 != 0 {
-        ratio = (ratio * U256::from_str_radix("9aa508b5b7a84e1c677de54f3e99bc9", 16).unwrap())
-            >> 128;
+        ratio =
+            (ratio * U256::from_str_radix("9aa508b5b7a84e1c677de54f3e99bc9", 16).unwrap()) >> 128;
     }
     // Bit 17: sqrt(1.0001^131072)
     if abs_tick & 0x20000 != 0 {
-        ratio = (ratio
-            * U256::from_str_radix("5d6af8dedb81196699c329225ee604", 16).unwrap())
-            >> 128;
+        ratio =
+            (ratio * U256::from_str_radix("5d6af8dedb81196699c329225ee604", 16).unwrap()) >> 128;
     }
     // Bit 18: sqrt(1.0001^262144)
     if abs_tick & 0x40000 != 0 {
-        ratio =
-            (ratio * U256::from_str_radix("2216e584f5fa1ea926041bedfe98", 16).unwrap()) >> 128;
+        ratio = (ratio * U256::from_str_radix("2216e584f5fa1ea926041bedfe98", 16).unwrap()) >> 128;
     }
     // Bit 19: sqrt(1.0001^524288)
     if abs_tick & 0x80000 != 0 {
@@ -181,8 +179,7 @@ mod tests {
     fn test_tick_1() {
         // Known value from Uniswap: tick 1 = 79232123823359799118286999568
         let result = tick_to_sqrt_price_x96(1);
-        let expected =
-            U256::from_str_radix("79232123823359799118286999568", 10).unwrap();
+        let expected = U256::from_str_radix("79232123823359799118286999568", 10).unwrap();
         assert_eq!(result, expected);
     }
 
@@ -190,8 +187,7 @@ mod tests {
     fn test_tick_negative_1() {
         // Known Uniswap value: tick -1 = 79224201403219477170569942574
         let result = tick_to_sqrt_price_x96(-1);
-        let expected =
-            U256::from_str_radix("79224201403219477170569942574", 10).unwrap();
+        let expected = U256::from_str_radix("79224201403219477170569942574", 10).unwrap();
         assert_eq!(result, expected);
     }
 


### PR DESCRIPTION
## Summary

Adds a handler dependency system that lets transformation handlers declare execution ordering constraints on other handlers. This ensures that when Handler B depends on Handler A, A always completes before B executes for a given block range — critical for handlers that populate shared caches (e.g., pool creation must run before swap processing).

- **Trait extension**: `handler_dependencies()` on `EventHandler` returns dependency handler names, with default empty vec for backwards compatibility
- **Registry validation**: dependency graph construction with cycle detection (topological sort) and missing-dependency validation at startup — invalid graphs panic with descriptive errors
- **Catchup mode**: handlers sorted in topological order before the sequential processing loop
- **Live mode dispatch**: unified call + handler dependency check in `process_events_message`, with cascading dispatch via `try_process_pending_events` (handles A→B→C chains), completion tracking per range in `LiveProcessingState`
- **No-op completion**: on `RangeCompleteKind::Logs`, untriggered dependency handlers are marked completed-no-op to unblock waiting handlers (prevents 5-minute timeout fallback)
- **Retry path**: topological ordering enforced in live retry to maintain dependency invariants

Also includes pool metrics foundation (phase 1) which was merged into this branch: accumulator, swap data extraction, tick math utilities, and migration tables.

## Key design decisions

- Dependencies reference `name()` (not versioned `handler_key()`), so bumping a dependency's version doesn't require updating dependents
- Handler deps stored in the same `pending_events` map as call deps (unified readiness check) rather than a separate tracking structure
- Independent chains execute concurrently — a handler blocks only on its declared dependencies, not an entire "level"
- No-op marking happens in the engine's `run()` loop before `process_range_complete`, since the engine has access to both finalizer and live state

## Files changed

| Area | Files |
|------|-------|
| Trait | `src/transformations/traits.rs` |
| Registry | `src/transformations/registry.rs` |
| Engine | `src/transformations/engine.rs` |
| Live state | `src/transformations/live_state.rs` |
| Executor | `src/transformations/executor.rs` |
| Retry | `src/transformations/retry.rs` |
| Pool metrics | `src/transformations/event/metrics/`, `src/transformations/util/` |
| Migrations | `migrations/tables/{liquidity_deltas,pool_snapshots,pool_state}.sql` |
| Design doc | `docs/designs/handler-dependency-chains.md` |