### PR TITLE
feat: chain-aware handler registration

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -14,7 +14,8 @@ use crate::live::{LiveProgressTracker, TransformRetryRequest};
 use crate::rpc::{SlidingWindowRateLimiter, UnifiedRpcClient};
 use crate::transformations::registry::TransformationRegistry;
 use crate::transformations::{
-    build_registry, DecodedCallsMessage, DecodedEventsMessage, RangeCompleteMessage, ReorgMessage,
+    build_registry_for_chain, DecodedCallsMessage, DecodedEventsMessage, RangeCompleteMessage,
+    ReorgMessage,
 };
 use crate::types::config::chain::{ChainConfig, RpcConfig};
 use crate::types::config::defaults::{raw_data as raw_data_defaults, rpc as rpc_defaults};
@@ -330,8 +331,8 @@ impl ChainRuntime {
         // Build RPC client with rate limiter from per-chain config
         let (rate_limiter, http_client) = build_rpc_client(&rpc_url, &chain.rpc, rpc_batch_size)?;
 
-        // Build transformation registry
-        let registry = build_registry();
+        // Build transformation registry filtered to this chain's contracts
+        let registry = build_registry_for_chain(&chain.contracts, &chain.factory_collections);
         let transformations_enabled = config.transformations.is_some() && !registry.is_empty();
 
         // Validate that all handler call dependencies are satisfied by config

--- a/src/transformations/mod.rs
+++ b/src/transformations/mod.rs
@@ -73,4 +73,4 @@ pub use engine::{
     RangeCompleteMessage, ReorgMessage, TransformationEngine, TransformationEngineConfig,
 };
 pub use error::TransformationError;
-pub use registry::build_registry;
+pub use registry::{build_registry, build_registry_for_chain};

--- a/src/transformations/registry.rs
+++ b/src/transformations/registry.rs
@@ -57,6 +57,9 @@ pub struct TransformationRegistry {
     call_handlers: HashMap<(String, String), Vec<Arc<dyn EthCallHandler>>>,
     /// All handlers for initialization (de-duplicated)
     all_handlers: Vec<Arc<dyn TransformationHandler>>,
+    /// When set, only handlers whose trigger sources are all present in this
+    /// set will be registered. Used to filter handlers per-chain.
+    available_sources: Option<HashSet<String>>,
 }
 
 impl TransformationRegistry {
@@ -66,15 +69,40 @@ impl TransformationRegistry {
             event_handlers: HashMap::new(),
             call_handlers: HashMap::new(),
             all_handlers: Vec::new(),
+            available_sources: None,
+        }
+    }
+
+    /// Create a registry that filters handlers by available sources.
+    ///
+    /// Only handlers whose trigger sources are ALL present in the set will
+    /// be registered. Handlers with missing sources are silently skipped.
+    pub fn with_source_filter(sources: HashSet<String>) -> Self {
+        Self {
+            event_handlers: HashMap::new(),
+            call_handlers: HashMap::new(),
+            all_handlers: Vec::new(),
+            available_sources: Some(sources),
         }
     }
 
     /// Register an event handler.
     ///
-    /// The handler will be invoked for all events matching its triggers.
+    /// If a source filter is set, the handler is skipped when any of its
+    /// trigger sources are missing from the filter set.
     pub fn register_event_handler<H: EventHandler + 'static>(&mut self, handler: H) {
         let handler = Arc::new(handler);
         let triggers = handler.triggers();
+
+        if let Some(ref sources) = self.available_sources {
+            if !triggers.iter().all(|t| sources.contains(&t.source)) {
+                tracing::debug!(
+                    "Skipping event handler {} — trigger sources not available for this chain",
+                    handler.name(),
+                );
+                return;
+            }
+        }
 
         for trigger in triggers {
             let key = (
@@ -92,11 +120,22 @@ impl TransformationRegistry {
 
     /// Register an eth_call handler.
     ///
-    /// The handler will be invoked for all call results matching its triggers.
+    /// If a source filter is set, the handler is skipped when any of its
+    /// trigger sources are missing from the filter set.
     #[allow(dead_code)]
     pub fn register_call_handler<H: EthCallHandler + 'static>(&mut self, handler: H) {
         let handler = Arc::new(handler);
         let triggers = handler.triggers();
+
+        if let Some(ref sources) = self.available_sources {
+            if !triggers.iter().all(|t| sources.contains(&t.source)) {
+                tracing::debug!(
+                    "Skipping call handler {} — trigger sources not available for this chain",
+                    handler.name(),
+                );
+                return;
+            }
+        }
 
         for trigger in triggers {
             let key = (trigger.source.clone(), trigger.function_name.clone());
@@ -280,7 +319,7 @@ pub fn validate_call_dependencies(
     }
 }
 
-/// Build the transformation registry with all handlers.
+/// Build the transformation registry with all handlers (unfiltered).
 ///
 /// This is where handlers are registered at compile-time.
 /// Add new handler registrations here as they are implemented.
@@ -295,6 +334,36 @@ pub fn build_registry() -> TransformationRegistry {
 
     tracing::info!(
         "Built transformation registry with {} handlers ({} event triggers, {} call triggers)",
+        registry.handler_count(),
+        registry.all_event_triggers().len(),
+        registry.all_call_triggers().len()
+    );
+
+    registry
+}
+
+/// Build a transformation registry filtered to handlers relevant for a specific chain.
+///
+/// Only handlers whose trigger sources all exist in the chain's contracts or
+/// factory collections are registered. This prevents handlers designed for one
+/// chain from being initialized, migrated, or validated on another.
+pub fn build_registry_for_chain(
+    contracts: &Contracts,
+    factory_collections: &FactoryCollections,
+) -> TransformationRegistry {
+    let mut available: HashSet<String> = contracts.keys().cloned().collect();
+    available.extend(factory_collections.keys().cloned());
+
+    let mut registry = TransformationRegistry::with_source_filter(available);
+
+    // Register event handlers (filtered by available sources)
+    super::event::register_handlers(&mut registry);
+
+    // Register eth_call handlers (filtered by available sources)
+    super::eth_call::register_handlers(&mut registry);
+
+    tracing::info!(
+        "Built chain-filtered transformation registry with {} handlers ({} event triggers, {} call triggers)",
         registry.handler_count(),
         registry.all_event_triggers().len(),
         registry.all_call_triggers().len()


### PR DESCRIPTION
## Summary

- Transformation handlers are now filtered per-chain based on which contract sources are actually configured
- `TransformationRegistry` gains an optional `available_sources` filter set via `with_source_filter()`
- `register_event_handler` and `register_call_handler` skip handlers whose trigger sources aren't all present in the filter
- New `build_registry_for_chain(contracts, factory_collections)` builds a filtered registry
- `ChainRuntime::build()` now uses `build_registry_for_chain` instead of the unfiltered `build_registry`

Previously, all handlers were registered globally for every chain. A handler designed for mainnet (e.g., referencing `EurcUsdcPool`) would cause `validate_call_dependencies` to panic when validating against a chain that doesn't have that contract. With this change, only handlers whose trigger sources exist in the chain's contracts/factory_collections are registered.

Part of concurrent multi-chain execution effort. Sibling PRs: `feat/rate-limit-groups`, `feat/shared-db-pool`, `feat/concurrent-chains`.