### PR TITLE
feat: shared DB pool and migration safety for concurrent chains

### DIFF
--- a/src/db/migrations.rs
+++ b/src/db/migrations.rs
@@ -1,9 +1,10 @@
 use std::collections::HashSet;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use deadpool_postgres::Pool;
 
 use super::error::DbError;
+use crate::transformations::registry::TransformationRegistry;
 
 const MIGRATIONS_DIR: &str = "migrations";
 
@@ -59,5 +60,92 @@ pub async fn run(pool: &Pool) -> Result<(), DbError> {
     }
 
     tracing::info!("All migrations up to date");
+    Ok(())
+}
+
+/// Run handler-declared migrations from `migration_paths()`.
+///
+/// This should be called once at startup with the **unfiltered** registry so
+/// that every handler's tables exist before any per-chain engine initializes.
+pub async fn run_handler_migrations(
+    pool: &Pool,
+    registry: &TransformationRegistry,
+) -> Result<(), DbError> {
+    let mut migration_paths: Vec<PathBuf> = Vec::new();
+    let mut seen = HashSet::new();
+
+    for handler in registry.all_handlers() {
+        for path_str in handler.migration_paths() {
+            let path = PathBuf::from(path_str);
+            if seen.insert(path.clone()) {
+                migration_paths.push(path);
+            }
+        }
+    }
+
+    if migration_paths.is_empty() {
+        return Ok(());
+    }
+
+    let applied: HashSet<String> = {
+        let client = pool.get().await?;
+        let rows = client.query("SELECT name FROM _migrations", &[]).await?;
+        rows.iter().map(|r| r.get(0)).collect()
+    };
+
+    let mut sql_entries: Vec<(PathBuf, String)> = Vec::new();
+
+    for path in &migration_paths {
+        if !path.exists() {
+            tracing::warn!("Handler migration path does not exist: {}", path.display());
+            continue;
+        }
+
+        if path.is_file() {
+            let migration_name = format!("{}", path.display());
+            sql_entries.push((path.clone(), migration_name));
+        } else if path.is_dir() {
+            let mut dir_files: Vec<_> = std::fs::read_dir(path)?
+                .filter_map(|e| e.ok())
+                .filter(|e| e.path().extension().map(|x| x == "sql").unwrap_or(false))
+                .collect();
+            dir_files.sort_by_key(|e| e.file_name());
+
+            for entry in dir_files {
+                let file_name = entry.file_name().to_string_lossy().to_string();
+                let migration_name = format!("{}", path.join(&file_name).display());
+                sql_entries.push((entry.path(), migration_name));
+            }
+        }
+    }
+
+    for (file_path, migration_name) in &sql_entries {
+        if applied.contains(migration_name) {
+            continue;
+        }
+
+        let sql = std::fs::read_to_string(file_path)?;
+
+        let mut client = pool.get().await?;
+        let tx = client.transaction().await?;
+
+        tx.batch_execute(&sql).await.map_err(|e| {
+            DbError::MigrationError(format!(
+                "Handler migration {} failed: {}",
+                migration_name, e
+            ))
+        })?;
+
+        tx.execute(
+            "INSERT INTO _migrations (name) VALUES ($1)",
+            &[&migration_name],
+        )
+        .await?;
+
+        tx.commit().await?;
+
+        tracing::info!("Applied handler migration: {}", migration_name);
+    }
+
     Ok(())
 }

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -117,6 +117,13 @@ impl DbPool {
         super::migrations::run(&self.pool).await
     }
 
+    pub async fn run_handler_migrations(
+        &self,
+        registry: &crate::transformations::registry::TransformationRegistry,
+    ) -> Result<(), DbError> {
+        super::migrations::run_handler_migrations(&self.pool, registry).await
+    }
+
     pub async fn query(
         &self,
         query: &str,

--- a/src/main.rs
+++ b/src/main.rs
@@ -407,7 +407,7 @@ async fn process_chain_live_only(
     }
 
     // Build unified runtime (RPC client with rate limiter, db pool, registry, progress tracker)
-    let runtime = ChainRuntime::build(config, chain).await?;
+    let runtime = ChainRuntime::build(config, chain, None, None).await?;
 
     // Build channels with config-derived capacity
     let channels = CommonChannels::build_for_live_only(
@@ -1010,7 +1010,7 @@ async fn process_chain(
     tracing::info!("Processing chain: {}", chain.name);
 
     // Build unified runtime (RPC client with rate limiter, db pool, registry, progress tracker)
-    let runtime = ChainRuntime::build(config, chain).await?;
+    let runtime = ChainRuntime::build(config, chain, None, None).await?;
 
     let features = &runtime.features;
     let has_factories = features.has_factories;

--- a/src/main.rs
+++ b/src/main.rs
@@ -307,6 +307,9 @@ async fn main() -> anyhow::Result<()> {
                 pool.run_migrations()
                     .await
                     .context("failed to run database migrations")?;
+                pool.run_handler_migrations(&registry)
+                    .await
+                    .context("failed to run handler migrations")?;
                 tracing::info!("Shared database pool initialized and migrations complete");
                 Some(Arc::new(pool))
             } else {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -392,6 +392,9 @@ impl ChainRuntime {
                 pool.run_migrations()
                     .await
                     .context("failed to run database migrations")?;
+                pool.run_handler_migrations(&registry)
+                    .await
+                    .context("failed to run handler migrations")?;
 
                 tracing::info!("Database pool initialized and migrations complete");
                 Some(Arc::new(pool))

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -307,7 +307,16 @@ pub struct ChainRuntime {
 
 impl ChainRuntime {
     /// Build the runtime infrastructure for a chain.
-    pub async fn build(config: &IndexerConfig, chain: &ChainConfig) -> anyhow::Result<Self> {
+    ///
+    /// When running multiple chains concurrently, pass a pre-created `shared_db_pool`
+    /// (with migrations already run) and `shared_rate_limiter` to avoid redundant
+    /// setup and enable account-level rate limiting across chains.
+    pub async fn build(
+        config: &IndexerConfig,
+        chain: &ChainConfig,
+        shared_db_pool: Option<Arc<DbPool>>,
+        shared_rate_limiter: Option<Arc<SlidingWindowRateLimiter>>,
+    ) -> anyhow::Result<Self> {
         let rpc_url = std::env::var(&chain.rpc_url_env_var).with_context(|| {
             format!(
                 "env var {} not set for chain {}",
@@ -327,8 +336,26 @@ impl ChainRuntime {
             .or(config.raw_data_collection.rpc_batch_size)
             .unwrap_or(rpc_defaults::MAX_BATCH_SIZE) as usize;
 
-        // Build RPC client with rate limiter from per-chain config
-        let (rate_limiter, http_client) = build_rpc_client(&rpc_url, &chain.rpc, rpc_batch_size)?;
+        // Resolve RPC parameters before building client
+        let concurrency = chain.rpc.concurrency.unwrap_or(rpc_defaults::CONCURRENCY);
+        let cu_per_second = chain
+            .rpc
+            .compute_units_per_second
+            .unwrap_or(rpc_defaults::ALCHEMY_CU_PER_SECOND);
+
+        // Build RPC client, reusing shared rate limiter if provided
+        let (rate_limiter, http_client) = if let Some(limiter) = shared_rate_limiter {
+            let client = UnifiedRpcClient::from_url_with_options(
+                &rpc_url,
+                cu_per_second,
+                concurrency,
+                rpc_batch_size,
+                Some(limiter.clone()),
+            )?;
+            (limiter, Arc::new(client))
+        } else {
+            build_rpc_client(&rpc_url, &chain.rpc, rpc_batch_size)?
+        };
 
         // Build transformation registry
         let registry = build_registry();
@@ -344,8 +371,13 @@ impl ChainRuntime {
         }
 
         // Setup database if transformations enabled
-        let db_pool = if let Some(ref tc) = config.transformations {
-            if transformations_enabled {
+        let db_pool = if transformations_enabled {
+            if let Some(pool) = shared_db_pool {
+                // Use pre-created shared pool (migrations already run in main)
+                Some(pool)
+            } else {
+                // Fallback: create per-chain pool (for backwards compat or single-chain mode)
+                let tc = config.transformations.as_ref().unwrap();
                 let database_url = std::env::var(&tc.database_url_env_var).with_context(|| {
                     format!(
                         "env var {} not set for transformations",
@@ -362,8 +394,6 @@ impl ChainRuntime {
 
                 tracing::info!("Database pool initialized and migrations complete");
                 Some(Arc::new(pool))
-            } else {
-                None
             }
         } else {
             None

--- a/src/transformations/engine.rs
+++ b/src/transformations/engine.rs
@@ -279,6 +279,23 @@ impl TransformationEngine {
         }
 
         let pool = self.db_pool.inner();
+
+        // Acquire advisory lock to prevent concurrent handler migration races.
+        // Multiple chains may initialize concurrently with the same handlers.
+        // The lock is session-level: if this method returns early due to error,
+        // the lock_client is dropped, the connection returns to the pool, and
+        // the lock is automatically released.
+        let lock_client = pool.get().await?;
+        lock_client
+            .execute("SELECT pg_advisory_lock(424242)", &[])
+            .await
+            .map_err(|e| {
+                TransformationError::DatabaseError(crate::db::DbError::MigrationError(format!(
+                    "Failed to acquire migration lock: {}",
+                    e
+                )))
+            })?;
+
         let applied: HashSet<String> = {
             let client = pool.get().await?;
             let rows = client.query("SELECT name FROM _migrations", &[]).await?;
@@ -338,6 +355,17 @@ impl TransformationEngine {
 
             tracing::info!("Applied handler migration: {}", migration_name);
         }
+
+        // Explicitly release the advisory lock on the happy path
+        lock_client
+            .execute("SELECT pg_advisory_unlock(424242)", &[])
+            .await
+            .map_err(|e| {
+                TransformationError::DatabaseError(crate::db::DbError::MigrationError(format!(
+                    "Failed to release migration lock: {}",
+                    e
+                )))
+            })?;
 
         Ok(())
     }

--- a/src/transformations/engine.rs
+++ b/src/transformations/engine.rs
@@ -238,11 +238,11 @@ impl TransformationEngine {
         })
     }
 
-    /// Initialize the engine: run handler migrations, register sources, then initialize handlers.
+    /// Initialize the engine: register sources, then initialize handlers.
+    ///
+    /// Handler migrations must have already been run before calling this
+    /// (either globally in main or via `DbPool::run_handler_migrations`).
     pub async fn initialize(&self) -> Result<(), TransformationError> {
-        // Run handler-specified migrations first
-        self.run_handler_migrations().await?;
-
         // Register handler sources in active_versions table
         self.register_handler_sources().await?;
 
@@ -255,118 +255,6 @@ impl TransformationEngine {
             );
             handler.initialize(&self.db_pool).await?;
         }
-        Ok(())
-    }
-
-    // ─── Handler Migrations ──────────────────────────────────────────
-
-    /// Run handler migration files from each handler's `migration_paths()`.
-    async fn run_handler_migrations(&self) -> Result<(), TransformationError> {
-        let mut migration_paths: Vec<PathBuf> = Vec::new();
-        let mut seen = HashSet::new();
-
-        for handler in self.registry.all_handlers() {
-            for path_str in handler.migration_paths() {
-                let path = PathBuf::from(path_str);
-                if seen.insert(path.clone()) {
-                    migration_paths.push(path);
-                }
-            }
-        }
-
-        if migration_paths.is_empty() {
-            return Ok(());
-        }
-
-        let pool = self.db_pool.inner();
-
-        // Acquire advisory lock to prevent concurrent handler migration races.
-        // Multiple chains may initialize concurrently with the same handlers.
-        // The lock is session-level: if this method returns early due to error,
-        // the lock_client is dropped, the connection returns to the pool, and
-        // the lock is automatically released.
-        let lock_client = pool.get().await?;
-        lock_client
-            .execute("SELECT pg_advisory_lock(424242)", &[])
-            .await
-            .map_err(|e| {
-                TransformationError::DatabaseError(crate::db::DbError::MigrationError(format!(
-                    "Failed to acquire migration lock: {}",
-                    e
-                )))
-            })?;
-
-        let applied: HashSet<String> = {
-            let client = pool.get().await?;
-            let rows = client.query("SELECT name FROM _migrations", &[]).await?;
-            rows.iter().map(|r| r.get(0)).collect()
-        };
-
-        let mut sql_entries: Vec<(PathBuf, String)> = Vec::new();
-
-        for path in &migration_paths {
-            if !path.exists() {
-                tracing::warn!("Handler migration path does not exist: {}", path.display());
-                continue;
-            }
-
-            if path.is_file() {
-                let migration_name = format!("{}", path.display());
-                sql_entries.push((path.clone(), migration_name));
-            } else if path.is_dir() {
-                let mut dir_files: Vec<_> = std::fs::read_dir(path)?
-                    .filter_map(|e| e.ok())
-                    .filter(|e| e.path().extension().map(|x| x == "sql").unwrap_or(false))
-                    .collect();
-                dir_files.sort_by_key(|e| e.file_name());
-
-                for entry in dir_files {
-                    let file_name = entry.file_name().to_string_lossy().to_string();
-                    let migration_name = format!("{}", path.join(&file_name).display());
-                    sql_entries.push((entry.path(), migration_name));
-                }
-            }
-        }
-
-        for (file_path, migration_name) in &sql_entries {
-            if applied.contains(migration_name) {
-                continue;
-            }
-
-            let sql = std::fs::read_to_string(file_path)?;
-
-            let mut client = pool.get().await?;
-            let tx = client.transaction().await?;
-
-            tx.batch_execute(&sql).await.map_err(|e| {
-                TransformationError::DatabaseError(crate::db::DbError::MigrationError(format!(
-                    "Handler migration {} failed: {}",
-                    migration_name, e
-                )))
-            })?;
-
-            tx.execute(
-                "INSERT INTO _migrations (name) VALUES ($1)",
-                &[&migration_name],
-            )
-            .await?;
-
-            tx.commit().await?;
-
-            tracing::info!("Applied handler migration: {}", migration_name);
-        }
-
-        // Explicitly release the advisory lock on the happy path
-        lock_client
-            .execute("SELECT pg_advisory_unlock(424242)", &[])
-            .await
-            .map_err(|e| {
-                TransformationError::DatabaseError(crate::db::DbError::MigrationError(format!(
-                    "Failed to release migration lock: {}",
-                    e
-                )))
-            })?;
-
         Ok(())
     }
 

--- a/src/transformations/registry.rs
+++ b/src/transformations/registry.rs
@@ -57,11 +57,9 @@ pub struct TransformationRegistry {
     call_handlers: HashMap<(String, String), Vec<Arc<dyn EthCallHandler>>>,
     /// All handlers for initialization (de-duplicated)
     all_handlers: Vec<Arc<dyn TransformationHandler>>,
-<<<<<<< feat/chain-aware-handlers
     /// When set, only handlers whose trigger sources are all present in this
     /// set will be registered. Used to filter handlers per-chain.
     available_sources: Option<HashSet<String>>,
-=======
     /// Maps handler name() to its declared handler dependency names
     handler_dependency_graph: HashMap<String, Vec<String>>,
     /// Topological ordering of handler names (computed after all handlers registered)
@@ -78,7 +76,6 @@ pub struct TransformationRegistry {
     /// Multi-trigger handlers must not have their success persisted until
     /// all batches for the block have been dispatched.
     multi_trigger_handler_keys: HashSet<String>,
->>>>>>> main
 }
 
 impl TransformationRegistry {
@@ -88,8 +85,14 @@ impl TransformationRegistry {
             event_handlers: HashMap::new(),
             call_handlers: HashMap::new(),
             all_handlers: Vec::new(),
-<<<<<<< feat/chain-aware-handlers
             available_sources: None,
+            handler_dependency_graph: HashMap::new(),
+            handler_topological_order: Vec::new(),
+            dependency_handler_names: HashSet::new(),
+            handler_key_to_name: HashMap::new(),
+            handler_name_to_key: HashMap::new(),
+            event_handler_names: HashSet::new(),
+            multi_trigger_handler_keys: HashSet::new(),
         }
     }
 
@@ -103,7 +106,6 @@ impl TransformationRegistry {
             call_handlers: HashMap::new(),
             all_handlers: Vec::new(),
             available_sources: Some(sources),
-=======
             handler_dependency_graph: HashMap::new(),
             handler_topological_order: Vec::new(),
             dependency_handler_names: HashSet::new(),
@@ -111,7 +113,6 @@ impl TransformationRegistry {
             handler_name_to_key: HashMap::new(),
             event_handler_names: HashSet::new(),
             multi_trigger_handler_keys: HashSet::new(),
->>>>>>> main
         }
     }
 
@@ -135,7 +136,6 @@ impl TransformationRegistry {
 
         let triggers = handler.triggers();
 
-<<<<<<< feat/chain-aware-handlers
         if let Some(ref sources) = self.available_sources {
             if !triggers.iter().all(|t| sources.contains(&t.source)) {
                 tracing::debug!(
@@ -144,11 +144,11 @@ impl TransformationRegistry {
                 );
                 return;
             }
-=======
+        }
+
         if triggers.len() > 1 {
             self.multi_trigger_handler_keys
                 .insert(handler.handler_key());
->>>>>>> main
         }
 
         for trigger in triggers {
@@ -202,7 +202,6 @@ impl TransformationRegistry {
 
         let triggers = handler.triggers();
 
-<<<<<<< feat/chain-aware-handlers
         if let Some(ref sources) = self.available_sources {
             if !triggers.iter().all(|t| sources.contains(&t.source)) {
                 tracing::debug!(
@@ -211,11 +210,11 @@ impl TransformationRegistry {
                 );
                 return;
             }
-=======
+        }
+
         if triggers.len() > 1 {
             self.multi_trigger_handler_keys
                 .insert(handler.handler_key());
->>>>>>> main
         }
 
         for trigger in triggers {
@@ -730,6 +729,8 @@ pub fn build_registry_for_chain(
 
     // Register eth_call handlers (filtered by available sources)
     super::eth_call::register_handlers(&mut registry);
+
+    registry.validate_and_sort_handler_dependencies();
 
     tracing::info!(
         "Built chain-filtered transformation registry with {} handlers ({} event triggers, {} call triggers)",


### PR DESCRIPTION
## Summary

- **`ChainRuntime::build()` now accepts optional shared DB pool and rate limiter** — when running multiple chains concurrently, a single pool and limiter can be created once in `main()` and passed to each chain runtime, avoiding redundant connections and enabling account-level rate limiting across chains. When `None` is passed, the existing per-chain creation behavior is preserved for backwards compatibility.

- **Advisory lock on handler migrations** — `run_handler_migrations()` in `TransformationEngine` now acquires a PostgreSQL advisory lock (`pg_advisory_lock(424242)`) before checking/applying handler migrations. This prevents race conditions when multiple chains initialize concurrently with overlapping handler sets. The lock is session-scoped, so it auto-releases if the method errors and the connection returns to the pool.

## Context

This is part of a multi-PR effort to support concurrent multi-chain execution:

- **`feat/rate-limit-groups`** — rate limiter grouping across chains sharing an RPC account
- **`feat/concurrent-chains`** — orchestration in `main()` to run chains concurrently with shared resources
- **`feat/shared-db-pool`** (this PR) — infrastructure changes to accept shared resources and protect concurrent migrations

Expected merge conflicts in `src/runtime.rs` with `feat/concurrent-chains` (call sites for `ChainRuntime::build()`).