### PR TITLE
fix: track per-contract factory collection completeness

### DIFF
--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -201,7 +201,7 @@ src/
 ├── raw_data/historical/ # Raw data collection (blocks, receipts, logs, eth_calls, factories)
 ├── decoding/            # ABI decoding (logs, eth_calls, catchup, current)
 ├── live/                # Live mode (collector, storage, compaction, reorg, progress)
-├── storage/             # S3 storage (local, s3, cached, manifest, upload, retry)
+├── storage/             # S3 storage (local, s3, cached, manifest, upload, retry, contract_index)
 ├── metrics/             # Prometheus metrics server and RPC metrics
 ├── transformations/     # Transformation engine, handlers, registry, utils
 └── types/               # Config types, shared types, decoded value types

--- a/docs/features/eth_call_collection.md
+++ b/docs/features/eth_call_collection.md
@@ -787,6 +787,19 @@ For `frequency: "once"` calls, the catchup logic is column-aware:
 
 This means you can add new `frequency: "once"` calls to an existing configuration without re-running all historical calls — only the new calls are executed and merged into existing files.
 
+### Contract-Index Completeness for Factory Once Calls
+
+Factory once calls use a two-level skip gate to decide whether a range needs processing:
+
+1. **Column-level check** — Does the parquet file contain all configured function columns with no unindexed nulls? (Existing behavior via `column_index.json`)
+2. **Address-level check** — Does `contract_index.json` confirm that the range was processed against the current set of expected factory source addresses? (New check)
+
+When a new factory source address is added to the config, the column check still passes (the existing parquet has all function columns for the addresses it knows about), but the contract-index check fails because the new address was never processed. This triggers re-processing for only the absent addresses.
+
+The `contract_index.json` sidecar is written alongside `column_index.json` after each successful parquet write, including for empty ranges (no factory addresses discovered). Without the empty-range write, zero-address ranges would retry indefinitely.
+
+**Optimization:** If the contract-index check fails but no new RPC calls are needed (the parquet data is already complete), only the missing `contract_index.json` is written — the parquet file is not rewritten. This avoids a no-op read/write cycle on the first run after upgrade.
+
 ### Factory Calls
 
 Factory eth_calls are processed in two ways:

--- a/docs/features/factory_collection.md
+++ b/docs/features/factory_collection.md
@@ -748,20 +748,59 @@ Collection is fully resumable with multiple safeguards:
 
 Existing parquet files are scanned on startup and their ranges are skipped during collection. When S3 storage is configured, the S3 manifest is also checked, so ranges already uploaded to S3 are skipped even if the local files have been cleaned up.
 
+### Contract Index Tracking
+
+Each data layer writes a `contract_index.json` sidecar file alongside its parquet files. The index records which factory source contracts (and their addresses) were included when each block range was processed:
+
+```json
+{
+  "0-999": {
+    "Airlock": ["0x660eaaedebc968f8f3694354fa8ec0b4c5ba8d12"],
+    "OtherInitializer": ["0xabc...", "0xdef..."]
+  },
+  "1000-1999": {
+    "Airlock": ["0x660eaaedebc968f8f3694354fa8ec0b4c5ba8d12"]
+  }
+}
+```
+
+On catchup, ranges are reprocessed when the current config lists contracts or addresses absent from the index. This handles:
+- A new factory source contract is added to the config
+- A new address is added to an existing multi-address contract
+- Factory collection was interrupted after writing parquet but before updating the index
+
+**Contract index locations:**
+
+| Layer | Path |
+|-------|------|
+| Factory addresses | `factories/{collection}/contract_index.json` |
+| Eth_calls regular | `eth_calls/{collection}/{function}/contract_index.json` |
+| Eth_calls once | `eth_calls/{collection}/once/contract_index.json` |
+| Eth_calls on_events | `eth_calls/{collection}/{function}/on_events/contract_index.json` |
+| Decoded logs | `decoded/logs/{collection}/{event_name}/contract_index.json` |
+
+**Write ordering:** Parquet files are always written before the contract index is updated. If a crash occurs between the two, the next run detects the missing index entry and reprocesses (safe, idempotent).
+
+**Atomic writes:** The contract index uses a write-to-temp + sync + rename pattern to prevent partial writes on crash.
+
+**S3 integration:** Contract index files are uploaded to S3 alongside parquet files and downloaded during catchup.
+
 ### Catchup Phase
 
 On startup, before processing new logs from the channel, the factory collector performs a catchup phase:
 
 1. **Load existing factory data**: Reads all existing factory parquet files and sends addresses to downstream collectors (logs, decoders)
 2. **Scan for gaps**: Scans `data/{chain}/historical/raw/logs/` for existing log parquet files (and S3 manifest ranges not present locally)
-3. **Check completeness**: For each log file, checks if corresponding factory files exist for all configured collections (checking both local files and S3 manifest)
-4. **Process gaps concurrently**: If any factory files are missing, reads logs from the existing parquet file (downloading from S3 if needed) and processes them using semaphore-bounded concurrency (controlled by `factory_concurrency` config)
-5. **Upload to S3**: If storage manager is configured, newly written factory parquet files are uploaded to S3
-6. **Signal completion**: Sends `factory_catchup_done_tx` oneshot to unblock dependent catchup phases (e.g., eth_calls)
+3. **Check completeness**: For each log file, checks if corresponding factory files exist for all configured collections (checking both local files and S3 manifest). Also checks the contract index to ensure all currently-configured contracts are represented.
+4. **Process gaps concurrently**: If any factory files are missing or the contract index shows missing contracts, reads logs from the existing parquet file (downloading from S3 if needed) and processes them using semaphore-bounded concurrency (controlled by `factory_concurrency` config)
+5. **Update contract index**: After all concurrent tasks complete, the contract index is updated in memory and written atomically to avoid concurrent write conflicts from the JoinSet tasks
+6. **Upload to S3**: If storage manager is configured, newly written factory parquet files and contract index files are uploaded to S3
+7. **Signal completion**: Sends `factory_catchup_done_tx` oneshot to unblock dependent catchup phases (e.g., eth_calls)
 
 This is particularly useful when:
 - Factory collection was interrupted mid-run
 - New factory configurations are added to existing contracts
+- A new address is added to an existing contract
 - Factory files were manually deleted for re-processing
 
 ### Synchronization with eth_calls

--- a/src/decoding/catchup/logs.rs
+++ b/src/decoding/catchup/logs.rs
@@ -11,6 +11,10 @@ use tokio::task::JoinSet;
 use crate::decoding::logs::{process_logs, EventMatcher, LogDecodingError};
 use crate::decoding::types::{FileProcessingEntry, LogDecoderOutputs, LogMatcherConfig};
 use crate::raw_data::historical::factories::RecollectRequest;
+use crate::storage::contract_index::{
+    build_expected_factory_contracts, get_missing_contracts, range_key, read_contract_index,
+    ContractIndex, ExpectedContracts,
+};
 use crate::storage::decoded_index::scan_existing_decoded_files;
 use crate::storage::factory_data::load_factory_addresses_by_range;
 use crate::storage::parquet_readers::read_raw_logs_from_parquet;
@@ -84,6 +88,29 @@ pub async fn catchup_decode_logs(
         factory_addresses.len()
     );
 
+    // Build expected contracts per collection for contract index checks
+    let expected_by_collection = build_expected_factory_contracts(&chain.contracts);
+
+    // Pre-load contract indexes for each factory collection
+    let factory_collection_names: HashSet<String> =
+        factory_matchers.keys().cloned().collect();
+    let mut contract_indexes: HashMap<String, ContractIndex> = HashMap::new();
+    for collection in &factory_collection_names {
+        // Each factory collection's decoded logs use the same output_base/{collection}/{event}/ layout
+        // We load one index per (collection, event) pair
+        for matchers in factory_matchers.get(collection).iter().flat_map(|v| v.iter()) {
+            let dir = output_base.join(collection).join(&matchers.event_name);
+            let idx = {
+                let dir_clone = dir.clone();
+                tokio::task::spawn_blocking(move || read_contract_index(&dir_clone))
+                    .await
+                    .unwrap_or_default()
+            };
+            let key = format!("{}/{}", collection, matchers.event_name);
+            contract_indexes.insert(key, idx);
+        }
+    }
+
     // Filter files that need processing and compute per-range missing matchers
     let files_to_process: Vec<FileProcessingEntry> = raw_files
         .into_iter()
@@ -94,6 +121,9 @@ pub async fn catchup_decode_logs(
                 regular_matchers,
                 factory_matchers,
                 &existing_decoded,
+                output_base,
+                &expected_by_collection,
+                &contract_indexes,
             );
             if missing_regular.is_empty() && missing_factory.is_empty() {
                 tracing::debug!(
@@ -129,6 +159,7 @@ pub async fn catchup_decode_logs(
     let output_base = Arc::new(output_base.to_path_buf());
     let semaphore = Arc::new(Semaphore::new(concurrency));
     let transform_tx = transform_tx.cloned();
+    let expected_by_collection = Arc::new(expected_by_collection);
 
     let mut join_set = JoinSet::new();
 
@@ -140,6 +171,7 @@ pub async fn catchup_decode_logs(
         let output_base = output_base.clone();
         let transform_tx = transform_tx.clone();
         let recollect_tx = recollect_tx.clone();
+        let expected_by_collection = expected_by_collection.clone();
 
         join_set.spawn(async move {
             let _permit = permit; // Hold permit until task completes
@@ -217,6 +249,7 @@ pub async fn catchup_decode_logs(
                 &factory_addrs,
                 &output_base,
                 &outputs,
+                Some(&expected_by_collection),
             )
             .await
         });
@@ -236,14 +269,22 @@ pub async fn catchup_decode_logs(
 
 /// Get matchers whose decoded output files don't exist yet for a given range.
 /// Returns only the matchers that still need decoding.
+///
+/// For factory matchers, even when the parquet file exists, the contract index
+/// is checked for missing contracts/addresses. If the index shows gaps, the
+/// matcher is included so the range gets reprocessed.
 fn get_missing_matchers(
     range_start: u64,
     range_end: u64,
     regular_matchers: &[EventMatcher],
     factory_matchers: &HashMap<String, Vec<EventMatcher>>,
     existing: &HashSet<String>,
+    _output_base: &Path,
+    expected_by_collection: &HashMap<String, ExpectedContracts>,
+    contract_indexes: &HashMap<String, ContractIndex>,
 ) -> (Vec<EventMatcher>, HashMap<String, Vec<EventMatcher>>) {
     let file_name = format!("{}-{}.parquet", range_start, range_end - 1);
+    let rk = range_key(range_start, range_end - 1);
 
     let missing_regular: Vec<EventMatcher> = regular_matchers
         .iter()
@@ -275,7 +316,31 @@ fn get_missing_matchers(
                     }
                     // Check if output file is missing
                     let rel_path = format!("{}/{}/{}", matcher.name, matcher.event_name, file_name);
-                    !existing.contains(&rel_path)
+                    if !existing.contains(&rel_path) {
+                        return true; // File missing — needs processing
+                    }
+
+                    // File exists — check contract index for missing contracts
+                    if let Some(expected) = expected_by_collection.get(collection) {
+                        let index_key = format!("{}/{}", collection, matcher.event_name);
+                        let index = contract_indexes
+                            .get(&index_key)
+                            .cloned()
+                            .unwrap_or_default();
+                        let missing = get_missing_contracts(&index, &rk, expected);
+                        if !missing.is_empty() {
+                            tracing::debug!(
+                                "Range {} file exists for {}/{} but contract index has {} missing contracts",
+                                rk,
+                                collection,
+                                matcher.event_name,
+                                missing.len()
+                            );
+                            return true; // Index shows gaps — reprocess
+                        }
+                    }
+
+                    false // File exists and index is complete
                 })
                 .cloned()
                 .collect();

--- a/src/decoding/catchup/logs.rs
+++ b/src/decoding/catchup/logs.rs
@@ -12,9 +12,10 @@ use crate::decoding::logs::{process_logs, EventMatcher, LogDecodingError};
 use crate::decoding::types::{FileProcessingEntry, LogDecoderOutputs, LogMatcherConfig};
 use crate::raw_data::historical::factories::RecollectRequest;
 use crate::storage::contract_index::{
-    build_expected_factory_contracts, get_missing_contracts, migrate_downstream_index, range_key,
-    read_contract_index, ContractIndex, ExpectedContracts,
+    build_expected_factory_contracts_for_range, get_missing_contracts, migrate_downstream_index,
+    range_key, read_contract_index, update_contract_index, write_contract_index, ContractIndex,
 };
+use crate::types::config::contract::Contracts;
 use crate::storage::paths::factories_dir as factories_dir_path;
 use crate::storage::decoded_index::scan_existing_decoded_files;
 use crate::storage::factory_data::load_factory_addresses_by_range;
@@ -89,9 +90,6 @@ pub async fn catchup_decode_logs(
         factory_addresses.len()
     );
 
-    // Build expected contracts per collection for contract index checks
-    let expected_by_collection = build_expected_factory_contracts(&chain.contracts);
-
     // Pre-load contract indexes for each factory collection
     let factory_collection_names: HashSet<String> =
         factory_matchers.keys().cloned().collect();
@@ -162,8 +160,7 @@ pub async fn catchup_decode_logs(
                 regular_matchers,
                 factory_matchers,
                 &existing_decoded,
-                output_base,
-                &expected_by_collection,
+                &chain.contracts,
                 &contract_indexes,
             );
             if missing_regular.is_empty() && missing_factory.is_empty() {
@@ -197,12 +194,34 @@ pub async fn catchup_decode_logs(
         concurrency
     );
 
+    // Build (range_start, range_end) -> missing_factory lookup before spawning
+    // (files_to_process is consumed by the spawn loop below)
+    let factory_by_range: HashMap<(u64, u64), HashMap<String, Vec<EventMatcher>>> =
+        files_to_process
+            .iter()
+            .map(|(rs, re, _, _, mf)| ((*rs, *re), mf.clone()))
+            .collect();
+
+    // Pre-load contract indexes for all (collection, event) pairs that will be written.
+    // Re-use the already-loaded contract_indexes to avoid duplicate disk reads.
+    let mut live_indexes: HashMap<(String, String), ContractIndex> = HashMap::new();
+    for (_, _, _, _, missing_factory) in &files_to_process {
+        for (collection, matchers) in missing_factory {
+            for matcher in matchers {
+                let key = (collection.clone(), matcher.event_name.clone());
+                live_indexes.entry(key).or_insert_with(|| {
+                    let index_key = format!("{}/{}", collection, matcher.event_name);
+                    contract_indexes.get(&index_key).cloned().unwrap_or_default()
+                });
+            }
+        }
+    }
+
     let output_base = Arc::new(output_base.to_path_buf());
     let semaphore = Arc::new(Semaphore::new(concurrency));
     let transform_tx = transform_tx.cloned();
-    let expected_by_collection = Arc::new(expected_by_collection);
 
-    let mut join_set = JoinSet::new();
+    let mut join_set: JoinSet<Result<Option<(u64, u64)>, LogDecodingError>> = JoinSet::new();
 
     let recollect_tx = recollect_tx.cloned();
 
@@ -212,7 +231,6 @@ pub async fn catchup_decode_logs(
         let output_base = output_base.clone();
         let transform_tx = transform_tx.clone();
         let recollect_tx = recollect_tx.clone();
-        let expected_by_collection = expected_by_collection.clone();
 
         join_set.spawn(async move {
             let _permit = permit; // Hold permit until task completes
@@ -264,7 +282,7 @@ pub async fn catchup_decode_logs(
                         }
                     }
 
-                    return Ok(());
+                    return Ok(None);
                 }
             };
 
@@ -290,19 +308,61 @@ pub async fn catchup_decode_logs(
                 &factory_addrs,
                 &output_base,
                 &outputs,
-                Some(&expected_by_collection),
+                None, // contract index writes are done serially after drain (Fix 3)
             )
             .await
+            .map(|_| Some((range_start, range_end)))
         });
     }
 
-    // Collect results and propagate errors
+    // Drain JoinSet with deferred error — collect processed ranges for serial index write
+    let mut processed_ranges: Vec<(u64, u64)> = Vec::new();
+    let mut first_error: Option<LogDecodingError> = None;
+
     while let Some(result) = join_set.join_next().await {
         match result {
-            Ok(Ok(())) => {}
-            Ok(Err(e)) => return Err(e),
-            Err(e) => return Err(LogDecodingError::JoinError(e.to_string())),
+            Ok(Ok(Some((start, end)))) => {
+                processed_ranges.push((start, end));
+            }
+            Ok(Ok(None)) => {}
+            Ok(Err(e)) => {
+                first_error.get_or_insert(e);
+            }
+            Err(e) => {
+                first_error.get_or_insert(LogDecodingError::JoinError(e.to_string()));
+            }
         }
+    }
+
+    // Serial contract index update — no concurrent R-M-W races (Fix 3)
+    for (start, end) in &processed_ranges {
+        let rk = range_key(*start, end - 1);
+        if let Some(missing_factory) = factory_by_range.get(&(*start, *end)) {
+            for (collection, matchers) in missing_factory {
+                for matcher in matchers {
+                    let key = (collection.clone(), matcher.event_name.clone());
+                    if let Some(index) = live_indexes.get_mut(&key) {
+                        let expected_for_range =
+                            build_expected_factory_contracts_for_range(&chain.contracts, *end);
+                        if let Some(expected) = expected_for_range.get(collection) {
+                            update_contract_index(index, &rk, expected);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Write each index once — no per-range repeated R-M-W
+    for ((collection, event_name), index) in &live_indexes {
+        let dir = output_base.join(collection).join(event_name);
+        if let Err(e) = write_contract_index(&dir, index) {
+            first_error.get_or_insert(LogDecodingError::Io(e));
+        }
+    }
+
+    if let Some(e) = first_error {
+        return Err(e);
     }
 
     Ok(())
@@ -320,12 +380,12 @@ fn get_missing_matchers(
     regular_matchers: &[EventMatcher],
     factory_matchers: &HashMap<String, Vec<EventMatcher>>,
     existing: &HashSet<String>,
-    _output_base: &Path,
-    expected_by_collection: &HashMap<String, ExpectedContracts>,
+    contracts: &Contracts,
     contract_indexes: &HashMap<String, ContractIndex>,
 ) -> (Vec<EventMatcher>, HashMap<String, Vec<EventMatcher>>) {
     let file_name = format!("{}-{}.parquet", range_start, range_end - 1);
     let rk = range_key(range_start, range_end - 1);
+    let expected_for_range = build_expected_factory_contracts_for_range(contracts, range_end);
 
     let missing_regular: Vec<EventMatcher> = regular_matchers
         .iter()
@@ -362,7 +422,7 @@ fn get_missing_matchers(
                     }
 
                     // File exists — check contract index for missing contracts
-                    if let Some(expected) = expected_by_collection.get(collection) {
+                    if let Some(expected) = expected_for_range.get(collection) {
                         let index_key = format!("{}/{}", collection, matcher.event_name);
                         let index = contract_indexes
                             .get(&index_key)

--- a/src/decoding/catchup/logs.rs
+++ b/src/decoding/catchup/logs.rs
@@ -12,11 +12,10 @@ use crate::decoding::logs::{process_logs, EventMatcher, LogDecodingError};
 use crate::decoding::types::{FileProcessingEntry, LogDecoderOutputs, LogMatcherConfig};
 use crate::raw_data::historical::factories::RecollectRequest;
 use crate::storage::contract_index::{
-    build_expected_factory_contracts_for_range, get_missing_contracts, migrate_downstream_index,
-    range_key, read_contract_index, update_contract_index, write_contract_index, ContractIndex,
+    build_expected_factory_contracts_for_range, get_missing_contracts, range_key,
+    read_contract_index, update_contract_index, write_contract_index, ContractIndex,
 };
 use crate::types::config::contract::Contracts;
-use crate::storage::paths::factories_dir as factories_dir_path;
 use crate::storage::decoded_index::scan_existing_decoded_files;
 use crate::storage::factory_data::load_factory_addresses_by_range;
 use crate::storage::parquet_readers::read_raw_logs_from_parquet;
@@ -107,46 +106,6 @@ pub async fn catchup_decode_logs(
             };
             let key = format!("{}/{}", collection, matchers.event_name);
             contract_indexes.insert(key, idx);
-        }
-    }
-
-    // =========================================================================
-    // Migration: seed decoded logs contract indexes from the factory layer
-    // =========================================================================
-    {
-        let factories_dir = factories_dir_path(&chain.name);
-        for collection in &factory_collection_names {
-            let factory_index = {
-                let dir = factories_dir.join(collection);
-                let d = dir.clone();
-                tokio::task::spawn_blocking(move || read_contract_index(&d))
-                    .await
-                    .unwrap_or_default()
-            };
-            if factory_index.is_empty() {
-                continue;
-            }
-
-            for matchers_list in factory_matchers.get(collection).iter().flat_map(|v| v.iter()) {
-                let key = format!("{}/{}", collection, matchers_list.event_name);
-                let downstream_dir =
-                    output_base.join(collection).join(&matchers_list.event_name);
-                let existing = &existing_decoded;
-                let coll = collection.clone();
-                let evt = matchers_list.event_name.clone();
-                let migrated = migrate_downstream_index(&downstream_dir, &factory_index, |rk| {
-                    let file = format!("{}/{}/{}.parquet", coll, evt, rk);
-                    existing.contains(&file)
-                });
-                if migrated {
-                    // Reload the index so the skip check uses the migrated data
-                    let d = downstream_dir.clone();
-                    let idx = tokio::task::spawn_blocking(move || read_contract_index(&d))
-                        .await
-                        .unwrap_or_default();
-                    contract_indexes.insert(key, idx);
-                }
-            }
         }
     }
 

--- a/src/decoding/catchup/logs.rs
+++ b/src/decoding/catchup/logs.rs
@@ -12,9 +12,10 @@ use crate::decoding::logs::{process_logs, EventMatcher, LogDecodingError};
 use crate::decoding::types::{FileProcessingEntry, LogDecoderOutputs, LogMatcherConfig};
 use crate::raw_data::historical::factories::RecollectRequest;
 use crate::storage::contract_index::{
-    build_expected_factory_contracts, get_missing_contracts, range_key, read_contract_index,
-    ContractIndex, ExpectedContracts,
+    build_expected_factory_contracts, get_missing_contracts, migrate_downstream_index, range_key,
+    read_contract_index, ContractIndex, ExpectedContracts,
 };
+use crate::storage::paths::factories_dir as factories_dir_path;
 use crate::storage::decoded_index::scan_existing_decoded_files;
 use crate::storage::factory_data::load_factory_addresses_by_range;
 use crate::storage::parquet_readers::read_raw_logs_from_parquet;
@@ -108,6 +109,46 @@ pub async fn catchup_decode_logs(
             };
             let key = format!("{}/{}", collection, matchers.event_name);
             contract_indexes.insert(key, idx);
+        }
+    }
+
+    // =========================================================================
+    // Migration: seed decoded logs contract indexes from the factory layer
+    // =========================================================================
+    {
+        let factories_dir = factories_dir_path(&chain.name);
+        for collection in &factory_collection_names {
+            let factory_index = {
+                let dir = factories_dir.join(collection);
+                let d = dir.clone();
+                tokio::task::spawn_blocking(move || read_contract_index(&d))
+                    .await
+                    .unwrap_or_default()
+            };
+            if factory_index.is_empty() {
+                continue;
+            }
+
+            for matchers_list in factory_matchers.get(collection).iter().flat_map(|v| v.iter()) {
+                let key = format!("{}/{}", collection, matchers_list.event_name);
+                let downstream_dir =
+                    output_base.join(collection).join(&matchers_list.event_name);
+                let existing = &existing_decoded;
+                let coll = collection.clone();
+                let evt = matchers_list.event_name.clone();
+                let migrated = migrate_downstream_index(&downstream_dir, &factory_index, |rk| {
+                    let file = format!("{}/{}/{}.parquet", coll, evt, rk);
+                    existing.contains(&file)
+                });
+                if migrated {
+                    // Reload the index so the skip check uses the migrated data
+                    let d = downstream_dir.clone();
+                    let idx = tokio::task::spawn_blocking(move || read_contract_index(&d))
+                        .await
+                        .unwrap_or_default();
+                    contract_indexes.insert(key, idx);
+                }
+            }
         }
     }
 

--- a/src/decoding/current/logs.rs
+++ b/src/decoding/current/logs.rs
@@ -145,6 +145,7 @@ pub async fn decode_logs_live(
                         &accumulated_factory_addresses,
                         output_base,
                         outputs,
+                        None,
                     )
                     .await?;
                 }

--- a/src/decoding/current/logs.rs
+++ b/src/decoding/current/logs.rs
@@ -10,7 +10,9 @@ use crate::decoding::logs::{
 };
 use crate::decoding::types::{DecoderMessage, LogDecoderOutputs, LogMatcherConfig};
 use crate::live::LiveStorage;
+use crate::storage::contract_index::build_expected_factory_contracts_for_range;
 use crate::storage::parquet_readers::read_factory_addresses_from_parquet;
+use crate::types::config::contract::Contracts;
 
 /// Load accumulated factory addresses from both compacted parquet and uncompacted bincode files.
 ///
@@ -96,6 +98,7 @@ pub async fn decode_logs_live(
     output_base: &Path,
     chain_name: &str,
     outputs: &LogDecoderOutputs<'_>,
+    contracts: Option<&Contracts>,
 ) -> Result<(), LogDecodingError> {
     // Load accumulated factory addresses from parquet and bincode files
     let mut accumulated_factory_addresses = load_accumulated_factory_addresses(chain_name)?;
@@ -135,8 +138,9 @@ pub async fn decode_logs_live(
                     .await?;
                 } else {
                     // Historical mode: write to parquet
-                    // For historical, we still use per-range factory addresses
-                    // (this path is only taken during catchup which has its own loading)
+                    // Build per-range expected contracts so the contract index gets an entry
+                    let expected_for_range = contracts
+                        .map(|c| build_expected_factory_contracts_for_range(c, range_end));
                     process_logs(
                         &logs,
                         range_start,
@@ -145,7 +149,7 @@ pub async fn decode_logs_live(
                         &accumulated_factory_addresses,
                         output_base,
                         outputs,
-                        None,
+                        expected_for_range.as_ref(),
                     )
                     .await?;
                 }

--- a/src/decoding/logs.rs
+++ b/src/decoding/logs.rs
@@ -174,6 +174,7 @@ pub async fn decode_logs(
         &output_base,
         &chain.name,
         &log_outputs,
+        Some(&chain.contracts),
     )
     .await?;
 

--- a/src/decoding/logs.rs
+++ b/src/decoding/logs.rs
@@ -21,6 +21,9 @@ use super::types::{BuiltMatchers, DecoderMessage, LogDecoderOutputs, LogMatcherC
 use crate::live::{LiveDecodedLog, LiveStorage};
 use crate::raw_data::historical::factories::RecollectRequest;
 use crate::raw_data::historical::receipts::LogData;
+use crate::storage::contract_index::{
+    range_key, read_contract_index, update_contract_index, write_contract_index, ExpectedContracts,
+};
 use crate::transformations::{
     DecodedEvent as TransformDecodedEvent, DecodedEventsMessage, RangeCompleteKind,
     RangeCompleteMessage,
@@ -266,6 +269,7 @@ pub(crate) async fn process_logs(
     factory_addresses: &HashMap<String, HashSet<[u8; 20]>>,
     output_base: &Path,
     outputs: &LogDecoderOutputs<'_>,
+    expected_by_collection: Option<&HashMap<String, ExpectedContracts>>,
 ) -> Result<(), LogDecodingError> {
     let regular_matchers = matchers.regular_matchers;
     let factory_matchers = matchers.factory_matchers;
@@ -464,6 +468,29 @@ pub(crate) async fn process_logs(
             if !output_path.exists() {
                 std::fs::create_dir_all(&output_dir)?;
                 write_decoded_logs_to_parquet(&[], &matcher.event, &output_path)?;
+            }
+        }
+    }
+
+    // Update contract index for factory collections so that catchup can skip
+    // ranges already processed with the current set of contracts/addresses.
+    if let Some(expected_map) = expected_by_collection {
+        let rk = range_key(range_start, range_end - 1);
+
+        // Collect unique (collection, event_name) pairs from factory matchers
+        let mut seen_pairs: HashSet<(String, String)> = HashSet::new();
+        for (collection, matchers) in factory_matchers {
+            for matcher in matchers {
+                seen_pairs.insert((collection.clone(), matcher.event_name.clone()));
+            }
+        }
+
+        for (collection, event_name) in seen_pairs {
+            if let Some(expected) = expected_map.get(&collection) {
+                let dir = output_base.join(&collection).join(&event_name);
+                let mut index = read_contract_index(&dir);
+                update_contract_index(&mut index, &rk, expected);
+                write_contract_index(&dir, &index)?;
             }
         }
     }

--- a/src/raw_data/historical/catchup/eth_calls.rs
+++ b/src/raw_data/historical/catchup/eth_calls.rs
@@ -23,7 +23,10 @@ use crate::raw_data::historical::eth_calls::{
     EthCallContext, FrequencyState,
 };
 use crate::raw_data::historical::factories::{get_factory_call_configs, FactoryAddressData};
-use crate::storage::contract_index::build_expected_factory_contracts;
+use crate::storage::contract_index::{
+    build_expected_factory_contracts, migrate_downstream_index, read_contract_index,
+};
+use crate::storage::paths::factories_dir as factories_dir_path;
 use crate::raw_data::historical::receipts::{build_event_trigger_matchers, extract_event_triggers};
 use crate::rpc::UnifiedRpcClient;
 use crate::storage::factory_data::{
@@ -157,6 +160,76 @@ pub async fn collect_eth_calls(
     );
 
     let existing_files = scan_existing_parquet_files_async(base_output_dir.clone()).await;
+
+    // =========================================================================
+    // Migration: seed downstream contract indexes from the factory layer
+    // =========================================================================
+    if has_factory_calls || has_factory_once_calls || has_event_triggered_calls {
+        let factories_dir = factories_dir_path(&chain.name);
+        let factory_collection_names: HashSet<String> =
+            factory_call_configs.keys().cloned().collect();
+
+        for collection in &factory_collection_names {
+            let factory_index = {
+                let dir = factories_dir.join(collection);
+                let d = dir.clone();
+                tokio::task::spawn_blocking(move || read_contract_index(&d))
+                    .await
+                    .unwrap_or_default()
+            };
+            if factory_index.is_empty() {
+                continue;
+            }
+
+            // Migrate regular call indexes: {collection}/{function}/contract_index.json
+            if let Some(configs) = factory_call_configs.get(collection) {
+                for config in configs {
+                    let function_name = config
+                        .function
+                        .split('(')
+                        .next()
+                        .unwrap_or(&config.function);
+                    let sub_dir = base_output_dir.join(collection).join(function_name);
+                    let ef = &existing_files;
+                    migrate_downstream_index(&sub_dir, &factory_index, |rk| {
+                        let file = format!("{}/{}/{}.parquet", collection, function_name, rk);
+                        ef.contains(&file)
+                    });
+                }
+            }
+
+            // Migrate once call indexes: {collection}/once/contract_index.json
+            let once_dir = base_output_dir.join(collection).join("once");
+            if once_dir.exists() {
+                let ef = &existing_files;
+                let coll = collection.clone();
+                migrate_downstream_index(&once_dir, &factory_index, |rk| {
+                    let file = format!("{}/once/{}.parquet", coll, rk);
+                    ef.contains(&file)
+                });
+            }
+
+            // Migrate on_events indexes: {collection}/{function}/on_events/contract_index.json
+            for configs in event_call_configs.values() {
+                for config in configs {
+                    if config.contract_name != *collection {
+                        continue;
+                    }
+                    let sub_dir = base_output_dir
+                        .join(collection)
+                        .join(&config.function_name)
+                        .join("on_events");
+                    if sub_dir.exists() {
+                        migrate_downstream_index(&sub_dir, &factory_index, |_rk| {
+                            // on_events uses overlap check, not exact match.
+                            // If the directory exists with parquet files, assume it needs migration.
+                            true
+                        });
+                    }
+                }
+            }
+        }
+    }
 
     let mut range_data: HashMap<u64, Vec<BlockInfo>> = HashMap::new();
     let range_factory_data: HashMap<u64, FactoryAddressData> = HashMap::new();

--- a/src/raw_data/historical/catchup/eth_calls.rs
+++ b/src/raw_data/historical/catchup/eth_calls.rs
@@ -24,7 +24,7 @@ use crate::raw_data::historical::eth_calls::{
 };
 use crate::raw_data::historical::factories::{get_factory_call_configs, FactoryAddressData};
 use crate::storage::contract_index::{
-    build_expected_factory_contracts, migrate_downstream_index, read_contract_index,
+    build_expected_factory_contracts_for_range, migrate_downstream_index, read_contract_index,
 };
 use crate::storage::paths::factories_dir as factories_dir_path;
 use crate::raw_data::historical::receipts::{build_event_trigger_matchers, extract_event_triggers};
@@ -126,7 +126,7 @@ pub async fn collect_eth_calls(
             range_regular_done: HashSet::new(),
             range_factory_done: HashSet::new(),
             factory_skipped_triggers: Vec::new(),
-            expected_by_collection: build_expected_factory_contracts(&chain.contracts),
+            contracts: chain.contracts.clone(),
         });
     }
 
@@ -682,7 +682,6 @@ pub async fn collect_eth_calls(
         let total_log_ranges = log_ranges.len();
         let mut event_catchup_count = 0;
         let s3_manifest_arc = s3_manifest.as_ref().map(|m| Arc::new(m.clone()));
-        let event_expected_by_collection = build_expected_factory_contracts(&chain.contracts);
 
         tracing::info!(
             "Event-triggered calls catchup: checking {} log ranges for chain {}",
@@ -691,6 +690,10 @@ pub async fn collect_eth_calls(
         );
 
         for (idx, log_range) in log_ranges.iter().enumerate() {
+            // Build per-range expected factory contracts (omits sources not yet active)
+            let event_expected_for_range =
+                build_expected_factory_contracts_for_range(&chain.contracts, log_range.end);
+
             // Check if output already exists for all event-triggered call configs
             let mut needs_processing = false;
             for configs in event_call_configs.values() {
@@ -703,7 +706,7 @@ pub async fn collect_eth_calls(
                     }
                     // For factory configs, pass expected contracts for contract index checking
                     let expected_for_config = if config.is_factory {
-                        event_expected_by_collection.get(&config.contract_name).cloned()
+                        event_expected_for_range.get(&config.contract_name).cloned()
                     } else {
                         None
                     };
@@ -795,7 +798,7 @@ pub async fn collect_eth_calls(
                     multicall_addr,
                     range_start,
                     range_end,
-                    &event_expected_by_collection,
+                    &chain.contracts,
                 )
                 .await?
             } else {
@@ -816,7 +819,7 @@ pub async fn collect_eth_calls(
                     &event_ctx,
                     range_start,
                     range_end,
-                    &event_expected_by_collection,
+                    &chain.contracts,
                 )
                 .await?
             };
@@ -888,6 +891,6 @@ pub async fn collect_eth_calls(
         range_regular_done,
         range_factory_done,
         factory_skipped_triggers: Vec::new(),
-        expected_by_collection: build_expected_factory_contracts(&chain.contracts),
+        contracts: chain.contracts.clone(),
     })
 }

--- a/src/raw_data/historical/catchup/eth_calls.rs
+++ b/src/raw_data/historical/catchup/eth_calls.rs
@@ -515,10 +515,6 @@ pub async fn collect_eth_calls(
                     }
                 }
 
-                if addresses_by_block.is_empty() {
-                    continue;
-                }
-
                 let factory_data = FactoryAddressData {
                     range_start: range.start,
                     range_end: range.end,

--- a/src/raw_data/historical/catchup/eth_calls.rs
+++ b/src/raw_data/historical/catchup/eth_calls.rs
@@ -20,7 +20,7 @@ use crate::raw_data::historical::eth_calls::{
     process_once_calls_multicall, process_once_calls_regular, process_range,
     process_range_multicall, read_logs_from_parquet_async, scan_existing_parquet_files_async,
     AbortOnDropHandles, BlockInfo, BlockRange, EthCallCatchupState, EthCallCollectionError,
-    EthCallContext, FrequencyState,
+    EthCallContext, FrequencyState, OnceCallConfig,
 };
 use crate::raw_data::historical::factories::{get_factory_call_configs, FactoryAddressData};
 use crate::storage::contract_index::build_expected_factory_contracts_for_range;
@@ -32,8 +32,37 @@ use crate::storage::factory_data::{
 use crate::storage::paths::raw_eth_calls_dir;
 use crate::storage::{DataLoader, S3Manifest, StorageManager};
 use crate::types::config::chain::ChainConfig;
-use crate::types::config::contract::AddressOrAddresses;
+use crate::types::config::contract::{AddressOrAddresses, Contracts};
 use crate::types::config::raw_data::RawDataCollectionConfig;
+
+/// Extracted helper: processes factory-once catchup for a single block range.
+///
+/// Builds a `FactoryAddressData` from the provided `addresses_by_block`, computes
+/// expected factory contracts for the range, and delegates to `process_factory_once_calls`.
+pub(crate) async fn process_factory_once_catchup_range(
+    range: &BlockRange,
+    addresses_by_block: HashMap<u64, Vec<(u64, Address, String)>>,
+    ctx: &EthCallContext<'_>,
+    factory_once_configs: &HashMap<String, Vec<OnceCallConfig>>,
+    factory_once_column_indexes: &HashMap<String, HashMap<String, Vec<String>>>,
+    contracts: &Contracts,
+) -> Result<(), EthCallCollectionError> {
+    let factory_data = FactoryAddressData {
+        range_start: range.start,
+        range_end: range.end,
+        addresses_by_block,
+    };
+    let expected_once = build_expected_factory_contracts_for_range(contracts, range.end);
+    process_factory_once_calls(
+        range,
+        ctx,
+        &factory_data,
+        factory_once_configs,
+        factory_once_column_indexes,
+        Some(&expected_once),
+    )
+    .await
+}
 
 #[allow(clippy::too_many_arguments)]
 pub async fn collect_eth_calls(
@@ -515,12 +544,6 @@ pub async fn collect_eth_calls(
                     }
                 }
 
-                let factory_data = FactoryAddressData {
-                    range_start: range.start,
-                    range_end: range.end,
-                    addresses_by_block,
-                };
-
                 let factory_once_ctx = EthCallContext {
                     client,
                     output_dir: &base_output_dir,
@@ -531,15 +554,14 @@ pub async fn collect_eth_calls(
                     storage_manager: storage_manager.as_ref(),
                     s3_manifest: &s3_manifest,
                 };
-                let expected_once =
-                    build_expected_factory_contracts_for_range(&chain.contracts, range.end);
-                process_factory_once_calls(
+
+                process_factory_once_catchup_range(
                     &range,
+                    addresses_by_block,
                     &factory_once_ctx,
-                    &factory_data,
                     &factory_once_configs,
                     &factory_once_column_indexes,
-                    Some(&expected_once),
+                    &chain.contracts,
                 )
                 .await?;
 
@@ -819,4 +841,94 @@ pub async fn collect_eth_calls(
         factory_skipped_triggers: Vec::new(),
         contracts: chain.contracts.clone(),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    use crate::raw_data::historical::eth_calls::parquet_io::{
+        extract_addresses_from_once_parquet, read_existing_once_parquet,
+        read_parquet_column_names,
+    };
+    use crate::rpc::UnifiedRpcClient;
+
+    #[tokio::test]
+    async fn test_factory_once_catchup_zero_address_range_still_processes() {
+        let tmp = TempDir::new().unwrap();
+        let client = Arc::new(UnifiedRpcClient::from_url("http://127.0.0.1:8545").unwrap());
+
+        let mut once_configs: HashMap<String, Vec<OnceCallConfig>> = HashMap::new();
+        once_configs.insert(
+            "test_collection".to_string(),
+            vec![OnceCallConfig {
+                function_name: "testFn".to_string(),
+                function_selector: [0u8; 4],
+                preencoded_calldata: None,
+                params: vec![],
+                target_addresses: None,
+                start_block: None,
+            }],
+        );
+
+        let column_indexes = HashMap::new();
+        let contracts = HashMap::new(); // empty contracts = no expected_contracts entries
+
+        let existing_files = HashSet::new();
+        let ctx = EthCallContext {
+            client: &client,
+            output_dir: tmp.path(),
+            existing_files: &existing_files,
+            rpc_batch_size: 10,
+            decoder_tx: &None,
+            chain_name: "test",
+            storage_manager: None,
+            s3_manifest: &None,
+        };
+
+        let range = BlockRange { start: 0, end: 100 };
+        let addresses_by_block = HashMap::new(); // empty = zero-address range
+
+        let result = process_factory_once_catchup_range(
+            &range,
+            addresses_by_block,
+            &ctx,
+            &once_configs,
+            &column_indexes,
+            &contracts,
+        )
+        .await;
+
+        assert!(result.is_ok(), "processing empty range should succeed");
+
+        // Verify empty parquet was written
+        let parquet_path = tmp.path().join("test_collection/once/0-99.parquet");
+        assert!(
+            parquet_path.exists(),
+            "empty parquet must be written for zero-address range"
+        );
+
+        // Verify column names include our test function
+        let cols = read_parquet_column_names(&parquet_path);
+        assert!(
+            cols.contains("testFn"),
+            "parquet schema must include testFn column"
+        );
+
+        // Verify zero rows
+        let batches = read_existing_once_parquet(&parquet_path).unwrap();
+        let addrs = extract_addresses_from_once_parquet(&batches);
+        assert!(addrs.is_empty(), "empty range parquet must have 0 rows");
+
+        // Verify column index was written
+        assert!(
+            tmp.path()
+                .join("test_collection/once/column_index.json")
+                .exists(),
+            "column_index.json must be written"
+        );
+    }
 }

--- a/src/raw_data/historical/catchup/eth_calls.rs
+++ b/src/raw_data/historical/catchup/eth_calls.rs
@@ -23,6 +23,7 @@ use crate::raw_data::historical::eth_calls::{
     EthCallContext, FrequencyState,
 };
 use crate::raw_data::historical::factories::{get_factory_call_configs, FactoryAddressData};
+use crate::storage::contract_index::build_expected_factory_contracts;
 use crate::raw_data::historical::receipts::{build_event_trigger_matchers, extract_event_triggers};
 use crate::rpc::UnifiedRpcClient;
 use crate::storage::factory_data::{
@@ -122,6 +123,7 @@ pub async fn collect_eth_calls(
             range_regular_done: HashSet::new(),
             range_factory_done: HashSet::new(),
             factory_skipped_triggers: Vec::new(),
+            expected_by_collection: build_expected_factory_contracts(&chain.contracts),
         });
     }
 
@@ -607,6 +609,7 @@ pub async fn collect_eth_calls(
         let total_log_ranges = log_ranges.len();
         let mut event_catchup_count = 0;
         let s3_manifest_arc = s3_manifest.as_ref().map(|m| Arc::new(m.clone()));
+        let event_expected_by_collection = build_expected_factory_contracts(&chain.contracts);
 
         tracing::info!(
             "Event-triggered calls catchup: checking {} log ranges for chain {}",
@@ -625,6 +628,12 @@ pub async fn collect_eth_calls(
                             continue;
                         }
                     }
+                    // For factory configs, pass expected contracts for contract index checking
+                    let expected_for_config = if config.is_factory {
+                        event_expected_by_collection.get(&config.contract_name).cloned()
+                    } else {
+                        None
+                    };
                     if !event_output_exists_async(
                         base_output_dir.clone(),
                         config.contract_name.clone(),
@@ -632,6 +641,7 @@ pub async fn collect_eth_calls(
                         log_range.start,
                         log_range.end,
                         s3_manifest_arc.clone(),
+                        expected_for_config,
                     )
                     .await?
                     {
@@ -712,6 +722,7 @@ pub async fn collect_eth_calls(
                     multicall_addr,
                     range_start,
                     range_end,
+                    &event_expected_by_collection,
                 )
                 .await?
             } else {
@@ -732,6 +743,7 @@ pub async fn collect_eth_calls(
                     &event_ctx,
                     range_start,
                     range_end,
+                    &event_expected_by_collection,
                 )
                 .await?
             };
@@ -803,5 +815,6 @@ pub async fn collect_eth_calls(
         range_regular_done,
         range_factory_done,
         factory_skipped_triggers: Vec::new(),
+        expected_by_collection: build_expected_factory_contracts(&chain.contracts),
     })
 }

--- a/src/raw_data/historical/catchup/eth_calls.rs
+++ b/src/raw_data/historical/catchup/eth_calls.rs
@@ -850,11 +850,16 @@ mod tests {
     use std::sync::Arc;
     use tempfile::TempDir;
 
+    use alloy::primitives::{Address, U256};
     use crate::raw_data::historical::eth_calls::parquet_io::{
         extract_addresses_from_once_parquet, read_existing_once_parquet,
         read_parquet_column_names,
     };
     use crate::rpc::UnifiedRpcClient;
+    use crate::types::config::contract::{
+        AddressOrAddresses, ContractConfig, FactoryConfig, FactoryEventConfig,
+        FactoryEventConfigOrArray, FactoryParameterLocation,
+    };
 
     #[tokio::test]
     async fn test_factory_once_catchup_zero_address_range_still_processes() {
@@ -875,7 +880,27 @@ mod tests {
         );
 
         let column_indexes = HashMap::new();
-        let contracts = HashMap::new(); // empty contracts = no expected_contracts entries
+        let mut contracts = HashMap::new();
+        contracts.insert(
+            "TestFactory".to_string(),
+            ContractConfig {
+                address: AddressOrAddresses::Single(Address::new([0xaa; 20])),
+                start_block: Some(U256::from(0)),
+                calls: None,
+                factories: Some(vec![FactoryConfig {
+                    collection: "test_collection".to_string(),
+                    factory_events: FactoryEventConfigOrArray::Single(FactoryEventConfig {
+                        name: "Created".to_string(),
+                        topics_signature: "Created(address)".to_string(),
+                        data_signature: None,
+                        factory_parameters: FactoryParameterLocation::Data(vec![0]),
+                    }),
+                    calls: None,
+                    events: None,
+                }]),
+                events: None,
+            },
+        );
 
         let existing_files = HashSet::new();
         let ctx = EthCallContext {
@@ -929,6 +954,14 @@ mod tests {
                 .join("test_collection/once/column_index.json")
                 .exists(),
             "column_index.json must be written"
+        );
+
+        // Verify contract index was written (requires non-empty contracts config)
+        assert!(
+            tmp.path()
+                .join("test_collection/once/contract_index.json")
+                .exists(),
+            "contract_index.json must be written when expected_contracts is non-empty"
         );
     }
 }

--- a/src/raw_data/historical/catchup/eth_calls.rs
+++ b/src/raw_data/historical/catchup/eth_calls.rs
@@ -23,10 +23,7 @@ use crate::raw_data::historical::eth_calls::{
     EthCallContext, FrequencyState,
 };
 use crate::raw_data::historical::factories::{get_factory_call_configs, FactoryAddressData};
-use crate::storage::contract_index::{
-    build_expected_factory_contracts_for_range, migrate_downstream_index, read_contract_index,
-};
-use crate::storage::paths::factories_dir as factories_dir_path;
+use crate::storage::contract_index::build_expected_factory_contracts_for_range;
 use crate::raw_data::historical::receipts::{build_event_trigger_matchers, extract_event_triggers};
 use crate::rpc::UnifiedRpcClient;
 use crate::storage::factory_data::{
@@ -160,76 +157,6 @@ pub async fn collect_eth_calls(
     );
 
     let existing_files = scan_existing_parquet_files_async(base_output_dir.clone()).await;
-
-    // =========================================================================
-    // Migration: seed downstream contract indexes from the factory layer
-    // =========================================================================
-    if has_factory_calls || has_factory_once_calls || has_event_triggered_calls {
-        let factories_dir = factories_dir_path(&chain.name);
-        let factory_collection_names: HashSet<String> =
-            factory_call_configs.keys().cloned().collect();
-
-        for collection in &factory_collection_names {
-            let factory_index = {
-                let dir = factories_dir.join(collection);
-                let d = dir.clone();
-                tokio::task::spawn_blocking(move || read_contract_index(&d))
-                    .await
-                    .unwrap_or_default()
-            };
-            if factory_index.is_empty() {
-                continue;
-            }
-
-            // Migrate regular call indexes: {collection}/{function}/contract_index.json
-            if let Some(configs) = factory_call_configs.get(collection) {
-                for config in configs {
-                    let function_name = config
-                        .function
-                        .split('(')
-                        .next()
-                        .unwrap_or(&config.function);
-                    let sub_dir = base_output_dir.join(collection).join(function_name);
-                    let ef = &existing_files;
-                    migrate_downstream_index(&sub_dir, &factory_index, |rk| {
-                        let file = format!("{}/{}/{}.parquet", collection, function_name, rk);
-                        ef.contains(&file)
-                    });
-                }
-            }
-
-            // Migrate once call indexes: {collection}/once/contract_index.json
-            let once_dir = base_output_dir.join(collection).join("once");
-            if once_dir.exists() {
-                let ef = &existing_files;
-                let coll = collection.clone();
-                migrate_downstream_index(&once_dir, &factory_index, |rk| {
-                    let file = format!("{}/once/{}.parquet", coll, rk);
-                    ef.contains(&file)
-                });
-            }
-
-            // Migrate on_events indexes: {collection}/{function}/on_events/contract_index.json
-            for configs in event_call_configs.values() {
-                for config in configs {
-                    if config.contract_name != *collection {
-                        continue;
-                    }
-                    let sub_dir = base_output_dir
-                        .join(collection)
-                        .join(&config.function_name)
-                        .join("on_events");
-                    if sub_dir.exists() {
-                        migrate_downstream_index(&sub_dir, &factory_index, |_rk| {
-                            // on_events uses overlap check, not exact match.
-                            // If the directory exists with parquet files, assume it needs migration.
-                            true
-                        });
-                    }
-                }
-            }
-        }
-    }
 
     let mut range_data: HashMap<u64, Vec<BlockInfo>> = HashMap::new();
     let range_factory_data: HashMap<u64, FactoryAddressData> = HashMap::new();
@@ -608,12 +535,15 @@ pub async fn collect_eth_calls(
                     storage_manager: storage_manager.as_ref(),
                     s3_manifest: &s3_manifest,
                 };
+                let expected_once =
+                    build_expected_factory_contracts_for_range(&chain.contracts, range.end);
                 process_factory_once_calls(
                     &range,
                     &factory_once_ctx,
                     &factory_data,
                     &factory_once_configs,
                     &factory_once_column_indexes,
+                    Some(&expected_once),
                 )
                 .await?;
 

--- a/src/raw_data/historical/catchup/factories.rs
+++ b/src/raw_data/historical/catchup/factories.rs
@@ -14,8 +14,12 @@ use crate::raw_data::historical::factories::{
     process_range_batches, read_log_batches_from_parquet_async, scan_existing_parquet_files,
     FactoryAddressData, FactoryCatchupState, FactoryCollectionError, RecollectRequest,
 };
+use crate::storage::contract_index::{
+    build_expected_factory_contracts, get_missing_contracts, range_key, read_contract_index,
+    update_contract_index, write_contract_index, ContractIndex,
+};
 use crate::storage::paths::factories_dir as factories_dir_path;
-use crate::storage::{DataLoader, S3Manifest, StorageManager};
+use crate::storage::{upload_sidecar_to_s3, DataLoader, S3Manifest, StorageManager};
 use crate::types::config::chain::ChainConfig;
 use crate::types::config::raw_data::RawDataCollectionConfig;
 
@@ -129,9 +133,25 @@ pub async fn collect_factories(
     let factory_collection_names: HashSet<String> =
         matchers.iter().map(|m| m.collection_name.clone()).collect();
 
+    // Build expected contracts per collection from current config
+    let expected_by_collection = build_expected_factory_contracts(&chain.contracts);
+
+    // Pre-load contract indexes for each collection to avoid repeated disk reads
+    let mut contract_indexes: HashMap<String, ContractIndex> = HashMap::new();
+    for collection in &factory_collection_names {
+        let dir = output_dir.join(collection);
+        let idx = {
+            let dir_clone = dir.clone();
+            tokio::task::spawn_blocking(move || read_contract_index(&dir_clone))
+                .await
+                .unwrap_or_default()
+        };
+        contract_indexes.insert(collection.clone(), idx);
+    }
+
     // =========================================================================
     // Catchup phase: Process existing logs files where factory files are missing
-    // This avoids re-fetching receipts when logs already exist
+    // or where the contract index shows missing contracts/addresses
     // =========================================================================
     let log_ranges = {
         let chain_name = chain.name.clone();
@@ -152,26 +172,43 @@ pub async fn collect_factories(
     let storage_manager = Arc::new(storage_manager);
     let chain_name = Arc::new(chain.name.clone());
 
+    // Track which ranges were successfully processed for contract index updates
+    let mut processed_ranges: Vec<(u64, u64)> = Vec::new();
+
     {
         let semaphore = Arc::new(Semaphore::new(factory_concurrency));
-        let mut join_set: JoinSet<Result<Option<FactoryAddressData>, FactoryCollectionError>> =
+        let mut join_set: JoinSet<Result<Option<(u64, u64, FactoryAddressData)>, FactoryCollectionError>> =
             JoinSet::new();
 
         for log_range in &log_ranges {
-            let all_factory_files_exist = factory_collection_names.iter().all(|collection| {
+            let rk = range_key(log_range.start, log_range.end - 1);
+
+            let range_complete = factory_collection_names.iter().all(|collection| {
                 let rel_path = format!(
                     "{}/{}-{}.parquet",
                     collection,
                     log_range.start,
                     log_range.end - 1
                 );
-                existing_files.contains(&rel_path)
+                let file_exists = existing_files.contains(&rel_path)
                     || s3_manifest.as_ref().as_ref().is_some_and(|m| {
                         m.has_factories(collection, log_range.start, log_range.end - 1)
-                    })
+                    });
+
+                if !file_exists {
+                    return false;
+                }
+
+                // File exists — check contract index for missing contracts
+                if let Some(expected) = expected_by_collection.get(collection) {
+                    let index = contract_indexes.get(collection).cloned().unwrap_or_default();
+                    get_missing_contracts(&index, &rk, expected).is_empty()
+                } else {
+                    true
+                }
             });
 
-            if all_factory_files_exist {
+            if range_complete {
                 continue;
             }
 
@@ -287,9 +324,9 @@ pub async fn collect_factories(
                     total_rows
                 );
 
-                process_range_batches(start, end, batches, &matchers, &output_dir, &existing_files, s3_manifest.as_ref().as_ref(), storage_manager.as_ref().as_ref(), &chain_name)
-                    .await
-                    .map(Some)
+                let data = process_range_batches(start, end, batches, &matchers, &output_dir, &existing_files, s3_manifest.as_ref().as_ref(), storage_manager.as_ref().as_ref(), &chain_name)
+                    .await?;
+                Ok(Some((start, end, data)))
             });
         }
 
@@ -297,7 +334,10 @@ pub async fn collect_factories(
 
         while let Some(result) = join_set.join_next().await {
             match result {
-                Ok(Ok(Some(data))) => catchup_results.push(data),
+                Ok(Ok(Some((start, end, data)))) => {
+                    processed_ranges.push((start, end));
+                    catchup_results.push(data);
+                }
                 Ok(Ok(None)) => {} // Skipped (corrupt/unreadable file)
                 Ok(Err(e)) => {
                     tracing::error!("Factory catchup task failed: {:?}", e);
@@ -366,6 +406,36 @@ pub async fn collect_factories(
             "Factory catchup complete: processed {} ranges from logs files for chain {}",
             catchup_count,
             chain.name
+        );
+    }
+
+    // Write contract index for all processed ranges (accumulated in memory to
+    // avoid concurrent writes from the JoinSet tasks).
+    if !processed_ranges.is_empty() {
+        for collection in &factory_collection_names {
+            if let Some(expected) = expected_by_collection.get(collection) {
+                let index = contract_indexes.entry(collection.clone()).or_default();
+                for &(start, end) in &processed_ranges {
+                    let rk = range_key(start, end - 1);
+                    update_contract_index(index, &rk, expected);
+                }
+                let dir = output_dir.join(collection);
+                write_contract_index(&dir, index)
+                    .map_err(|e| FactoryCollectionError::Io(e))?;
+
+                // Upload contract index to S3
+                if let Some(ref sm) = storage_manager.as_ref() {
+                    let index_path = dir.join("contract_index.json");
+                    upload_sidecar_to_s3(sm, &index_path)
+                        .await
+                        .map_err(|e| FactoryCollectionError::Io(std::io::Error::other(e.to_string())))?;
+                }
+            }
+        }
+        tracing::info!(
+            "Updated contract index for {} factory collections ({} ranges)",
+            factory_collection_names.len(),
+            processed_ranges.len()
         );
     }
 

--- a/src/raw_data/historical/catchup/factories.rs
+++ b/src/raw_data/historical/catchup/factories.rs
@@ -15,8 +15,9 @@ use crate::raw_data::historical::factories::{
     FactoryAddressData, FactoryCatchupState, FactoryCollectionError, RecollectRequest,
 };
 use crate::storage::contract_index::{
-    build_expected_factory_contracts, get_missing_contracts, range_key, read_contract_index,
-    update_contract_index, write_contract_index, ContractIndex,
+    build_address_contract_map, build_expected_factory_contracts, detect_contracts_in_log_parquet,
+    get_missing_contracts, range_key, read_contract_index, update_contract_index,
+    write_contract_index, ContractIndex,
 };
 use crate::storage::paths::factories_dir as factories_dir_path;
 use crate::storage::{upload_sidecar_to_s3, DataLoader, S3Manifest, StorageManager};
@@ -147,6 +148,133 @@ pub async fn collect_factories(
                 .unwrap_or_default()
         };
         contract_indexes.insert(collection.clone(), idx);
+    }
+
+    // =========================================================================
+    // Migration: build contract_index.json from existing data if missing
+    // =========================================================================
+    let needs_migration = factory_collection_names
+        .iter()
+        .any(|c| contract_indexes.get(c).map_or(true, |idx| idx.is_empty()));
+
+    if needs_migration {
+        tracing::info!(
+            "Contract index migration: scanning log files to build index for existing factory ranges"
+        );
+        let address_maps = build_address_contract_map(&chain.contracts);
+        let log_ranges_for_migration = {
+            let chain_name = chain.name.clone();
+            let s3_manifest_clone = s3_manifest.clone();
+            tokio::task::spawn_blocking(move || {
+                get_existing_log_ranges(&chain_name, s3_manifest_clone.as_ref())
+            })
+            .await
+            .map_err(|e| FactoryCollectionError::JoinError(e.to_string()))?
+        };
+
+        let mut migrated_count = 0usize;
+        for log_range in &log_ranges_for_migration {
+            let rk = range_key(log_range.start, log_range.end - 1);
+
+            // Only migrate ranges that have factory parquet but no index entry
+            let any_needs_migration = factory_collection_names.iter().any(|collection| {
+                let rel_path = format!(
+                    "{}/{}-{}.parquet",
+                    collection,
+                    log_range.start,
+                    log_range.end - 1
+                );
+                let file_exists = existing_files.contains(&rel_path)
+                    || s3_manifest
+                        .as_ref()
+                        .is_some_and(|m| m.has_factories(collection, log_range.start, log_range.end - 1));
+                if !file_exists {
+                    return false;
+                }
+                let index = contract_indexes.get(collection).cloned().unwrap_or_default();
+                !index.contains_key(&rk)
+            });
+
+            if !any_needs_migration {
+                continue;
+            }
+
+            // Scan the log parquet to detect which contracts were present
+            if !log_range.file_path.exists() {
+                continue;
+            }
+
+            match detect_contracts_in_log_parquet(&log_range.file_path, &address_maps) {
+                Ok(detected) => {
+                    for (collection, contracts_found) in &detected {
+                        let index = contract_indexes.entry(collection.clone()).or_default();
+                        if !index.contains_key(&rk) {
+                            update_contract_index(index, &rk, contracts_found);
+                        }
+                    }
+                    // Also record collections where no source addresses were found
+                    // (the range was processed but had no matching events)
+                    for collection in &factory_collection_names {
+                        if !detected.contains_key(collection) {
+                            let rel_path = format!(
+                                "{}/{}-{}.parquet",
+                                collection,
+                                log_range.start,
+                                log_range.end - 1
+                            );
+                            let file_exists = existing_files.contains(&rel_path)
+                                || s3_manifest.as_ref().is_some_and(|m| {
+                                    m.has_factories(collection, log_range.start, log_range.end - 1)
+                                });
+                            if file_exists {
+                                let index = contract_indexes.entry(collection.clone()).or_default();
+                                if !index.contains_key(&rk) {
+                                    // No source addresses matched, but the file exists.
+                                    // Record an empty entry so we don't re-scan.
+                                    // Use detected (empty for this collection) which is correct:
+                                    // no contracts contributed, so empty map.
+                                    update_contract_index(
+                                        index,
+                                        &rk,
+                                        detected.get(collection).unwrap_or(&HashMap::new()),
+                                    );
+                                }
+                            }
+                        }
+                    }
+                    migrated_count += 1;
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "Migration: failed to scan log parquet {}: {}",
+                        log_range.file_path.display(),
+                        e
+                    );
+                }
+            }
+        }
+
+        // Write migrated indexes
+        if migrated_count > 0 {
+            for collection in &factory_collection_names {
+                if let Some(index) = contract_indexes.get(collection) {
+                    if !index.is_empty() {
+                        let dir = output_dir.join(collection);
+                        if let Err(e) = write_contract_index(&dir, index) {
+                            tracing::warn!(
+                                "Migration: failed to write contract index for {}: {}",
+                                collection,
+                                e
+                            );
+                        }
+                    }
+                }
+            }
+            tracing::info!(
+                "Contract index migration complete: built index from {} log ranges",
+                migrated_count
+            );
+        }
     }
 
     // =========================================================================

--- a/src/raw_data/historical/catchup/factories.rs
+++ b/src/raw_data/historical/catchup/factories.rs
@@ -15,9 +15,9 @@ use crate::raw_data::historical::factories::{
     FactoryAddressData, FactoryCatchupState, FactoryCollectionError, RecollectRequest,
 };
 use crate::storage::contract_index::{
-    build_address_contract_map, build_expected_factory_contracts, detect_contracts_in_log_parquet,
-    get_missing_contracts, range_key, read_contract_index, update_contract_index,
-    write_contract_index, ContractIndex,
+    build_address_contract_map, build_expected_factory_contracts_for_range,
+    detect_contracts_in_log_parquet, get_missing_contracts, range_key, read_contract_index,
+    update_contract_index, write_contract_index, ContractIndex,
 };
 use crate::storage::paths::factories_dir as factories_dir_path;
 use crate::storage::{upload_sidecar_to_s3, DataLoader, S3Manifest, StorageManager};
@@ -133,9 +133,6 @@ pub async fn collect_factories(
     // Get the factory collection names from matchers
     let factory_collection_names: HashSet<String> =
         matchers.iter().map(|m| m.collection_name.clone()).collect();
-
-    // Build expected contracts per collection from current config
-    let expected_by_collection = build_expected_factory_contracts(&chain.contracts);
 
     // Pre-load contract indexes for each collection to avoid repeated disk reads
     let mut contract_indexes: HashMap<String, ContractIndex> = HashMap::new();
@@ -328,7 +325,11 @@ pub async fn collect_factories(
                 }
 
                 // File exists — check contract index for missing contracts
-                if let Some(expected) = expected_by_collection.get(collection) {
+                let expected_for_range = build_expected_factory_contracts_for_range(
+                    &chain.contracts,
+                    log_range.end,
+                );
+                if let Some(expected) = expected_for_range.get(collection) {
                     let index = contract_indexes.get(collection).cloned().unwrap_or_default();
                     get_missing_contracts(&index, &rk, expected).is_empty()
                 } else {
@@ -541,12 +542,18 @@ pub async fn collect_factories(
     // avoid concurrent writes from the JoinSet tasks).
     if !processed_ranges.is_empty() {
         for collection in &factory_collection_names {
-            if let Some(expected) = expected_by_collection.get(collection) {
-                let index = contract_indexes.entry(collection.clone()).or_default();
-                for &(start, end) in &processed_ranges {
-                    let rk = range_key(start, end - 1);
+            let index = contract_indexes.entry(collection.clone()).or_default();
+            let mut wrote_any = false;
+            for &(start, end) in &processed_ranges {
+                let rk = range_key(start, end - 1);
+                let expected_for_range =
+                    build_expected_factory_contracts_for_range(&chain.contracts, end);
+                if let Some(expected) = expected_for_range.get(collection) {
                     update_contract_index(index, &rk, expected);
+                    wrote_any = true;
                 }
+            }
+            if wrote_any {
                 let dir = output_dir.join(collection);
                 write_contract_index(&dir, index)
                     .map_err(|e| FactoryCollectionError::Io(e))?;

--- a/src/raw_data/historical/current/eth_calls/events.rs
+++ b/src/raw_data/historical/current/eth_calls/events.rs
@@ -63,6 +63,7 @@ pub(super) async fn handle_event_trigger_message(
                         multicall_addr,
                         range_start,
                         inclusive_end,
+                        &state.expected_by_collection,
                     )
                     .await?
                 } else {
@@ -73,6 +74,7 @@ pub(super) async fn handle_event_trigger_message(
                         &ctx,
                         range_start,
                         inclusive_end,
+                        &state.expected_by_collection,
                     )
                     .await?
                 };

--- a/src/raw_data/historical/current/eth_calls/events.rs
+++ b/src/raw_data/historical/current/eth_calls/events.rs
@@ -11,6 +11,10 @@ use crate::raw_data::historical::eth_calls::{
 };
 use crate::raw_data::historical::receipts::EventTriggerMessage;
 use crate::rpc::UnifiedRpcClient;
+use crate::storage::contract_index::{
+    build_expected_factory_contracts_for_range, range_key, read_contract_index,
+    update_contract_index, write_contract_index,
+};
 use crate::storage::StorageManager;
 
 /// Handle a single `EventTriggerMessage` received from the event trigger channel.
@@ -63,7 +67,7 @@ pub(super) async fn handle_event_trigger_message(
                         multicall_addr,
                         range_start,
                         inclusive_end,
-                        &state.expected_by_collection,
+                        &state.contracts,
                     )
                     .await?
                 } else {
@@ -74,7 +78,7 @@ pub(super) async fn handle_event_trigger_message(
                         &ctx,
                         range_start,
                         inclusive_end,
-                        &state.expected_by_collection,
+                        &state.contracts,
                     )
                     .await?
                 };
@@ -132,6 +136,21 @@ pub(super) async fn handle_event_trigger_message(
                             "Wrote empty event-triggered eth_call file to {} (no matching events)",
                             output_path.display()
                         );
+                        let expected_for_range = build_expected_factory_contracts_for_range(
+                            &state.contracts,
+                            inclusive_end + 1,
+                        );
+                        if let Some(expected) = expected_for_range.get(&contract_name) {
+                            let rk = range_key(range_start, inclusive_end);
+                            let mut ci = read_contract_index(&sub_dir);
+                            update_contract_index(&mut ci, &rk, expected);
+                            if let Err(e) = write_contract_index(&sub_dir, &ci) {
+                                tracing::warn!(
+                                    "Failed to write contract index (empty on_events current): {}",
+                                    e
+                                );
+                            }
+                        }
                     }
                 }
             }

--- a/src/raw_data/historical/current/eth_calls/factory.rs
+++ b/src/raw_data/historical/current/eth_calls/factory.rs
@@ -94,7 +94,7 @@ pub(super) async fn handle_factory_message(
                                 multicall_addr,
                                 buf_range_start,
                                 buf_range_end,
-                                &state.expected_by_collection,
+                                &state.contracts,
                             )
                             .await?
                         } else {
@@ -105,7 +105,7 @@ pub(super) async fn handle_factory_message(
                                 &ctx,
                                 buf_range_start,
                                 buf_range_end,
-                                &state.expected_by_collection,
+                                &state.contracts,
                             )
                             .await?
                         };
@@ -175,7 +175,7 @@ pub(super) async fn handle_factory_message(
                                 &mut state.frequency_state,
                                 multicall_addr,
                                 None,
-                                &state.expected_by_collection,
+                                &state.contracts,
                             )
                             .await?;
                         } else {
@@ -188,7 +188,7 @@ pub(super) async fn handle_factory_message(
                                 state.factory_max_params,
                                 &mut state.frequency_state,
                                 None,
-                                &state.expected_by_collection,
+                                &state.contracts,
                             )
                             .await?;
                         }

--- a/src/raw_data/historical/current/eth_calls/factory.rs
+++ b/src/raw_data/historical/current/eth_calls/factory.rs
@@ -294,14 +294,44 @@ mod tests {
     use std::sync::Arc;
     use tempfile::TempDir;
 
+    use alloy::primitives::{Address, U256};
     use crate::raw_data::historical::eth_calls::{
         BlockInfo, EthCallCatchupState, FrequencyState, OnceCallConfig,
     };
     use crate::raw_data::historical::factories::FactoryAddressData;
     use crate::rpc::UnifiedRpcClient;
+    use crate::types::config::contract::{
+        AddressOrAddresses, ContractConfig, FactoryConfig, FactoryEventConfig,
+        FactoryEventConfigOrArray, FactoryParameterLocation,
+    };
 
     fn dummy_client() -> Arc<UnifiedRpcClient> {
         Arc::new(UnifiedRpcClient::from_url("http://127.0.0.1:8545").unwrap())
+    }
+
+    fn test_contracts() -> HashMap<String, ContractConfig> {
+        let mut contracts = HashMap::new();
+        contracts.insert(
+            "TestFactory".to_string(),
+            ContractConfig {
+                address: AddressOrAddresses::Single(Address::new([0xaa; 20])),
+                start_block: Some(U256::from(0)),
+                calls: None,
+                factories: Some(vec![FactoryConfig {
+                    collection: "test_collection".to_string(),
+                    factory_events: FactoryEventConfigOrArray::Single(FactoryEventConfig {
+                        name: "Created".to_string(),
+                        topics_signature: "Created(address)".to_string(),
+                        data_signature: None,
+                        factory_parameters: FactoryParameterLocation::Data(vec![0]),
+                    }),
+                    calls: None,
+                    events: None,
+                }]),
+                events: None,
+            },
+        );
+        contracts
     }
 
     fn factory_once_only_state(base_dir: &Path) -> EthCallCatchupState {
@@ -346,7 +376,7 @@ mod tests {
             range_regular_done: HashSet::new(),
             range_factory_done: HashSet::new(),
             factory_skipped_triggers: vec![],
-            contracts: HashMap::new(),
+            contracts: test_contracts(),
         }
     }
 
@@ -411,6 +441,12 @@ mod tests {
                 .join("test_collection/once/column_index.json")
                 .exists(),
             "column_index.json must be written"
+        );
+        assert!(
+            tmp.path()
+                .join("test_collection/once/contract_index.json")
+                .exists(),
+            "contract_index.json must be written when expected_contracts is non-empty"
         );
     }
 }

--- a/src/raw_data/historical/current/eth_calls/factory.rs
+++ b/src/raw_data/historical/current/eth_calls/factory.rs
@@ -94,6 +94,7 @@ pub(super) async fn handle_factory_message(
                                 multicall_addr,
                                 buf_range_start,
                                 buf_range_end,
+                                &state.expected_by_collection,
                             )
                             .await?
                         } else {
@@ -104,6 +105,7 @@ pub(super) async fn handle_factory_message(
                                 &ctx,
                                 buf_range_start,
                                 buf_range_end,
+                                &state.expected_by_collection,
                             )
                             .await?
                         };
@@ -173,6 +175,7 @@ pub(super) async fn handle_factory_message(
                                 &mut state.frequency_state,
                                 multicall_addr,
                                 None,
+                                &state.expected_by_collection,
                             )
                             .await?;
                         } else {
@@ -185,6 +188,7 @@ pub(super) async fn handle_factory_message(
                                 state.factory_max_params,
                                 &mut state.frequency_state,
                                 None,
+                                &state.expected_by_collection,
                             )
                             .await?;
                         }

--- a/src/raw_data/historical/current/eth_calls/factory.rs
+++ b/src/raw_data/historical/current/eth_calls/factory.rs
@@ -203,6 +203,7 @@ pub(super) async fn handle_factory_message(
                                     &state.factory_once_configs,
                                     &empty_index,
                                     multicall_addr,
+                                    None,
                                 )
                                 .await?;
                             } else {
@@ -212,6 +213,7 @@ pub(super) async fn handle_factory_message(
                                     factory_data,
                                     &state.factory_once_configs,
                                     &empty_index,
+                                    None,
                                 )
                                 .await?;
                             }

--- a/src/raw_data/historical/current/eth_calls/factory.rs
+++ b/src/raw_data/historical/current/eth_calls/factory.rs
@@ -11,6 +11,7 @@ use crate::raw_data::historical::eth_calls::{
 };
 use crate::raw_data::historical::factories::{FactoryAddressData, FactoryMessage};
 use crate::rpc::UnifiedRpcClient;
+use crate::storage::contract_index::build_expected_factory_contracts_for_range;
 use crate::storage::StorageManager;
 
 /// Handle a single `FactoryMessage` received from the factory channel.
@@ -143,7 +144,9 @@ pub(super) async fn handle_factory_message(
             range_end,
         }) => {
             if state.range_regular_done.contains(&range_start) {
-                if state.has_factory_calls && !state.range_factory_done.contains(&range_start) {
+                if (state.has_factory_calls || state.has_factory_once_calls)
+                    && !state.range_factory_done.contains(&range_start)
+                {
                     let range = BlockRange {
                         start: range_start,
                         end: range_end,
@@ -164,37 +167,43 @@ pub(super) async fn handle_factory_message(
                             s3_manifest: &state.s3_manifest,
                         };
 
-                        if let Some(multicall_addr) = state.multicall3_address {
-                            process_factory_range_multicall(
-                                &range,
-                                blocks,
-                                &ctx,
-                                factory_data,
-                                &state.factory_call_configs,
-                                state.factory_max_params,
-                                &mut state.frequency_state,
-                                multicall_addr,
-                                None,
-                                &state.contracts,
-                            )
-                            .await?;
-                        } else {
-                            process_factory_range(
-                                &range,
-                                blocks,
-                                &ctx,
-                                factory_data,
-                                &state.factory_call_configs,
-                                state.factory_max_params,
-                                &mut state.frequency_state,
-                                None,
-                                &state.contracts,
-                            )
-                            .await?;
+                        if state.has_factory_calls {
+                            if let Some(multicall_addr) = state.multicall3_address {
+                                process_factory_range_multicall(
+                                    &range,
+                                    blocks,
+                                    &ctx,
+                                    factory_data,
+                                    &state.factory_call_configs,
+                                    state.factory_max_params,
+                                    &mut state.frequency_state,
+                                    multicall_addr,
+                                    None,
+                                    &state.contracts,
+                                )
+                                .await?;
+                            } else {
+                                process_factory_range(
+                                    &range,
+                                    blocks,
+                                    &ctx,
+                                    factory_data,
+                                    &state.factory_call_configs,
+                                    state.factory_max_params,
+                                    &mut state.frequency_state,
+                                    None,
+                                    &state.contracts,
+                                )
+                                .await?;
+                            }
                         }
 
                         if state.has_factory_once_calls {
                             let empty_index = HashMap::new();
+                            let expected_once = build_expected_factory_contracts_for_range(
+                                &state.contracts,
+                                range.end,
+                            );
                             if let Some(multicall_addr) = state.multicall3_address {
                                 process_factory_once_calls_multicall(
                                     &range,
@@ -203,7 +212,7 @@ pub(super) async fn handle_factory_message(
                                     &state.factory_once_configs,
                                     &empty_index,
                                     multicall_addr,
-                                    None,
+                                    Some(&expected_once),
                                 )
                                 .await?;
                             } else {
@@ -213,7 +222,7 @@ pub(super) async fn handle_factory_message(
                                     factory_data,
                                     &state.factory_once_configs,
                                     &empty_index,
-                                    None,
+                                    Some(&expected_once),
                                 )
                                 .await?;
                             }
@@ -249,7 +258,8 @@ pub(super) async fn handle_factory_message(
                 }
 
                 if state.range_regular_done.contains(&range_start)
-                    && (!state.has_factory_calls || state.range_factory_done.contains(&range_start))
+                    && ((!state.has_factory_calls && !state.has_factory_once_calls)
+                        || state.range_factory_done.contains(&range_start))
                 {
                     state.range_data.remove(&range_start);
                     state.range_factory_data.remove(&range_start);

--- a/src/raw_data/historical/current/eth_calls/factory.rs
+++ b/src/raw_data/historical/current/eth_calls/factory.rs
@@ -285,3 +285,132 @@ pub(super) async fn handle_factory_message(
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::{HashMap, HashSet};
+    use std::path::Path;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    use crate::raw_data::historical::eth_calls::{
+        BlockInfo, EthCallCatchupState, FrequencyState, OnceCallConfig,
+    };
+    use crate::raw_data::historical::factories::FactoryAddressData;
+    use crate::rpc::UnifiedRpcClient;
+
+    fn dummy_client() -> Arc<UnifiedRpcClient> {
+        Arc::new(UnifiedRpcClient::from_url("http://127.0.0.1:8545").unwrap())
+    }
+
+    fn factory_once_only_state(base_dir: &Path) -> EthCallCatchupState {
+        let mut factory_once_configs = HashMap::new();
+        factory_once_configs.insert(
+            "test_collection".to_string(),
+            vec![OnceCallConfig {
+                function_name: "testFn".to_string(),
+                function_selector: [0u8; 4],
+                preencoded_calldata: None,
+                params: vec![],
+                target_addresses: None,
+                start_block: None,
+            }],
+        );
+
+        EthCallCatchupState {
+            base_output_dir: base_dir.to_path_buf(),
+            range_size: 100,
+            rpc_batch_size: 10,
+            multicall3_address: None,
+            call_configs: vec![],
+            factory_call_configs: HashMap::new(),
+            event_call_configs: HashMap::new(),
+            once_configs: HashMap::new(),
+            factory_once_configs,
+            has_regular_calls: false,
+            has_once_calls: false,
+            has_factory_calls: false,
+            has_factory_once_calls: true,
+            has_event_triggered_calls: false,
+            max_params: 0,
+            factory_max_params: 0,
+            existing_files: HashSet::new(),
+            s3_manifest: None,
+            factory_addresses: HashMap::new(),
+            frequency_state: FrequencyState {
+                last_call_times: HashMap::new(),
+            },
+            range_data: HashMap::new(),
+            range_factory_data: HashMap::new(),
+            range_regular_done: HashSet::new(),
+            range_factory_done: HashSet::new(),
+            factory_skipped_triggers: vec![],
+            contracts: HashMap::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_factory_rangecomplete_runs_factory_once_without_factory_calls() {
+        let tmp = TempDir::new().unwrap();
+        let client = dummy_client();
+        let mut state = factory_once_only_state(tmp.path());
+
+        // Pre-populate: regular processing done, block data available
+        state.range_regular_done.insert(0);
+        state
+            .range_data
+            .insert(0, vec![BlockInfo { block_number: 0, timestamp: 100 }]);
+        state.range_factory_data.insert(
+            0,
+            FactoryAddressData {
+                range_start: 0,
+                range_end: 100,
+                addresses_by_block: HashMap::new(),
+            },
+        );
+
+        let mut factory_rx = None;
+
+        handle_factory_message(
+            Some(FactoryMessage::RangeComplete {
+                range_start: 0,
+                range_end: 100,
+            }),
+            &mut state,
+            &client,
+            &mut factory_rx,
+            &None,
+            "test",
+            None,
+        )
+        .await
+        .unwrap();
+
+        // Factory processing marked done
+        assert!(
+            state.range_factory_done.contains(&0),
+            "range_factory_done must be set"
+        );
+        // Both regular and factory done -> range data cleaned up
+        assert!(
+            !state.range_data.contains_key(&0),
+            "range_data should be cleaned up"
+        );
+
+        // Verify empty parquet was written (BlockRange { start: 0, end: 100 } -> 0-99.parquet)
+        let parquet_path = tmp.path().join("test_collection/once/0-99.parquet");
+        assert!(
+            parquet_path.exists(),
+            "empty parquet must be written via late-arrival factory-once path"
+        );
+
+        // Verify sidecars
+        assert!(
+            tmp.path()
+                .join("test_collection/once/column_index.json")
+                .exists(),
+            "column_index.json must be written"
+        );
+    }
+}

--- a/src/raw_data/historical/current/eth_calls/range_processor.rs
+++ b/src/raw_data/historical/current/eth_calls/range_processor.rs
@@ -333,10 +333,15 @@ mod tests {
     use std::sync::Arc;
     use tempfile::TempDir;
 
+    use alloy::primitives::{Address, U256};
     use crate::raw_data::historical::eth_calls::{BlockInfo, OnceCallConfig, FrequencyState};
     use crate::raw_data::historical::factories::FactoryAddressData;
     use crate::rpc::UnifiedRpcClient;
     use crate::types::config::chain::ChainConfig;
+    use crate::types::config::contract::{
+        AddressOrAddresses, ContractConfig, FactoryConfig, FactoryEventConfig,
+        FactoryEventConfigOrArray, FactoryParameterLocation,
+    };
 
     fn test_chain() -> ChainConfig {
         ChainConfig {
@@ -354,6 +359,34 @@ mod tests {
 
     fn dummy_client() -> Arc<UnifiedRpcClient> {
         Arc::new(UnifiedRpcClient::from_url("http://127.0.0.1:8545").unwrap())
+    }
+
+    /// Contracts config with a factory entry for "test_collection" so that
+    /// `build_expected_factory_contracts_for_range` returns a non-empty map
+    /// and the contract_index.json write path is exercised.
+    fn test_contracts() -> HashMap<String, ContractConfig> {
+        let mut contracts = HashMap::new();
+        contracts.insert(
+            "TestFactory".to_string(),
+            ContractConfig {
+                address: AddressOrAddresses::Single(Address::new([0xaa; 20])),
+                start_block: Some(U256::from(0)),
+                calls: None,
+                factories: Some(vec![FactoryConfig {
+                    collection: "test_collection".to_string(),
+                    factory_events: FactoryEventConfigOrArray::Single(FactoryEventConfig {
+                        name: "Created".to_string(),
+                        topics_signature: "Created(address)".to_string(),
+                        data_signature: None,
+                        factory_parameters: FactoryParameterLocation::Data(vec![0]),
+                    }),
+                    calls: None,
+                    events: None,
+                }]),
+                events: None,
+            },
+        );
+        contracts
     }
 
     fn factory_once_only_state(base_dir: &Path) -> EthCallCatchupState {
@@ -398,7 +431,7 @@ mod tests {
             range_regular_done: HashSet::new(),
             range_factory_done: HashSet::new(),
             factory_skipped_triggers: vec![],
-            contracts: HashMap::new(),
+            contracts: test_contracts(),
         }
     }
 
@@ -466,6 +499,12 @@ mod tests {
                 .join("test_collection/once/column_index.json")
                 .exists(),
             "column_index.json must be written"
+        );
+        assert!(
+            tmp.path()
+                .join("test_collection/once/contract_index.json")
+                .exists(),
+            "contract_index.json must be written when expected_contracts is non-empty"
         );
     }
 }

--- a/src/raw_data/historical/current/eth_calls/range_processor.rs
+++ b/src/raw_data/historical/current/eth_calls/range_processor.rs
@@ -324,3 +324,148 @@ pub(super) async fn process_incomplete_range(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::{HashMap, HashSet};
+    use std::path::Path;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    use crate::raw_data::historical::eth_calls::{BlockInfo, OnceCallConfig, FrequencyState};
+    use crate::raw_data::historical::factories::FactoryAddressData;
+    use crate::rpc::UnifiedRpcClient;
+    use crate::types::config::chain::ChainConfig;
+
+    fn test_chain() -> ChainConfig {
+        ChainConfig {
+            name: "test".to_string(),
+            chain_id: 1,
+            rpc_url_env_var: "RPC_URL".to_string(),
+            ws_url_env_var: None,
+            start_block: None,
+            contracts: HashMap::new(),
+            block_receipts_method: None,
+            factory_collections: HashMap::new(),
+            rpc: Default::default(),
+        }
+    }
+
+    fn dummy_client() -> Arc<UnifiedRpcClient> {
+        Arc::new(UnifiedRpcClient::from_url("http://127.0.0.1:8545").unwrap())
+    }
+
+    fn factory_once_only_state(base_dir: &Path) -> EthCallCatchupState {
+        let mut factory_once_configs = HashMap::new();
+        factory_once_configs.insert(
+            "test_collection".to_string(),
+            vec![OnceCallConfig {
+                function_name: "testFn".to_string(),
+                function_selector: [0u8; 4],
+                preencoded_calldata: None,
+                params: vec![],
+                target_addresses: None,
+                start_block: None,
+            }],
+        );
+
+        EthCallCatchupState {
+            base_output_dir: base_dir.to_path_buf(),
+            range_size: 100,
+            rpc_batch_size: 10,
+            multicall3_address: None,
+            call_configs: vec![],
+            factory_call_configs: HashMap::new(),
+            event_call_configs: HashMap::new(),
+            once_configs: HashMap::new(),
+            factory_once_configs,
+            has_regular_calls: false,
+            has_once_calls: false,
+            has_factory_calls: false,
+            has_factory_once_calls: true,
+            has_event_triggered_calls: false,
+            max_params: 0,
+            factory_max_params: 0,
+            existing_files: HashSet::new(),
+            s3_manifest: None,
+            factory_addresses: HashMap::new(),
+            frequency_state: FrequencyState {
+                last_call_times: HashMap::new(),
+            },
+            range_data: HashMap::new(),
+            range_factory_data: HashMap::new(),
+            range_regular_done: HashSet::new(),
+            range_factory_done: HashSet::new(),
+            factory_skipped_triggers: vec![],
+            contracts: HashMap::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_complete_range_factory_once_only_retains_state_until_factory_arrives() {
+        let tmp = TempDir::new().unwrap();
+        let client = dummy_client();
+        let chain = test_chain();
+        let mut state = factory_once_only_state(tmp.path());
+
+        // Pre-populate range_data with one block
+        state
+            .range_data
+            .insert(0, vec![BlockInfo { block_number: 0, timestamp: 100 }]);
+        // Do NOT insert range_factory_data — factory hasn't arrived yet
+
+        process_complete_range(0, &mut state, &client, &chain, &None, None)
+            .await
+            .unwrap();
+
+        // Regular processing done
+        assert!(state.range_regular_done.contains(&0));
+        // Range data retained — factory-once still pending
+        assert!(
+            state.range_data.contains_key(&0),
+            "range_data must not be cleaned up while factory-once is pending"
+        );
+        // Factory not done yet
+        assert!(!state.range_factory_done.contains(&0));
+    }
+
+    #[tokio::test]
+    async fn test_incomplete_range_flush_runs_factory_once_without_factory_calls() {
+        let tmp = TempDir::new().unwrap();
+        let client = dummy_client();
+        let chain = test_chain();
+        let mut state = factory_once_only_state(tmp.path());
+
+        // Pre-populate factory data (empty addresses)
+        state.range_factory_data.insert(
+            0,
+            FactoryAddressData {
+                range_start: 0,
+                range_end: 50,
+                addresses_by_block: HashMap::new(),
+            },
+        );
+
+        let blocks = vec![BlockInfo { block_number: 0, timestamp: 100 }];
+
+        process_incomplete_range(0, blocks, &mut state, &client, &chain, &None, None)
+            .await
+            .unwrap();
+
+        // Verify empty parquet was written (range end = max_block + 1 = 1, so file is 0-0.parquet)
+        let parquet_path = tmp.path().join("test_collection/once/0-0.parquet");
+        assert!(
+            parquet_path.exists(),
+            "empty parquet must be written for factory-once-only flush"
+        );
+
+        // Verify sidecars
+        assert!(
+            tmp.path()
+                .join("test_collection/once/column_index.json")
+                .exists(),
+            "column_index.json must be written"
+        );
+    }
+}

--- a/src/raw_data/historical/current/eth_calls/range_processor.rs
+++ b/src/raw_data/historical/current/eth_calls/range_processor.rs
@@ -107,6 +107,7 @@ pub(super) async fn process_complete_range(
                     &mut state.frequency_state,
                     multicall_addr,
                     None,
+                    &state.expected_by_collection,
                 )
                 .await?;
             } else {
@@ -119,6 +120,7 @@ pub(super) async fn process_complete_range(
                     state.factory_max_params,
                     &mut state.frequency_state,
                     None,
+                    &state.expected_by_collection,
                 )
                 .await?;
             }
@@ -263,6 +265,7 @@ pub(super) async fn process_incomplete_range(
                         &mut state.frequency_state,
                         multicall_addr,
                         None,
+                        &state.expected_by_collection,
                     )
                     .await?;
                 } else {
@@ -275,6 +278,7 @@ pub(super) async fn process_incomplete_range(
                         state.factory_max_params,
                         &mut state.frequency_state,
                         None,
+                        &state.expected_by_collection,
                     )
                     .await?;
                 }

--- a/src/raw_data/historical/current/eth_calls/range_processor.rs
+++ b/src/raw_data/historical/current/eth_calls/range_processor.rs
@@ -136,6 +136,7 @@ pub(super) async fn process_complete_range(
                     &state.factory_once_configs,
                     &empty_index,
                     multicall_addr,
+                    None,
                 )
                 .await?;
             } else {
@@ -145,6 +146,7 @@ pub(super) async fn process_complete_range(
                     factory_data,
                     &state.factory_once_configs,
                     &empty_index,
+                    None,
                 )
                 .await?;
             }
@@ -293,6 +295,7 @@ pub(super) async fn process_incomplete_range(
                             &state.factory_once_configs,
                             &empty_index,
                             multicall_addr,
+                            None,
                         )
                         .await?;
                     } else {
@@ -302,6 +305,7 @@ pub(super) async fn process_incomplete_range(
                             factory_data,
                             &state.factory_once_configs,
                             &empty_index,
+                            None,
                         )
                         .await?;
                     }

--- a/src/raw_data/historical/current/eth_calls/range_processor.rs
+++ b/src/raw_data/historical/current/eth_calls/range_processor.rs
@@ -107,7 +107,7 @@ pub(super) async fn process_complete_range(
                     &mut state.frequency_state,
                     multicall_addr,
                     None,
-                    &state.expected_by_collection,
+                    &state.contracts,
                 )
                 .await?;
             } else {
@@ -120,7 +120,7 @@ pub(super) async fn process_complete_range(
                     state.factory_max_params,
                     &mut state.frequency_state,
                     None,
-                    &state.expected_by_collection,
+                    &state.contracts,
                 )
                 .await?;
             }
@@ -265,7 +265,7 @@ pub(super) async fn process_incomplete_range(
                         &mut state.frequency_state,
                         multicall_addr,
                         None,
-                        &state.expected_by_collection,
+                        &state.contracts,
                     )
                     .await?;
                 } else {
@@ -278,7 +278,7 @@ pub(super) async fn process_incomplete_range(
                         state.factory_max_params,
                         &mut state.frequency_state,
                         None,
-                        &state.expected_by_collection,
+                        &state.contracts,
                     )
                     .await?;
                 }

--- a/src/raw_data/historical/current/eth_calls/range_processor.rs
+++ b/src/raw_data/historical/current/eth_calls/range_processor.rs
@@ -11,6 +11,7 @@ use crate::raw_data::historical::eth_calls::{
     EthCallCollectionError, EthCallContext,
 };
 use crate::rpc::UnifiedRpcClient;
+use crate::storage::contract_index::build_expected_factory_contracts_for_range;
 use crate::storage::StorageManager;
 use crate::types::config::chain::ChainConfig;
 
@@ -128,6 +129,8 @@ pub(super) async fn process_complete_range(
 
         if state.has_factory_once_calls {
             let empty_index = HashMap::new();
+            let expected_once =
+                build_expected_factory_contracts_for_range(&state.contracts, range.end);
             if let Some(multicall_addr) = state.multicall3_address {
                 process_factory_once_calls_multicall(
                     &range,
@@ -136,7 +139,7 @@ pub(super) async fn process_complete_range(
                     &state.factory_once_configs,
                     &empty_index,
                     multicall_addr,
-                    None,
+                    Some(&expected_once),
                 )
                 .await?;
             } else {
@@ -146,7 +149,7 @@ pub(super) async fn process_complete_range(
                     factory_data,
                     &state.factory_once_configs,
                     &empty_index,
-                    None,
+                    Some(&expected_once),
                 )
                 .await?;
             }
@@ -155,7 +158,8 @@ pub(super) async fn process_complete_range(
     }
 
     if state.range_regular_done.contains(&range_start)
-        && (!state.has_factory_calls || state.range_factory_done.contains(&range_start))
+        && ((!state.has_factory_calls && !state.has_factory_once_calls)
+            || state.range_factory_done.contains(&range_start))
     {
         state.range_data.remove(&range_start);
         state.range_factory_data.remove(&range_start);
@@ -253,40 +257,44 @@ pub(super) async fn process_incomplete_range(
         }
     }
 
-    if state.has_factory_calls {
+    if state.has_factory_calls || state.has_factory_once_calls {
         if let Some(factory_data) = state.range_factory_data.get(&range_start) {
             if !state.range_factory_done.contains(&range_start) {
-                if let Some(multicall_addr) = state.multicall3_address {
-                    process_factory_range_multicall(
-                        &range,
-                        &blocks,
-                        &ctx,
-                        factory_data,
-                        &state.factory_call_configs,
-                        state.factory_max_params,
-                        &mut state.frequency_state,
-                        multicall_addr,
-                        None,
-                        &state.contracts,
-                    )
-                    .await?;
-                } else {
-                    process_factory_range(
-                        &range,
-                        &blocks,
-                        &ctx,
-                        factory_data,
-                        &state.factory_call_configs,
-                        state.factory_max_params,
-                        &mut state.frequency_state,
-                        None,
-                        &state.contracts,
-                    )
-                    .await?;
+                if state.has_factory_calls {
+                    if let Some(multicall_addr) = state.multicall3_address {
+                        process_factory_range_multicall(
+                            &range,
+                            &blocks,
+                            &ctx,
+                            factory_data,
+                            &state.factory_call_configs,
+                            state.factory_max_params,
+                            &mut state.frequency_state,
+                            multicall_addr,
+                            None,
+                            &state.contracts,
+                        )
+                        .await?;
+                    } else {
+                        process_factory_range(
+                            &range,
+                            &blocks,
+                            &ctx,
+                            factory_data,
+                            &state.factory_call_configs,
+                            state.factory_max_params,
+                            &mut state.frequency_state,
+                            None,
+                            &state.contracts,
+                        )
+                        .await?;
+                    }
                 }
 
                 if state.has_factory_once_calls {
                     let empty_index = HashMap::new();
+                    let expected_once =
+                        build_expected_factory_contracts_for_range(&state.contracts, range.end);
                     if let Some(multicall_addr) = state.multicall3_address {
                         process_factory_once_calls_multicall(
                             &range,
@@ -295,7 +303,7 @@ pub(super) async fn process_incomplete_range(
                             &state.factory_once_configs,
                             &empty_index,
                             multicall_addr,
-                            None,
+                            Some(&expected_once),
                         )
                         .await?;
                     } else {
@@ -305,7 +313,7 @@ pub(super) async fn process_incomplete_range(
                             factory_data,
                             &state.factory_once_configs,
                             &empty_index,
-                            None,
+                            Some(&expected_once),
                         )
                         .await?;
                     }

--- a/src/raw_data/historical/current/factories.rs
+++ b/src/raw_data/historical/current/factories.rs
@@ -10,7 +10,11 @@ use crate::raw_data::historical::factories::{
     process_range, FactoryAddressData, FactoryCollectionError, FactoryMatcher, FactoryMessage,
 };
 use crate::raw_data::historical::receipts::{LogData, LogMessage};
-use crate::storage::{S3Manifest, StorageManager};
+use crate::storage::contract_index::{
+    build_expected_factory_contracts, range_key, read_contract_index, update_contract_index,
+    write_contract_index,
+};
+use crate::storage::{upload_sidecar_to_s3, S3Manifest, StorageManager};
 use crate::types::config::chain::ChainConfig;
 use crate::types::config::raw_data::RawDataCollectionConfig;
 
@@ -106,6 +110,11 @@ pub async fn collect_factories(
     // Streaming phase: Process new logs from channel
     // =========================================================================
     let mut range_data: HashMap<u64, Vec<LogData>> = HashMap::new();
+
+    // Build expected contracts for contract index tracking
+    let expected_by_collection = build_expected_factory_contracts(&chain.contracts);
+    let factory_collection_names: HashSet<String> =
+        matchers.iter().map(|m| m.collection_name.clone()).collect();
 
     tracing::info!(
         "Starting factory collection for chain {} with {} matchers",
@@ -212,6 +221,33 @@ pub async fn collect_factories(
                             addresses,
                         })
                         .await;
+                }
+
+                // Update contract index for each collection
+                let rk = range_key(range_start, range_end - 1);
+                for collection in &factory_collection_names {
+                    if let Some(expected) = expected_by_collection.get(collection) {
+                        let dir = output_dir.join(collection);
+                        let mut index = read_contract_index(&dir);
+                        update_contract_index(&mut index, &rk, expected);
+                        if let Err(e) = write_contract_index(&dir, &index) {
+                            tracing::error!(
+                                "Failed to write contract index for {}: {}",
+                                collection, e
+                            );
+                        }
+
+                        // Upload to S3
+                        if let Some(ref sm) = storage_manager {
+                            let index_path = dir.join("contract_index.json");
+                            if let Err(e) = upload_sidecar_to_s3(sm, &index_path).await {
+                                tracing::warn!(
+                                    "Failed to upload contract index for {} to S3: {}",
+                                    collection, e
+                                );
+                            }
+                        }
+                    }
                 }
             }
             LogMessage::AllRangesComplete => {

--- a/src/raw_data/historical/current/factories.rs
+++ b/src/raw_data/historical/current/factories.rs
@@ -11,8 +11,8 @@ use crate::raw_data::historical::factories::{
 };
 use crate::raw_data::historical::receipts::{LogData, LogMessage};
 use crate::storage::contract_index::{
-    build_expected_factory_contracts, range_key, read_contract_index, update_contract_index,
-    write_contract_index,
+    build_expected_factory_contracts_for_range, range_key, read_contract_index,
+    update_contract_index, write_contract_index,
 };
 use crate::storage::{upload_sidecar_to_s3, S3Manifest, StorageManager};
 use crate::types::config::chain::ChainConfig;
@@ -111,8 +111,6 @@ pub async fn collect_factories(
     // =========================================================================
     let mut range_data: HashMap<u64, Vec<LogData>> = HashMap::new();
 
-    // Build expected contracts for contract index tracking
-    let expected_by_collection = build_expected_factory_contracts(&chain.contracts);
     let factory_collection_names: HashSet<String> =
         matchers.iter().map(|m| m.collection_name.clone()).collect();
 
@@ -225,8 +223,10 @@ pub async fn collect_factories(
 
                 // Update contract index for each collection
                 let rk = range_key(range_start, range_end - 1);
+                let expected_for_range =
+                    build_expected_factory_contracts_for_range(&chain.contracts, range_end);
                 for collection in &factory_collection_names {
-                    if let Some(expected) = expected_by_collection.get(collection) {
+                    if let Some(expected) = expected_for_range.get(collection) {
                         let dir = output_dir.join(collection);
                         let mut index = read_contract_index(&dir);
                         update_contract_index(&mut index, &rk, expected);

--- a/src/raw_data/historical/eth_calls/event_triggers.rs
+++ b/src/raw_data/historical/eth_calls/event_triggers.rs
@@ -25,7 +25,8 @@ use super::{execute_multicalls_generic, BlockMulticall, EventCallMeta, Multicall
 use crate::decoding::{DecoderMessage, EventCallResult as DecoderEventCallResult};
 use crate::raw_data::historical::receipts::EventTriggerData;
 use crate::storage::contract_index::{
-    range_key, read_contract_index, update_contract_index, write_contract_index, ExpectedContracts,
+    build_expected_factory_contracts_for_range, range_key, read_contract_index,
+    update_contract_index, write_contract_index,
 };
 use crate::storage::{upload_parquet_to_s3, upload_sidecar_to_s3};
 use crate::types::config::contract::{AddressOrAddresses, Contracts};
@@ -487,7 +488,7 @@ pub(crate) async fn process_event_triggers(
     ctx: &EthCallContext<'_>,
     range_start: u64,
     range_end: u64,
-    expected_by_collection: &HashMap<String, ExpectedContracts>,
+    contracts: &Contracts,
 ) -> Result<Vec<SkippedFactoryTrigger>, EthCallCollectionError> {
     let mut skipped_factory_triggers: Vec<SkippedFactoryTrigger> = Vec::new();
 
@@ -510,6 +511,20 @@ pub(crate) async fn process_event_triggers(
                 range_end,
             )
             .await?;
+            let sub_dir = ctx.output_dir.join(contract_name).join(function_name).join("on_events");
+            let expected_for_range =
+                build_expected_factory_contracts_for_range(contracts, range_end + 1);
+            if let Some(expected) = expected_for_range.get(contract_name.as_str()) {
+                let rk = range_key(range_start, range_end);
+                let mut ci = read_contract_index(&sub_dir);
+                update_contract_index(&mut ci, &rk, expected);
+                if let Err(e) = write_contract_index(&sub_dir, &ci) {
+                    tracing::warn!(
+                        "Failed to write contract index (empty on_events): {}",
+                        e
+                    );
+                }
+            }
         }
         return Ok(skipped_factory_triggers);
     }
@@ -771,7 +786,9 @@ pub(crate) async fn process_event_triggers(
             }
 
             // Update contract index for on_events
-            if let Some(expected) = expected_by_collection.get(&contract_name) {
+            let expected_for_range =
+                build_expected_factory_contracts_for_range(contracts, range_end + 1);
+            if let Some(expected) = expected_for_range.get(&contract_name) {
                 let rk = range_key(range_start, range_end);
                 let mut ci = read_contract_index(&sub_dir);
                 update_contract_index(&mut ci, &rk, expected);
@@ -825,6 +842,21 @@ pub(crate) async fn process_event_triggers(
                 range_end,
             )
             .await?;
+            let sub_dir =
+                ctx.output_dir.join(&contract_name).join(&function_name).join("on_events");
+            let expected_for_range =
+                build_expected_factory_contracts_for_range(contracts, range_end + 1);
+            if let Some(expected) = expected_for_range.get(contract_name.as_str()) {
+                let rk = range_key(range_start, range_end);
+                let mut ci = read_contract_index(&sub_dir);
+                update_contract_index(&mut ci, &rk, expected);
+                if let Err(e) = write_contract_index(&sub_dir, &ci) {
+                    tracing::warn!(
+                        "Failed to write contract index (empty on_events): {}",
+                        e
+                    );
+                }
+            }
         }
     }
 
@@ -868,7 +900,7 @@ pub(crate) async fn process_event_triggers_multicall(
     multicall3_address: Address,
     range_start: u64,
     range_end: u64,
-    expected_by_collection: &HashMap<String, ExpectedContracts>,
+    contracts: &Contracts,
 ) -> Result<Vec<SkippedFactoryTrigger>, EthCallCollectionError> {
     let mut skipped_factory_triggers: Vec<SkippedFactoryTrigger> = Vec::new();
 
@@ -891,6 +923,20 @@ pub(crate) async fn process_event_triggers_multicall(
                 range_end,
             )
             .await?;
+            let sub_dir = ctx.output_dir.join(contract_name).join(function_name).join("on_events");
+            let expected_for_range =
+                build_expected_factory_contracts_for_range(contracts, range_end + 1);
+            if let Some(expected) = expected_for_range.get(contract_name.as_str()) {
+                let rk = range_key(range_start, range_end);
+                let mut ci = read_contract_index(&sub_dir);
+                update_contract_index(&mut ci, &rk, expected);
+                if let Err(e) = write_contract_index(&sub_dir, &ci) {
+                    tracing::warn!(
+                        "Failed to write contract index (empty on_events): {}",
+                        e
+                    );
+                }
+            }
         }
         return Ok(skipped_factory_triggers);
     }
@@ -1182,7 +1228,9 @@ pub(crate) async fn process_event_triggers_multicall(
         }
 
         // Update contract index for on_events
-        if let Some(expected) = expected_by_collection.get(&contract_name) {
+        let expected_for_range =
+            build_expected_factory_contracts_for_range(contracts, range_end + 1);
+        if let Some(expected) = expected_for_range.get(&contract_name) {
             let rk = range_key(range_start, range_end);
             let mut ci = read_contract_index(&sub_dir);
             update_contract_index(&mut ci, &rk, expected);
@@ -1235,6 +1283,21 @@ pub(crate) async fn process_event_triggers_multicall(
                 range_end,
             )
             .await?;
+            let sub_dir =
+                ctx.output_dir.join(&contract_name).join(&function_name).join("on_events");
+            let expected_for_range =
+                build_expected_factory_contracts_for_range(contracts, range_end + 1);
+            if let Some(expected) = expected_for_range.get(contract_name.as_str()) {
+                let rk = range_key(range_start, range_end);
+                let mut ci = read_contract_index(&sub_dir);
+                update_contract_index(&mut ci, &rk, expected);
+                if let Err(e) = write_contract_index(&sub_dir, &ci) {
+                    tracing::warn!(
+                        "Failed to write contract index (empty on_events): {}",
+                        e
+                    );
+                }
+            }
         }
     }
 

--- a/src/raw_data/historical/eth_calls/event_triggers.rs
+++ b/src/raw_data/historical/eth_calls/event_triggers.rs
@@ -24,7 +24,10 @@ use super::types::{
 use super::{execute_multicalls_generic, BlockMulticall, EventCallMeta, MulticallSlotGeneric};
 use crate::decoding::{DecoderMessage, EventCallResult as DecoderEventCallResult};
 use crate::raw_data::historical::receipts::EventTriggerData;
-use crate::storage::upload_parquet_to_s3;
+use crate::storage::contract_index::{
+    range_key, read_contract_index, update_contract_index, write_contract_index, ExpectedContracts,
+};
+use crate::storage::{upload_parquet_to_s3, upload_sidecar_to_s3};
 use crate::types::config::contract::{AddressOrAddresses, Contracts};
 use crate::types::config::eth_call::{
     encode_call_with_params, EventFieldLocation, EvmType, ParamConfig,
@@ -484,6 +487,7 @@ pub(crate) async fn process_event_triggers(
     ctx: &EthCallContext<'_>,
     range_start: u64,
     range_end: u64,
+    expected_by_collection: &HashMap<String, ExpectedContracts>,
 ) -> Result<Vec<SkippedFactoryTrigger>, EthCallCollectionError> {
     let mut skipped_factory_triggers: Vec<SkippedFactoryTrigger> = Vec::new();
 
@@ -766,6 +770,31 @@ pub(crate) async fn process_event_triggers(
                 .map_err(|e| EthCallCollectionError::Io(std::io::Error::other(e.to_string())))?;
             }
 
+            // Update contract index for on_events
+            if let Some(expected) = expected_by_collection.get(&contract_name) {
+                let rk = range_key(range_start, range_end);
+                let mut ci = read_contract_index(&sub_dir);
+                update_contract_index(&mut ci, &rk, expected);
+                if let Err(e) = write_contract_index(&sub_dir, &ci) {
+                    tracing::warn!(
+                        "Failed to write contract index for {}.{}/on_events: {}",
+                        contract_name,
+                        function_name,
+                        e
+                    );
+                } else if let Some(sm) = ctx.storage_manager {
+                    let index_path = sub_dir.join("contract_index.json");
+                    if let Err(e) = upload_sidecar_to_s3(sm, &index_path).await {
+                        tracing::warn!(
+                            "Failed to upload contract index sidecar for {}.{}/on_events: {}",
+                            contract_name,
+                            function_name,
+                            e
+                        );
+                    }
+                }
+            }
+
             // Send to decoder for decoding (range_end + 1 for exclusive convention)
             if let Some(tx) = ctx.decoder_tx {
                 if let Some(decoder_results) = decoder_results {
@@ -839,6 +868,7 @@ pub(crate) async fn process_event_triggers_multicall(
     multicall3_address: Address,
     range_start: u64,
     range_end: u64,
+    expected_by_collection: &HashMap<String, ExpectedContracts>,
 ) -> Result<Vec<SkippedFactoryTrigger>, EthCallCollectionError> {
     let mut skipped_factory_triggers: Vec<SkippedFactoryTrigger> = Vec::new();
 
@@ -1149,6 +1179,31 @@ pub(crate) async fn process_event_triggers_multicall(
             )
             .await
             .map_err(|e| EthCallCollectionError::Io(std::io::Error::other(e.to_string())))?;
+        }
+
+        // Update contract index for on_events
+        if let Some(expected) = expected_by_collection.get(&contract_name) {
+            let rk = range_key(range_start, range_end);
+            let mut ci = read_contract_index(&sub_dir);
+            update_contract_index(&mut ci, &rk, expected);
+            if let Err(e) = write_contract_index(&sub_dir, &ci) {
+                tracing::warn!(
+                    "Failed to write contract index for {}.{}/on_events: {}",
+                    contract_name,
+                    function_name,
+                    e
+                );
+            } else if let Some(sm) = ctx.storage_manager {
+                let index_path = sub_dir.join("contract_index.json");
+                if let Err(e) = upload_sidecar_to_s3(sm, &index_path).await {
+                    tracing::warn!(
+                        "Failed to upload contract index sidecar for {}.{}/on_events: {}",
+                        contract_name,
+                        function_name,
+                        e
+                    );
+                }
+            }
         }
 
         // Send to decoder (range_end + 1 for exclusive convention)

--- a/src/raw_data/historical/eth_calls/factory.rs
+++ b/src/raw_data/historical/eth_calls/factory.rs
@@ -162,6 +162,13 @@ pub(crate) fn event_output_exists(
         let func_key = format!("{}/on_events", function_name);
         if manifest.has_raw_eth_calls_granular(contract_name, &func_key, range_start, range_end - 1)
         {
+            if let Some(expected) = expected_contracts {
+                let index = read_contract_index(&sub_dir);
+                let rk = range_key(range_start, range_end - 1);
+                if !get_missing_contracts(&index, &rk, expected).is_empty() {
+                    return false;
+                }
+            }
             return true;
         }
     }

--- a/src/raw_data/historical/eth_calls/factory.rs
+++ b/src/raw_data/historical/eth_calls/factory.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use super::types::EthCallCollectionError;
+use crate::storage::contract_index::{get_missing_contracts, range_key, read_contract_index, ExpectedContracts};
 use crate::storage::paths::{parse_range_from_filename, raw_logs_dir};
 use crate::storage::S3Manifest;
 
@@ -89,6 +90,10 @@ pub(crate) fn get_existing_log_ranges(
 }
 
 /// Check if on_events output already exists for a range (locally or in S3)
+///
+/// When `expected_contracts` is provided, also checks the contract index for
+/// completeness. Returns `false` if the file exists but the contract index
+/// shows missing contracts (forcing re-processing).
 pub(crate) fn event_output_exists(
     output_dir: &Path,
     contract_name: &str,
@@ -96,6 +101,7 @@ pub(crate) fn event_output_exists(
     range_start: u64,
     range_end: u64,
     s3_manifest: Option<&S3Manifest>,
+    expected_contracts: Option<&ExpectedContracts>,
 ) -> bool {
     // Check local first
     let sub_dir = output_dir
@@ -123,6 +129,23 @@ pub(crate) fn event_output_exists(
                             // Ranges overlap if: start1 < end2 AND start2 < end1 (using exclusive ends)
                             let file_end_exclusive = file_end_inclusive + 1;
                             if range_start < file_end_exclusive && file_start < range_end {
+                                // File exists, but check contract index if expected contracts provided
+                                if let Some(expected) = expected_contracts {
+                                    let index = read_contract_index(&sub_dir);
+                                    let rk = range_key(file_start, file_end_inclusive);
+                                    let missing = get_missing_contracts(&index, &rk, expected);
+                                    if !missing.is_empty() {
+                                        tracing::info!(
+                                            "on_events {}.{} range {}-{}: file exists but contract index has missing contracts: {:?}",
+                                            contract_name,
+                                            function_name,
+                                            file_start,
+                                            file_end_inclusive,
+                                            missing.keys().collect::<Vec<_>>()
+                                        );
+                                        return false;
+                                    }
+                                }
                                 return true;
                             }
                         }
@@ -180,6 +203,7 @@ pub(crate) async fn event_output_exists_async(
     range_start: u64,
     range_end: u64,
     s3_manifest: Option<Arc<S3Manifest>>,
+    expected_contracts: Option<ExpectedContracts>,
 ) -> Result<bool, EthCallCollectionError> {
     tokio::task::spawn_blocking(move || {
         event_output_exists(
@@ -189,6 +213,7 @@ pub(crate) async fn event_output_exists_async(
             range_start,
             range_end,
             s3_manifest.as_deref(),
+            expected_contracts.as_ref(),
         )
     })
     .await

--- a/src/raw_data/historical/eth_calls/factory.rs
+++ b/src/raw_data/historical/eth_calls/factory.rs
@@ -163,10 +163,16 @@ pub(crate) fn event_output_exists(
         if manifest.has_raw_eth_calls_granular(contract_name, &func_key, range_start, range_end - 1)
         {
             if let Some(expected) = expected_contracts {
-                let index = read_contract_index(&sub_dir);
-                let rk = range_key(range_start, range_end - 1);
-                if !get_missing_contracts(&index, &rk, expected).is_empty() {
-                    return false;
+                // Only check local sidecar if it actually exists.
+                // In S3-backed deployments with local files pruned, sub_dir won't exist;
+                // treat the manifest hit as complete in that case.
+                let index_path = sub_dir.join("contract_index.json");
+                if index_path.exists() {
+                    let index = read_contract_index(&sub_dir);
+                    let rk = range_key(range_start, range_end - 1);
+                    if !get_missing_contracts(&index, &rk, expected).is_empty() {
+                        return false;
+                    }
                 }
             }
             return true;
@@ -225,4 +231,82 @@ pub(crate) async fn event_output_exists_async(
     })
     .await
     .map_err(|e| EthCallCollectionError::JoinError(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::fs;
+    use tempfile::TempDir;
+
+    use crate::storage::contract_index::{
+        write_contract_index, range_key, ExpectedContracts,
+    };
+    use crate::storage::S3Manifest;
+
+    #[test]
+    fn test_event_output_exists_s3_no_local_sidecar() {
+        let tmp = TempDir::new().unwrap();
+        // Do NOT create any subdirectories — no on_events/ subdir.
+
+        let mut manifest = S3Manifest::new();
+        manifest.add_raw_eth_calls_granular("test_contract", "test_func/on_events", 0, 999);
+
+        let mut expected: ExpectedContracts = HashMap::new();
+        expected.insert("ContractX".to_string(), vec!["0xaaa".to_string()]);
+
+        let result = event_output_exists(
+            tmp.path(),
+            "test_contract",
+            "test_func",
+            0,
+            1000,
+            Some(&manifest),
+            Some(&expected),
+        );
+
+        assert!(result, "S3 manifest hit should be trusted when no local sidecar exists");
+    }
+
+    #[test]
+    fn test_event_output_exists_local_sidecar_present_missing_contracts() {
+        let tmp = TempDir::new().unwrap();
+
+        let on_events_dir = tmp
+            .path()
+            .join("test_contract")
+            .join("test_func")
+            .join("on_events");
+        fs::create_dir_all(&on_events_dir).unwrap();
+
+        // Write a contract_index.json with only ContractX (missing ContractY).
+        let mut index = HashMap::new();
+        let mut range_map = HashMap::new();
+        range_map.insert("ContractX".to_string(), vec!["0xaaa".to_string()]);
+        index.insert(range_key(0, 999), range_map);
+        write_contract_index(&on_events_dir, &index).unwrap();
+
+        // Create a dummy parquet file so the S3 path is what we're testing.
+        fs::write(on_events_dir.join("0-999.parquet"), b"dummy").unwrap();
+
+        let mut manifest = S3Manifest::new();
+        manifest.add_raw_eth_calls_granular("test_contract", "test_func/on_events", 0, 999);
+
+        let mut expected: ExpectedContracts = HashMap::new();
+        expected.insert("ContractX".to_string(), vec!["0xaaa".to_string()]);
+        expected.insert("ContractY".to_string(), vec!["0xbbb".to_string()]);
+
+        let result = event_output_exists(
+            tmp.path(),
+            "test_contract",
+            "test_func",
+            0,
+            1000,
+            Some(&manifest),
+            Some(&expected),
+        );
+
+        assert!(!result, "Should return false when local sidecar shows missing contracts");
+    }
 }

--- a/src/raw_data/historical/eth_calls/once_calls.rs
+++ b/src/raw_data/historical/eth_calls/once_calls.rs
@@ -562,7 +562,7 @@ pub(crate) async fn process_factory_once_calls(
 
         let absent_addresses: Vec<(&Address, &(u64, u64))> = address_discovery
             .iter()
-            .filter(|(addr, _)| !existing_addr_set.is_empty() && !existing_addr_set.contains(&addr.0 .0))
+            .filter(|(addr, _)| !existing_addr_set.contains(&addr.0 .0))
             .collect();
 
         let mut pending_calls: Vec<(TransactionRequest, BlockId, Address, u64, u64, String)> =
@@ -685,6 +685,25 @@ pub(crate) async fn process_factory_once_calls(
         // H. No-op optimization: if contract-index gate fell through but no calls needed,
         // just write the missing contract_index.json and skip the parquet rewrite.
         if pending_calls.is_empty() && has_existing_file {
+            // Rewrite empty parquet with full schema when columns are missing
+            if !missing_fn_names.is_empty() && existing_addr_set.is_empty() {
+                write_once_results_to_parquet_async(
+                    vec![],
+                    output_path.clone(),
+                    all_fn_names.clone(),
+                )
+                .await?;
+                let mut index = read_once_column_index_async(sub_dir.clone()).await;
+                index.insert(file_name.clone(), all_fn_names.clone());
+                write_once_column_index_async(sub_dir.to_path_buf(), index).await?;
+                tracing::info!(
+                    "Factory once {} blocks {}-{}: rewrote empty parquet with {} columns",
+                    collection_name,
+                    range.start,
+                    range.end - 1,
+                    all_fn_names.len()
+                );
+            }
             if let Some(expected) = expected_contracts.and_then(|m| m.get(collection_name)) {
                 let rk = range_key(range.start, range.end - 1);
                 let mut ci = read_contract_index(&sub_dir);
@@ -1463,8 +1482,46 @@ pub(crate) async fn process_factory_once_calls_multicall(
 
         let absent_addresses: Vec<(&Address, &(u64, u64))> = address_discovery
             .iter()
-            .filter(|(addr, _)| !existing_addr_set.is_empty() && !existing_addr_set.contains(&addr.0 .0))
+            .filter(|(addr, _)| !existing_addr_set.contains(&addr.0 .0))
             .collect();
+
+        // Rewrite empty parquet with full schema when columns are missing and file is empty
+        if address_discovery.is_empty()
+            && has_existing_file
+            && !missing_fn_names.is_empty()
+            && existing_addr_set.is_empty()
+        {
+            tokio::fs::create_dir_all(&sub_dir).await?;
+            write_once_results_to_parquet_async(
+                vec![],
+                output_path.clone(),
+                all_fn_names.clone(),
+            )
+            .await?;
+            let mut index = read_once_column_index_async(sub_dir.clone()).await;
+            index.insert(file_name.clone(), all_fn_names.clone());
+            write_once_column_index_async(sub_dir.to_path_buf(), index).await?;
+            if let Some(expected) = expected_contracts.and_then(|m| m.get(collection_name)) {
+                let rk = range_key(range.start, range.end - 1);
+                let mut ci = read_contract_index(&sub_dir);
+                update_contract_index(&mut ci, &rk, expected);
+                if let Err(e) = write_contract_index(&sub_dir, &ci) {
+                    tracing::warn!(
+                        "Failed to write once contract index for {}: {}",
+                        collection_name,
+                        e
+                    );
+                }
+            }
+            tracing::info!(
+                "Factory once multicall {} blocks {}-{}: rewrote empty parquet with {} columns",
+                collection_name,
+                range.start,
+                range.end - 1,
+                all_fn_names.len()
+            );
+            continue;
+        }
 
         // Missing columns: slots for ALL discovered addresses
         for call_config in &configs_to_call {
@@ -1929,11 +1986,17 @@ pub(crate) async fn process_factory_once_calls_multicall(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use tempfile::TempDir;
 
+    use crate::raw_data::historical::eth_calls::{
+        extract_addresses_from_once_parquet, read_existing_once_parquet,
+        read_parquet_column_names, write_once_results_to_parquet,
+    };
     use crate::storage::contract_index::{
-        get_missing_contracts, range_key, read_contract_index, update_contract_index,
-        write_contract_index, ExpectedContracts,
+        build_expected_factory_contracts_for_range, get_missing_contracts, range_key,
+        read_contract_index, update_contract_index, write_contract_index, ExpectedContracts,
     };
 
     /// When no contract_index.json exists, `read_contract_index` returns an empty
@@ -2042,6 +2105,145 @@ mod tests {
         assert!(
             !missing_x.contains(&"0xaaa".to_string()),
             "0xaaa should NOT be reported as missing for ContractX"
+        );
+    }
+
+    /// P1 regression: when an existing once parquet has zero rows, all newly
+    /// discovered factory addresses must be treated as absent so they get
+    /// backfilled for existing functions.
+    #[test]
+    fn test_empty_parquet_absent_addresses_filter() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.parquet");
+
+        // Write an empty parquet with schema [A, B] but 0 rows.
+        write_once_results_to_parquet(
+            &[],
+            &path,
+            &["getA".to_string(), "getB".to_string()],
+        )
+        .unwrap();
+
+        // Read back and extract addresses — should be empty.
+        let batches = read_existing_once_parquet(&path).unwrap();
+        let existing_addr_set: HashSet<[u8; 20]> = extract_addresses_from_once_parquet(&batches)
+            .into_keys()
+            .collect();
+        assert!(
+            existing_addr_set.is_empty(),
+            "empty parquet must yield empty address set"
+        );
+
+        // The fixed filter: `!existing_addr_set.contains(&addr)` must return true
+        // for any address, meaning all addresses are "absent" and eligible for backfill.
+        let test_addr: [u8; 20] = [0xaa; 20];
+        assert!(
+            !existing_addr_set.contains(&test_addr),
+            "any address must be treated as absent when parquet is empty"
+        );
+    }
+
+    /// P2 regression: when an empty once parquet exists with stale schema and a
+    /// new function column is added, rewriting the parquet with the full schema
+    /// must converge — the new column appears in the schema and no rows are lost.
+    #[test]
+    fn test_empty_parquet_schema_rewrite_converges() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.parquet");
+
+        // Step 1: write empty parquet with columns [A].
+        write_once_results_to_parquet(&[], &path, &["getA".to_string()]).unwrap();
+
+        let cols = read_parquet_column_names(&path);
+        assert!(cols.contains("getA"), "initial schema must contain getA");
+        assert!(!cols.contains("getB"), "initial schema must NOT contain getB");
+
+        // Step 2: rewrite with full schema [A, B] (the P2 fix).
+        write_once_results_to_parquet(
+            &[],
+            &path,
+            &["getA".to_string(), "getB".to_string()],
+        )
+        .unwrap();
+
+        let cols = read_parquet_column_names(&path);
+        assert!(cols.contains("getA"), "rewritten schema must contain getA");
+        assert!(cols.contains("getB"), "rewritten schema must contain getB");
+
+        // Step 3: verify no spurious rows were created.
+        let batches = read_existing_once_parquet(&path).unwrap();
+        let addrs = extract_addresses_from_once_parquet(&batches);
+        assert!(addrs.is_empty(), "rewritten empty parquet must have 0 rows");
+
+        // Step 4: a subsequent read_parquet_column_names returns full schema,
+        // so the missing-column check would now pass — no infinite loop.
+        let final_cols = read_parquet_column_names(&path);
+        let all_fn_names = vec!["getA".to_string(), "getB".to_string()];
+        let missing: Vec<&String> = all_fn_names
+            .iter()
+            .filter(|f| !final_cols.contains(*f))
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "no columns should be missing after rewrite — loop must converge"
+        );
+    }
+
+    /// P3 regression: `build_expected_factory_contracts_for_range` must return
+    /// correct collection→contract→addresses mapping from a Contracts config
+    /// that has factory entries, so that the live/current path can write
+    /// contract_index.json.
+    #[test]
+    fn test_build_expected_factory_contracts_for_range() {
+        use alloy_primitives::{Address, U256};
+        use crate::types::config::contract::{
+            AddressOrAddresses, ContractConfig, FactoryConfig, FactoryEventConfig,
+            FactoryEventConfigOrArray, FactoryParameterLocation,
+        };
+
+        let addr_a = Address::new([0xaa; 20]);
+        let addr_b = Address::new([0xbb; 20]);
+
+        let mut contracts = std::collections::HashMap::new();
+
+        // Contract with factory → collection "v3_pools", start_block 100.
+        contracts.insert(
+            "UniswapV3Factory".to_string(),
+            ContractConfig {
+                address: AddressOrAddresses::Multiple(vec![addr_a, addr_b]),
+                start_block: Some(U256::from(100)),
+                calls: None,
+                factories: Some(vec![FactoryConfig {
+                    collection: "v3_pools".to_string(),
+                    factory_events: FactoryEventConfigOrArray::Single(FactoryEventConfig {
+                        name: "PoolCreated".to_string(),
+                        topics_signature: "PoolCreated(address,address,uint24,int24,address)".to_string(),
+                        data_signature: None,
+                        factory_parameters: FactoryParameterLocation::Data(vec![4]),
+                    }),
+                    calls: None,
+                    events: None,
+                }]),
+                events: None,
+            },
+        );
+
+        // range_end > start_block → included
+        let result = build_expected_factory_contracts_for_range(&contracts, 200);
+        assert!(result.contains_key("v3_pools"), "collection must be present");
+        let expected = &result["v3_pools"];
+        assert!(
+            expected.contains_key("UniswapV3Factory"),
+            "contract must be present"
+        );
+        let addrs = &expected["UniswapV3Factory"];
+        assert_eq!(addrs.len(), 2, "both addresses must be listed");
+
+        // range_end <= start_block → excluded
+        let result = build_expected_factory_contracts_for_range(&contracts, 100);
+        assert!(
+            result.is_empty(),
+            "contract with start_block >= range_end must be excluded"
         );
     }
 }

--- a/src/raw_data/historical/eth_calls/once_calls.rs
+++ b/src/raw_data/historical/eth_calls/once_calls.rs
@@ -24,6 +24,10 @@ use super::types::{
 };
 use crate::decoding::{DecoderMessage, OnceCallResult as DecoderOnceCallResult};
 use crate::raw_data::historical::factories::FactoryAddressData;
+use crate::storage::contract_index::{
+    get_missing_contracts, range_key, read_contract_index, update_contract_index,
+    write_contract_index, ExpectedContracts,
+};
 use crate::storage::upload_parquet_to_s3;
 use crate::types::config::contract::{AddressOrAddresses, Contracts};
 
@@ -384,6 +388,7 @@ pub(crate) async fn process_factory_once_calls(
     factory_data: &FactoryAddressData,
     once_configs: &HashMap<String, Vec<OnceCallConfig>>,
     column_indexes: &HashMap<String, HashMap<String, Vec<String>>>,
+    expected_contracts: Option<&HashMap<String, ExpectedContracts>>,
 ) -> Result<(), EthCallCollectionError> {
     for (collection_name, call_configs) in once_configs {
         if call_configs.is_empty() {
@@ -442,13 +447,30 @@ pub(crate) async fn process_factory_once_calls(
             };
 
             if missing.is_empty() && null_entries.is_empty() {
-                tracing::debug!(
-                    "Skipping factory once eth_calls for {} blocks {}-{} (all columns present and indexed)",
+                // Column check passes. Also verify contract-index completeness.
+                let index_complete = match expected_contracts.and_then(|m| m.get(collection_name)) {
+                    None => true,
+                    Some(expected) => {
+                        let index = read_contract_index(&sub_dir);
+                        let rk = range_key(range.start, range.end - 1);
+                        get_missing_contracts(&index, &rk, expected).is_empty()
+                    }
+                };
+                if index_complete {
+                    tracing::debug!(
+                        "Skipping factory once eth_calls for {} blocks {}-{} (all columns present and indexed)",
+                        collection_name,
+                        range.start,
+                        range.end - 1
+                    );
+                    continue;
+                }
+                tracing::info!(
+                    "Factory once {} blocks {}-{}: columns complete but contract index incomplete, re-checking",
                     collection_name,
                     range.start,
                     range.end - 1
                 );
-                continue;
             }
             if !missing.is_empty() {
                 tracing::info!(
@@ -507,6 +529,14 @@ pub(crate) async fn process_factory_once_calls(
             let mut index = read_once_column_index_async(sub_dir.clone()).await;
             index.insert(file_name.clone(), all_fn_names.clone());
             write_once_column_index_async(sub_dir.to_path_buf(), index).await?;
+            if let Some(expected) = expected_contracts.and_then(|m| m.get(collection_name)) {
+                let rk = range_key(range.start, range.end - 1);
+                let mut ci = read_contract_index(&sub_dir);
+                update_contract_index(&mut ci, &rk, expected);
+                if let Err(e) = write_contract_index(&sub_dir, &ci) {
+                    tracing::warn!("Failed to write once contract index (empty range) for {}: {}", collection_name, e);
+                }
+            }
             if let Some(tx) = ctx.decoder_tx {
                 let _ = tx
                     .send(DecoderMessage::OnceFileBackfilled {
@@ -518,6 +548,22 @@ pub(crate) async fn process_factory_once_calls(
             }
             continue;
         }
+
+        // C. Read parquet early to identify absent addresses
+        let (mut existing_batches_opt, existing_addr_set) = if has_existing_file {
+            let batches = read_existing_once_parquet_async(output_path.clone()).await?;
+            let addrs: HashSet<[u8; 20]> = extract_addresses_from_once_parquet(&batches)
+                .into_keys()
+                .collect();
+            (Some(batches), addrs)
+        } else {
+            (None, HashSet::new())
+        };
+
+        let absent_addresses: Vec<(&Address, &(u64, u64))> = address_discovery
+            .iter()
+            .filter(|(addr, _)| !existing_addr_set.is_empty() && !existing_addr_set.contains(&addr.0 .0))
+            .collect();
 
         let mut pending_calls: Vec<(TransactionRequest, BlockId, Address, u64, u64, String)> =
             Vec::new();
@@ -594,6 +640,67 @@ pub(crate) async fn process_factory_once_calls(
             }
         }
 
+        // D. Absent addresses: call existing functions for addresses not yet in the parquet
+        if !absent_addresses.is_empty() {
+            let already_covered_by_global: HashSet<&str> =
+                configs_to_call.iter().map(|c| c.function_name.as_str()).collect();
+
+            for (addr, (block_number, timestamp)) in &absent_addresses {
+                let block_id = BlockId::Number(BlockNumberOrTag::Number(*block_number));
+
+                for call_config in call_configs.iter() {
+                    if already_covered_by_global.contains(call_config.function_name.as_str()) {
+                        continue;
+                    }
+                    let target_address = call_config
+                        .target_addresses
+                        .as_ref()
+                        .and_then(|addrs| addrs.first().copied())
+                        .unwrap_or(**addr);
+
+                    let calldata = if let Some(preencoded) = &call_config.preencoded_calldata {
+                        preencoded.clone()
+                    } else {
+                        encode_once_call_params(
+                            call_config.function_selector,
+                            &call_config.params,
+                            **addr,
+                        )?
+                    };
+                    let tx = TransactionRequest::default()
+                        .to(target_address)
+                        .input(calldata.into());
+                    pending_calls.push((
+                        tx,
+                        block_id,
+                        **addr,
+                        *block_number,
+                        *timestamp,
+                        call_config.function_name.clone(),
+                    ));
+                }
+            }
+        }
+
+        // H. No-op optimization: if contract-index gate fell through but no calls needed,
+        // just write the missing contract_index.json and skip the parquet rewrite.
+        if pending_calls.is_empty() && has_existing_file {
+            if let Some(expected) = expected_contracts.and_then(|m| m.get(collection_name)) {
+                let rk = range_key(range.start, range.end - 1);
+                let mut ci = read_contract_index(&sub_dir);
+                update_contract_index(&mut ci, &rk, expected);
+                if let Err(e) = write_contract_index(&sub_dir, &ci) {
+                    tracing::warn!("Failed to write once contract index for {}: {}", collection_name, e);
+                } else {
+                    tracing::info!(
+                        "Factory once {} blocks {}-{}: wrote missing contract index (no parquet changes needed)",
+                        collection_name, range.start, range.end - 1
+                    );
+                }
+            }
+            continue;
+        }
+
         // Skip only if no pending calls AND no existing file to backfill
         if pending_calls.is_empty() && !has_existing_file {
             continue;
@@ -655,7 +762,11 @@ pub(crate) async fn process_factory_once_calls(
                 .map(|(addr, (_, _, fns))| (addr.0 .0, fns))
                 .collect();
 
-            let existing_batches = read_existing_once_parquet_async(output_path.clone()).await?;
+            // E. Reuse pre-read batches from step C (or read now if not available)
+            let existing_batches = match existing_batches_opt.take() {
+                Some(batches) => batches,
+                None => read_existing_once_parquet_async(output_path.clone()).await?,
+            };
             if !existing_batches.is_empty() {
                 // Check which addresses already have data for the missing functions
                 let existing_results =
@@ -837,6 +948,16 @@ pub(crate) async fn process_factory_once_calls(
             actual_cols.len(),
             actual_cols
         );
+
+        // F. Write contract index after parquet write
+        if let Some(expected) = expected_contracts.and_then(|m| m.get(collection_name)) {
+            let rk = range_key(range.start, range.end - 1);
+            let mut ci = read_contract_index(&sub_dir);
+            update_contract_index(&mut ci, &rk, expected);
+            if let Err(e) = write_contract_index(&sub_dir, &ci) {
+                tracing::warn!("Failed to write once contract index for {}: {}", collection_name, e);
+            }
+        }
 
         // Notify decoder that this file was updated so it can decode new columns
         if let Some(tx) = ctx.decoder_tx {
@@ -1202,6 +1323,7 @@ pub(crate) async fn process_factory_once_calls_multicall(
     once_configs: &HashMap<String, Vec<OnceCallConfig>>,
     column_indexes: &HashMap<String, HashMap<String, Vec<String>>>,
     multicall3_address: Address,
+    expected_contracts: Option<&HashMap<String, ExpectedContracts>>,
 ) -> Result<(), EthCallCollectionError> {
     // Collect all calls across all collections into one multicall
     let mut all_slots: Vec<MulticallSlotGeneric<FactoryOnceSlotMeta>> = Vec::new();
@@ -1262,7 +1384,25 @@ pub(crate) async fn process_factory_once_calls_multicall(
                 };
 
                 if missing.is_empty() && null_entries.is_empty() {
-                    continue;
+                    // Column check passes. Also verify contract-index completeness.
+                    let index_complete =
+                        match expected_contracts.and_then(|m| m.get(collection_name)) {
+                            None => true,
+                            Some(expected) => {
+                                let index = read_contract_index(&sub_dir);
+                                let rk = range_key(range.start, range.end - 1);
+                                get_missing_contracts(&index, &rk, expected).is_empty()
+                            }
+                        };
+                    if index_complete {
+                        continue;
+                    }
+                    tracing::info!(
+                        "Factory once multicall {} blocks {}-{}: columns complete but contract index incomplete, re-checking",
+                        collection_name,
+                        range.start,
+                        range.end - 1
+                    );
                 }
                 (missing, true, null_entries)
             } else {
@@ -1299,8 +1439,32 @@ pub(crate) async fn process_factory_once_calls_multicall(
             let mut index = read_once_column_index_async(sub_dir.clone()).await;
             index.insert(file_name.clone(), all_fn_names.clone());
             write_once_column_index_async(sub_dir.to_path_buf(), index).await?;
+            // G. Write contract index in empty-file branch
+            if let Some(expected) = expected_contracts.and_then(|m| m.get(collection_name)) {
+                let rk = range_key(range.start, range.end - 1);
+                let mut ci = read_contract_index(&sub_dir);
+                update_contract_index(&mut ci, &rk, expected);
+                if let Err(e) = write_contract_index(&sub_dir, &ci) {
+                    tracing::warn!("Failed to write once contract index (empty range) for {}: {}", collection_name, e);
+                }
+            }
             continue;
         }
+
+        // C. Read parquet early to identify absent addresses
+        let existing_addr_set: HashSet<[u8; 20]> = if has_existing_file {
+            let batches = read_existing_once_parquet_async(output_path.clone()).await?;
+            extract_addresses_from_once_parquet(&batches)
+                .into_keys()
+                .collect()
+        } else {
+            HashSet::new()
+        };
+
+        let absent_addresses: Vec<(&Address, &(u64, u64))> = address_discovery
+            .iter()
+            .filter(|(addr, _)| !existing_addr_set.is_empty() && !existing_addr_set.contains(&addr.0 .0))
+            .collect();
 
         // Missing columns: slots for ALL discovered addresses
         for call_config in &configs_to_call {
@@ -1373,6 +1537,49 @@ pub(crate) async fn process_factory_once_calls_multicall(
                         block_timestamp: *timestamp,
                     },
                 });
+            }
+        }
+
+        // D. Absent addresses: add slots for existing functions for addresses not yet in the parquet
+        if !absent_addresses.is_empty() {
+            let already_covered_by_global: HashSet<&str> =
+                configs_to_call.iter().map(|c| c.function_name.as_str()).collect();
+
+            for (addr, (block_num, timestamp)) in &absent_addresses {
+                for call_config in call_configs.iter() {
+                    if already_covered_by_global.contains(call_config.function_name.as_str()) {
+                        continue;
+                    }
+                    let target_address = call_config
+                        .target_addresses
+                        .as_ref()
+                        .and_then(|addrs| addrs.first().copied())
+                        .unwrap_or(**addr);
+
+                    let calldata = if let Some(preencoded) = &call_config.preencoded_calldata {
+                        preencoded.clone()
+                    } else {
+                        encode_once_call_params(
+                            call_config.function_selector,
+                            &call_config.params,
+                            **addr,
+                        )?
+                    };
+
+                    all_slots.push(MulticallSlotGeneric {
+                        block_number: *block_num,
+                        block_timestamp: *timestamp,
+                        target_address,
+                        encoded_calldata: calldata,
+                        metadata: FactoryOnceSlotMeta {
+                            collection_name: collection_name.clone(),
+                            function_name: call_config.function_name.clone(),
+                            address: **addr,
+                            block_number: *block_num,
+                            block_timestamp: *timestamp,
+                        },
+                    });
+                }
             }
         }
 
@@ -1464,6 +1671,27 @@ pub(crate) async fn process_factory_once_calls_multicall(
 
         // Get results for this collection (may be None if no new addresses discovered)
         let results_by_address = results_by_collection.remove(&collection_name);
+
+        // H. No-op optimization: if contract-index gate fell through but no slots were
+        // queued for this collection and the parquet already exists, just write the
+        // missing contract_index.json and skip the parquet rewrite.
+        let has_results = results_by_address.as_ref().map_or(false, |r| !r.is_empty());
+        if !has_results && has_existing_file && missing_fn_names.is_empty() && patch_fn_names.is_empty() {
+            if let Some(expected) = expected_contracts.and_then(|m| m.get(&collection_name)) {
+                let rk = range_key(range.start, range.end - 1);
+                let mut ci = read_contract_index(sub_dir);
+                update_contract_index(&mut ci, &rk, expected);
+                if let Err(e) = write_contract_index(sub_dir, &ci) {
+                    tracing::warn!("Failed to write once contract index for {}: {}", collection_name, e);
+                } else {
+                    tracing::info!(
+                        "Factory once multicall {} blocks {}-{}: wrote missing contract index (no parquet changes needed)",
+                        collection_name, range.start, range.end - 1
+                    );
+                }
+            }
+            continue;
+        }
 
         // Process if we have results OR if existing file needs backfill
         if results_by_address.is_some() || has_existing_file {
@@ -1674,6 +1902,16 @@ pub(crate) async fn process_factory_once_calls_multicall(
             index.insert(file_name.clone(), actual_cols.clone());
             write_once_column_index_async(sub_dir.to_path_buf(), index).await?;
 
+            // F. Write contract index after parquet write
+            if let Some(expected) = expected_contracts.and_then(|m| m.get(&collection_name)) {
+                let rk = range_key(range.start, range.end - 1);
+                let mut ci = read_contract_index(sub_dir);
+                update_contract_index(&mut ci, &rk, expected);
+                if let Err(e) = write_contract_index(sub_dir, &ci) {
+                    tracing::warn!("Failed to write once contract index for {}: {}", collection_name, e);
+                }
+            }
+
             if let Some(tx) = ctx.decoder_tx {
                 let _ = tx
                     .send(DecoderMessage::OnceFileBackfilled {
@@ -1687,4 +1925,123 @@ pub(crate) async fn process_factory_once_calls_multicall(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use crate::storage::contract_index::{
+        get_missing_contracts, range_key, read_contract_index, update_contract_index,
+        write_contract_index, ExpectedContracts,
+    };
+
+    /// When no contract_index.json exists, `read_contract_index` returns an empty
+    /// index and `get_missing_contracts` reports everything as missing. The skip
+    /// gate must NOT be taken.
+    #[test]
+    fn test_factory_once_skip_requires_contract_index_completeness() {
+        let dir = TempDir::new().unwrap();
+
+        // No contract_index.json written to dir.
+
+        let mut expected = ExpectedContracts::new();
+        expected.insert(
+            "ContractX".to_string(),
+            vec!["0xaaa".to_string(), "0xbbb".to_string()],
+        );
+        expected.insert("ContractY".to_string(), vec!["0xccc".to_string()]);
+
+        let index = read_contract_index(dir.path());
+        assert!(index.is_empty(), "index should be empty when file is absent");
+
+        let rk = range_key(0, 999);
+        let missing = get_missing_contracts(&index, &rk, &expected);
+
+        assert!(
+            !missing.is_empty(),
+            "missing must be non-empty when contract index is absent — skip should NOT be taken"
+        );
+        // Every expected entry should be reported missing.
+        assert!(missing.contains_key("ContractX"));
+        assert!(missing.contains_key("ContractY"));
+    }
+
+    /// When the contract_index.json contains all expected contracts and addresses
+    /// for the range, `get_missing_contracts` returns an empty map. The skip gate
+    /// IS taken.
+    #[test]
+    fn test_factory_once_skip_allowed_when_contract_index_complete() {
+        let dir = TempDir::new().unwrap();
+
+        let mut expected = ExpectedContracts::new();
+        expected.insert(
+            "ContractX".to_string(),
+            vec!["0xaaa".to_string(), "0xbbb".to_string()],
+        );
+        expected.insert("ContractY".to_string(), vec!["0xccc".to_string()]);
+
+        // Write a fully-populated contract index.
+        let mut index = read_contract_index(dir.path());
+        let rk = range_key(0, 999);
+        update_contract_index(&mut index, &rk, &expected);
+        write_contract_index(dir.path(), &index).unwrap();
+
+        // Re-read from disk to confirm roundtrip fidelity.
+        let index = read_contract_index(dir.path());
+        let missing = get_missing_contracts(&index, &rk, &expected);
+
+        assert!(
+            missing.is_empty(),
+            "missing must be empty when contract index is complete — skip IS taken"
+        );
+    }
+
+    /// When the contract_index.json only has partial data (one contract missing
+    /// entirely, another missing an address), `get_missing_contracts` reports the
+    /// gaps. The skip gate must NOT be taken.
+    #[test]
+    fn test_factory_once_contract_index_partial_not_complete() {
+        let dir = TempDir::new().unwrap();
+
+        let mut expected = ExpectedContracts::new();
+        expected.insert(
+            "ContractX".to_string(),
+            vec!["0xaaa".to_string(), "0xbbb".to_string()],
+        );
+        expected.insert("ContractY".to_string(), vec!["0xccc".to_string()]);
+
+        // Write a partial index: only ContractX with one of its two addresses.
+        let rk = range_key(0, 999);
+        let mut partial = ExpectedContracts::new();
+        partial.insert("ContractX".to_string(), vec!["0xaaa".to_string()]);
+
+        let mut index = read_contract_index(dir.path());
+        update_contract_index(&mut index, &rk, &partial);
+        write_contract_index(dir.path(), &index).unwrap();
+
+        // Re-read from disk.
+        let index = read_contract_index(dir.path());
+        let missing = get_missing_contracts(&index, &rk, &expected);
+
+        assert!(
+            !missing.is_empty(),
+            "missing must be non-empty when contract index is partial — skip should NOT be taken"
+        );
+        // ContractY is entirely absent.
+        assert!(
+            missing.contains_key("ContractY"),
+            "ContractY should be reported as missing"
+        );
+        // ContractX is present but missing address 0xbbb.
+        let missing_x = missing.get("ContractX").expect("ContractX should have missing addresses");
+        assert!(
+            missing_x.contains(&"0xbbb".to_string()),
+            "0xbbb should be reported as missing for ContractX"
+        );
+        assert!(
+            !missing_x.contains(&"0xaaa".to_string()),
+            "0xaaa should NOT be reported as missing for ContractX"
+        );
+    }
 }

--- a/src/raw_data/historical/eth_calls/once_calls.rs
+++ b/src/raw_data/historical/eth_calls/once_calls.rs
@@ -1986,18 +1986,22 @@ pub(crate) async fn process_factory_once_calls_multicall(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
+    use std::collections::{HashMap, HashSet};
+    use std::sync::Arc;
 
     use tempfile::TempDir;
 
     use crate::raw_data::historical::eth_calls::{
         extract_addresses_from_once_parquet, read_existing_once_parquet,
-        read_parquet_column_names, write_once_results_to_parquet,
+        read_parquet_column_names, write_once_results_to_parquet, EthCallContext, OnceCallConfig,
     };
+    use crate::raw_data::historical::factories::FactoryAddressData;
+    use crate::rpc::UnifiedRpcClient;
     use crate::storage::contract_index::{
         build_expected_factory_contracts_for_range, get_missing_contracts, range_key,
         read_contract_index, update_contract_index, write_contract_index, ExpectedContracts,
     };
+    use crate::storage::BlockRange;
 
     /// When no contract_index.json exists, `read_contract_index` returns an empty
     /// index and `get_missing_contracts` reports everything as missing. The skip
@@ -2244,6 +2248,137 @@ mod tests {
         assert!(
             result.is_empty(),
             "contract with start_block >= range_end must be excluded"
+        );
+    }
+
+    /// Calling `process_factory_once_calls` with empty factory data (no addresses
+    /// discovered) must still write the empty-range outputs: a parquet file with
+    /// the function schema, a column_index.json, and a contract_index.json.
+    #[tokio::test]
+    async fn test_factory_once_empty_range_writes_outputs() {
+        use alloy_primitives::{Address, U256};
+        use crate::types::config::contract::{
+            AddressOrAddresses, ContractConfig, FactoryConfig, FactoryEventConfig,
+            FactoryEventConfigOrArray, FactoryParameterLocation,
+        };
+
+        let tmp = TempDir::new().unwrap();
+        let dummy_client = Arc::new(UnifiedRpcClient::from_url("http://127.0.0.1:8545").unwrap());
+        let existing_files: HashSet<String> = HashSet::new();
+        let decoder_tx: Option<tokio::sync::mpsc::Sender<crate::decoding::DecoderMessage>> = None;
+        let s3_manifest: Option<crate::storage::S3Manifest> = None;
+
+        let ctx = EthCallContext {
+            client: &dummy_client,
+            output_dir: tmp.path(),
+            existing_files: &existing_files,
+            rpc_batch_size: 10,
+            decoder_tx: &decoder_tx,
+            chain_name: "test",
+            storage_manager: None,
+            s3_manifest: &s3_manifest,
+        };
+
+        let factory_data = FactoryAddressData {
+            range_start: 0,
+            range_end: 100,
+            addresses_by_block: HashMap::new(),
+        };
+
+        let mut once_configs: HashMap<String, Vec<OnceCallConfig>> = HashMap::new();
+        once_configs.insert(
+            "test_collection".to_string(),
+            vec![OnceCallConfig {
+                function_name: "testFn".to_string(),
+                function_selector: [0u8; 4],
+                preencoded_calldata: None,
+                params: vec![],
+                target_addresses: None,
+                start_block: None,
+            }],
+        );
+
+        let column_indexes: HashMap<String, HashMap<String, Vec<String>>> = HashMap::new();
+
+        // Build expected contracts using the same ContractConfig pattern as
+        // test_build_expected_factory_contracts_for_range.
+        let addr_a = Address::new([0xaa; 20]);
+        let addr_b = Address::new([0xbb; 20]);
+
+        let mut contracts = HashMap::new();
+        contracts.insert(
+            "UniswapV3Factory".to_string(),
+            ContractConfig {
+                address: AddressOrAddresses::Multiple(vec![addr_a, addr_b]),
+                start_block: Some(U256::from(100)),
+                calls: None,
+                factories: Some(vec![FactoryConfig {
+                    collection: "test_collection".to_string(),
+                    factory_events: FactoryEventConfigOrArray::Single(FactoryEventConfig {
+                        name: "PoolCreated".to_string(),
+                        topics_signature:
+                            "PoolCreated(address,address,uint24,int24,address)".to_string(),
+                        data_signature: None,
+                        factory_parameters: FactoryParameterLocation::Data(vec![4]),
+                    }),
+                    calls: None,
+                    events: None,
+                }]),
+                events: None,
+            },
+        );
+
+        // range_end must be > start_block for the contract to be included.
+        let expected = build_expected_factory_contracts_for_range(&contracts, 101);
+        let range = BlockRange { start: 0, end: 100 };
+
+        super::process_factory_once_calls(
+            &range,
+            &ctx,
+            &factory_data,
+            &once_configs,
+            &column_indexes,
+            Some(&expected),
+        )
+        .await
+        .unwrap();
+
+        // 1. Parquet file exists (range 0..100 → file "0-99.parquet")
+        let parquet_path = tmp.path().join("test_collection/once/0-99.parquet");
+        assert!(
+            parquet_path.exists(),
+            "parquet file must exist after empty-range write"
+        );
+
+        // 2. Column names include our function
+        let col_names = read_parquet_column_names(&parquet_path);
+        assert!(
+            col_names.contains("testFn"),
+            "parquet schema must contain 'testFn'"
+        );
+
+        // 3. No rows (empty factory data → 0 addresses)
+        let batches = read_existing_once_parquet(&parquet_path).unwrap();
+        let addrs = extract_addresses_from_once_parquet(&batches);
+        assert!(
+            addrs.is_empty(),
+            "empty factory data must produce 0-row parquet"
+        );
+
+        // 4. Column index sidecar exists
+        assert!(
+            tmp.path()
+                .join("test_collection/once/column_index.json")
+                .exists(),
+            "column_index.json must exist after empty-range write"
+        );
+
+        // 5. Contract index sidecar exists
+        assert!(
+            tmp.path()
+                .join("test_collection/once/contract_index.json")
+                .exists(),
+            "contract_index.json must exist after empty-range write"
         );
     }
 }

--- a/src/raw_data/historical/eth_calls/regular_calls.rs
+++ b/src/raw_data/historical/eth_calls/regular_calls.rs
@@ -23,6 +23,11 @@ use super::types::{
     EthCallCollectionError, EthCallContext, FrequencyState,
 };
 use crate::raw_data::historical::factories::FactoryAddressData;
+use crate::storage::contract_index::{
+    get_missing_contracts, range_key, read_contract_index, update_contract_index,
+    write_contract_index, ExpectedContracts,
+};
+use crate::storage::upload_sidecar_to_s3;
 use crate::types::config::eth_call::{encode_call_with_params, EthCallConfig};
 
 #[allow(clippy::too_many_arguments)]
@@ -35,6 +40,7 @@ pub(crate) async fn process_factory_range(
     max_params: usize,
     frequency_state: &mut FrequencyState,
     mut pending_writes: Option<&mut AbortOnDropHandles>,
+    expected_by_collection: &HashMap<String, ExpectedContracts>,
 ) -> Result<(), EthCallCollectionError> {
     let mut addresses_by_collection: HashMap<String, HashSet<Address>> = HashMap::new();
     for addrs in factory_data.addresses_by_block.values() {
@@ -69,14 +75,42 @@ pub(crate) async fn process_factory_range(
             let rel_path = format!("{}/{}/{}", collection_name, function_name, file_name);
 
             if ctx.existing_files.contains(&rel_path) {
-                tracing::debug!(
-                    "Skipping factory eth_calls for {}.{} blocks {}-{} (already exists)",
-                    collection_name,
-                    function_name,
-                    range.start,
-                    range.end - 1
-                );
-                continue;
+                // File exists locally, but check contract index for missing contracts
+                if let Some(expected) = expected_by_collection.get(collection_name) {
+                    let index_dir = ctx.output_dir.join(collection_name).join(&function_name);
+                    let index = read_contract_index(&index_dir);
+                    let rk = range_key(range.start, range.end - 1);
+                    let missing = get_missing_contracts(&index, &rk, expected);
+                    if !missing.is_empty() {
+                        tracing::info!(
+                            "Factory eth_calls {}.{} blocks {}-{}: file exists but contract index has missing contracts: {:?}",
+                            collection_name,
+                            function_name,
+                            range.start,
+                            range.end - 1,
+                            missing.keys().collect::<Vec<_>>()
+                        );
+                        // Fall through to re-process
+                    } else {
+                        tracing::debug!(
+                            "Skipping factory eth_calls for {}.{} blocks {}-{} (already exists, contract index complete)",
+                            collection_name,
+                            function_name,
+                            range.start,
+                            range.end - 1
+                        );
+                        continue;
+                    }
+                } else {
+                    tracing::debug!(
+                        "Skipping factory eth_calls for {}.{} blocks {}-{} (already exists)",
+                        collection_name,
+                        function_name,
+                        range.start,
+                        range.end - 1
+                    );
+                    continue;
+                }
             }
 
             let param_combinations = generate_param_combinations(&call_config.params)?;
@@ -227,7 +261,7 @@ pub(crate) async fn process_factory_range(
             let finalize_params = FinalizeRegularParams {
                 results: all_results,
                 max_params,
-                sub_dir,
+                sub_dir: sub_dir.clone(),
                 file_name,
                 log_label: "factory eth_call".to_string(),
                 s3_data_type: format!("raw/eth_calls/{}/{}", collection_name, function_name),
@@ -254,6 +288,31 @@ pub(crate) async fn process_factory_range(
             } else {
                 finalize_regular_results(finalize_params).await?;
             }
+
+            // Update contract index after successful write
+            if let Some(expected) = expected_by_collection.get(collection_name) {
+                let rk = range_key(range.start, range.end - 1);
+                let mut index = read_contract_index(&sub_dir);
+                update_contract_index(&mut index, &rk, expected);
+                if let Err(e) = write_contract_index(&sub_dir, &index) {
+                    tracing::warn!(
+                        "Failed to write contract index for {}.{}: {}",
+                        collection_name,
+                        function_name,
+                        e
+                    );
+                } else if let Some(sm) = ctx.storage_manager {
+                    let index_path = sub_dir.join("contract_index.json");
+                    if let Err(e) = upload_sidecar_to_s3(sm, &index_path).await {
+                        tracing::warn!(
+                            "Failed to upload contract index sidecar for {}.{}: {}",
+                            collection_name,
+                            function_name,
+                            e
+                        );
+                    }
+                }
+            }
         }
     }
 
@@ -272,6 +331,7 @@ pub(crate) async fn process_factory_range_multicall(
     frequency_state: &mut FrequencyState,
     multicall3_address: Address,
     mut pending_writes: Option<&mut AbortOnDropHandles>,
+    expected_by_collection: &HashMap<String, ExpectedContracts>,
 ) -> Result<(), EthCallCollectionError> {
     // Collect factory addresses by collection
     let mut addresses_by_collection: HashMap<String, HashSet<Address>> = HashMap::new();
@@ -310,14 +370,42 @@ pub(crate) async fn process_factory_range_multicall(
             let rel_path = format!("{}/{}/{}", collection_name, function_name, file_name);
 
             if ctx.existing_files.contains(&rel_path) {
-                tracing::debug!(
-                    "Skipping factory eth_calls for {}.{} blocks {}-{} (already exists)",
-                    collection_name,
-                    function_name,
-                    range.start,
-                    range.end - 1
-                );
-                continue;
+                // File exists locally, but check contract index for missing contracts
+                if let Some(expected) = expected_by_collection.get(collection_name) {
+                    let index_dir = ctx.output_dir.join(collection_name).join(&function_name);
+                    let index = read_contract_index(&index_dir);
+                    let rk = range_key(range.start, range.end - 1);
+                    let missing = get_missing_contracts(&index, &rk, expected);
+                    if !missing.is_empty() {
+                        tracing::info!(
+                            "Factory eth_calls {}.{} blocks {}-{}: file exists but contract index has missing contracts: {:?}",
+                            collection_name,
+                            function_name,
+                            range.start,
+                            range.end - 1,
+                            missing.keys().collect::<Vec<_>>()
+                        );
+                        // Fall through to re-process
+                    } else {
+                        tracing::debug!(
+                            "Skipping factory eth_calls for {}.{} blocks {}-{} (already exists, contract index complete)",
+                            collection_name,
+                            function_name,
+                            range.start,
+                            range.end - 1
+                        );
+                        continue;
+                    }
+                } else {
+                    tracing::debug!(
+                        "Skipping factory eth_calls for {}.{} blocks {}-{} (already exists)",
+                        collection_name,
+                        function_name,
+                        range.start,
+                        range.end - 1
+                    );
+                    continue;
+                }
             }
 
             let param_combinations = generate_param_combinations(&call_config.params)?;
@@ -492,7 +580,7 @@ pub(crate) async fn process_factory_range_multicall(
             let finalize_params = FinalizeRegularParams {
                 results: std::mem::take(results),
                 max_params,
-                sub_dir,
+                sub_dir: sub_dir.clone(),
                 file_name,
                 log_label: "multicall factory eth_call".to_string(),
                 s3_data_type: format!(
@@ -517,6 +605,31 @@ pub(crate) async fn process_factory_range_multicall(
                 writes.push(handle);
             } else {
                 finalize_regular_results(finalize_params).await?;
+            }
+
+            // Update contract index after successful write
+            if let Some(expected) = expected_by_collection.get(&group.collection_name) {
+                let rk = range_key(range.start, range.end - 1);
+                let mut index = read_contract_index(&sub_dir);
+                update_contract_index(&mut index, &rk, expected);
+                if let Err(e) = write_contract_index(&sub_dir, &index) {
+                    tracing::warn!(
+                        "Failed to write contract index for {}.{}: {}",
+                        group.collection_name,
+                        group.function_name,
+                        e
+                    );
+                } else if let Some(sm) = ctx.storage_manager {
+                    let index_path = sub_dir.join("contract_index.json");
+                    if let Err(e) = upload_sidecar_to_s3(sm, &index_path).await {
+                        tracing::warn!(
+                            "Failed to upload contract index sidecar for {}.{}: {}",
+                            group.collection_name,
+                            group.function_name,
+                            e
+                        );
+                    }
+                }
             }
         }
     }

--- a/src/raw_data/historical/eth_calls/regular_calls.rs
+++ b/src/raw_data/historical/eth_calls/regular_calls.rs
@@ -24,10 +24,11 @@ use super::types::{
 };
 use crate::raw_data::historical::factories::FactoryAddressData;
 use crate::storage::contract_index::{
-    get_missing_contracts, range_key, read_contract_index, update_contract_index,
-    write_contract_index, ExpectedContracts,
+    build_expected_factory_contracts_for_range, get_missing_contracts, range_key,
+    read_contract_index, update_contract_index, write_contract_index,
 };
 use crate::storage::upload_sidecar_to_s3;
+use crate::types::config::contract::Contracts;
 use crate::types::config::eth_call::{encode_call_with_params, EthCallConfig};
 
 #[allow(clippy::too_many_arguments)]
@@ -40,7 +41,7 @@ pub(crate) async fn process_factory_range(
     max_params: usize,
     frequency_state: &mut FrequencyState,
     mut pending_writes: Option<&mut AbortOnDropHandles>,
-    expected_by_collection: &HashMap<String, ExpectedContracts>,
+    contracts: &Contracts,
 ) -> Result<(), EthCallCollectionError> {
     let mut addresses_by_collection: HashMap<String, HashSet<Address>> = HashMap::new();
     for addrs in factory_data.addresses_by_block.values() {
@@ -76,7 +77,9 @@ pub(crate) async fn process_factory_range(
 
             if ctx.existing_files.contains(&rel_path) {
                 // File exists locally, but check contract index for missing contracts
-                if let Some(expected) = expected_by_collection.get(collection_name) {
+                let expected_for_range =
+                    build_expected_factory_contracts_for_range(contracts, range.end);
+                if let Some(expected) = expected_for_range.get(collection_name) {
                     let index_dir = ctx.output_dir.join(collection_name).join(&function_name);
                     let index = read_contract_index(&index_dir);
                     let rk = range_key(range.start, range.end - 1);
@@ -290,7 +293,9 @@ pub(crate) async fn process_factory_range(
             }
 
             // Update contract index after successful write
-            if let Some(expected) = expected_by_collection.get(collection_name) {
+            let expected_for_range =
+                build_expected_factory_contracts_for_range(contracts, range.end);
+            if let Some(expected) = expected_for_range.get(collection_name) {
                 let rk = range_key(range.start, range.end - 1);
                 let mut index = read_contract_index(&sub_dir);
                 update_contract_index(&mut index, &rk, expected);
@@ -331,7 +336,7 @@ pub(crate) async fn process_factory_range_multicall(
     frequency_state: &mut FrequencyState,
     multicall3_address: Address,
     mut pending_writes: Option<&mut AbortOnDropHandles>,
-    expected_by_collection: &HashMap<String, ExpectedContracts>,
+    contracts: &Contracts,
 ) -> Result<(), EthCallCollectionError> {
     // Collect factory addresses by collection
     let mut addresses_by_collection: HashMap<String, HashSet<Address>> = HashMap::new();
@@ -371,7 +376,9 @@ pub(crate) async fn process_factory_range_multicall(
 
             if ctx.existing_files.contains(&rel_path) {
                 // File exists locally, but check contract index for missing contracts
-                if let Some(expected) = expected_by_collection.get(collection_name) {
+                let expected_for_range =
+                    build_expected_factory_contracts_for_range(contracts, range.end);
+                if let Some(expected) = expected_for_range.get(collection_name) {
                     let index_dir = ctx.output_dir.join(collection_name).join(&function_name);
                     let index = read_contract_index(&index_dir);
                     let rk = range_key(range.start, range.end - 1);
@@ -608,7 +615,9 @@ pub(crate) async fn process_factory_range_multicall(
             }
 
             // Update contract index after successful write
-            if let Some(expected) = expected_by_collection.get(&group.collection_name) {
+            let expected_for_range =
+                build_expected_factory_contracts_for_range(contracts, range.end);
+            if let Some(expected) = expected_for_range.get(&group.collection_name) {
                 let rk = range_key(range.start, range.end - 1);
                 let mut index = read_contract_index(&sub_dir);
                 update_contract_index(&mut index, &rk, expected);

--- a/src/raw_data/historical/eth_calls/types.rs
+++ b/src/raw_data/historical/eth_calls/types.rs
@@ -13,6 +13,7 @@ use crate::decoding::DecoderMessage;
 use crate::raw_data::historical::eth_calls::event_triggers::SkippedFactoryTrigger;
 use crate::raw_data::historical::factories::FactoryAddressData;
 use crate::rpc::{RpcError, UnifiedRpcClient};
+use crate::storage::contract_index::ExpectedContracts;
 use crate::storage::{S3Manifest, StorageManager};
 use crate::types::config::eth_call::{
     EthCallConfig, EvmType, Frequency, ParamConfig, ParamError, ParamValue,
@@ -261,4 +262,6 @@ pub struct EthCallCatchupState {
     /// Buffered triggers skipped because factory addresses weren't known yet.
     /// Each entry: (skipped_triggers, range_start, range_end_inclusive)
     pub factory_skipped_triggers: Vec<(Vec<SkippedFactoryTrigger>, u64, u64)>,
+    /// Expected factory contracts per collection for contract index tracking.
+    pub expected_by_collection: HashMap<String, ExpectedContracts>,
 }

--- a/src/raw_data/historical/eth_calls/types.rs
+++ b/src/raw_data/historical/eth_calls/types.rs
@@ -13,8 +13,8 @@ use crate::decoding::DecoderMessage;
 use crate::raw_data::historical::eth_calls::event_triggers::SkippedFactoryTrigger;
 use crate::raw_data::historical::factories::FactoryAddressData;
 use crate::rpc::{RpcError, UnifiedRpcClient};
-use crate::storage::contract_index::ExpectedContracts;
 use crate::storage::{S3Manifest, StorageManager};
+use crate::types::config::contract::Contracts;
 use crate::types::config::eth_call::{
     EthCallConfig, EvmType, Frequency, ParamConfig, ParamError, ParamValue,
 };
@@ -262,6 +262,6 @@ pub struct EthCallCatchupState {
     /// Buffered triggers skipped because factory addresses weren't known yet.
     /// Each entry: (skipped_triggers, range_start, range_end_inclusive)
     pub factory_skipped_triggers: Vec<(Vec<SkippedFactoryTrigger>, u64, u64)>,
-    /// Expected factory contracts per collection for contract index tracking.
-    pub expected_by_collection: HashMap<String, ExpectedContracts>,
+    /// Contracts config, used to build per-range expected factory contracts for contract index tracking.
+    pub contracts: Contracts,
 }

--- a/src/raw_data/historical/factories.rs
+++ b/src/raw_data/historical/factories.rs
@@ -96,6 +96,8 @@ pub struct FactoryMatcher {
     pub param_location: FactoryParameterLocation,
     pub data_types: Vec<DynSolType>,
     pub collection_name: String,
+    /// Name of the contract in the config that owns this factory matcher.
+    pub contract_name: String,
 }
 
 /// State computed during factory catchup, passed to current/streaming phase
@@ -146,6 +148,7 @@ pub fn build_factory_matchers(contracts: &Contracts) -> Vec<FactoryMatcher> {
                             param_location: param_location.clone(),
                             data_types: data_types.clone(),
                             collection_name: factory.collection.clone(),
+                            contract_name: contract_name.clone(),
                         });
                     }
                 }
@@ -281,6 +284,7 @@ pub(crate) async fn process_range(
         s3_manifest,
         storage_manager,
         chain_name,
+        false, // don't force rewrite for streaming
     )
     .await?;
 
@@ -480,6 +484,7 @@ pub(crate) async fn process_range_batches(
         s3_manifest,
         storage_manager,
         chain_name,
+        true, // force rewrite during catchup (contract index handles skip)
     )
     .await?;
 
@@ -492,6 +497,9 @@ pub(crate) async fn process_range_batches(
 
 /// Write factory records to parquet files, grouped by collection.
 /// Writes empty parquet files for collections with no matching events.
+///
+/// When `force_rewrite` is true, existing files are overwritten (used when the
+/// contract index shows missing contracts for a range that already has parquet files).
 #[allow(clippy::too_many_arguments)]
 async fn write_factory_parquet_files(
     range_start: u64,
@@ -503,6 +511,7 @@ async fn write_factory_parquet_files(
     s3_manifest: Option<&S3Manifest>,
     storage_manager: Option<&Arc<StorageManager>>,
     chain_name: &str,
+    force_rewrite: bool,
 ) -> Result<(), FactoryCollectionError> {
     let mut by_collection: HashMap<String, Vec<FactoryRecord>> = HashMap::new();
     for record in records {
@@ -518,9 +527,10 @@ async fn write_factory_parquet_files(
         let file_name = format!("{}-{}.parquet", range_start, range_end - 1);
         let rel_path = format!("{}/{}", collection_name, file_name);
 
-        if existing_files.contains(&rel_path)
-            || s3_manifest
-                .is_some_and(|m| m.has_factories(&collection_name, range_start, range_end - 1))
+        if !force_rewrite
+            && (existing_files.contains(&rel_path)
+                || s3_manifest
+                    .is_some_and(|m| m.has_factories(&collection_name, range_start, range_end - 1)))
         {
             tracing::debug!(
                 "Skipping factory parquet for {} blocks {}-{} (already exists)",
@@ -566,9 +576,10 @@ async fn write_factory_parquet_files(
             let file_name = format!("{}-{}.parquet", range_start, range_end - 1);
             let rel_path = format!("{}/{}", collection_name, file_name);
 
-            if !existing_files.contains(&rel_path)
-                && !s3_manifest
-                    .is_some_and(|m| m.has_factories(collection_name, range_start, range_end - 1))
+            if force_rewrite
+                || (!existing_files.contains(&rel_path)
+                    && !s3_manifest
+                        .is_some_and(|m| m.has_factories(collection_name, range_start, range_end - 1)))
             {
                 let sub_dir = output_dir.join(collection_name);
                 tokio::fs::create_dir_all(&sub_dir).await?;

--- a/src/storage/contract_index.rs
+++ b/src/storage/contract_index.rs
@@ -12,7 +12,6 @@ use std::io;
 use std::path::Path;
 
 use arrow::array::Array;
-use serde::{Deserialize, Serialize};
 
 use crate::types::config::contract::{AddressOrAddresses, Contracts};
 
@@ -262,45 +261,6 @@ pub async fn write_contract_index_async(
 /// Migrate a downstream contract index (eth_calls, decoded logs) by seeding it
 /// from the factory layer's contract_index.json.
 ///
-/// For each range in the factory index, if the downstream index has no entry,
-/// copy the factory index entry. This avoids full reprocessing for downstream
-/// layers when the factory layer already has a correct index.
-///
-/// `downstream_dir` is the directory where the downstream contract_index.json lives.
-/// `factory_index` is the already-loaded factory contract_index for the same collection.
-/// `existing_file_check` is a closure that returns true if the downstream parquet exists
-/// for a given range key (e.g. "0-999").
-///
-/// Returns true if any entries were added and the index was written.
-pub fn migrate_downstream_index(
-    downstream_dir: &Path,
-    factory_index: &ContractIndex,
-    existing_file_check: impl Fn(&str) -> bool,
-) -> bool {
-    let mut downstream = read_contract_index(downstream_dir);
-    let mut added = false;
-
-    for (rk, contracts) in factory_index {
-        if !downstream.contains_key(rk) && existing_file_check(rk) {
-            downstream.insert(rk.clone(), contracts.clone());
-            added = true;
-        }
-    }
-
-    if added {
-        if let Err(e) = write_contract_index(downstream_dir, &downstream) {
-            tracing::warn!(
-                "Migration: failed to write downstream contract index at {}: {}",
-                downstream_dir.display(),
-                e
-            );
-            return false;
-        }
-    }
-
-    added
-}
-
 /// Address-to-contract lookup built from factory matchers.
 ///
 /// Maps `[u8; 20]` factory source addresses → `(contract_name, hex_address)`.

--- a/src/storage/contract_index.rs
+++ b/src/storage/contract_index.rs
@@ -227,6 +227,48 @@ pub async fn write_contract_index_async(
 // Migration: build contract_index from existing log parquet files
 // ---------------------------------------------------------------------------
 
+/// Migrate a downstream contract index (eth_calls, decoded logs) by seeding it
+/// from the factory layer's contract_index.json.
+///
+/// For each range in the factory index, if the downstream index has no entry,
+/// copy the factory index entry. This avoids full reprocessing for downstream
+/// layers when the factory layer already has a correct index.
+///
+/// `downstream_dir` is the directory where the downstream contract_index.json lives.
+/// `factory_index` is the already-loaded factory contract_index for the same collection.
+/// `existing_file_check` is a closure that returns true if the downstream parquet exists
+/// for a given range key (e.g. "0-999").
+///
+/// Returns true if any entries were added and the index was written.
+pub fn migrate_downstream_index(
+    downstream_dir: &Path,
+    factory_index: &ContractIndex,
+    existing_file_check: impl Fn(&str) -> bool,
+) -> bool {
+    let mut downstream = read_contract_index(downstream_dir);
+    let mut added = false;
+
+    for (rk, contracts) in factory_index {
+        if !downstream.contains_key(rk) && existing_file_check(rk) {
+            downstream.insert(rk.clone(), contracts.clone());
+            added = true;
+        }
+    }
+
+    if added {
+        if let Err(e) = write_contract_index(downstream_dir, &downstream) {
+            tracing::warn!(
+                "Migration: failed to write downstream contract index at {}: {}",
+                downstream_dir.display(),
+                e
+            );
+            return false;
+        }
+    }
+
+    added
+}
+
 /// Address-to-contract lookup built from factory matchers.
 ///
 /// Maps `[u8; 20]` factory source addresses → `(contract_name, hex_address)`.

--- a/src/storage/contract_index.rs
+++ b/src/storage/contract_index.rs
@@ -1,0 +1,342 @@
+//! Contract index tracking for factory collection completeness.
+//!
+//! Each data layer (factories, eth_calls, decoded logs) writes a `contract_index.json`
+//! sidecar alongside its parquet files. The index records which factory source contracts
+//! (and their addresses) were included when each block range was processed.
+//!
+//! On catchup, ranges are reprocessed when the current config lists contracts or
+//! addresses absent from the index.
+
+use std::collections::HashMap;
+use std::io;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::types::config::contract::{AddressOrAddresses, Contracts};
+
+/// Per-range tracking of which contracts (and their addresses) were processed.
+///
+/// Outer key: range string like `"0-999"` (inclusive end, matching parquet filenames).
+/// Inner key: contract name (e.g. `"Airlock"`).
+/// Inner value: sorted list of lowercase hex addresses with `0x` prefix.
+pub type ContractIndex = HashMap<String, HashMap<String, Vec<String>>>;
+
+/// The contracts currently expected from configuration.
+///
+/// Key: contract name. Value: sorted list of lowercase hex addresses.
+pub type ExpectedContracts = HashMap<String, Vec<String>>;
+
+const INDEX_FILENAME: &str = "contract_index.json";
+
+// ---------------------------------------------------------------------------
+// Range key helper
+// ---------------------------------------------------------------------------
+
+/// Build the range key used as the outer key in `ContractIndex`.
+///
+/// Both `start` and `end_inclusive` match the parquet filename convention.
+pub fn range_key(start: u64, end_inclusive: u64) -> String {
+    format!("{}-{}", start, end_inclusive)
+}
+
+// ---------------------------------------------------------------------------
+// Expected contracts from config
+// ---------------------------------------------------------------------------
+
+/// Build expected factory source contracts per collection from the contracts config.
+///
+/// Returns `collection_name -> { contract_name -> [sorted hex addresses] }`.
+pub fn build_expected_factory_contracts(contracts: &Contracts) -> HashMap<String, ExpectedContracts> {
+    let mut result: HashMap<String, ExpectedContracts> = HashMap::new();
+
+    for (contract_name, config) in contracts {
+        let mut addresses = addresses_to_hex(&config.address);
+        addresses.sort();
+
+        if let Some(factories) = &config.factories {
+            for factory in factories {
+                result
+                    .entry(factory.collection.clone())
+                    .or_default()
+                    .insert(contract_name.clone(), addresses.clone());
+            }
+        }
+    }
+    result
+}
+
+/// Convert `AddressOrAddresses` to a list of lowercase `0x`-prefixed hex strings.
+fn addresses_to_hex(addr: &AddressOrAddresses) -> Vec<String> {
+    match addr {
+        AddressOrAddresses::Single(a) => vec![format!("0x{}", hex::encode(a.0 .0))],
+        AddressOrAddresses::Multiple(addrs) => addrs
+            .iter()
+            .map(|a| format!("0x{}", hex::encode(a.0 .0)))
+            .collect(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Missing-contracts check
+// ---------------------------------------------------------------------------
+
+/// Return the subset of `expected` contracts that are missing from the index
+/// for the given range key.
+///
+/// A contract is considered missing if:
+/// - Its name is absent from the index entry, or
+/// - Any of its configured addresses are absent from the indexed list.
+///
+/// Returns an empty map when the range is fully covered.
+pub fn get_missing_contracts(
+    index: &ContractIndex,
+    rk: &str,
+    expected: &ExpectedContracts,
+) -> ExpectedContracts {
+    let indexed = match index.get(rk) {
+        Some(entry) => entry,
+        None => return expected.clone(), // no entry at all → everything is missing
+    };
+
+    let mut missing = ExpectedContracts::new();
+
+    for (contract_name, expected_addrs) in expected {
+        match indexed.get(contract_name) {
+            None => {
+                // Entire contract is missing.
+                missing.insert(contract_name.clone(), expected_addrs.clone());
+            }
+            Some(indexed_addrs) => {
+                let absent: Vec<String> = expected_addrs
+                    .iter()
+                    .filter(|a| !indexed_addrs.contains(a))
+                    .cloned()
+                    .collect();
+                if !absent.is_empty() {
+                    missing.insert(contract_name.clone(), absent);
+                }
+            }
+        }
+    }
+
+    missing
+}
+
+// ---------------------------------------------------------------------------
+// Update helper
+// ---------------------------------------------------------------------------
+
+/// Merge `contracts` into the index for the given range key.
+///
+/// Overwrites the entry for `rk` with the provided contracts map.
+pub fn update_contract_index(
+    index: &mut ContractIndex,
+    rk: &str,
+    contracts: &ExpectedContracts,
+) {
+    index.insert(rk.to_string(), contracts.clone());
+}
+
+// ---------------------------------------------------------------------------
+// I/O – sync (called via spawn_blocking)
+// ---------------------------------------------------------------------------
+
+/// Read `contract_index.json` from `dir`. Returns an empty index if the file
+/// is missing or cannot be parsed.
+pub fn read_contract_index(dir: &Path) -> ContractIndex {
+    let path = dir.join(INDEX_FILENAME);
+    match std::fs::read_to_string(&path) {
+        Ok(content) => {
+            let index: ContractIndex = serde_json::from_str(&content).unwrap_or_default();
+            tracing::debug!(
+                "Read contract index from {}: {} ranges tracked",
+                path.display(),
+                index.len()
+            );
+            index
+        }
+        Err(e) => {
+            tracing::debug!(
+                "No contract index at {} ({}), starting fresh",
+                path.display(),
+                e.kind()
+            );
+            HashMap::new()
+        }
+    }
+}
+
+/// Atomically write `contract_index.json` to `dir`.
+///
+/// Uses the write-to-temp + sync + rename pattern so a crash never leaves a
+/// partially-written file.
+pub fn write_contract_index(dir: &Path, index: &ContractIndex) -> Result<(), io::Error> {
+    use std::io::Write;
+
+    std::fs::create_dir_all(dir)?;
+
+    let path = dir.join(INDEX_FILENAME);
+    let content = serde_json::to_string_pretty(index)
+        .map_err(|e| io::Error::other(format!("JSON serialize error: {}", e)))?;
+
+    // Atomic write: temp file with random suffix → sync → rename.
+    let random_suffix: u64 = rand::random();
+    let tmp_name = format!("{}.{:x}.tmp", INDEX_FILENAME, random_suffix);
+    let tmp_path = dir.join(tmp_name);
+
+    {
+        let mut f = std::fs::File::create(&tmp_path)?;
+        f.write_all(content.as_bytes())?;
+        f.sync_all()?;
+    }
+
+    std::fs::rename(&tmp_path, &path)?;
+
+    tracing::debug!(
+        "Wrote contract index to {}: {} ranges tracked",
+        path.display(),
+        index.len()
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// I/O – async wrappers
+// ---------------------------------------------------------------------------
+
+/// Async wrapper around [`read_contract_index`].
+pub async fn read_contract_index_async(dir: std::path::PathBuf) -> ContractIndex {
+    tokio::task::spawn_blocking(move || read_contract_index(&dir))
+        .await
+        .unwrap_or_default()
+}
+
+/// Async wrapper around [`write_contract_index`].
+pub async fn write_contract_index_async(
+    dir: std::path::PathBuf,
+    index: ContractIndex,
+) -> Result<(), io::Error> {
+    tokio::task::spawn_blocking(move || write_contract_index(&dir, &index))
+        .await
+        .map_err(|e| io::Error::other(format!("JoinError: {}", e)))?
+}
+
+// ---------------------------------------------------------------------------
+// Serde helpers for inline usage
+// ---------------------------------------------------------------------------
+
+/// Wrapper used when the index must be serialized for S3 upload.
+#[derive(Serialize, Deserialize)]
+struct ContractIndexWrapper(ContractIndex);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn sample_expected() -> ExpectedContracts {
+        let mut m = ExpectedContracts::new();
+        m.insert(
+            "Airlock".to_string(),
+            vec!["0xaaa".to_string()],
+        );
+        m.insert(
+            "OtherInit".to_string(),
+            vec!["0xbbb".to_string(), "0xccc".to_string()],
+        );
+        m
+    }
+
+    #[test]
+    fn test_range_key() {
+        assert_eq!(range_key(0, 999), "0-999");
+        assert_eq!(range_key(1000, 1999), "1000-1999");
+    }
+
+    #[test]
+    fn test_missing_contracts_empty_index() {
+        let index = ContractIndex::new();
+        let expected = sample_expected();
+        let missing = get_missing_contracts(&index, "0-999", &expected);
+        assert_eq!(missing, expected);
+    }
+
+    #[test]
+    fn test_missing_contracts_complete() {
+        let mut index = ContractIndex::new();
+        index.insert("0-999".to_string(), sample_expected());
+        let expected = sample_expected();
+        let missing = get_missing_contracts(&index, "0-999", &expected);
+        assert!(missing.is_empty());
+    }
+
+    #[test]
+    fn test_missing_contracts_partial_name() {
+        let mut index = ContractIndex::new();
+        let mut partial = ExpectedContracts::new();
+        partial.insert("Airlock".to_string(), vec!["0xaaa".to_string()]);
+        index.insert("0-999".to_string(), partial);
+
+        let expected = sample_expected();
+        let missing = get_missing_contracts(&index, "0-999", &expected);
+        assert!(missing.contains_key("OtherInit"));
+        assert!(!missing.contains_key("Airlock"));
+    }
+
+    #[test]
+    fn test_missing_contracts_partial_address() {
+        let mut index = ContractIndex::new();
+        let mut partial = sample_expected();
+        // Remove one address from OtherInit
+        partial.insert(
+            "OtherInit".to_string(),
+            vec!["0xbbb".to_string()], // missing 0xccc
+        );
+        index.insert("0-999".to_string(), partial);
+
+        let expected = sample_expected();
+        let missing = get_missing_contracts(&index, "0-999", &expected);
+        assert!(!missing.contains_key("Airlock"));
+        assert_eq!(
+            missing.get("OtherInit").unwrap(),
+            &vec!["0xccc".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_read_write_roundtrip() {
+        let dir = TempDir::new().unwrap();
+        let mut index = ContractIndex::new();
+        index.insert("0-999".to_string(), sample_expected());
+
+        write_contract_index(dir.path(), &index).unwrap();
+        let loaded = read_contract_index(dir.path());
+        assert_eq!(loaded, index);
+    }
+
+    #[test]
+    fn test_read_missing_file() {
+        let dir = TempDir::new().unwrap();
+        let loaded = read_contract_index(dir.path());
+        assert!(loaded.is_empty());
+    }
+
+    #[test]
+    fn test_update_contract_index() {
+        let mut index = ContractIndex::new();
+        let expected = sample_expected();
+        update_contract_index(&mut index, "0-999", &expected);
+        assert_eq!(index.get("0-999").unwrap(), &expected);
+
+        // Update same range overwrites
+        let mut new_expected = ExpectedContracts::new();
+        new_expected.insert("NewContract".to_string(), vec!["0xddd".to_string()]);
+        update_contract_index(&mut index, "0-999", &new_expected);
+        assert_eq!(index.get("0-999").unwrap(), &new_expected);
+    }
+}

--- a/src/storage/contract_index.rs
+++ b/src/storage/contract_index.rs
@@ -67,6 +67,38 @@ pub fn build_expected_factory_contracts(contracts: &Contracts) -> HashMap<String
     result
 }
 
+/// Like [`build_expected_factory_contracts`] but omits sources whose
+/// `start_block >= range_end_exclusive`.
+///
+/// Uses an exclusive end to match the `range.end` convention used throughout.
+pub fn build_expected_factory_contracts_for_range(
+    contracts: &Contracts,
+    range_end_exclusive: u64,
+) -> HashMap<String, ExpectedContracts> {
+    let mut result: HashMap<String, ExpectedContracts> = HashMap::new();
+
+    for (contract_name, config) in contracts {
+        if let Some(sb) = config.start_block {
+            if sb.to::<u64>() >= range_end_exclusive {
+                continue;
+            }
+        }
+
+        let mut addresses = addresses_to_hex(&config.address);
+        addresses.sort();
+
+        if let Some(factories) = &config.factories {
+            for factory in factories {
+                result
+                    .entry(factory.collection.clone())
+                    .or_default()
+                    .insert(contract_name.clone(), addresses.clone());
+            }
+        }
+    }
+    result
+}
+
 /// Convert `AddressOrAddresses` to a list of lowercase `0x`-prefixed hex strings.
 fn addresses_to_hex(addr: &AddressOrAddresses) -> Vec<String> {
     match addr {

--- a/src/storage/contract_index.rs
+++ b/src/storage/contract_index.rs
@@ -11,6 +11,7 @@ use std::collections::HashMap;
 use std::io;
 use std::path::Path;
 
+use arrow::array::Array;
 use serde::{Deserialize, Serialize};
 
 use crate::types::config::contract::{AddressOrAddresses, Contracts};
@@ -223,12 +224,127 @@ pub async fn write_contract_index_async(
 }
 
 // ---------------------------------------------------------------------------
-// Serde helpers for inline usage
+// Migration: build contract_index from existing log parquet files
 // ---------------------------------------------------------------------------
 
-/// Wrapper used when the index must be serialized for S3 upload.
-#[derive(Serialize, Deserialize)]
-struct ContractIndexWrapper(ContractIndex);
+/// Address-to-contract lookup built from factory matchers.
+///
+/// Maps `[u8; 20]` factory source addresses → `(contract_name, hex_address)`.
+pub type AddressContractMap = HashMap<[u8; 20], (String, String)>;
+
+/// Build a lookup from factory source addresses to `(contract_name, hex_addr)`.
+///
+/// This is used during migration to determine which contracts were active
+/// when an existing range was processed, by checking which source addresses
+/// appear in the log parquet.
+pub fn build_address_contract_map(contracts: &Contracts) -> HashMap<String, AddressContractMap> {
+    let mut result: HashMap<String, AddressContractMap> = HashMap::new();
+
+    for (contract_name, config) in contracts {
+        let addrs: Vec<([u8; 20], String)> = match &config.address {
+            AddressOrAddresses::Single(a) => {
+                vec![(a.0 .0, format!("0x{}", hex::encode(a.0 .0)))]
+            }
+            AddressOrAddresses::Multiple(addrs) => addrs
+                .iter()
+                .map(|a| (a.0 .0, format!("0x{}", hex::encode(a.0 .0))))
+                .collect(),
+        };
+
+        if let Some(factories) = &config.factories {
+            for factory in factories {
+                let map = result.entry(factory.collection.clone()).or_default();
+                for (raw, hex_str) in &addrs {
+                    map.insert(*raw, (contract_name.clone(), hex_str.clone()));
+                }
+            }
+        }
+    }
+    result
+}
+
+/// Scan a log parquet file and return which factory source contracts have
+/// matching addresses in the `address` column.
+///
+/// Returns an `ExpectedContracts` map containing only the contracts whose
+/// source addresses actually appear in the log file. This tells us what was
+/// configured when the range was originally processed.
+pub fn detect_contracts_in_log_parquet(
+    log_path: &Path,
+    address_maps: &HashMap<String, AddressContractMap>,
+) -> io::Result<HashMap<String, ExpectedContracts>> {
+    use std::collections::HashSet;
+    use std::fs::File;
+
+    let file = File::open(log_path).map_err(|e| {
+        io::Error::other(format!("Failed to open log parquet {}: {}", log_path.display(), e))
+    })?;
+
+    let builder = parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(file)
+        .map_err(|e| io::Error::other(format!("Parquet reader error: {}", e)))?;
+
+    let schema = builder.schema().clone();
+    let addr_col_idx = match schema.index_of("address") {
+        Ok(idx) => idx,
+        Err(_) => return Ok(HashMap::new()), // no address column
+    };
+
+    let mask =
+        parquet::arrow::ProjectionMask::roots(builder.parquet_schema(), vec![addr_col_idx]);
+    let reader = builder
+        .with_projection(mask)
+        .build()
+        .map_err(|e| io::Error::other(format!("Parquet build error: {}", e)))?;
+
+    // Collect unique 20-byte addresses from the column
+    let mut unique_addresses: HashSet<[u8; 20]> = HashSet::new();
+
+    for batch_result in reader {
+        let batch = match batch_result {
+            Ok(b) => b,
+            Err(_) => continue,
+        };
+        let col = match batch
+            .column_by_name("address")
+            .and_then(|c| c.as_any().downcast_ref::<arrow::array::FixedSizeBinaryArray>())
+        {
+            Some(c) => c,
+            None => continue,
+        };
+        for i in 0..col.len() {
+            let bytes = col.value(i);
+            if bytes.len() == 20 {
+                let mut addr = [0u8; 20];
+                addr.copy_from_slice(bytes);
+                unique_addresses.insert(addr);
+            }
+        }
+    }
+
+    // Match against each collection's address map
+    let mut result: HashMap<String, ExpectedContracts> = HashMap::new();
+    for (collection, addr_map) in address_maps {
+        let mut contracts_found: ExpectedContracts = ExpectedContracts::new();
+        for addr in &unique_addresses {
+            if let Some((contract_name, hex_addr)) = addr_map.get(addr) {
+                contracts_found
+                    .entry(contract_name.clone())
+                    .or_default()
+                    .push(hex_addr.clone());
+            }
+        }
+        // Sort addresses for deterministic comparison
+        for addrs in contracts_found.values_mut() {
+            addrs.sort();
+            addrs.dedup();
+        }
+        if !contracts_found.is_empty() {
+            result.insert(collection.clone(), contracts_found);
+        }
+    }
+
+    Ok(result)
+}
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -30,6 +30,7 @@
 //! ```
 
 mod cached;
+pub mod contract_index;
 mod data_loader;
 pub mod decoded_index;
 mod error;
@@ -52,7 +53,7 @@ pub use manifest::{ManifestManager, S3Manifest};
 pub use paths::BlockRange;
 pub use retry::RetryQueue;
 pub use s3::S3Backend;
-pub use upload::upload_parquet_to_s3;
+pub use upload::{upload_parquet_to_s3, upload_sidecar_to_s3};
 
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/src/storage/upload.rs
+++ b/src/storage/upload.rs
@@ -55,6 +55,35 @@ pub async fn upload_parquet_to_s3(
     Ok(())
 }
 
+/// Upload a sidecar file (e.g. `contract_index.json`) to S3.
+///
+/// Unlike [`upload_parquet_to_s3`], this does **not** write a marker because
+/// sidecar files are not range-based. The S3 key is derived from the local
+/// path by stripping the `data/` prefix.
+///
+/// No-op if S3 is not enabled.
+pub async fn upload_sidecar_to_s3(
+    storage_manager: &Arc<StorageManager>,
+    local_path: &Path,
+) -> Result<(), StorageError> {
+    if !storage_manager.is_s3_enabled() {
+        return Ok(());
+    }
+
+    let data = tokio::fs::read(local_path).await?;
+    let s3_key = compute_s3_key(local_path)?;
+
+    match storage_manager.s3_backend() {
+        Some(s3) => s3.write(&s3_key, &data).await?,
+        None => {
+            storage_manager.backend().write(&s3_key, &data).await?;
+        }
+    }
+
+    tracing::debug!("Uploaded sidecar {} to S3", s3_key);
+    Ok(())
+}
+
 /// Compute the S3 key from a local path by stripping the "data/" prefix.
 ///
 /// Returns an error if the path does not contain a "data/" segment,

--- a/src/transformations/registry.rs
+++ b/src/transformations/registry.rs
@@ -57,11 +57,9 @@ pub struct TransformationRegistry {
     call_handlers: HashMap<(String, String), Vec<Arc<dyn EthCallHandler>>>,
     /// All handlers for initialization (de-duplicated)
     all_handlers: Vec<Arc<dyn TransformationHandler>>,
-<<<<<<< feat/chain-aware-handlers
     /// When set, only handlers whose trigger sources are all present in this
     /// set will be registered. Used to filter handlers per-chain.
     available_sources: Option<HashSet<String>>,
-=======
     /// Maps handler name() to its declared handler dependency names
     handler_dependency_graph: HashMap<String, Vec<String>>,
     /// Topological ordering of handler names (computed after all handlers registered)
@@ -78,7 +76,6 @@ pub struct TransformationRegistry {
     /// Multi-trigger handlers must not have their success persisted until
     /// all batches for the block have been dispatched.
     multi_trigger_handler_keys: HashSet<String>,
->>>>>>> main
 }
 
 impl TransformationRegistry {
@@ -88,8 +85,14 @@ impl TransformationRegistry {
             event_handlers: HashMap::new(),
             call_handlers: HashMap::new(),
             all_handlers: Vec::new(),
-<<<<<<< feat/chain-aware-handlers
             available_sources: None,
+            handler_dependency_graph: HashMap::new(),
+            handler_topological_order: Vec::new(),
+            dependency_handler_names: HashSet::new(),
+            handler_key_to_name: HashMap::new(),
+            handler_name_to_key: HashMap::new(),
+            event_handler_names: HashSet::new(),
+            multi_trigger_handler_keys: HashSet::new(),
         }
     }
 
@@ -103,7 +106,6 @@ impl TransformationRegistry {
             call_handlers: HashMap::new(),
             all_handlers: Vec::new(),
             available_sources: Some(sources),
-=======
             handler_dependency_graph: HashMap::new(),
             handler_topological_order: Vec::new(),
             dependency_handler_names: HashSet::new(),
@@ -111,7 +113,6 @@ impl TransformationRegistry {
             handler_name_to_key: HashMap::new(),
             event_handler_names: HashSet::new(),
             multi_trigger_handler_keys: HashSet::new(),
->>>>>>> main
         }
     }
 
@@ -135,7 +136,6 @@ impl TransformationRegistry {
 
         let triggers = handler.triggers();
 
-<<<<<<< feat/chain-aware-handlers
         if let Some(ref sources) = self.available_sources {
             if !triggers.iter().all(|t| sources.contains(&t.source)) {
                 tracing::debug!(
@@ -144,11 +144,11 @@ impl TransformationRegistry {
                 );
                 return;
             }
-=======
+        }
+
         if triggers.len() > 1 {
             self.multi_trigger_handler_keys
                 .insert(handler.handler_key());
->>>>>>> main
         }
 
         for trigger in triggers {
@@ -202,7 +202,6 @@ impl TransformationRegistry {
 
         let triggers = handler.triggers();
 
-<<<<<<< feat/chain-aware-handlers
         if let Some(ref sources) = self.available_sources {
             if !triggers.iter().all(|t| sources.contains(&t.source)) {
                 tracing::debug!(
@@ -211,11 +210,11 @@ impl TransformationRegistry {
                 );
                 return;
             }
-=======
+        }
+
         if triggers.len() > 1 {
             self.multi_trigger_handler_keys
                 .insert(handler.handler_key());
->>>>>>> main
         }
 
         for trigger in triggers {


### PR DESCRIPTION
## Summary

- Factory collection previously skipped ranges when a parquet file existed for a collection, regardless of which source contracts contributed. Adding a new contract or address would not reprocess historical ranges.
- Adds `contract_index.json` sidecar files at each data layer tracking which source contracts/addresses were included per block range. On catchup, ranges with missing contracts are reprocessed.
- Covers all five factory data layers: factory addresses, regular eth_calls, once eth_calls, on_events eth_calls, and decoded logs.

## Notes

- First run after this change reprocesses all historical factory ranges (one-time migration cost).
- Parquet written before index update ensures crash safety.
- Resolves pre-existing merge conflicts in registry.rs.