### PR TITLE
feat: add completion tracker and DAG scheduler primitives

### DIFF
--- a/src/transformations/executor.rs
+++ b/src/transformations/executor.rs
@@ -84,9 +84,6 @@ impl HandlerExecutor {
             let events = task.events;
             let calls = task.calls;
             let tx_addresses = task.tx_addresses;
-            let handler_name = handler.name();
-            let handler_version = handler.version();
-            let handler_key = handler.handler_key();
             let snapshot_chain = match db_exec_mode {
                 DbExecMode::Direct => None,
                 DbExecMode::WithSnapshotCapture { chain_name } => Some(chain_name.clone()),
@@ -94,70 +91,32 @@ impl HandlerExecutor {
 
             join_set.spawn(async move {
                 let _permit = permit;
-                let ctx = TransformationContext::new(
+                let db_exec_mode = match snapshot_chain {
+                    Some(cn) => DbExecMode::WithSnapshotCapture { chain_name: cn },
+                    None => DbExecMode::Direct,
+                };
+                // run_handler_task logs handler/transaction failures internally;
+                // we convert its Err variant to Ok(None) to keep the existing
+                // join-set contract (caller never sees a propagated error).
+                match run_handler_task(
+                    handler,
+                    events,
+                    calls,
+                    tx_addresses,
                     chain_name,
                     chain_id,
                     range_start,
                     range_end,
-                    events,
-                    calls,
-                    tx_addresses,
                     historical,
                     rpc,
                     contracts,
-                );
-
-                match handler.handle(&ctx).await {
-                    Ok(ops) => {
-                        if !ops.is_empty() {
-                            let ops = inject_source_version(ops, handler_name, handler_version);
-
-                            let result = if let Some(ref cn) = snapshot_chain {
-                                let storage = LiveStorage::new(cn);
-                                execute_with_snapshot_capture(
-                                    ops,
-                                    &db_pool,
-                                    Some(&storage),
-                                    range_start,
-                                    handler_name,
-                                    handler_version,
-                                )
-                                .await
-                            } else {
-                                db_pool
-                                    .execute_transaction(ops)
-                                    .await
-                                    .map_err(TransformationError::DatabaseError)
-                            };
-
-                            if let Err(e) = result {
-                                tracing::error!(
-                                    "Handler {} transaction failed for range {}-{}: {:?}",
-                                    handler_key,
-                                    range_start,
-                                    range_end,
-                                    e
-                                );
-                                return Ok(None);
-                            }
-                        }
-                        Ok(Some(HandlerOutcome {
-                            handler_key,
-                            handler_name: handler_name.to_string(),
-                            range_start,
-                            range_end,
-                        }))
-                    }
-                    Err(e) => {
-                        tracing::error!(
-                            "Handler {} failed for range {}-{}: {}",
-                            handler_key,
-                            range_start,
-                            range_end,
-                            e
-                        );
-                        Ok(None)
-                    }
+                    db_pool,
+                    &db_exec_mode,
+                )
+                .await
+                {
+                    Ok(outcome) => Ok(Some(outcome)),
+                    Err(_) => Ok(None),
                 }
             });
         }
@@ -178,6 +137,106 @@ impl HandlerExecutor {
 
         outcomes
     }
+}
+
+/// Run a single handler on a single range: build context, invoke the handler,
+/// inject `source`/`source_version`, and execute the resulting DB ops.
+///
+/// Returns the handler outcome on success. On handler or DB failure, logs the
+/// error (matching the prior inline behavior) and returns `Err`. Callers that
+/// want to tolerate failures should pattern-match on the result; the
+/// [`HandlerExecutor`] converts `Err` to `Ok(None)` to preserve its existing
+/// fire-and-forget contract.
+///
+/// Shared between [`HandlerExecutor`] and (in subsequent phases) the DAG-aware
+/// scheduler in [`super::scheduler`].
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn run_handler_task(
+    handler: Arc<dyn TransformationHandler>,
+    events: Arc<Vec<DecodedEvent>>,
+    calls: Arc<Vec<DecodedCall>>,
+    tx_addresses: HashMap<[u8; 32], TransactionAddresses>,
+    chain_name: String,
+    chain_id: u64,
+    range_start: u64,
+    range_end: u64,
+    historical: Arc<HistoricalDataReader>,
+    rpc: Arc<UnifiedRpcClient>,
+    contracts: Arc<Contracts>,
+    db_pool: Arc<DbPool>,
+    db_exec_mode: &DbExecMode,
+) -> Result<HandlerOutcome, TransformationError> {
+    let handler_name = handler.name();
+    let handler_version = handler.version();
+    let handler_key = handler.handler_key();
+
+    let ctx = TransformationContext::new(
+        chain_name,
+        chain_id,
+        range_start,
+        range_end,
+        events,
+        calls,
+        tx_addresses,
+        historical,
+        rpc,
+        contracts,
+    );
+
+    let ops = match handler.handle(&ctx).await {
+        Ok(ops) => ops,
+        Err(e) => {
+            tracing::error!(
+                "Handler {} failed for range {}-{}: {}",
+                handler_key,
+                range_start,
+                range_end,
+                e
+            );
+            return Err(e);
+        }
+    };
+
+    if !ops.is_empty() {
+        let ops = inject_source_version(ops, handler_name, handler_version);
+
+        let result = match db_exec_mode {
+            DbExecMode::WithSnapshotCapture { chain_name: cn } => {
+                let storage = LiveStorage::new(cn);
+                execute_with_snapshot_capture(
+                    ops,
+                    &db_pool,
+                    Some(&storage),
+                    range_start,
+                    handler_name,
+                    handler_version,
+                )
+                .await
+            }
+            DbExecMode::Direct => db_pool
+                .execute_transaction(ops)
+                .await
+                .map_err(TransformationError::DatabaseError),
+        };
+
+        if let Err(e) = result {
+            tracing::error!(
+                "Handler {} transaction failed for range {}-{}: {:?}",
+                handler_key,
+                range_start,
+                range_end,
+                e
+            );
+            return Err(e);
+        }
+    }
+
+    Ok(HandlerOutcome {
+        handler_key,
+        handler_name: handler_name.to_string(),
+        range_start,
+        range_end,
+    })
 }
 
 // ─── Source/Version Injection (free functions) ───────────────────────

--- a/src/transformations/mod.rs
+++ b/src/transformations/mod.rs
@@ -64,6 +64,7 @@ pub mod historical;
 mod live_state;
 pub mod registry;
 mod retry;
+pub(crate) mod scheduler;
 pub mod traits;
 pub mod util;
 

--- a/src/transformations/scheduler/dag.rs
+++ b/src/transformations/scheduler/dag.rs
@@ -1,0 +1,634 @@
+//! Pipelined DAG scheduler — executes [`WorkItem`]s with per-range dependency gating.
+//!
+//! See module docs in [`super`]. Each item is spawned as an independent Tokio
+//! task. Each task:
+//!
+//!   1. awaits [`CompletionTracker::wait_ready`] on its `(dep_names, range_start)`,
+//!   2. acquires a permit from the global concurrency semaphore,
+//!   3. invokes a caller-supplied runner closure with the item,
+//!   4. marks itself completed or failed on the tracker, waking dependents.
+//!
+//! Waiting happens *before* permit acquisition to prevent a permit-deadlock
+//! where all permits are held by waiters.
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::future::Future;
+use std::sync::Arc;
+
+use tokio::sync::Semaphore;
+use tokio::task::{Id, JoinSet};
+
+use super::tracker::CompletionTracker;
+
+/// One atomic unit of work: run one handler on one range.
+///
+/// The `payload` is opaque to the scheduler — the caller supplies a runner
+/// closure that downcasts it to its concrete type. This keeps the scheduler
+/// decoupled from handler traits, DB types, and context construction.
+pub(crate) struct WorkItem {
+    pub handler_name: String,
+    pub range_start: u64,
+    pub range_end: u64,
+    pub dep_names: Vec<String>,
+    pub payload: Box<dyn Any + Send + Sync>,
+}
+
+/// Terminal result of one [`WorkItem`] execution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WorkItemOutcome {
+    pub handler_name: String,
+    pub range_start: u64,
+    pub range_end: u64,
+    pub status: OutcomeStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum OutcomeStatus {
+    /// Runner returned `Ok(())`.
+    Succeeded,
+    /// Runner returned `Err(reason)`.
+    HandlerFailed { reason: String },
+    /// A dependency was marked failed, so this item was cascade-skipped.
+    DepCascadeFailed { dep_name: String },
+    /// Runner panicked or the task was cancelled.
+    Panicked,
+}
+
+/// Pure DAG scheduler — owns the [`CompletionTracker`] and a concurrency semaphore.
+///
+/// DB writes, handler invocation, and context construction all live in the
+/// runner closure passed to [`execute`]. Phase 2 wires a catchup runner on
+/// top of this; tests use a trivial recording runner.
+///
+/// [`execute`]: DagScheduler::execute
+pub(crate) struct DagScheduler {
+    tracker: Arc<CompletionTracker>,
+    global_permits: Arc<Semaphore>,
+}
+
+impl DagScheduler {
+    pub(crate) fn new(tracker: Arc<CompletionTracker>, concurrency: usize) -> Self {
+        Self {
+            tracker,
+            global_permits: Arc::new(Semaphore::new(concurrency.max(1))),
+        }
+    }
+
+    /// Spawn one task per item, returning an outcome for every item.
+    ///
+    /// Items whose deps are already satisfied start immediately (modulo the
+    /// concurrency bound). Items with unsatisfied deps park in
+    /// [`CompletionTracker::wait_ready`] until their deps complete or fail.
+    /// Cascade failures short-circuit downstream items with
+    /// [`OutcomeStatus::DepCascadeFailed`].
+    pub(crate) async fn execute<R, Fut>(
+        &self,
+        items: Vec<WorkItem>,
+        runner: R,
+    ) -> Vec<WorkItemOutcome>
+    where
+        R: Fn(WorkItem) -> Fut + Send + Sync + Clone + 'static,
+        Fut: Future<Output = Result<(), String>> + Send + 'static,
+    {
+        if items.is_empty() {
+            return Vec::new();
+        }
+
+        let mut join_set: JoinSet<WorkItemOutcome> = JoinSet::new();
+        // Tracks identity per Tokio task ID so we can report a full outcome
+        // even if the task panics (JoinError carries no user payload).
+        let mut identity: HashMap<Id, (String, u64, u64)> = HashMap::new();
+
+        for item in items {
+            let name = item.handler_name.clone();
+            let range_start = item.range_start;
+            let range_end = item.range_end;
+            let dep_names = item.dep_names.clone();
+            let tracker = self.tracker.clone();
+            let permits = self.global_permits.clone();
+            let runner = runner.clone();
+
+            // Data captured by the spawned task:
+            let name_for_task = name.clone();
+            let handle = join_set.spawn(async move {
+                // 1. Gate on dependencies.
+                if let Err(dep_failed) = tracker.wait_ready(&dep_names, range_start).await {
+                    // Cascade: our own dependents must also short-circuit.
+                    tracker.mark_failed(&name_for_task, range_start).await;
+                    return WorkItemOutcome {
+                        handler_name: name_for_task,
+                        range_start,
+                        range_end,
+                        status: OutcomeStatus::DepCascadeFailed {
+                            dep_name: dep_failed.dep_name,
+                        },
+                    };
+                }
+
+                // 2. Acquire permit AFTER waiting to avoid permit-deadlock.
+                let _permit = permits
+                    .acquire_owned()
+                    .await
+                    .expect("semaphore never closed");
+
+                // 3. Invoke runner.
+                let result = runner(item).await;
+
+                // 4. Propagate result to tracker + return outcome.
+                match result {
+                    Ok(()) => {
+                        tracker.mark_completed(&name_for_task, range_start).await;
+                        WorkItemOutcome {
+                            handler_name: name_for_task,
+                            range_start,
+                            range_end,
+                            status: OutcomeStatus::Succeeded,
+                        }
+                    }
+                    Err(reason) => {
+                        tracker.mark_failed(&name_for_task, range_start).await;
+                        WorkItemOutcome {
+                            handler_name: name_for_task,
+                            range_start,
+                            range_end,
+                            status: OutcomeStatus::HandlerFailed { reason },
+                        }
+                    }
+                }
+            });
+            identity.insert(handle.id(), (name, range_start, range_end));
+        }
+
+        let mut outcomes = Vec::new();
+        while let Some(res) = join_set.join_next_with_id().await {
+            match res {
+                Ok((id, outcome)) => {
+                    identity.remove(&id);
+                    outcomes.push(outcome);
+                }
+                Err(join_error) => {
+                    let id = join_error.id();
+                    let (name, range_start, range_end) = identity
+                        .remove(&id)
+                        .expect("every spawned task's id was recorded");
+                    tracing::error!(
+                        "WorkItem task panicked: handler={} range_start={} err={}",
+                        name,
+                        range_start,
+                        join_error
+                    );
+                    // Panic means the task never reached mark_completed/mark_failed,
+                    // so downstream waiters would hang. Mark failed here.
+                    self.tracker.mark_failed(&name, range_start).await;
+                    outcomes.push(WorkItemOutcome {
+                        handler_name: name,
+                        range_start,
+                        range_end,
+                        status: OutcomeStatus::Panicked,
+                    });
+                }
+            }
+        }
+
+        outcomes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::{Duration, Instant};
+    use tokio::sync::Mutex as TokioMutex;
+
+    /// (handler_name, range_start, kind) — kind is "start" or "end".
+    type EventLog = Arc<TokioMutex<Vec<(String, u64, &'static str)>>>;
+
+    /// Observable side-effects of a test runner. Shared across all spawned tasks
+    /// so assertions can inspect ordering, concurrency, and timing.
+    struct Recorder {
+        events: EventLog,
+        in_flight: Arc<AtomicUsize>,
+        max_in_flight: Arc<AtomicUsize>,
+        fail_on: HashSet<(String, u64)>,
+        panic_on: HashSet<(String, u64)>,
+        hold_ms: u64,
+    }
+
+    impl Recorder {
+        fn new(hold_ms: u64) -> Arc<Self> {
+            Arc::new(Self {
+                events: Arc::new(TokioMutex::new(Vec::new())),
+                in_flight: Arc::new(AtomicUsize::new(0)),
+                max_in_flight: Arc::new(AtomicUsize::new(0)),
+                fail_on: HashSet::new(),
+                panic_on: HashSet::new(),
+                hold_ms,
+            })
+        }
+
+        fn with_fails(hold_ms: u64, fail_on: &[(&str, u64)]) -> Arc<Self> {
+            Arc::new(Self {
+                events: Arc::new(TokioMutex::new(Vec::new())),
+                in_flight: Arc::new(AtomicUsize::new(0)),
+                max_in_flight: Arc::new(AtomicUsize::new(0)),
+                fail_on: fail_on.iter().map(|(n, r)| (n.to_string(), *r)).collect(),
+                panic_on: HashSet::new(),
+                hold_ms,
+            })
+        }
+
+        fn with_panics(hold_ms: u64, panic_on: &[(&str, u64)]) -> Arc<Self> {
+            Arc::new(Self {
+                events: Arc::new(TokioMutex::new(Vec::new())),
+                in_flight: Arc::new(AtomicUsize::new(0)),
+                max_in_flight: Arc::new(AtomicUsize::new(0)),
+                fail_on: HashSet::new(),
+                panic_on: panic_on.iter().map(|(n, r)| (n.to_string(), *r)).collect(),
+                hold_ms,
+            })
+        }
+
+        fn runner(
+            self: &Arc<Self>,
+        ) -> impl Fn(WorkItem) -> std::pin::Pin<Box<dyn Future<Output = Result<(), String>> + Send>>
+               + Send
+               + Sync
+               + Clone
+               + 'static {
+            let rec = self.clone();
+            move |item: WorkItem| {
+                let rec = rec.clone();
+                Box::pin(async move {
+                    let key = (item.handler_name.clone(), item.range_start);
+
+                    rec.events
+                        .lock()
+                        .await
+                        .push((item.handler_name.clone(), item.range_start, "start"));
+
+                    let now = rec.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                    rec.max_in_flight.fetch_max(now, Ordering::SeqCst);
+
+                    if rec.hold_ms > 0 {
+                        tokio::time::sleep(Duration::from_millis(rec.hold_ms)).await;
+                    }
+
+                    if rec.panic_on.contains(&key) {
+                        panic!("test-forced panic at {}:{}", key.0, key.1);
+                    }
+
+                    rec.in_flight.fetch_sub(1, Ordering::SeqCst);
+                    rec.events
+                        .lock()
+                        .await
+                        .push((item.handler_name.clone(), item.range_start, "end"));
+
+                    if rec.fail_on.contains(&key) {
+                        Err(format!("test-forced failure at {}:{}", key.0, key.1))
+                    } else {
+                        Ok(())
+                    }
+                })
+            }
+        }
+    }
+
+    fn item(name: &str, range_start: u64, deps: &[&str]) -> WorkItem {
+        WorkItem {
+            handler_name: name.to_string(),
+            range_start,
+            range_end: range_start + 1,
+            dep_names: deps.iter().map(|s| s.to_string()).collect(),
+            payload: Box::new(()),
+        }
+    }
+
+    /// Return the index in `events` of the first (name, range, "start") entry,
+    /// or panic if not found.
+    fn idx_start(events: &[(String, u64, &'static str)], name: &str, range: u64) -> usize {
+        events
+            .iter()
+            .position(|(n, r, k)| n == name && *r == range && *k == "start")
+            .unwrap_or_else(|| panic!("no start event for {}:{}", name, range))
+    }
+
+    fn idx_end(events: &[(String, u64, &'static str)], name: &str, range: u64) -> usize {
+        events
+            .iter()
+            .position(|(n, r, k)| n == name && *r == range && *k == "end")
+            .unwrap_or_else(|| panic!("no end event for {}:{}", name, range))
+    }
+
+    #[tokio::test]
+    async fn empty_items_returns_empty_outcomes() {
+        let tracker = Arc::new(CompletionTracker::new());
+        let scheduler = DagScheduler::new(tracker, 4);
+        let rec = Recorder::new(0);
+        let outcomes = scheduler.execute(Vec::new(), rec.runner()).await;
+        assert!(outcomes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn outcomes_returned_for_every_item() {
+        let tracker = Arc::new(CompletionTracker::new());
+        let scheduler = DagScheduler::new(tracker, 4);
+        let rec = Recorder::new(0);
+        let items = vec![
+            item("A", 100, &[]),
+            item("A", 101, &[]),
+            item("B", 100, &[]),
+        ];
+        let outcomes = scheduler.execute(items, rec.runner()).await;
+        assert_eq!(outcomes.len(), 3);
+        let mut keys: Vec<_> = outcomes
+            .iter()
+            .map(|o| (o.handler_name.clone(), o.range_start))
+            .collect();
+        keys.sort();
+        assert_eq!(
+            keys,
+            vec![
+                ("A".to_string(), 100),
+                ("A".to_string(), 101),
+                ("B".to_string(), 100),
+            ]
+        );
+        for o in &outcomes {
+            assert_eq!(o.status, OutcomeStatus::Succeeded);
+        }
+    }
+
+    #[tokio::test]
+    async fn linear_chain_respects_order() {
+        // A -> B -> C on a single range.
+        let tracker = Arc::new(CompletionTracker::new());
+        let scheduler = DagScheduler::new(tracker, 4);
+        let rec = Recorder::new(10);
+        let items = vec![
+            item("A", 100, &[]),
+            item("B", 100, &["A"]),
+            item("C", 100, &["B"]),
+        ];
+        let outcomes = scheduler.execute(items, rec.runner()).await;
+        assert_eq!(outcomes.len(), 3);
+
+        let events = rec.events.lock().await.clone();
+        assert!(idx_end(&events, "A", 100) < idx_start(&events, "B", 100));
+        assert!(idx_end(&events, "B", 100) < idx_start(&events, "C", 100));
+    }
+
+    #[tokio::test]
+    async fn diamond_partial_ordering() {
+        // A -> B, A -> C, B -> D, C -> D. 5 ranges.
+        let tracker = Arc::new(CompletionTracker::new());
+        let scheduler = DagScheduler::new(tracker, 16);
+        let rec = Recorder::new(5);
+        let mut items = Vec::new();
+        for r in [100u64, 101, 102, 103, 104] {
+            items.push(item("A", r, &[]));
+            items.push(item("B", r, &["A"]));
+            items.push(item("C", r, &["A"]));
+            items.push(item("D", r, &["B", "C"]));
+        }
+        let outcomes = scheduler.execute(items, rec.runner()).await;
+        assert_eq!(outcomes.len(), 20);
+        for o in &outcomes {
+            assert_eq!(o.status, OutcomeStatus::Succeeded, "{:?}", o);
+        }
+        let events = rec.events.lock().await.clone();
+        for r in [100u64, 101, 102, 103, 104] {
+            // A before B/C/D
+            assert!(idx_end(&events, "A", r) < idx_start(&events, "B", r));
+            assert!(idx_end(&events, "A", r) < idx_start(&events, "C", r));
+            // B and C before D
+            assert!(idx_end(&events, "B", r) < idx_start(&events, "D", r));
+            assert!(idx_end(&events, "C", r) < idx_start(&events, "D", r));
+        }
+    }
+
+    #[tokio::test]
+    async fn independent_handlers_run_in_parallel() {
+        // 4 handlers, no deps, concurrency=4, hold=50ms.
+        // Total wall-clock should be ~50ms, not ~200ms.
+        let tracker = Arc::new(CompletionTracker::new());
+        let scheduler = DagScheduler::new(tracker, 4);
+        let rec = Recorder::new(50);
+        let items = vec![
+            item("A", 100, &[]),
+            item("B", 100, &[]),
+            item("C", 100, &[]),
+            item("D", 100, &[]),
+        ];
+        let start = Instant::now();
+        let outcomes = scheduler.execute(items, rec.runner()).await;
+        let elapsed = start.elapsed();
+        assert_eq!(outcomes.len(), 4);
+        assert!(
+            elapsed < Duration::from_millis(150),
+            "expected parallel (~50ms), got {:?}",
+            elapsed
+        );
+        assert_eq!(rec.max_in_flight.load(Ordering::SeqCst), 4);
+    }
+
+    #[tokio::test]
+    async fn concurrency_bound_honored() {
+        let tracker = Arc::new(CompletionTracker::new());
+        let scheduler = DagScheduler::new(tracker, 2);
+        let rec = Recorder::new(20);
+        // 10 independent items with concurrency=2.
+        let items: Vec<_> = (0..10).map(|i| item("H", 100 + i, &[])).collect();
+        let outcomes = scheduler.execute(items, rec.runner()).await;
+        assert_eq!(outcomes.len(), 10);
+        assert_eq!(rec.max_in_flight.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn cascade_failure_short_circuits_downstream() {
+        // A -> B -> C on 3 ranges. A fails on range 101. B and C should
+        // cascade-fail on range 101, and succeed on 100 and 102.
+        let tracker = Arc::new(CompletionTracker::new());
+        let scheduler = DagScheduler::new(tracker, 8);
+        let rec = Recorder::with_fails(5, &[("A", 101)]);
+        let mut items = Vec::new();
+        for r in [100u64, 101, 102] {
+            items.push(item("A", r, &[]));
+            items.push(item("B", r, &["A"]));
+            items.push(item("C", r, &["B"]));
+        }
+        let outcomes = scheduler.execute(items, rec.runner()).await;
+        assert_eq!(outcomes.len(), 9);
+
+        let get = |name: &str, r: u64| {
+            outcomes
+                .iter()
+                .find(|o| o.handler_name == name && o.range_start == r)
+                .cloned()
+                .unwrap()
+        };
+
+        assert_eq!(get("A", 100).status, OutcomeStatus::Succeeded);
+        assert_eq!(get("B", 100).status, OutcomeStatus::Succeeded);
+        assert_eq!(get("C", 100).status, OutcomeStatus::Succeeded);
+
+        assert!(matches!(
+            get("A", 101).status,
+            OutcomeStatus::HandlerFailed { .. }
+        ));
+        assert_eq!(
+            get("B", 101).status,
+            OutcomeStatus::DepCascadeFailed {
+                dep_name: "A".to_string()
+            }
+        );
+        assert_eq!(
+            get("C", 101).status,
+            OutcomeStatus::DepCascadeFailed {
+                dep_name: "B".to_string()
+            }
+        );
+
+        assert_eq!(get("A", 102).status, OutcomeStatus::Succeeded);
+        assert_eq!(get("B", 102).status, OutcomeStatus::Succeeded);
+        assert_eq!(get("C", 102).status, OutcomeStatus::Succeeded);
+    }
+
+    #[tokio::test]
+    async fn pipelined_per_range_gating() {
+        // A -> B on 3 ranges. A's range-100 is slow (100ms); A's 101/102 are
+        // fast (10ms). B's range-101 should start BEFORE A's range-100 ends,
+        // proving per-range gating (not per-handler barrier).
+        let tracker = Arc::new(CompletionTracker::new());
+        let scheduler = DagScheduler::new(tracker, 8);
+
+        // Custom runner that varies hold time per item.
+        struct VarRec {
+            events: EventLog,
+        }
+        let vrec = Arc::new(VarRec {
+            events: Arc::new(TokioMutex::new(Vec::new())),
+        });
+        let runner = {
+            let vrec = vrec.clone();
+            move |item: WorkItem| {
+                let vrec = vrec.clone();
+                Box::pin(async move {
+                    vrec.events
+                        .lock()
+                        .await
+                        .push((item.handler_name.clone(), item.range_start, "start"));
+                    let hold = if item.handler_name == "A" && item.range_start == 100 {
+                        100u64
+                    } else {
+                        10u64
+                    };
+                    tokio::time::sleep(Duration::from_millis(hold)).await;
+                    vrec.events
+                        .lock()
+                        .await
+                        .push((item.handler_name.clone(), item.range_start, "end"));
+                    Ok::<(), String>(())
+                })
+                    as std::pin::Pin<
+                        Box<dyn Future<Output = Result<(), String>> + Send>,
+                    >
+            }
+        };
+
+        let items = vec![
+            item("A", 100, &[]),
+            item("A", 101, &[]),
+            item("A", 102, &[]),
+            item("B", 100, &["A"]),
+            item("B", 101, &["A"]),
+            item("B", 102, &["A"]),
+        ];
+        let outcomes = scheduler.execute(items, runner).await;
+        assert_eq!(outcomes.len(), 6);
+        for o in &outcomes {
+            assert_eq!(o.status, OutcomeStatus::Succeeded);
+        }
+
+        let events = vrec.events.lock().await.clone();
+        // B's range-101 must start before A's range-100 ends (pipelined).
+        let b_101_start = idx_start(&events, "B", 101);
+        let a_100_end = idx_end(&events, "A", 100);
+        assert!(
+            b_101_start < a_100_end,
+            "expected B:101 start ({}) before A:100 end ({})  events: {:?}",
+            b_101_start,
+            a_100_end,
+            events
+        );
+    }
+
+    #[tokio::test]
+    async fn panic_in_runner_reports_panicked_outcome() {
+        let tracker = Arc::new(CompletionTracker::new());
+        let scheduler = DagScheduler::new(tracker, 4);
+        let rec = Recorder::with_panics(5, &[("A", 101)]);
+        let items = vec![
+            item("A", 100, &[]),
+            item("A", 101, &[]),
+            item("A", 102, &[]),
+        ];
+        let outcomes = scheduler.execute(items, rec.runner()).await;
+        assert_eq!(outcomes.len(), 3);
+
+        let get = |r: u64| {
+            outcomes
+                .iter()
+                .find(|o| o.handler_name == "A" && o.range_start == r)
+                .cloned()
+                .unwrap()
+        };
+        assert_eq!(get(100).status, OutcomeStatus::Succeeded);
+        assert_eq!(get(101).status, OutcomeStatus::Panicked);
+        assert_eq!(get(102).status, OutcomeStatus::Succeeded);
+    }
+
+    #[tokio::test]
+    async fn panic_cascades_to_dependents() {
+        // A's range-100 panics; B (dep on A) at range-100 should cascade-fail
+        // (proving we call mark_failed in the panic-handling branch).
+        let tracker = Arc::new(CompletionTracker::new());
+        let scheduler = DagScheduler::new(tracker, 4);
+        let rec = Recorder::with_panics(5, &[("A", 100)]);
+        let items = vec![item("A", 100, &[]), item("B", 100, &["A"])];
+        let outcomes = scheduler.execute(items, rec.runner()).await;
+        assert_eq!(outcomes.len(), 2);
+
+        let get = |name: &str, r: u64| {
+            outcomes
+                .iter()
+                .find(|o| o.handler_name == name && o.range_start == r)
+                .cloned()
+                .unwrap()
+        };
+        assert_eq!(get("A", 100).status, OutcomeStatus::Panicked);
+        assert_eq!(
+            get("B", 100).status,
+            OutcomeStatus::DepCascadeFailed {
+                dep_name: "A".to_string()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn seeded_tracker_unblocks_items_immediately() {
+        // Pre-seed tracker so B's deps are already satisfied at submit time.
+        let tracker = Arc::new(CompletionTracker::new());
+        tracker.seed_completed("A", [100, 101]).await;
+        let scheduler = DagScheduler::new(tracker, 4);
+        let rec = Recorder::new(0);
+        let items = vec![item("B", 100, &["A"]), item("B", 101, &["A"])];
+        let outcomes = scheduler.execute(items, rec.runner()).await;
+        assert_eq!(outcomes.len(), 2);
+        for o in &outcomes {
+            assert_eq!(o.status, OutcomeStatus::Succeeded);
+        }
+    }
+}

--- a/src/transformations/scheduler/mod.rs
+++ b/src/transformations/scheduler/mod.rs
@@ -1,0 +1,33 @@
+//! DAG-aware handler scheduling primitives.
+//!
+//! Provides [`CompletionTracker`] and [`DagScheduler`], the pipelined
+//! dependency-aware scheduler that replaces the sequential topological loop
+//! in `run_handler_catchup` (Phase 2) and the dep-unaware task spawn in
+//! `process_range` (Phase 3). See `docs/concurrent_handlers/design.md`.
+//!
+//! # Unit of work
+//!
+//! Every atomic work unit is a `(handler, range_start)` pair represented by
+//! [`WorkItem`]. For each dependency edge `B depends on A`, no execution of
+//! `B` on range `R` starts until `A` on range `R` is recorded as completed
+//! in the [`CompletionTracker`]. Different ranges of the same DAG proceed
+//! independently and concurrently.
+//!
+//! # Layering
+//!
+//! [`DagScheduler`] is pure: it knows only about tracker state, a global
+//! concurrency semaphore, and a caller-supplied async runner closure. DB
+//! writes, handler invocation, and context construction live in the runner
+//! (wired up in Phase 2). This keeps the scheduler fully testable without
+//! a `DbPool`.
+//!
+//! [`CompletionTracker`]: tracker::CompletionTracker
+//! [`DagScheduler`]: dag::DagScheduler
+//! [`WorkItem`]: dag::WorkItem
+
+// Phase 1 adds these primitives with no production callers yet; Phase 2 wires
+// them into catchup. Silence dead-code warnings until then.
+#![allow(dead_code)]
+
+pub(crate) mod dag;
+pub(crate) mod tracker;

--- a/src/transformations/scheduler/tracker.rs
+++ b/src/transformations/scheduler/tracker.rs
@@ -1,0 +1,398 @@
+//! Completion tracking with notify-based wake-up for dependency waiters.
+//!
+//! [`CompletionTracker`] is the synchronization primitive used by [`DagScheduler`]
+//! to gate each `(handler, range_start)` work item on its dependencies. Each
+//! waiter registers a single `Notify::notified()` future, checks shared state,
+//! and awaits the future if any dep is still pending. Every `mark_completed` /
+//! `mark_failed` call wakes all waiters so they can re-check.
+//!
+//! # Wake mechanism
+//!
+//! [`tokio::sync::Notify`] with `notify_waiters` on every completion/failure.
+//! The codebase has no other `Notify` usage, but here it's the natural primitive:
+//! each waiter re-checks its predicate against shared state after being woken.
+//! Under heavy cascade-failure the wake-storm could become noisy; a per-handler
+//! `watch<HashSet<u64>>` would be an isolated drop-in swap if profiling shows
+//! contention.
+//!
+//! [`DagScheduler`]: super::dag::DagScheduler
+
+use std::collections::{HashMap, HashSet};
+
+use tokio::sync::{Mutex, Notify};
+
+/// In-memory state of per-`(handler_name, range_start)` completion/failure.
+///
+/// Seeded at startup from `_handler_progress`, then updated as [`WorkItem`]s
+/// finish. Waiters register interest via [`wait_ready`] and are woken on every
+/// state transition.
+///
+/// [`WorkItem`]: super::dag::WorkItem
+/// [`wait_ready`]: CompletionTracker::wait_ready
+pub(crate) struct CompletionTracker {
+    completed: Mutex<HashMap<String, HashSet<u64>>>,
+    failed: Mutex<HashMap<String, HashSet<u64>>>,
+    notify: Notify,
+}
+
+/// Snapshot view of whether a set of dependencies is satisfied for a range.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DepState {
+    /// All deps have the given range marked completed.
+    Ready,
+    /// At least one dep has not yet marked the range completed or failed.
+    Waiting,
+    /// At least one dep has the range marked failed.
+    DepFailed { dep_name: String },
+}
+
+/// Returned by [`wait_ready`] when a dependency has failed.
+///
+/// [`wait_ready`]: CompletionTracker::wait_ready
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("dependency '{dep_name}' failed for range_start {range_start}")]
+pub(crate) struct DepFailed {
+    pub dep_name: String,
+    pub range_start: u64,
+}
+
+impl CompletionTracker {
+    pub(crate) fn new() -> Self {
+        Self {
+            completed: Mutex::new(HashMap::new()),
+            failed: Mutex::new(HashMap::new()),
+            notify: Notify::new(),
+        }
+    }
+
+    /// Pre-populate completed ranges for a handler. Intended for startup
+    /// seeding from `_handler_progress`; safe to call before any waiters exist.
+    pub(crate) async fn seed_completed(
+        &self,
+        handler_name: &str,
+        ranges: impl IntoIterator<Item = u64>,
+    ) {
+        let mut completed = self.completed.lock().await;
+        let entry = completed
+            .entry(handler_name.to_string())
+            .or_insert_with(HashSet::new);
+        for range in ranges {
+            entry.insert(range);
+        }
+    }
+
+    /// Snapshot check: are all `deps` completed for `range_start`?
+    pub(crate) async fn probe(&self, deps: &[String], range_start: u64) -> DepState {
+        // Check failed first so a failed dep is reported even if others are completed.
+        {
+            let failed = self.failed.lock().await;
+            for dep in deps {
+                if failed
+                    .get(dep)
+                    .map(|ranges| ranges.contains(&range_start))
+                    .unwrap_or(false)
+                {
+                    return DepState::DepFailed {
+                        dep_name: dep.clone(),
+                    };
+                }
+            }
+        }
+        let completed = self.completed.lock().await;
+        for dep in deps {
+            let has = completed
+                .get(dep)
+                .map(|ranges| ranges.contains(&range_start))
+                .unwrap_or(false);
+            if !has {
+                return DepState::Waiting;
+            }
+        }
+        DepState::Ready
+    }
+
+    /// Await until every `(dep, range_start)` pair is completed, or return
+    /// [`DepFailed`] if any dep has that range marked failed.
+    ///
+    /// The loop registers the `notified()` future *before* probing state so
+    /// wake-ups cannot be lost between the check and the await.
+    pub(crate) async fn wait_ready(
+        &self,
+        deps: &[String],
+        range_start: u64,
+    ) -> Result<(), DepFailed> {
+        loop {
+            // Register interest BEFORE probing — otherwise a mark() between
+            // probe and await could leave this waiter parked forever.
+            let notified = self.notify.notified();
+            match self.probe(deps, range_start).await {
+                DepState::Ready => return Ok(()),
+                DepState::DepFailed { dep_name } => {
+                    return Err(DepFailed {
+                        dep_name,
+                        range_start,
+                    })
+                }
+                DepState::Waiting => notified.await,
+            }
+        }
+    }
+
+    /// Mark `(handler_name, range_start)` as completed and wake all waiters.
+    pub(crate) async fn mark_completed(&self, handler_name: &str, range_start: u64) {
+        {
+            let mut completed = self.completed.lock().await;
+            completed
+                .entry(handler_name.to_string())
+                .or_insert_with(HashSet::new)
+                .insert(range_start);
+        }
+        self.notify.notify_waiters();
+    }
+
+    /// Mark `(handler_name, range_start)` as failed and wake all waiters.
+    pub(crate) async fn mark_failed(&self, handler_name: &str, range_start: u64) {
+        {
+            let mut failed = self.failed.lock().await;
+            failed
+                .entry(handler_name.to_string())
+                .or_insert_with(HashSet::new)
+                .insert(range_start);
+        }
+        self.notify.notify_waiters();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    fn names(xs: &[&str]) -> Vec<String> {
+        xs.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[tokio::test]
+    async fn empty_deps_is_ready() {
+        let tracker = CompletionTracker::new();
+        // Empty deps: should resolve immediately for any range.
+        tracker.wait_ready(&[], 100).await.unwrap();
+        tracker.wait_ready(&[], 999).await.unwrap();
+        assert_eq!(tracker.probe(&[], 100).await, DepState::Ready);
+    }
+
+    #[tokio::test]
+    async fn seed_then_wait_returns_immediately() {
+        let tracker = CompletionTracker::new();
+        tracker.seed_completed("A", [100, 101, 102]).await;
+        // Must return without blocking even if we never call mark_completed.
+        tokio::time::timeout(
+            Duration::from_millis(50),
+            tracker.wait_ready(&names(&["A"]), 100),
+        )
+        .await
+        .expect("wait_ready should return immediately after seed")
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn wait_then_complete_wakes_waiter() {
+        let tracker = Arc::new(CompletionTracker::new());
+        let tracker2 = tracker.clone();
+        let handle = tokio::spawn(async move {
+            tracker2.wait_ready(&names(&["A"]), 100).await.unwrap();
+        });
+        // Yield so the spawned task has a chance to register.
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        assert!(!handle.is_finished());
+        tracker.mark_completed("A", 100).await;
+        tokio::time::timeout(Duration::from_millis(100), handle)
+            .await
+            .expect("waiter should resolve within timeout")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn multiple_waiters_on_same_dep_all_wake() {
+        let tracker = Arc::new(CompletionTracker::new());
+        let mut handles = Vec::new();
+        for _ in 0..5 {
+            let tracker = tracker.clone();
+            handles.push(tokio::spawn(async move {
+                tracker.wait_ready(&names(&["A"]), 100).await.unwrap();
+            }));
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        tracker.mark_completed("A", 100).await;
+        for handle in handles {
+            tokio::time::timeout(Duration::from_millis(100), handle)
+                .await
+                .expect("every waiter should resolve")
+                .unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn wait_returns_dep_failed_on_failure() {
+        let tracker = CompletionTracker::new();
+        tracker.mark_failed("A", 100).await;
+        let err = tracker.wait_ready(&names(&["A"]), 100).await.unwrap_err();
+        assert_eq!(err.dep_name, "A");
+        assert_eq!(err.range_start, 100);
+    }
+
+    #[tokio::test]
+    async fn failed_dep_wakes_waiters_immediately() {
+        let tracker = Arc::new(CompletionTracker::new());
+        let tracker2 = tracker.clone();
+        let handle = tokio::spawn(async move { tracker2.wait_ready(&names(&["A"]), 100).await });
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        assert!(!handle.is_finished());
+        tracker.mark_failed("A", 100).await;
+        let result = tokio::time::timeout(Duration::from_millis(100), handle)
+            .await
+            .expect("waiter should resolve")
+            .unwrap();
+        let err = result.unwrap_err();
+        assert_eq!(err.dep_name, "A");
+    }
+
+    #[tokio::test]
+    async fn multiple_deps_all_must_complete() {
+        let tracker = Arc::new(CompletionTracker::new());
+        let tracker2 = tracker.clone();
+        let handle = tokio::spawn(async move {
+            tracker2
+                .wait_ready(&names(&["A", "B"]), 100)
+                .await
+                .unwrap();
+        });
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        tracker.mark_completed("A", 100).await;
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        assert!(!handle.is_finished(), "should still wait for B");
+
+        tracker.mark_completed("B", 100).await;
+        tokio::time::timeout(Duration::from_millis(100), handle)
+            .await
+            .expect("waiter should resolve after both deps complete")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn unrelated_marks_dont_resolve_waiter() {
+        let tracker = Arc::new(CompletionTracker::new());
+        let tracker2 = tracker.clone();
+        let handle = tokio::spawn(async move {
+            tracker2.wait_ready(&names(&["A"]), 100).await.unwrap();
+        });
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        // Mark a different range for A.
+        tracker.mark_completed("A", 200).await;
+        // Mark the same range but for a different handler.
+        tracker.mark_completed("B", 100).await;
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        assert!(
+            !handle.is_finished(),
+            "unrelated marks must not resolve waiter"
+        );
+
+        // Now mark the actual dep.
+        tracker.mark_completed("A", 100).await;
+        tokio::time::timeout(Duration::from_millis(100), handle)
+            .await
+            .expect("waiter should resolve after correct mark")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn concurrent_mark_and_wait_no_lost_wakeup() {
+        // Stress test: many waiters spawned concurrently with marks, all should
+        // resolve. This exercises the register-before-probe invariant.
+        let tracker = Arc::new(CompletionTracker::new());
+        let n = 50usize;
+
+        let mut waiters = Vec::new();
+        for i in 0..n {
+            let tracker = tracker.clone();
+            waiters.push(tokio::spawn(async move {
+                let name = format!("H{}", i);
+                let range = (i as u64) * 10;
+                tokio::time::timeout(
+                    Duration::from_secs(2),
+                    tracker.wait_ready(&[name], range),
+                )
+                .await
+                .expect("no lost wakeup")
+                .unwrap();
+            }));
+        }
+
+        // Interleave marks with the waiter spawns completing registration.
+        for i in 0..n {
+            let tracker = tracker.clone();
+            let name = format!("H{}", i);
+            let range = (i as u64) * 10;
+            tokio::spawn(async move {
+                tracker.mark_completed(&name, range).await;
+            });
+        }
+
+        for w in waiters {
+            w.await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn probe_matches_wait_outcome() {
+        let tracker = CompletionTracker::new();
+
+        // Waiting.
+        assert_eq!(
+            tracker.probe(&names(&["A"]), 100).await,
+            DepState::Waiting
+        );
+
+        // Ready.
+        tracker.mark_completed("A", 100).await;
+        assert_eq!(tracker.probe(&names(&["A"]), 100).await, DepState::Ready);
+        tracker.wait_ready(&names(&["A"]), 100).await.unwrap();
+
+        // DepFailed.
+        tracker.mark_failed("B", 200).await;
+        assert_eq!(
+            tracker.probe(&names(&["B"]), 200).await,
+            DepState::DepFailed {
+                dep_name: "B".to_string()
+            }
+        );
+        let err = tracker.wait_ready(&names(&["B"]), 200).await.unwrap_err();
+        assert_eq!(err.dep_name, "B");
+    }
+
+    #[tokio::test]
+    async fn failed_dep_reported_even_if_others_complete() {
+        // A is completed, B is failed: wait_ready should return DepFailed for B.
+        let tracker = CompletionTracker::new();
+        tracker.mark_completed("A", 100).await;
+        tracker.mark_failed("B", 100).await;
+        let err = tracker
+            .wait_ready(&names(&["A", "B"]), 100)
+            .await
+            .unwrap_err();
+        assert_eq!(err.dep_name, "B");
+    }
+
+    #[tokio::test]
+    async fn seed_merges_with_subsequent_marks() {
+        let tracker = CompletionTracker::new();
+        tracker.seed_completed("A", [100, 101]).await;
+        tracker.mark_completed("A", 102).await;
+        tracker.wait_ready(&names(&["A"]), 100).await.unwrap();
+        tracker.wait_ready(&names(&["A"]), 101).await.unwrap();
+        tracker.wait_ready(&names(&["A"]), 102).await.unwrap();
+    }
+}


### PR DESCRIPTION
First of four phases adding pipelined dependency-aware handler execution. Ships the scheduling primitives as a new `src/transformations/scheduler/` module with no production wiring yet — Phase 2 rewires catchup onto them.

## What changed

- `scheduler/tracker.rs` — `CompletionTracker`: per-`(handler_name, range_start)` completion/failure state with `tokio::sync::Notify`-based wake-up for waiters. Seeded at startup from `_handler_progress`; updated as work items finish.
- `scheduler/dag.rs` — `DagScheduler`: pure scheduler that accepts `Vec<WorkItem>`, spawns one Tokio task per item, waits on deps via the tracker, acquires a global concurrency permit (wait-before-permit to avoid deadlock), runs a caller-supplied async runner closure, and marks the tracker on success/failure. Cascade failures short-circuit downstream items; panics are caught via `JoinSet::join_next_with_id` and reported as `OutcomeStatus::Panicked` with a `mark_failed` so dependents cascade.
- `executor.rs` — extracted the inline per-task body from `HandlerExecutor::execute_handlers` into `pub(crate) async fn run_handler_task(...)`. Pure refactor; same logs, same behavior. Phases 2/3 will share this with the DAG scheduler's runner.

## Why

Today catchup runs handlers strictly sequentially in topological order — downstream handlers cannot start their first range until upstream has finished every range. The DAG scheduler gates each `(handler, range)` unit on `(dep_handler, same_range)` completion, so ranges pipeline across the handler DAG.

This phase is additive-only: no production code path calls the new primitives. They exist as reviewable, testable building blocks with a stable API.

## Design notes

- **Pure scheduler, caller-supplied runner** keeps the scheduler decoupled from `DbPool`, handler traits, and `TransformationContext`. Phase 2 will wrap it with a catchup-specific runner that loads parquet data and calls `run_handler_task`.
- **`Box<dyn Any>` payload** on `WorkItem` keeps the scheduler module independent of handler types.
- **Wake mechanism**: `Notify::notify_waiters()` on every state transition; waiters register interest before probing state to prevent lost wakeups. A per-handler `watch<HashSet<u64>>` is an isolated drop-in if profiling later shows wake-storm contention.

23 new unit/integration tests cover: lost-wakeup avoidance, seeding, multi-dep gating, cascade failures, panic handling, per-range pipelining, and concurrency bounds.