### PR TITLE
feat: rate limit groups and unified RPC rate limiting

### DIFF
--- a/src/rpc/provider.rs
+++ b/src/rpc/provider.rs
@@ -17,6 +17,8 @@ use governor::{Jitter, Quota, RateLimiter};
 use thiserror::Error;
 use url::Url;
 
+use super::alchemy::SlidingWindowRateLimiter;
+
 /// Trait for RPC providers that can execute Ethereum JSON-RPC calls.
 /// This abstracts over different client implementations (standard, Alchemy, etc.)
 /// and allows unified usage while each implementation handles rate limiting differently.
@@ -390,6 +392,7 @@ pub struct RpcClient {
     config: RpcClientConfig,
     rate_limiter: Option<Arc<StandardRateLimiter>>,
     jitter: Option<Jitter>,
+    sliding_limiter: Option<Arc<SlidingWindowRateLimiter>>,
 }
 
 #[allow(dead_code)]
@@ -414,6 +417,21 @@ impl RpcClient {
             config,
             rate_limiter,
             jitter,
+            sliding_limiter: None,
+        })
+    }
+
+    pub fn new_with_shared_limiter(
+        config: RpcClientConfig,
+        limiter: Arc<SlidingWindowRateLimiter>,
+    ) -> Result<Self, RpcError> {
+        let provider = RootProvider::<Ethereum>::new_http(config.url.clone());
+        Ok(Self {
+            provider,
+            config,
+            rate_limiter: None,
+            jitter: None,
+            sliding_limiter: Some(limiter),
         })
     }
 
@@ -439,7 +457,9 @@ impl RpcClient {
     }
 
     async fn wait_for_rate_limit(&self) {
-        if let (Some(limiter), Some(jitter)) = (&self.rate_limiter, &self.jitter) {
+        if let Some(ref limiter) = self.sliding_limiter {
+            limiter.acquire(1).await;
+        } else if let (Some(limiter), Some(jitter)) = (&self.rate_limiter, &self.jitter) {
             limiter.until_ready_with_jitter(*jitter).await;
         }
     }

--- a/src/rpc/unified.rs
+++ b/src/rpc/unified.rs
@@ -77,7 +77,12 @@ impl UnifiedRpcClient {
             let parsed_url =
                 url::Url::parse(url).map_err(|e| RpcError::InvalidUrl(e.to_string()))?;
             let config = RpcClientConfig::new(parsed_url).with_batch_size(max_batch_size);
-            Ok(Self::Standard(RpcClient::new(config)?))
+            let client = if let Some(limiter) = shared_limiter {
+                RpcClient::new_with_shared_limiter(config, limiter)?
+            } else {
+                RpcClient::new(config)?
+            };
+            Ok(Self::Standard(client))
         }
     }
 

--- a/src/types/config/chain.rs
+++ b/src/types/config/chain.rs
@@ -32,6 +32,14 @@ impl BlockReceiptsMethod {
     }
 }
 
+/// Configuration for a shared RPC rate limit group.
+///
+/// Multiple chains can reference the same group to share a single rate limit budget.
+#[derive(Debug, Clone, Deserialize)]
+pub struct RpcRateLimitGroup {
+    pub units_per_second: u32,
+}
+
 /// RPC client configuration for a chain.
 ///
 /// All fields are optional and fall back to defaults in `defaults::rpc`.
@@ -43,6 +51,10 @@ pub struct RpcConfig {
     pub compute_units_per_second: Option<u32>,
     /// Max batch size for RPC requests (default: 100)
     pub batch_size: Option<u32>,
+    /// Name of a shared rate limit group (defined in top-level rpc_rate_limits).
+    /// Mutually exclusive with compute_units_per_second.
+    #[serde(default)]
+    pub rate_limit_group: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/types/config/indexer.rs
+++ b/src/types/config/indexer.rs
@@ -1,8 +1,9 @@
+use std::collections::HashMap;
 use std::path::Path;
 
 use serde::Deserialize;
 
-use crate::types::config::chain::{resolve_chain_config, ChainConfig, ChainConfigRaw};
+use crate::types::config::chain::{resolve_chain_config, ChainConfig, ChainConfigRaw, RpcRateLimitGroup};
 use crate::types::config::metrics::MetricsConfig;
 use crate::types::config::raw_data::RawDataCollectionConfig;
 use crate::types::config::storage::StorageConfig;
@@ -18,15 +19,18 @@ pub struct IndexerConfigRaw {
     pub metrics: Option<MetricsConfig>,
     #[serde(default)]
     pub storage: Option<StorageConfig>,
+    #[serde(default)]
+    pub rpc_rate_limits: Option<HashMap<String, RpcRateLimitGroup>>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct IndexerConfig {
     pub chains: Vec<ChainConfig>,
     pub raw_data_collection: RawDataCollectionConfig,
     pub transformations: Option<TransformationConfig>,
     pub metrics: Option<MetricsConfig>,
     pub storage: Option<StorageConfig>,
+    pub rpc_rate_limits: Option<HashMap<String, RpcRateLimitGroup>>,
 }
 
 impl IndexerConfig {
@@ -47,12 +51,36 @@ impl IndexerConfig {
             .collect::<anyhow::Result<Vec<_>>>()
             .map_err(|e| anyhow::anyhow!("Failed to resolve chain config: {}", e))?;
 
+        let rpc_rate_limits = raw_config.rpc_rate_limits;
+
+        // Validate rate limit group references
+        for chain in &chains {
+            if let Some(ref group_name) = chain.rpc.rate_limit_group {
+                let valid = rpc_rate_limits
+                    .as_ref()
+                    .is_some_and(|groups| groups.contains_key(group_name));
+                if !valid {
+                    anyhow::bail!(
+                        "Chain '{}' references rate_limit_group '{}' which is not defined in rpc_rate_limits",
+                        chain.name, group_name
+                    );
+                }
+            }
+            if chain.rpc.rate_limit_group.is_some() && chain.rpc.compute_units_per_second.is_some() {
+                anyhow::bail!(
+                    "Chain '{}' has both rate_limit_group and compute_units_per_second; the group defines the rate budget",
+                    chain.name
+                );
+            }
+        }
+
         Ok(IndexerConfig {
             chains,
             raw_data_collection: raw_config.raw_data_collection,
             transformations: raw_config.transformations,
             metrics: raw_config.metrics,
             storage: raw_config.storage,
+            rpc_rate_limits,
         })
     }
 }


### PR DESCRIPTION
## Summary

- Add `RpcRateLimitGroup` struct and top-level `rpc_rate_limits` config map so multiple chains can share a single rate limit budget by referencing a named group.
- Add `rate_limit_group` field to per-chain `RpcConfig`, mutually exclusive with `compute_units_per_second`. Config validation rejects undefined group references and conflicting settings.
- Add `Clone` derive to `IndexerConfig` for shared ownership across concurrent chain executors.
- Add `SlidingWindowRateLimiter` support to the standard `RpcClient` via `new_with_shared_limiter()`, and wire it through `UnifiedRpcClient::from_url_with_options()` so non-Alchemy providers can also use the sliding window limiter when a shared limiter is provided.

Part of the multi-PR concurrent chain execution effort. Sibling PRs: `feat/shared-db-pool`, `feat/concurrent-chains`. Expected merge conflicts in `src/types/config/indexer.rs`.