### PR TITLE
feat: concurrent multi-chain execution with --chains CLI filter

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -98,7 +98,44 @@ async fn main() -> anyhow::Result<()> {
         anyhow::bail!("Cannot use --catch-up-only and --decode-only together");
     }
 
-    let config = IndexerConfig::load(Path::new("config/config.json"))?;
+    let chains_filter: Option<Vec<String>> = args
+        .iter()
+        .position(|a| a == "--chains")
+        .and_then(|i| args.get(i + 1))
+        .map(|v| v.split(',').map(|s| s.trim().to_string()).collect())
+        .or_else(|| {
+            args.iter()
+                .find(|a| a.starts_with("--chains="))
+                .map(|a| {
+                    a.trim_start_matches("--chains=")
+                        .split(',')
+                        .map(|s| s.trim().to_string())
+                        .collect()
+                })
+        });
+
+    let mut config = IndexerConfig::load(Path::new("config/config.json"))?;
+
+    if let Some(ref filter) = chains_filter {
+        for name in filter {
+            if !config.chains.iter().any(|c| c.name == *name) {
+                let available: Vec<&str> = config.chains.iter().map(|c| c.name.as_str()).collect();
+                anyhow::bail!(
+                    "Unknown chain '{}' in --chains filter. Available chains: {}",
+                    name,
+                    available.join(", ")
+                );
+            }
+        }
+        let before = config.chains.len();
+        config.chains.retain(|c| filter.contains(&c.name));
+        tracing::info!(
+            "Filtered to {} of {} configured chains: {:?}",
+            config.chains.len(),
+            before,
+            filter
+        );
+    }
     if !decode_only {
         load_required_env_vars(&config)?;
     }
@@ -254,17 +291,95 @@ async fn main() -> anyhow::Result<()> {
 
     tracing::info!("Loaded config with {} chain(s)", config.chains.len());
 
-    for chain in &config.chains {
-        if live_only {
-            process_chain_live_only(&config, chain).await?;
-        } else if decode_only {
-            decode_only_chain(&config, chain).await?;
+    let shared_db_pool: Option<Arc<DbPool>> = if !decode_only {
+        if let Some(ref tc) = config.transformations {
+            let registry = transformations::build_registry();
+            if !registry.is_empty() {
+                let database_url = std::env::var(&tc.database_url_env_var).with_context(|| {
+                    format!(
+                        "env var {} not set for transformations",
+                        tc.database_url_env_var
+                    )
+                })?;
+                let pool = DbPool::new(&database_url)
+                    .await
+                    .context("failed to create shared database pool")?;
+                pool.run_migrations()
+                    .await
+                    .context("failed to run database migrations")?;
+                tracing::info!("Shared database pool initialized and migrations complete");
+                Some(Arc::new(pool))
+            } else {
+                None
+            }
         } else {
-            process_chain(&config, chain, storage_manager.clone(), catch_up_only).await?;
+            None
+        }
+    } else {
+        None
+    };
+
+    let mut chain_tasks: JoinSet<(String, anyhow::Result<()>)> = JoinSet::new();
+
+    for chain in &config.chains {
+        let chain_name = chain.name.clone();
+        let config = config.clone();
+        let storage_manager = storage_manager.clone();
+        let shared_db_pool = shared_db_pool.clone();
+        let chain = chain.clone();
+
+        chain_tasks.spawn(async move {
+            let result = if live_only {
+                process_chain_live_only(&config, &chain, shared_db_pool).await
+            } else if decode_only {
+                decode_only_chain(&config, &chain).await
+            } else {
+                process_chain(
+                    &config,
+                    &chain,
+                    storage_manager,
+                    catch_up_only,
+                    shared_db_pool,
+                )
+                .await
+            };
+            (chain_name, result)
+        });
+    }
+
+    let mut failures: Vec<(String, String)> = Vec::new();
+
+    while let Some(result) = chain_tasks.join_next().await {
+        match result {
+            Ok((chain_name, Ok(()))) => {
+                tracing::info!("Chain {} completed successfully", chain_name);
+            }
+            Ok((chain_name, Err(e))) => {
+                tracing::error!("Chain {} failed: {:?}", chain_name, e);
+                failures.push((chain_name, format!("{:?}", e)));
+            }
+            Err(join_error) => {
+                tracing::error!("Chain task panicked: {:?}", join_error);
+                failures.push(("unknown".to_string(), format!("{:?}", join_error)));
+            }
         }
     }
 
-    tracing::info!("All chains processed successfully");
+    if !failures.is_empty() {
+        for (name, err) in &failures {
+            tracing::error!("  Chain '{}': {}", name, err);
+        }
+        anyhow::bail!(
+            "{} chain(s) failed: {}",
+            failures.len(),
+            failures
+                .iter()
+                .map(|(n, _)| n.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
+
     Ok(())
 }
 
@@ -388,6 +503,7 @@ async fn decode_only_chain(config: &IndexerConfig, chain: &ChainConfig) -> anyho
 async fn process_chain_live_only(
     config: &IndexerConfig,
     chain: &ChainConfig,
+    shared_db_pool: Option<Arc<DbPool>>,
 ) -> anyhow::Result<()> {
     tracing::info!("Processing chain {} in live-only mode", chain.name);
 
@@ -407,7 +523,7 @@ async fn process_chain_live_only(
     }
 
     // Build unified runtime (RPC client with rate limiter, db pool, registry, progress tracker)
-    let runtime = ChainRuntime::build(config, chain).await?;
+    let runtime = ChainRuntime::build(config, chain, shared_db_pool, None).await?;
 
     // Build channels with config-derived capacity
     let channels = CommonChannels::build_for_live_only(
@@ -1006,11 +1122,12 @@ async fn process_chain(
     chain: &ChainConfig,
     storage_manager: Arc<StorageManager>,
     catch_up_only: bool,
+    shared_db_pool: Option<Arc<DbPool>>,
 ) -> anyhow::Result<()> {
     tracing::info!("Processing chain: {}", chain.name);
 
     // Build unified runtime (RPC client with rate limiter, db pool, registry, progress tracker)
-    let runtime = ChainRuntime::build(config, chain).await?;
+    let runtime = ChainRuntime::build(config, chain, shared_db_pool, None).await?;
 
     let features = &runtime.features;
     let has_factories = features.has_factories;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -307,7 +307,12 @@ pub struct ChainRuntime {
 
 impl ChainRuntime {
     /// Build the runtime infrastructure for a chain.
-    pub async fn build(config: &IndexerConfig, chain: &ChainConfig) -> anyhow::Result<Self> {
+    pub async fn build(
+        config: &IndexerConfig,
+        chain: &ChainConfig,
+        shared_db_pool: Option<Arc<DbPool>>,
+        shared_rate_limiter: Option<Arc<SlidingWindowRateLimiter>>,
+    ) -> anyhow::Result<Self> {
         let rpc_url = std::env::var(&chain.rpc_url_env_var).with_context(|| {
             format!(
                 "env var {} not set for chain {}",
@@ -328,7 +333,27 @@ impl ChainRuntime {
             .unwrap_or(rpc_defaults::MAX_BATCH_SIZE) as usize;
 
         // Build RPC client with rate limiter from per-chain config
-        let (rate_limiter, http_client) = build_rpc_client(&rpc_url, &chain.rpc, rpc_batch_size)?;
+        let concurrency = chain
+            .rpc
+            .concurrency
+            .unwrap_or(rpc_defaults::CONCURRENCY);
+        let cu_per_second = chain
+            .rpc
+            .compute_units_per_second
+            .unwrap_or(rpc_defaults::ALCHEMY_CU_PER_SECOND);
+
+        let (rate_limiter, http_client) = if let Some(limiter) = shared_rate_limiter {
+            let client = UnifiedRpcClient::from_url_with_options(
+                &rpc_url,
+                cu_per_second,
+                concurrency,
+                rpc_batch_size,
+                Some(limiter.clone()),
+            )?;
+            (limiter, Arc::new(client))
+        } else {
+            build_rpc_client(&rpc_url, &chain.rpc, rpc_batch_size)?
+        };
 
         // Build transformation registry
         let registry = build_registry();
@@ -344,8 +369,11 @@ impl ChainRuntime {
         }
 
         // Setup database if transformations enabled
-        let db_pool = if let Some(ref tc) = config.transformations {
-            if transformations_enabled {
+        let db_pool = if transformations_enabled {
+            if let Some(pool) = shared_db_pool {
+                Some(pool)
+            } else {
+                let tc = config.transformations.as_ref().unwrap();
                 let database_url = std::env::var(&tc.database_url_env_var).with_context(|| {
                     format!(
                         "env var {} not set for transformations",
@@ -362,8 +390,6 @@ impl ChainRuntime {
 
                 tracing::info!("Database pool initialized and migrations complete");
                 Some(Arc::new(pool))
-            } else {
-                None
             }
         } else {
             None

--- a/src/types/config/indexer.rs
+++ b/src/types/config/indexer.rs
@@ -20,7 +20,7 @@ pub struct IndexerConfigRaw {
     pub storage: Option<StorageConfig>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct IndexerConfig {
     pub chains: Vec<ChainConfig>,
     pub raw_data_collection: RawDataCollectionConfig,


### PR DESCRIPTION
## Summary

- **Concurrent chain execution**: Chains now run concurrently in independent tokio tasks via `JoinSet`, each transitioning through historical -> live mode independently. One chain failing does not kill others; all failures are collected and reported at the end.
- **`--chains` CLI filter**: Added `--chains name1,name2` (or `--chains=name1,name2`) argument to run only a subset of configured chains. Validates against available chains and exits early on unknown names.
- **Shared DB pool**: A single database connection pool is created before spawning chain tasks and passed to each `ChainRuntime::build()`, avoiding redundant pool creation and migration runs per chain.
- **`IndexerConfig` is now `Clone`**: Required for moving config into concurrent task closures.
- **`ChainRuntime::build()` extended**: Accepts optional `shared_db_pool` and `shared_rate_limiter` parameters, using them when provided instead of creating new instances.

## Context

Part of a multi-PR concurrent chain execution effort.

**Sibling PRs:**
- `feat/rate-limit-groups` — config types for rate limit group sharing
- `feat/shared-db-pool` — migration safety for concurrent pool usage

**Expected merge conflicts** with both sibling PRs in `src/types/config/indexer.rs` and `src/runtime.rs`. Recommended merge order: sibling PRs first, then this PR with conflict resolution.