### PR TITLE
feat: V4 base pool metrics handler (Phase 4)

### DIFF
--- a/docs/pool-metrics/metrics_implementation_phases.md
+++ b/docs/pool-metrics/metrics_implementation_phases.md
@@ -40,7 +40,7 @@ Keyed by `(chain_id, pool_id, block_number, log_index)`. tick_lower, tick_upper,
 | ScheduledMulticurveLiquidityMetricsHandler | UniswapV4ScheduledMulticurveInitializerHook | ModifyLiquidity (flat) | — | extract_bytes32("id") | 3 ✅ | — |
 | DhookSwapMetricsHandler | DopplerHookInitializer | V4 hook Swap | getSlot0 on_event call | extract_bytes32("poolId") | 3 ✅ | Initializer emits events |
 | DhookLiquidityMetricsHandler | DopplerHookInitializer | ModifyLiquidity (tuple) | — | PoolKey::pool_id() | 3 ✅ | — |
-| V4BaseMetricsHandler | DopplerV4Hook | `Swap(int24, uint256, uint256)` | tick_to_sqrt_price_x96() | hook_address → v4_pool_configs | 4 | **Sequential** proceeds tracker |
+| V4BaseMetricsHandler | DopplerV4Hook | `Swap(int24, uint256, uint256)` | tick_to_sqrt_price_x96() | hook_address → v4_pool_configs | 4 ✅ | **Sequential** proceeds tracker |
 | MigrationPoolMetricsHandler | UniswapV4PoolManager + MigratorHook | PoolManager Swap + ModifyLiquidity | From event | topics[1] (id) | 5 | Migration pool ID filter |
 
 ---
@@ -74,7 +74,7 @@ Keyed by `(chain_id, pool_id, block_number, log_index)`. tick_lower, tick_upper,
 | Swap → pool_snapshots | Parallel OK | Per-block, idempotent upsert on conflict |
 | Swap → pool_state | Parallel OK | Conditional upsert (only if newer block) |
 | Mint/Burn/ModifyLiquidity → liquidity_deltas | Parallel OK | Append-only INSERT with PK |
-| V4 base Swap (proceeds) | Sequential | In-memory cumulative state |
+| V4 base Swap (proceeds) | **Sequential** (`requires_sequential=true`) | Cumulative totals require ordered per-pool deltas; enforced via capacity-1 FIFO semaphore in catchup |
 | TVL computation | Deferred | Separate future pass over liquidity_deltas |
 
 ---
@@ -100,7 +100,7 @@ src/transformations/
 │   ├── decay_multicurve/metrics.rs    # Decay multicurve swap + liquidity handlers (Phase 3)
 │   ├── scheduled_multicurve/metrics.rs # Scheduled multicurve swap + liquidity handlers (Phase 3)
 │   ├── dhook/metrics.rs               # Dhook swap + liquidity handlers (Phase 3)
-│   ├── v4/metrics.rs                  # V4 base handler (Phase 4 — future)
+│   ├── v4/metrics.rs                  # V4 base (DopplerV4Hook) handler (Phase 4)
 │   └── migration_pool/metrics.rs      # Migration pool handler (Phase 5 — future)
 ```
 
@@ -370,3 +370,7 @@ multicurve::metrics::register_handlers(registry, chain_id, multicurve_cache);
 - **V4 hook metadata caches**: each pool type gets its own `Arc<PoolMetadataCache>`, not shared with create handlers (create handlers don't use the cache)
 - **Shared V4 extraction functions**: `metrics/v4_hook_extract.rs` avoids duplication across 4 handler files
 - **`refresh_cache_if_needed` shared**: moved from `v3/metrics.rs` to `metrics/swap_data.rs` for reuse by all swap handlers
+- **Sequential handlers**: `TransformationHandler::requires_sequential()` method gates the catchup semaphore at capacity 1, with Tokio's FIFO permit ordering guaranteeing ascending-range execution. Per-handler, not global.
+- **V4 base proceeds state**: in-memory `RwLock<HashMap<[u8;32], (U256, U256)>>` cache + durable `v4_base_proceeds_state` checkpoint table. Loaded at init, refilled only for missing pool IDs via `pool_id = ANY($4)`. Optimistic update on commit; restart rehydrates from checkpoint. Minimizes DB reads while staying durable across process restarts.
+- **V4 base amount signs**: `proceeds_delta` is quote inflow, `tokens_delta` is base outflow. `is_token_0=true` → `amount0 = -tokens_delta`, `amount1 = proceeds_delta`; reversed for `is_token_0=false`.
+- **V4 base liquidity**: `U256::ZERO` — the V4 base Swap event doesn't carry liquidity, and Doppler auction "active liquidity" isn't meaningful in the same way as a v3 pool.

--- a/docs/pool-metrics/metrics_implementation_phases.md
+++ b/docs/pool-metrics/metrics_implementation_phases.md
@@ -275,24 +275,26 @@ multicurve::metrics::register_handlers(registry, chain_id, multicurve_cache);
 
 ---
 
-## Phase 4: V4 Base Handler
+## Phase 4: V4 Base Handler ✅
+
+**Status**: Complete
 
 **Goal**: Handle the unique cumulative-counter Swap event on DopplerV4Hook.
 
-### Tasks
-1. Implement `src/transformations/event/v4/metrics.rs` — V4BaseMetricsHandler
-2. Register in `v4/mod.rs`
-3. Test sequential processing with cumulative proceeds tracking
+**Delivered**:
+- `migrations/tables/v4_base_proceeds_state.sql` — checkpoint table for cumulative proceeds per pool
+- `src/transformations/event/v4/metrics.rs` — V4BaseMetricsHandler (8 passing tests)
+- `src/transformations/traits.rs` — `requires_sequential()` method added to TransformationHandler
+- `src/transformations/engine.rs` — capacity-1 FIFO semaphore for sequential handlers in catchup
 
-### Handler specifics
-- Source: `DopplerV4Hook` (factory collection)
-- Swap event: `Swap(int24 currentTick, uint256 totalProceeds, uint256 totalTokensSold)`
-- **No poolId in event**: map hook contract_address → pool_id via `v4_pool_configs` table (loaded on init into `HashMap<[u8;20], [u8;32]>`)
-- **No sqrtPriceX96 in event**: derive from currentTick via `tick_to_sqrt_price_x96()`
-- **Cumulative counters**: in-memory `RwLock<HashMap<Vec<u8>, (U256, U256)>>` for (last_totalProceeds, last_totalTokensSold). Compute per-swap deltas. Rebuild from pool_snapshots or a dedicated column on init.
-- **Sequential processing required**: this handler cannot be parallelized across block ranges
-- No liquidity events (liquidity only changes via swaps or post-migration MigratorHook events)
-- amount0/amount1 derived from proceeds/tokens_sold deltas using is_token_0 orientation
+**Key design decisions**:
+- **Sequential enforcement**: `requires_sequential() = true` causes the catchup engine to create a capacity-1 semaphore for this handler. Tokio's FIFO `acquire_owned()` guarantee ensures ranges execute in ascending order, preventing delta corruption.
+- **DB-read approach for cumulative state**: rather than purely in-memory counters (which would be wrong on retry after a failed transaction), each `handle()` reads the previous checkpoint from `v4_base_proceeds_state` and writes back the new totals as part of the same atomic transaction. This makes retries safe.
+- **hook_address → pool_id lookup**: loaded from `v4_pool_configs` at init, refreshed on cache miss. `handler_dependencies = ["V4CreateHandler"]` ensures the config exists.
+- **sqrtPriceX96**: derived from `currentTick` via `tick_to_sqrt_price_x96()` (no extra RPC call).
+- **amount0/amount1**: `proceeds_delta` = quote inflow (positive for pool), `tokens_delta` = base outflow (negative for pool). Signs flipped via `is_token_0` from metadata cache.
+- **liquidity**: set to `U256::ZERO` — not available from the V4 base Swap event.
+- **No liquidity handler**: DopplerV4Hook has no ModifyLiquidity events (the pool only sells tokens; migration liquidity is handled by Phase 5's MigratorHook handler).
 
 ---
 

--- a/docs/pool-metrics/metrics_implementation_phases.md
+++ b/docs/pool-metrics/metrics_implementation_phases.md
@@ -283,13 +283,13 @@ multicurve::metrics::register_handlers(registry, chain_id, multicurve_cache);
 
 **Delivered**:
 - `migrations/tables/v4_base_proceeds_state.sql` — checkpoint table for cumulative proceeds per pool
-- `src/transformations/event/v4/metrics.rs` — V4BaseMetricsHandler (8 passing tests)
+- `src/transformations/event/v4/metrics.rs` — V4BaseMetricsHandler (9 passing tests)
 - `src/transformations/traits.rs` — `requires_sequential()` method added to TransformationHandler
 - `src/transformations/engine.rs` — capacity-1 FIFO semaphore for sequential handlers in catchup
 
 **Key design decisions**:
 - **Sequential enforcement**: `requires_sequential() = true` causes the catchup engine to create a capacity-1 semaphore for this handler. Tokio's FIFO `acquire_owned()` guarantee ensures ranges execute in ascending order, preventing delta corruption.
-- **DB-read approach for cumulative state**: rather than purely in-memory counters (which would be wrong on retry after a failed transaction), each `handle()` reads the previous checkpoint from `v4_base_proceeds_state` and writes back the new totals as part of the same atomic transaction. This makes retries safe.
+- **In-memory cache + durable checkpoint**: cumulative `(totalProceeds, totalTokensSold)` per pool is kept in a `RwLock<HashMap>` loaded from `v4_base_proceeds_state` at init and refilled on miss (for just the missing pool IDs, using `pool_id = ANY($4)`). Pools with no checkpoint get cached as `(0, 0)` so misses aren't re-queried. `handle()` reads from the cache, returns upserts to `v4_base_proceeds_state` inside the same transaction as the snapshot writes, and updates the cache optimistically. On restart the cache rehydrates from the last-committed checkpoint.
 - **hook_address → pool_id lookup**: loaded from `v4_pool_configs` at init, refreshed on cache miss. `handler_dependencies = ["V4CreateHandler"]` ensures the config exists.
 - **sqrtPriceX96**: derived from `currentTick` via `tick_to_sqrt_price_x96()` (no extra RPC call).
 - **amount0/amount1**: `proceeds_delta` = quote inflow (positive for pool), `tokens_delta` = base outflow (negative for pool). Signs flipped via `is_token_0` from metadata cache.

--- a/docs/pool-metrics/pool_metrics.md
+++ b/docs/pool-metrics/pool_metrics.md
@@ -379,8 +379,15 @@ This handler sets `requires_sequential() = true`. The catchup engine creates a c
 
 ### Retry & recovery
 
-- If the transaction for range N fails, `requires_sequential` causes catchup to halt further ranges for this handler. On restart, `initialize()` rebuilds the cache from the last committed `v4_base_proceeds_state` row, so the next invocation reads the correct prior cumulative.
-- Live-retry correctness relies on the same invariant: if a range fails mid-session, the live retry path must either restart the process or invalidate the in-memory cache entries for affected pools before re-running.
+The handler uses three trait hooks (`on_commit_success`, `on_commit_failure`, `on_reorg`) to keep the in-memory `proceeds_state` cache consistent with the committed DB state across failures and reorgs:
+
+- **Optimistic cache snapshot**: before the optimistic cache update, `handle()` stashes the current (pre-update) cumulative per touched pool into `in_flight_pre`.
+- **`on_commit_success(range)`** (called by executor/engine/retry after a successful tx): drains `in_flight_pre` and removes `range` from `failed_ranges`.
+- **`on_commit_failure(range)`** (called after a failed tx): restores the cache from `in_flight_pre` (reverting the optimistic update) and records `range` in `failed_ranges`.
+- **Gate in `handle()`**: if `failed_ranges` contains any range smaller than the current one, the handler returns `TransformationError::TransientBlocked`, which the retry machinery surfaces as a retryable failure. This blocks subsequent ranges from advancing the cumulative past a stuck block. The retry of the failed range itself is always admitted (`current == min_failed`), so the handler converges as soon as the underlying error clears.
+- **`on_reorg(orphaned)`**: called by the finalizer after DB rollback. Clears `proceeds_state`, `in_flight_pre`, and `failed_ranges` entirely; the next `handle()` lazily reloads the cache from `v4_base_proceeds_state`.
+
+Catchup has its own guardrail: a commit failure halts catchup via the engine's `handler_errored` flag, so restart still rebuilds the cache correctly for historical ranges.
 
 ### pool_id lookup
 

--- a/docs/pool-metrics/pool_metrics.md
+++ b/docs/pool-metrics/pool_metrics.md
@@ -337,6 +337,61 @@ The retry path always uses snapshot capture. Before retrying a handler for a blo
 
 ---
 
+## V4 Base Cumulative Counters
+
+`DopplerV4Hook` emits `Swap(int24 currentTick, uint256 totalProceeds, uint256 totalTokensSold)` where `totalProceeds` and `totalTokensSold` are **cumulative since pool creation**, not per-swap deltas. To feed the shared `process_swaps()` pipeline (which expects per-swap `amount0`/`amount1`), the `V4BaseMetricsHandler` computes deltas by subtracting the previous cumulative values for each pool.
+
+### State storage
+
+**Durable**: `v4_base_proceeds_state` — one row per `(chain_id, pool_id, source, source_version)` storing the most recent cumulative totals. Upserted inside the same transaction as the `pool_snapshots`/`pool_state` writes.
+
+```sql
+CREATE TABLE IF NOT EXISTS v4_base_proceeds_state (
+    chain_id           BIGINT NOT NULL,
+    pool_id            BYTEA NOT NULL,
+    total_proceeds     NUMERIC NOT NULL DEFAULT '0',
+    total_tokens_sold  NUMERIC NOT NULL DEFAULT '0',
+    source             VARCHAR(255) NOT NULL,
+    source_version     INT NOT NULL,
+    UNIQUE (chain_id, pool_id, source, source_version)
+);
+```
+
+**In-memory**: `RwLock<HashMap<[u8;32], (U256, U256)>>` on the handler. Loaded from `v4_base_proceeds_state` at `initialize()`, refilled on miss (one scoped `pool_id = ANY($4)` query for just the missing IDs), and updated optimistically in `handle()` after computing deltas.
+
+### Amount sign convention
+
+The protocol sells base tokens for quote tokens. For each delta:
+
+```
+proceeds_delta  = quote received by pool (inflow)
+tokens_delta    = base sold out of pool  (outflow)
+```
+
+| is_token_0 | amount0              | amount1              |
+|------------|----------------------|----------------------|
+| `true`     | `-(tokens_delta)`    | `+proceeds_delta`    |
+| `false`    | `+proceeds_delta`    | `-(tokens_delta)`    |
+
+### Sequential processing
+
+This handler sets `requires_sequential() = true`. The catchup engine creates a capacity-1 `Semaphore` for this handler only, and Tokio's FIFO permit ordering guarantees ranges run in ascending block order so the "prev cumulative" used for each delta is always the immediately preceding range's committed state.
+
+### Retry & recovery
+
+- If the transaction for range N fails, `requires_sequential` causes catchup to halt further ranges for this handler. On restart, `initialize()` rebuilds the cache from the last committed `v4_base_proceeds_state` row, so the next invocation reads the correct prior cumulative.
+- Live-retry correctness relies on the same invariant: if a range fails mid-session, the live retry path must either restart the process or invalidate the in-memory cache entries for affected pools before re-running.
+
+### pool_id lookup
+
+The V4 base Swap event has no `poolId` field. The handler maps `event.contract_address` (the hook address) to the 32-byte `pool_id` via `v4_pool_configs`. The map is loaded at init and refreshed on cache miss; `handler_dependencies = ["V4CreateHandler"]` guarantees the config row exists before metrics run for a range.
+
+### active_liquidity
+
+V4 base Swap events do not emit liquidity, and Doppler auction "active liquidity" isn't directly analogous to a v3 pool's. The handler writes `active_liquidity = 0` for V4 base snapshots.
+
+---
+
 ## Handler Flow
 
 ```python

--- a/migrations/tables/v4_base_proceeds_state.sql
+++ b/migrations/tables/v4_base_proceeds_state.sql
@@ -1,0 +1,16 @@
+-- Cumulative proceeds checkpoint for V4BaseMetricsHandler.
+--
+-- Stores the latest totalProceeds and totalTokensSold per pool so the handler
+-- can restore its cumulative delta state on restart without reprocessing all
+-- historical blocks. One row per (chain, pool, source_version); upserted after
+-- each committed batch.
+
+CREATE TABLE IF NOT EXISTS v4_base_proceeds_state (
+    chain_id           BIGINT NOT NULL,
+    pool_id            BYTEA NOT NULL,
+    total_proceeds     NUMERIC NOT NULL DEFAULT '0',
+    total_tokens_sold  NUMERIC NOT NULL DEFAULT '0',
+    source             VARCHAR(255) NOT NULL,
+    source_version     INT NOT NULL,
+    UNIQUE (chain_id, pool_id, source, source_version)
+);

--- a/src/transformations/engine.rs
+++ b/src/transformations/engine.rs
@@ -691,7 +691,14 @@ impl TransformationEngine {
                 let mut processed = 0;
                 let mut skipped_ranges: Vec<(u64, u64)> = Vec::new();
 
-                let semaphore = Arc::new(Semaphore::new(self.handler_concurrency));
+                // Sequential handlers get a capacity-1 semaphore so ranges run
+                // one at a time in FIFO order (Tokio guarantees FIFO permit acquisition).
+                let semaphore_capacity = if handler.requires_sequential() {
+                    1
+                } else {
+                    self.handler_concurrency
+                };
+                let semaphore = Arc::new(Semaphore::new(semaphore_capacity));
                 let mut join_set: JoinSet<HandlerTaskResult> = JoinSet::new();
 
                 for (range_start, range_end) in &ranges_to_attempt {

--- a/src/transformations/engine.rs
+++ b/src/transformations/engine.rs
@@ -409,7 +409,17 @@ impl TransformationEngine {
                 Ok(ops) => {
                     if !ops.is_empty() {
                         let ops = inject_source_version(ops, handler_name, handler_version);
-                        db_pool.execute_transaction(ops).await?;
+                        match db_pool.execute_transaction(ops).await {
+                            Ok(()) => {
+                                handler.on_commit_success((range_start, range_end)).await?;
+                            }
+                            Err(e) => {
+                                handler.on_commit_failure((range_start, range_end)).await?;
+                                return Err(TransformationError::DatabaseError(e));
+                            }
+                        }
+                    } else {
+                        handler.on_commit_success((range_start, range_end)).await?;
                     }
                     Ok(Some((handler_key, range_start, range_end)))
                 }

--- a/src/transformations/error.rs
+++ b/src/transformations/error.rs
@@ -58,6 +58,9 @@ pub enum TransformationError {
 
     #[error("Live storage error: {0}")]
     LiveStorage(#[from] StorageError),
+
+    #[error("Handler transiently blocked: {0}")]
+    TransientBlocked(String),
 }
 
 #[allow(dead_code)]

--- a/src/transformations/event/mod.rs
+++ b/src/transformations/event/mod.rs
@@ -48,4 +48,8 @@ pub fn register_handlers(registry: &mut TransformationRegistry, chain_id: u64) {
 
     let dhook_cache = Arc::new(PoolMetadataCache::new());
     dhook::metrics::register_handlers(registry, chain_id, dhook_cache);
+
+    // V4 base (DopplerV4Hook) — sequential handler, own cache
+    let v4_base_cache = Arc::new(PoolMetadataCache::new());
+    v4::metrics::register_handlers(registry, chain_id, v4_base_cache);
 }

--- a/src/transformations/event/v4/metrics.rs
+++ b/src/transformations/event/v4/metrics.rs
@@ -29,7 +29,7 @@
 //! `contract_address` (the hook address) to the pool ID via `v4_pool_configs`. The map
 //! is loaded at `initialize()` and refreshed on cache miss.
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::sync::{Arc, Once, OnceLock, RwLock};
 
 use alloy_primitives::{I256, U256};
@@ -61,6 +61,15 @@ pub struct V4BaseMetricsHandler {
     /// pool_id → (total_proceeds, total_tokens_sold) — loaded from v4_base_proceeds_state
     /// at init, refreshed on cache miss, updated optimistically in handle().
     proceeds_state: RwLock<HashMap<[u8; 32], (U256, U256)>>,
+    /// Pre-update cumulatives for the currently-in-flight batch, used by
+    /// `on_commit_failure` to revert the optimistic cache update. Populated
+    /// by `handle()` just before the optimistic write; drained by either
+    /// commit hook. Always `None` between batches in normal operation.
+    in_flight_pre: RwLock<Option<HashMap<[u8; 32], (U256, U256)>>>,
+    /// Ranges whose commit failed. `handle()` refuses any range strictly
+    /// greater than the minimum entry so delta computation never advances
+    /// past a stuck block. Retries drain this set via `on_commit_success`.
+    failed_ranges: RwLock<BTreeSet<(u64, u64)>>,
 }
 
 #[async_trait]
@@ -93,6 +102,23 @@ impl TransformationHandler for V4BaseMetricsHandler {
         &self,
         ctx: &TransformationContext,
     ) -> Result<Vec<DbOperation>, TransformationError> {
+        // Gate: if an earlier range's commit is still outstanding, refuse any
+        // range that is strictly greater. This keeps delta computation from
+        // advancing past a stuck block — the failed range must retry and drain
+        // `failed_ranges` before later ranges can proceed.
+        {
+            let failed = self.failed_ranges.read().unwrap();
+            if let Some(&min_failed) = failed.iter().next() {
+                let current = (ctx.blockrange_start, ctx.blockrange_end);
+                if current > min_failed {
+                    return Err(TransformationError::TransientBlocked(format!(
+                        "V4BaseMetricsHandler: waiting on failed range {:?} before processing {:?}",
+                        min_failed, current
+                    )));
+                }
+            }
+        }
+
         self.decimals_init.call_once(|| {
             self.metadata_cache.resolve_quote_decimals(&ctx.contracts);
         });
@@ -165,7 +191,7 @@ impl TransformationHandler for V4BaseMetricsHandler {
             return Ok(Vec::new());
         }
 
-        let mut ops = process_swaps(&swaps, &self.metadata_cache, ctx.chain_id);
+        let mut ops = process_swaps(&swaps, &self.metadata_cache, self.chain_id);
 
         // Durably checkpoint the new cumulative totals.
         for (pool_id, (total_proceeds, total_tokens_sold)) in &new_cumulative {
@@ -177,10 +203,24 @@ impl TransformationHandler for V4BaseMetricsHandler {
             ));
         }
 
-        // Update the in-memory cache optimistically. Because requires_sequential() is true,
-        // the next range won't run until this one finishes. If the DB transaction fails
-        // the engine halts further processing for this handler, so on restart the cache
-        // is rebuilt from the last-committed checkpoint.
+        // Stash pre-update cumulatives so `on_commit_failure` can revert the
+        // optimistic cache write if the transaction fails.
+        let pre: HashMap<[u8; 32], (U256, U256)> = {
+            let state = self.proceeds_state.read().unwrap();
+            new_cumulative
+                .keys()
+                .map(|id| {
+                    let prev = state.get(id).copied().unwrap_or((U256::ZERO, U256::ZERO));
+                    (*id, prev)
+                })
+                .collect()
+        };
+        *self.in_flight_pre.write().unwrap() = Some(pre);
+
+        // Update the in-memory cache optimistically. `on_commit_success` drains
+        // `in_flight_pre` after the transaction commits; `on_commit_failure`
+        // restores these entries and records the range so subsequent ranges
+        // block until the retry succeeds.
         {
             let mut state = self.proceeds_state.write().unwrap();
             for (pool_id, totals) in new_cumulative {
@@ -197,6 +237,47 @@ impl TransformationHandler for V4BaseMetricsHandler {
         self.load_hook_pool_map(db_pool).await?;
         self.load_all_proceeds_state(db_pool).await?;
         tracing::info!("V4BaseMetricsHandler initialized");
+        Ok(())
+    }
+
+    async fn on_reorg(&self, _orphaned: &[u64]) -> Result<(), TransformationError> {
+        // The DB has just been rolled back to its pre-reorg state by the
+        // finalizer; clear all in-memory state so subsequent handle() calls
+        // lazily reload from the (now-restored) DB.
+        self.proceeds_state.write().unwrap().clear();
+        *self.in_flight_pre.write().unwrap() = None;
+        self.failed_ranges.write().unwrap().clear();
+        tracing::info!("V4BaseMetricsHandler: cleared in-memory state after reorg");
+        Ok(())
+    }
+
+    async fn on_commit_success(
+        &self,
+        range: (u64, u64),
+    ) -> Result<(), TransformationError> {
+        *self.in_flight_pre.write().unwrap() = None;
+        self.failed_ranges.write().unwrap().remove(&range);
+        Ok(())
+    }
+
+    async fn on_commit_failure(
+        &self,
+        range: (u64, u64),
+    ) -> Result<(), TransformationError> {
+        // Revert the optimistic cache update using the pre-values stashed in
+        // handle(). If no pre-values are stashed (e.g., handle() returned
+        // empty ops or failed before the stash), there is nothing to revert.
+        if let Some(pre) = self.in_flight_pre.write().unwrap().take() {
+            let mut state = self.proceeds_state.write().unwrap();
+            for (pool_id, prev) in pre {
+                state.insert(pool_id, prev);
+            }
+        }
+        self.failed_ranges.write().unwrap().insert(range);
+        tracing::warn!(
+            "V4BaseMetricsHandler: commit failed for range {:?}, blocking later ranges until retry succeeds",
+            range
+        );
         Ok(())
     }
 }
@@ -294,6 +375,20 @@ impl V4BaseMetricsHandler {
                 hook_addr.copy_from_slice(&hook_addr_bytes);
                 map.entry(hook_addr).or_insert(pool_id);
             }
+        }
+
+        let still_missing: Vec<_> = events
+            .iter()
+            .filter(|e| !map.contains_key(&e.contract_address))
+            .map(|e| hex::encode(e.contract_address))
+            .collect();
+        if !still_missing.is_empty() {
+            tracing::warn!(
+                "V4BaseMetricsHandler: {} hook address(es) still missing from v4_pool_configs \
+                 after refresh; swaps from those hooks will be skipped: {:?}",
+                still_missing.len(),
+                still_missing,
+            );
         }
 
         Ok(())
@@ -499,6 +594,13 @@ impl V4BaseMetricsHandler {
                         prev_proceeds,
                         total_proceeds,
                     );
+                    // NOTE: "treat as full value" (i.e. prev=0) also serves as crash-replay
+                    // idempotency. If the process crashed after committing the DB row but before
+                    // updating handler progress, the in-memory cache is reloaded from the
+                    // post-commit checkpoint on restart, so `prev_proceeds` exceeds this event's
+                    // cumulative. Using `total_proceeds` as the delta resets prev to the current
+                    // event's baseline, producing identical pool_snapshots to the original run.
+                    // Do NOT convert this warn to an error without preserving that invariant.
                     total_proceeds
                 };
 
@@ -651,6 +753,8 @@ pub fn register_handlers(
         db_pool: OnceLock::new(),
         hook_pool_map: RwLock::new(HashMap::new()),
         proceeds_state: RwLock::new(HashMap::new()),
+        in_flight_pre: RwLock::new(None),
+        failed_ranges: RwLock::new(BTreeSet::new()),
     });
 }
 
@@ -699,6 +803,8 @@ mod tests {
             db_pool: OnceLock::new(),
             hook_pool_map: RwLock::new(HashMap::new()),
             proceeds_state: RwLock::new(HashMap::new()),
+            in_flight_pre: RwLock::new(None),
+            failed_ranges: RwLock::new(BTreeSet::new()),
         }
     }
 
@@ -937,5 +1043,183 @@ mod tests {
             }
             _ => panic!("expected Upsert"),
         }
+    }
+
+    // ── commit hooks / gate / reorg ───────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_on_reorg_clears_all_in_memory_state() {
+        let handler = make_handler(8453);
+        let pool_id = make_pool_id(0x10);
+
+        // Pre-populate all three caches/structures.
+        handler
+            .proceeds_state
+            .write()
+            .unwrap()
+            .insert(pool_id, (U256::from(42u64), U256::from(21u64)));
+        *handler.in_flight_pre.write().unwrap() =
+            Some([(pool_id, (U256::ZERO, U256::ZERO))].into_iter().collect());
+        handler.failed_ranges.write().unwrap().insert((100, 101));
+
+        handler.on_reorg(&[100, 101]).await.unwrap();
+
+        assert!(handler.proceeds_state.read().unwrap().is_empty());
+        assert!(handler.in_flight_pre.read().unwrap().is_none());
+        assert!(handler.failed_ranges.read().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_on_commit_failure_reverts_cache_and_records_range() {
+        let handler = make_handler(8453);
+        let pool_id = make_pool_id(0x11);
+
+        // Simulate the in-flight state right before a commit failure:
+        //   cache is at (100, 50) (the optimistic post-update), but the
+        //   pre-update state was (70, 35).
+        handler
+            .proceeds_state
+            .write()
+            .unwrap()
+            .insert(pool_id, (U256::from(100u64), U256::from(50u64)));
+        *handler.in_flight_pre.write().unwrap() = Some(
+            [(pool_id, (U256::from(70u64), U256::from(35u64)))]
+                .into_iter()
+                .collect(),
+        );
+
+        handler.on_commit_failure((200, 201)).await.unwrap();
+
+        // Cache should have been reverted to the pre-update value.
+        let state = handler.proceeds_state.read().unwrap();
+        assert_eq!(
+            state.get(&pool_id).copied(),
+            Some((U256::from(70u64), U256::from(35u64)))
+        );
+        // in_flight_pre should be drained.
+        assert!(handler.in_flight_pre.read().unwrap().is_none());
+        // Range should be recorded as failed.
+        assert!(handler.failed_ranges.read().unwrap().contains(&(200, 201)));
+    }
+
+    #[tokio::test]
+    async fn test_on_commit_success_clears_pending_and_drains_range() {
+        let handler = make_handler(8453);
+        let pool_id = make_pool_id(0x12);
+
+        *handler.in_flight_pre.write().unwrap() =
+            Some([(pool_id, (U256::ZERO, U256::ZERO))].into_iter().collect());
+        handler.failed_ranges.write().unwrap().insert((300, 301));
+
+        handler.on_commit_success((300, 301)).await.unwrap();
+
+        assert!(handler.in_flight_pre.read().unwrap().is_none());
+        assert!(handler.failed_ranges.read().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_on_commit_success_for_unrelated_range_preserves_others() {
+        let handler = make_handler(8453);
+        handler.failed_ranges.write().unwrap().insert((100, 101));
+        handler.failed_ranges.write().unwrap().insert((102, 103));
+
+        handler.on_commit_success((102, 103)).await.unwrap();
+
+        let remaining = handler.failed_ranges.read().unwrap();
+        assert!(remaining.contains(&(100, 101)));
+        assert!(!remaining.contains(&(102, 103)));
+    }
+
+    #[tokio::test]
+    async fn test_on_commit_failure_with_no_in_flight_is_noop_on_cache() {
+        // If handle() returned empty ops (or failed before the stash) then
+        // in_flight_pre is None — on_commit_failure should still record the
+        // range but leave the cache alone.
+        let handler = make_handler(8453);
+        let pool_id = make_pool_id(0x13);
+        handler
+            .proceeds_state
+            .write()
+            .unwrap()
+            .insert(pool_id, (U256::from(999u64), U256::from(888u64)));
+
+        handler.on_commit_failure((400, 401)).await.unwrap();
+
+        let state = handler.proceeds_state.read().unwrap();
+        assert_eq!(
+            state.get(&pool_id).copied(),
+            Some((U256::from(999u64), U256::from(888u64)))
+        );
+        assert!(handler.failed_ranges.read().unwrap().contains(&(400, 401)));
+    }
+
+    // Gate tests — exercised by constructing an empty context and driving
+    // handle() with the failed_ranges set pre-populated. We don't need
+    // events since the gate is the very first check.
+
+    fn empty_ctx(range_start: u64, range_end: u64) -> TransformationContext {
+        use crate::rpc::UnifiedRpcClient;
+        use crate::transformations::historical::HistoricalDataReader;
+        use std::collections::HashMap as StdHashMap;
+
+        // These services aren't exercised because handle() returns before
+        // touching them when the gate trips or events are empty.
+        let historical = Arc::new(
+            HistoricalDataReader::new("test_chain_v4_metrics")
+                .expect("HistoricalDataReader::new should succeed"),
+        );
+        let rpc = Arc::new(
+            UnifiedRpcClient::from_url("http://localhost:8545")
+                .expect("RPC client construction should succeed"),
+        );
+        TransformationContext::new(
+            "test".to_string(),
+            8453,
+            range_start,
+            range_end,
+            Arc::new(Vec::new()),
+            Arc::new(Vec::new()),
+            StdHashMap::new(),
+            historical,
+            rpc,
+            Arc::new(StdHashMap::new()),
+        )
+    }
+
+    #[tokio::test]
+    async fn test_gate_blocks_later_ranges_after_failure() {
+        let handler = make_handler(8453);
+        // Simulate a prior commit failure for range (100, 101).
+        handler.failed_ranges.write().unwrap().insert((100, 101));
+
+        // A later range should be refused.
+        let ctx = empty_ctx(200, 201);
+        let result = handler.handle(&ctx).await;
+        match result {
+            Err(TransformationError::TransientBlocked(_)) => {}
+            other => panic!("expected TransientBlocked, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_gate_allows_the_failed_range_to_retry() {
+        let handler = make_handler(8453);
+        // The failed range is (100, 101); retrying it should be allowed.
+        handler.failed_ranges.write().unwrap().insert((100, 101));
+
+        let ctx = empty_ctx(100, 101);
+        // No events present in the context, so handle() returns Ok(vec![])
+        // after passing the gate. If the gate had refused we'd get
+        // TransientBlocked instead.
+        let result = handler.handle(&ctx).await;
+        assert!(matches!(result, Ok(ops) if ops.is_empty()));
+    }
+
+    #[tokio::test]
+    async fn test_gate_allows_any_range_when_failed_ranges_empty() {
+        let handler = make_handler(8453);
+        let ctx = empty_ctx(9999, 10000);
+        let result = handler.handle(&ctx).await;
+        assert!(matches!(result, Ok(ops) if ops.is_empty()));
     }
 }

--- a/src/transformations/event/v4/metrics.rs
+++ b/src/transformations/event/v4/metrics.rs
@@ -1,0 +1,794 @@
+//! V4 base (DopplerV4Hook) pool metrics handler.
+//!
+//! Processes `Swap(int24 currentTick, uint256 totalProceeds, uint256 totalTokensSold)` events
+//! from DopplerV4Hook factory contracts into pool_state and pool_snapshots.
+//!
+//! ## Design
+//!
+//! The V4 base swap event emits **cumulative** counters rather than per-swap deltas, so this
+//! handler must compute deltas by subtracting the previous cumulative values. The previous
+//! values are read from the `v4_base_proceeds_state` checkpoint table at the start of each
+//! batch and written back at the end. This DB-read approach (rather than purely in-memory
+//! state) ensures correctness across retries: if a transaction is rolled back, the next
+//! attempt re-reads the last committed checkpoint.
+//!
+//! ## Sequential processing
+//!
+//! `requires_sequential()` returns `true`. The catchup engine enforces one-at-a-time range
+//! execution via a capacity-1 FIFO semaphore, so the DB checkpoint is always up-to-date
+//! when the next range reads it.
+//!
+//! ## Pool ID lookup
+//!
+//! The swap event has no pool ID field. Pool IDs are resolved by mapping the event's
+//! `contract_address` (the hook address) to the pool ID via `v4_pool_configs`. The map
+//! is loaded at `initialize()` and refreshed on cache miss.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Once, OnceLock, RwLock};
+
+use alloy_primitives::{I256, U256};
+use async_trait::async_trait;
+use deadpool_postgres::Pool;
+
+use crate::db::{DbOperation, DbPool, DbValue};
+use crate::transformations::context::{DecodedEvent, FieldExtractor, TransformationContext};
+use crate::transformations::error::TransformationError;
+use crate::transformations::event::metrics::swap_data::{
+    process_swaps, refresh_cache_if_needed, SwapInput,
+};
+use crate::transformations::registry::TransformationRegistry;
+use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
+use crate::transformations::util::pool_metadata::PoolMetadataCache;
+use crate::transformations::util::tick_math::tick_to_sqrt_price_x96;
+
+const SOURCE: &str = "DopplerV4Hook";
+
+// ─── Handler ─────────────────────────────────────────────────────────────────
+
+pub struct V4BaseMetricsHandler {
+    metadata_cache: Arc<PoolMetadataCache>,
+    decimals_init: Once,
+    chain_id: u64,
+    db_pool: OnceLock<Pool>,
+    /// hook_address → pool_id, loaded from v4_pool_configs at init, refreshed on miss.
+    hook_pool_map: RwLock<HashMap<[u8; 20], [u8; 32]>>,
+}
+
+#[async_trait]
+impl TransformationHandler for V4BaseMetricsHandler {
+    fn name(&self) -> &'static str {
+        "V4BaseMetricsHandler"
+    }
+
+    fn version(&self) -> u32 {
+        1
+    }
+
+    fn migration_paths(&self) -> Vec<&'static str> {
+        vec![
+            "migrations/tables/pool_state.sql",
+            "migrations/tables/pool_snapshots.sql",
+            "migrations/tables/v4_base_proceeds_state.sql",
+        ]
+    }
+
+    fn reorg_tables(&self) -> Vec<&'static str> {
+        vec!["pool_state", "pool_snapshots"]
+    }
+
+    fn requires_sequential(&self) -> bool {
+        true
+    }
+
+    async fn handle(
+        &self,
+        ctx: &TransformationContext,
+    ) -> Result<Vec<DbOperation>, TransformationError> {
+        self.decimals_init.call_once(|| {
+            self.metadata_cache.resolve_quote_decimals(&ctx.contracts);
+        });
+
+        let events: Vec<&DecodedEvent> = ctx.events_of_type(SOURCE, "Swap").collect();
+        if events.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Ensure all hook addresses in this batch are in the map.
+        self.refresh_hook_pool_map_for_events(&events).await?;
+
+        // Collect unique pool IDs — block scope ensures the guard is dropped before any await.
+        let pool_id_vecs: Vec<Vec<u8>> = {
+            let hook_pool_map = self.hook_pool_map.read().unwrap();
+            let mut seen: std::collections::HashSet<[u8; 32]> = std::collections::HashSet::new();
+            events
+                .iter()
+                .filter_map(|e| hook_pool_map.get(&e.contract_address).copied())
+                .filter(|id| seen.insert(*id))
+                .map(|id| id.to_vec())
+                .collect()
+            // hook_pool_map guard dropped here
+        };
+
+        if pool_id_vecs.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Refresh pool metadata cache so decimals / is_token_0 are available.
+        refresh_cache_if_needed(
+            pool_id_vecs.iter(),
+            &self.metadata_cache,
+            &self.db_pool,
+            self.chain_id,
+            &ctx.contracts,
+        )
+        .await?;
+
+        // Convert to fixed-size arrays for the DB checkpoint query.
+        let pool_ids: Vec<[u8; 32]> = pool_id_vecs
+            .iter()
+            .filter_map(|v| {
+                if v.len() == 32 {
+                    let mut arr = [0u8; 32];
+                    arr.copy_from_slice(v);
+                    Some(arr)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        // Read previous cumulative totals from the DB checkpoint.
+        let prev_state = self.load_prev_cumulative(&pool_ids).await?;
+
+        // Extract swap inputs + determine new cumulative totals.
+        let (swaps, new_cumulative) = self.extract_swaps(&events, &prev_state)?;
+
+        if swaps.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut ops = process_swaps(&swaps, &self.metadata_cache, ctx.chain_id);
+
+        // Checkpoint the new cumulative totals so the next range reads them.
+        for (pool_id, (total_proceeds, total_tokens_sold)) in &new_cumulative {
+            ops.push(upsert_proceeds_state(
+                self.chain_id,
+                pool_id,
+                total_proceeds,
+                total_tokens_sold,
+            ));
+        }
+
+        Ok(ops)
+    }
+
+    async fn initialize(&self, db_pool: &DbPool) -> Result<(), TransformationError> {
+        self.db_pool.set(db_pool.inner().clone()).ok();
+        self.metadata_cache.load_into(db_pool, self.chain_id).await?;
+        self.load_hook_pool_map(db_pool).await?;
+        tracing::info!("V4BaseMetricsHandler initialized");
+        Ok(())
+    }
+}
+
+impl EventHandler for V4BaseMetricsHandler {
+    fn triggers(&self) -> Vec<EventTrigger> {
+        vec![EventTrigger::new(SOURCE, "Swap(int24,uint256,uint256)")]
+    }
+
+    fn handler_dependencies(&self) -> Vec<&'static str> {
+        vec!["V4CreateHandler"]
+    }
+}
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+impl V4BaseMetricsHandler {
+    /// Load hook_address → pool_id map from v4_pool_configs for this chain.
+    async fn load_hook_pool_map(&self, db_pool: &DbPool) -> Result<(), TransformationError> {
+        let client = db_pool
+            .inner()
+            .get()
+            .await
+            .map_err(|e| TransformationError::DatabaseError(e.into()))?;
+
+        let rows = client
+            .query(
+                "SELECT pool_id, hook_address FROM v4_pool_configs WHERE chain_id = $1",
+                &[&(self.chain_id as i64)],
+            )
+            .await
+            .map_err(|e| TransformationError::DatabaseError(e.into()))?;
+
+        let mut map = self.hook_pool_map.write().unwrap();
+        for row in &rows {
+            let pool_id_bytes: Vec<u8> = row.get("pool_id");
+            let hook_addr_bytes: Vec<u8> = row.get("hook_address");
+            if pool_id_bytes.len() == 32 && hook_addr_bytes.len() == 20 {
+                let mut pool_id = [0u8; 32];
+                let mut hook_addr = [0u8; 20];
+                pool_id.copy_from_slice(&pool_id_bytes);
+                hook_addr.copy_from_slice(&hook_addr_bytes);
+                map.entry(hook_addr).or_insert(pool_id);
+            }
+        }
+
+        tracing::debug!(
+            "V4BaseMetricsHandler: loaded {} hook→pool entries",
+            map.len()
+        );
+        Ok(())
+    }
+
+    /// Re-query v4_pool_configs if any event's hook address is missing from the map.
+    async fn refresh_hook_pool_map_for_events(
+        &self,
+        events: &[&DecodedEvent],
+    ) -> Result<(), TransformationError> {
+        let missing = {
+            let map = self.hook_pool_map.read().unwrap();
+            events
+                .iter()
+                .any(|e| !map.contains_key(&e.contract_address))
+        };
+
+        if !missing {
+            return Ok(());
+        }
+
+        let Some(pool) = self.db_pool.get() else {
+            return Ok(());
+        };
+
+        let client = pool
+            .get()
+            .await
+            .map_err(|e| TransformationError::DatabaseError(e.into()))?;
+
+        let rows = client
+            .query(
+                "SELECT pool_id, hook_address FROM v4_pool_configs WHERE chain_id = $1",
+                &[&(self.chain_id as i64)],
+            )
+            .await
+            .map_err(|e| TransformationError::DatabaseError(e.into()))?;
+
+        let mut map = self.hook_pool_map.write().unwrap();
+        for row in &rows {
+            let pool_id_bytes: Vec<u8> = row.get("pool_id");
+            let hook_addr_bytes: Vec<u8> = row.get("hook_address");
+            if pool_id_bytes.len() == 32 && hook_addr_bytes.len() == 20 {
+                let mut pool_id = [0u8; 32];
+                let mut hook_addr = [0u8; 20];
+                pool_id.copy_from_slice(&pool_id_bytes);
+                hook_addr.copy_from_slice(&hook_addr_bytes);
+                map.entry(hook_addr).or_insert(pool_id);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Read the last committed cumulative totals for the given pool IDs.
+    ///
+    /// Returns defaults of (0, 0) for pools with no prior checkpoint.
+    async fn load_prev_cumulative(
+        &self,
+        pool_ids: &[[u8; 32]],
+    ) -> Result<HashMap<[u8; 32], (U256, U256)>, TransformationError> {
+        let Some(pool) = self.db_pool.get() else {
+            return Ok(HashMap::new());
+        };
+
+        let client = pool
+            .get()
+            .await
+            .map_err(|e| TransformationError::DatabaseError(e.into()))?;
+
+        let rows = client
+            .query(
+                "SELECT pool_id, total_proceeds::text, total_tokens_sold::text \
+                 FROM v4_base_proceeds_state \
+                 WHERE chain_id = $1 AND source = $2 AND source_version = $3",
+                &[
+                    &(self.chain_id as i64),
+                    &self.name(),
+                    &(self.version() as i32),
+                ],
+            )
+            .await
+            .map_err(|e| TransformationError::DatabaseError(e.into()))?;
+
+        let mut result: HashMap<[u8; 32], (U256, U256)> = HashMap::new();
+        for row in &rows {
+            let pool_id_bytes: Vec<u8> = row.get("pool_id");
+            if pool_id_bytes.len() != 32 {
+                continue;
+            }
+            let mut pool_id = [0u8; 32];
+            pool_id.copy_from_slice(&pool_id_bytes);
+
+            if !pool_ids.contains(&pool_id) {
+                continue;
+            }
+
+            let proceeds_str: String = row.get("total_proceeds");
+            let tokens_str: String = row.get("total_tokens_sold");
+
+            let proceeds =
+                U256::from_str_radix(proceeds_str.trim(), 10).unwrap_or(U256::ZERO);
+            let tokens = U256::from_str_radix(tokens_str.trim(), 10).unwrap_or(U256::ZERO);
+
+            result.insert(pool_id, (proceeds, tokens));
+        }
+
+        Ok(result)
+    }
+
+    /// Extract swap inputs from V4 base Swap events, computing per-swap deltas.
+    ///
+    /// Events are sorted by (block_number, log_index) per pool so that cumulative
+    /// deltas are always computed from the immediately preceding event.
+    ///
+    /// Returns (swap_inputs, new_cumulative) where new_cumulative maps each seen
+    /// pool_id to its final (totalProceeds, totalTokensSold) after this batch.
+    fn extract_swaps(
+        &self,
+        events: &[&DecodedEvent],
+        prev_state: &HashMap<[u8; 32], (U256, U256)>,
+    ) -> Result<(Vec<SwapInput>, HashMap<[u8; 32], (U256, U256)>), TransformationError> {
+        let hook_pool_map = self.hook_pool_map.read().unwrap();
+
+        // Group events by pool_id.
+        let mut pool_events: HashMap<[u8; 32], Vec<&DecodedEvent>> = HashMap::new();
+        for event in events {
+            match hook_pool_map.get(&event.contract_address) {
+                Some(&pool_id) => pool_events.entry(pool_id).or_default().push(event),
+                None => tracing::warn!(
+                    "V4BaseMetricsHandler: no pool_id for hook {} at block {}, skipping",
+                    hex::encode(event.contract_address),
+                    event.block_number,
+                ),
+            }
+        }
+        drop(hook_pool_map);
+
+        let mut swaps: Vec<SwapInput> = Vec::new();
+        let mut new_cumulative: HashMap<[u8; 32], (U256, U256)> = HashMap::new();
+
+        for (pool_id, mut pool_evts) in pool_events {
+            pool_evts.sort_by_key(|e| (e.block_number, e.log_index));
+
+            let (mut prev_proceeds, mut prev_tokens) = prev_state
+                .get(&pool_id)
+                .copied()
+                .unwrap_or((U256::ZERO, U256::ZERO));
+
+            let meta = match self.metadata_cache.get(pool_id.as_ref()) {
+                Some(m) => m,
+                None => {
+                    tracing::warn!(
+                        "V4BaseMetricsHandler: no metadata for pool {}, skipping {} events",
+                        hex::encode(pool_id),
+                        pool_evts.len(),
+                    );
+                    continue;
+                }
+            };
+
+            for event in pool_evts {
+                let tick = event.extract_i32_flexible("currentTick")?;
+                let total_proceeds = event.extract_uint256("totalProceeds")?;
+                let total_tokens_sold = event.extract_uint256("totalTokensSold")?;
+
+                // Cumulative counters should be non-decreasing; guard against wrap/reset.
+                let proceeds_delta = if total_proceeds >= prev_proceeds {
+                    total_proceeds - prev_proceeds
+                } else {
+                    tracing::warn!(
+                        "V4BaseMetricsHandler: totalProceeds decreased for pool {} at block {} \
+                         (prev={}, cur={}); treating as full value",
+                        hex::encode(pool_id),
+                        event.block_number,
+                        prev_proceeds,
+                        total_proceeds,
+                    );
+                    total_proceeds
+                };
+
+                let tokens_delta = if total_tokens_sold >= prev_tokens {
+                    total_tokens_sold - prev_tokens
+                } else {
+                    tracing::warn!(
+                        "V4BaseMetricsHandler: totalTokensSold decreased for pool {} at block {} \
+                         (prev={}, cur={}); treating as full value",
+                        hex::encode(pool_id),
+                        event.block_number,
+                        prev_tokens,
+                        total_tokens_sold,
+                    );
+                    total_tokens_sold
+                };
+
+                // Derive sqrtPriceX96 from the current tick.
+                let sqrt_price_x96 = match tick_to_sqrt_price_x96(tick) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        tracing::warn!(
+                            "V4BaseMetricsHandler: invalid tick {} at block {}: {}, skipping",
+                            tick, event.block_number, e
+                        );
+                        prev_proceeds = total_proceeds;
+                        prev_tokens = total_tokens_sold;
+                        continue;
+                    }
+                };
+
+                // Map cumulative deltas to signed amount0 / amount1.
+                //
+                // V4 base auctions sell base tokens for quote tokens:
+                //   proceeds_delta  = quote received by the pool (inflow)
+                //   tokens_delta    = base sold out of the pool   (outflow)
+                //
+                // If is_token_0 = true  → base is token0, quote is token1
+                //   amount0 = -(tokens_delta)   [base leaves]
+                //   amount1 =  proceeds_delta   [quote enters]
+                //
+                // If is_token_0 = false → base is token1, quote is token0
+                //   amount0 =  proceeds_delta   [quote enters]
+                //   amount1 = -(tokens_delta)   [base leaves]
+                let (amount0, amount1) = signed_amounts(proceeds_delta, tokens_delta, meta.is_token_0);
+
+                swaps.push(SwapInput {
+                    pool_id: pool_id.to_vec(),
+                    block_number: event.block_number,
+                    block_timestamp: event.block_timestamp,
+                    log_index: event.log_index,
+                    amount0,
+                    amount1,
+                    sqrt_price_x96,
+                    tick,
+                    liquidity: U256::ZERO, // not available from V4 base Swap event
+                });
+
+                prev_proceeds = total_proceeds;
+                prev_tokens = total_tokens_sold;
+            }
+
+            new_cumulative.insert(pool_id, (prev_proceeds, prev_tokens));
+        }
+
+        Ok((swaps, new_cumulative))
+    }
+}
+
+// ─── Free helpers ─────────────────────────────────────────────────────────────
+
+/// Compute signed amount0 / amount1 from unsigned delta values.
+///
+/// Exported for tests.
+pub(crate) fn signed_amounts(
+    proceeds_delta: U256,
+    tokens_delta: U256,
+    is_token_0: bool,
+) -> (I256, I256) {
+    // U256 → I256: safe for values well below 2^255 (bounded by token supply).
+    let proceeds_i = i256_from_u256(proceeds_delta);
+    let tokens_i = i256_from_u256(tokens_delta);
+
+    if is_token_0 {
+        // base = token0, quote = token1
+        (-tokens_i, proceeds_i)
+    } else {
+        // base = token1, quote = token0
+        (proceeds_i, -tokens_i)
+    }
+}
+
+/// Convert U256 to I256, clamping at I256::MAX to avoid wrapping.
+fn i256_from_u256(v: U256) -> I256 {
+    // I256::MAX = 2^255 - 1. Token values are far below this threshold.
+    let max = U256::from_limbs([u64::MAX, u64::MAX, u64::MAX, i64::MAX as u64]);
+    if v > max {
+        I256::MAX
+    } else {
+        I256::try_from(v).unwrap_or(I256::MAX)
+    }
+}
+
+/// Build a `DbOperation` that upserts the cumulative checkpoint for one pool.
+fn upsert_proceeds_state(
+    chain_id: u64,
+    pool_id: &[u8; 32],
+    total_proceeds: &U256,
+    total_tokens_sold: &U256,
+) -> DbOperation {
+    DbOperation::Upsert {
+        table: "v4_base_proceeds_state".to_string(),
+        conflict_columns: vec![
+            "chain_id".to_string(),
+            "pool_id".to_string(),
+            "source".to_string(),
+            "source_version".to_string(),
+        ],
+        update_columns: vec![
+            "total_proceeds".to_string(),
+            "total_tokens_sold".to_string(),
+        ],
+        update_condition: None,
+        columns: vec![
+            "chain_id".to_string(),
+            "pool_id".to_string(),
+            "total_proceeds".to_string(),
+            "total_tokens_sold".to_string(),
+        ],
+        values: vec![
+            DbValue::Int64(chain_id as i64),
+            DbValue::Bytes32(*pool_id),
+            DbValue::Numeric(total_proceeds.to_string()),
+            DbValue::Numeric(total_tokens_sold.to_string()),
+        ],
+    }
+}
+
+// ─── Registration ─────────────────────────────────────────────────────────────
+
+pub fn register_handlers(
+    registry: &mut TransformationRegistry,
+    chain_id: u64,
+    cache: Arc<PoolMetadataCache>,
+) {
+    registry.register_event_handler(V4BaseMetricsHandler {
+        metadata_cache: cache,
+        decimals_init: Once::new(),
+        chain_id,
+        db_pool: OnceLock::new(),
+        hook_pool_map: RwLock::new(HashMap::new()),
+    });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── signed_amounts ────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_signed_amounts_is_token_0_true() {
+        // base = token0, quote = token1
+        // tokens_delta = 100 base leaves pool  → amount0 = -100
+        // proceeds_delta = 50 quote enters pool → amount1 =  +50
+        let (a0, a1) = signed_amounts(U256::from(50u64), U256::from(100u64), true);
+        assert_eq!(a0, I256::try_from(-100i64).unwrap());
+        assert_eq!(a1, I256::try_from(50i64).unwrap());
+    }
+
+    #[test]
+    fn test_signed_amounts_is_token_0_false() {
+        // base = token1, quote = token0
+        // proceeds_delta = 50 quote enters  → amount0 = +50
+        // tokens_delta = 100 base leaves    → amount1 = -100
+        let (a0, a1) = signed_amounts(U256::from(50u64), U256::from(100u64), false);
+        assert_eq!(a0, I256::try_from(50i64).unwrap());
+        assert_eq!(a1, I256::try_from(-100i64).unwrap());
+    }
+
+    #[test]
+    fn test_signed_amounts_zero_deltas() {
+        let (a0, a1) = signed_amounts(U256::ZERO, U256::ZERO, true);
+        assert_eq!(a0, I256::ZERO);
+        assert_eq!(a1, I256::ZERO);
+    }
+
+    // ── delta computation via extract_swaps ───────────────────────────────────
+
+    fn make_handler(chain_id: u64) -> V4BaseMetricsHandler {
+        V4BaseMetricsHandler {
+            metadata_cache: Arc::new(PoolMetadataCache::new()),
+            decimals_init: Once::new(),
+            chain_id,
+            db_pool: OnceLock::new(),
+            hook_pool_map: RwLock::new(HashMap::new()),
+        }
+    }
+
+    fn make_pool_id(seed: u8) -> [u8; 32] {
+        [seed; 32]
+    }
+
+    fn make_hook_addr(seed: u8) -> [u8; 20] {
+        [seed; 20]
+    }
+
+    fn make_event_params(
+        tick: i32,
+        total_proceeds: u64,
+        total_tokens_sold: u64,
+    ) -> std::collections::HashMap<String, crate::types::decoded::DecodedValue> {
+        use crate::types::decoded::DecodedValue;
+        let mut params = std::collections::HashMap::new();
+        params.insert(
+            "currentTick".to_string(),
+            DecodedValue::Int32(tick),
+        );
+        params.insert(
+            "totalProceeds".to_string(),
+            DecodedValue::Uint256(U256::from(total_proceeds)),
+        );
+        params.insert(
+            "totalTokensSold".to_string(),
+            DecodedValue::Uint256(U256::from(total_tokens_sold)),
+        );
+        params
+    }
+
+    fn make_decoded_event(
+        hook_addr: [u8; 20],
+        block_number: u64,
+        log_index: u32,
+        tick: i32,
+        total_proceeds: u64,
+        total_tokens_sold: u64,
+    ) -> DecodedEvent {
+        DecodedEvent {
+            block_number,
+            block_timestamp: block_number * 12,
+            transaction_hash: [0u8; 32],
+            log_index,
+            contract_address: hook_addr,
+            source_name: SOURCE.to_string(),
+            event_name: "Swap".to_string(),
+            event_signature: "Swap(int24,uint256,uint256)".to_string(),
+            params: make_event_params(tick, total_proceeds, total_tokens_sold),
+        }
+    }
+
+    fn setup_handler_with_pool(
+        handler: &V4BaseMetricsHandler,
+        hook_addr: [u8; 20],
+        pool_id: [u8; 32],
+        is_token_0: bool,
+    ) {
+        use crate::transformations::util::pool_metadata::PoolMetadata;
+
+        handler
+            .hook_pool_map
+            .write()
+            .unwrap()
+            .insert(hook_addr, pool_id);
+
+        handler.metadata_cache.insert_if_absent(
+            pool_id.to_vec(),
+            PoolMetadata {
+                pool_id: pool_id.to_vec(),
+                base_token: [1u8; 20],
+                quote_token: [2u8; 20],
+                is_token_0,
+                pool_type: "v4".to_string(),
+                base_decimals: 18,
+                quote_decimals: 18,
+            },
+        );
+    }
+
+    #[test]
+    fn test_extract_swaps_first_event_no_prev_state() {
+        let handler = make_handler(8453);
+        let hook_addr = make_hook_addr(0xAA);
+        let pool_id = make_pool_id(0x01);
+        setup_handler_with_pool(&handler, hook_addr, pool_id, true);
+
+        let event = make_decoded_event(hook_addr, 100, 0, 0, 1000, 500);
+        let events = vec![&event];
+
+        let prev_state = HashMap::new(); // no prior checkpoint
+        let (swaps, new_cum) = handler.extract_swaps(&events, &prev_state).unwrap();
+
+        assert_eq!(swaps.len(), 1);
+        let swap = &swaps[0];
+        // No prev state → delta = full cumulative value
+        // is_token_0 = true: amount0 = -500 (tokens out), amount1 = +1000 (proceeds in)
+        assert_eq!(swap.amount0, I256::try_from(-500i64).unwrap());
+        assert_eq!(swap.amount1, I256::try_from(1000i64).unwrap());
+        assert_eq!(swap.tick, 0);
+        assert_eq!(swap.block_number, 100);
+
+        // Cumulative checkpoint should be updated
+        let (tp, ts) = new_cum[&pool_id];
+        assert_eq!(tp, U256::from(1000u64));
+        assert_eq!(ts, U256::from(500u64));
+    }
+
+    #[test]
+    fn test_extract_swaps_delta_from_prev_state() {
+        let handler = make_handler(8453);
+        let hook_addr = make_hook_addr(0xBB);
+        let pool_id = make_pool_id(0x02);
+        setup_handler_with_pool(&handler, hook_addr, pool_id, false);
+
+        // Prev state: pool already has 1000 proceeds, 500 tokens sold
+        let mut prev_state = HashMap::new();
+        prev_state.insert(pool_id, (U256::from(1000u64), U256::from(500u64)));
+
+        // New event: cumulative is now 1200 proceeds, 600 tokens
+        let event = make_decoded_event(hook_addr, 101, 0, 100, 1200, 600);
+        let events = vec![&event];
+
+        let (swaps, new_cum) = handler.extract_swaps(&events, &prev_state).unwrap();
+
+        assert_eq!(swaps.len(), 1);
+        let swap = &swaps[0];
+        // is_token_0 = false: amount0 = +200 (proceeds in), amount1 = -100 (tokens out)
+        assert_eq!(swap.amount0, I256::try_from(200i64).unwrap());
+        assert_eq!(swap.amount1, I256::try_from(-100i64).unwrap());
+
+        let (tp, ts) = new_cum[&pool_id];
+        assert_eq!(tp, U256::from(1200u64));
+        assert_eq!(ts, U256::from(600u64));
+    }
+
+    #[test]
+    fn test_extract_swaps_multiple_events_same_pool_same_block() {
+        let handler = make_handler(8453);
+        let hook_addr = make_hook_addr(0xCC);
+        let pool_id = make_pool_id(0x03);
+        setup_handler_with_pool(&handler, hook_addr, pool_id, true);
+
+        let prev_state = HashMap::new();
+
+        // Two swap events in the same block; second should delta from first.
+        let e0 = make_decoded_event(hook_addr, 200, 0, 0, 500, 250);
+        let e1 = make_decoded_event(hook_addr, 200, 1, 10, 800, 400);
+        let events = vec![&e0, &e1];
+
+        let (swaps, new_cum) = handler.extract_swaps(&events, &prev_state).unwrap();
+
+        assert_eq!(swaps.len(), 2);
+        // First swap: delta from 0 → (500, 250)
+        assert_eq!(swaps[0].amount0, I256::try_from(-250i64).unwrap()); // -tokens
+        assert_eq!(swaps[0].amount1, I256::try_from(500i64).unwrap());  //  proceeds
+
+        // Second swap: delta from (500,250) → (800,400) = (300,150)
+        assert_eq!(swaps[1].amount0, I256::try_from(-150i64).unwrap());
+        assert_eq!(swaps[1].amount1, I256::try_from(300i64).unwrap());
+
+        let (tp, ts) = new_cum[&pool_id];
+        assert_eq!(tp, U256::from(800u64));
+        assert_eq!(ts, U256::from(400u64));
+    }
+
+    #[test]
+    fn test_extract_swaps_no_pool_id_skipped() {
+        let handler = make_handler(8453);
+        // No entry in hook_pool_map
+        let hook_addr = make_hook_addr(0xDD);
+
+        let event = make_decoded_event(hook_addr, 100, 0, 0, 1000, 500);
+        let events = vec![&event];
+
+        let (swaps, new_cum) = handler
+            .extract_swaps(&events, &HashMap::new())
+            .unwrap();
+
+        assert!(swaps.is_empty());
+        assert!(new_cum.is_empty());
+    }
+
+    #[test]
+    fn test_upsert_proceeds_state_op() {
+        let pool_id = make_pool_id(0xFF);
+        let op = upsert_proceeds_state(8453, &pool_id, &U256::from(9999u64), &U256::from(1234u64));
+        match op {
+            DbOperation::Upsert { table, conflict_columns, update_columns, .. } => {
+                assert_eq!(table, "v4_base_proceeds_state");
+                assert!(conflict_columns.contains(&"pool_id".to_string()));
+                assert!(update_columns.contains(&"total_proceeds".to_string()));
+                assert!(update_columns.contains(&"total_tokens_sold".to_string()));
+            }
+            _ => panic!("expected Upsert"),
+        }
+    }
+}

--- a/src/transformations/event/v4/metrics.rs
+++ b/src/transformations/event/v4/metrics.rs
@@ -6,17 +6,22 @@
 //! ## Design
 //!
 //! The V4 base swap event emits **cumulative** counters rather than per-swap deltas, so this
-//! handler must compute deltas by subtracting the previous cumulative values. The previous
-//! values are read from the `v4_base_proceeds_state` checkpoint table at the start of each
-//! batch and written back at the end. This DB-read approach (rather than purely in-memory
-//! state) ensures correctness across retries: if a transaction is rolled back, the next
-//! attempt re-reads the last committed checkpoint.
+//! handler must compute deltas by subtracting the previous cumulative values.
+//!
+//! Previous values live in an in-memory `RwLock<HashMap>`. The cache is:
+//!   - Populated from `v4_base_proceeds_state` at `initialize()`.
+//!   - Refilled on cache miss (only for the specific missing pool IDs).
+//!   - Updated optimistically inside `handle()` after computing deltas.
+//!
+//! Each `handle()` returns an upsert to `v4_base_proceeds_state` for every pool it touched,
+//! so the checkpoint table is always durable. On restart the cache is rebuilt from the
+//! checkpoint.
 //!
 //! ## Sequential processing
 //!
 //! `requires_sequential()` returns `true`. The catchup engine enforces one-at-a-time range
-//! execution via a capacity-1 FIFO semaphore, so the DB checkpoint is always up-to-date
-//! when the next range reads it.
+//! execution via a capacity-1 FIFO semaphore, so in-memory cache updates serialize naturally
+//! and the DB checkpoint is always up-to-date relative to what any pending range will read.
 //!
 //! ## Pool ID lookup
 //!
@@ -53,6 +58,9 @@ pub struct V4BaseMetricsHandler {
     db_pool: OnceLock<Pool>,
     /// hook_address → pool_id, loaded from v4_pool_configs at init, refreshed on miss.
     hook_pool_map: RwLock<HashMap<[u8; 20], [u8; 32]>>,
+    /// pool_id → (total_proceeds, total_tokens_sold) — loaded from v4_base_proceeds_state
+    /// at init, refreshed on cache miss, updated optimistically in handle().
+    proceeds_state: RwLock<HashMap<[u8; 32], (U256, U256)>>,
 }
 
 #[async_trait]
@@ -124,7 +132,7 @@ impl TransformationHandler for V4BaseMetricsHandler {
         )
         .await?;
 
-        // Convert to fixed-size arrays for the DB checkpoint query.
+        // Convert to fixed-size arrays for cache lookups.
         let pool_ids: Vec<[u8; 32]> = pool_id_vecs
             .iter()
             .filter_map(|v| {
@@ -138,8 +146,17 @@ impl TransformationHandler for V4BaseMetricsHandler {
             })
             .collect();
 
-        // Read previous cumulative totals from the DB checkpoint.
-        let prev_state = self.load_prev_cumulative(&pool_ids).await?;
+        // Fetch any pools missing from the in-memory cache.
+        self.refresh_proceeds_state_for_pools(&pool_ids).await?;
+
+        // Snapshot the current in-memory cumulative state for the pools in this batch.
+        let prev_state: HashMap<[u8; 32], (U256, U256)> = {
+            let state = self.proceeds_state.read().unwrap();
+            pool_ids
+                .iter()
+                .filter_map(|id| state.get(id).map(|&v| (*id, v)))
+                .collect()
+        };
 
         // Extract swap inputs + determine new cumulative totals.
         let (swaps, new_cumulative) = self.extract_swaps(&events, &prev_state)?;
@@ -150,7 +167,7 @@ impl TransformationHandler for V4BaseMetricsHandler {
 
         let mut ops = process_swaps(&swaps, &self.metadata_cache, ctx.chain_id);
 
-        // Checkpoint the new cumulative totals so the next range reads them.
+        // Durably checkpoint the new cumulative totals.
         for (pool_id, (total_proceeds, total_tokens_sold)) in &new_cumulative {
             ops.push(upsert_proceeds_state(
                 self.chain_id,
@@ -160,6 +177,17 @@ impl TransformationHandler for V4BaseMetricsHandler {
             ));
         }
 
+        // Update the in-memory cache optimistically. Because requires_sequential() is true,
+        // the next range won't run until this one finishes. If the DB transaction fails
+        // the engine halts further processing for this handler, so on restart the cache
+        // is rebuilt from the last-committed checkpoint.
+        {
+            let mut state = self.proceeds_state.write().unwrap();
+            for (pool_id, totals) in new_cumulative {
+                state.insert(pool_id, totals);
+            }
+        }
+
         Ok(ops)
     }
 
@@ -167,6 +195,7 @@ impl TransformationHandler for V4BaseMetricsHandler {
         self.db_pool.set(db_pool.inner().clone()).ok();
         self.metadata_cache.load_into(db_pool, self.chain_id).await?;
         self.load_hook_pool_map(db_pool).await?;
+        self.load_all_proceeds_state(db_pool).await?;
         tracing::info!("V4BaseMetricsHandler initialized");
         Ok(())
     }
@@ -270,18 +299,13 @@ impl V4BaseMetricsHandler {
         Ok(())
     }
 
-    /// Read the last committed cumulative totals for the given pool IDs.
-    ///
-    /// Returns defaults of (0, 0) for pools with no prior checkpoint.
-    async fn load_prev_cumulative(
+    /// Load all committed checkpoints into the in-memory cache at startup.
+    async fn load_all_proceeds_state(
         &self,
-        pool_ids: &[[u8; 32]],
-    ) -> Result<HashMap<[u8; 32], (U256, U256)>, TransformationError> {
-        let Some(pool) = self.db_pool.get() else {
-            return Ok(HashMap::new());
-        };
-
-        let client = pool
+        db_pool: &DbPool,
+    ) -> Result<(), TransformationError> {
+        let client = db_pool
+            .inner()
             .get()
             .await
             .map_err(|e| TransformationError::DatabaseError(e.into()))?;
@@ -300,7 +324,7 @@ impl V4BaseMetricsHandler {
             .await
             .map_err(|e| TransformationError::DatabaseError(e.into()))?;
 
-        let mut result: HashMap<[u8; 32], (U256, U256)> = HashMap::new();
+        let mut state = self.proceeds_state.write().unwrap();
         for row in &rows {
             let pool_id_bytes: Vec<u8> = row.get("pool_id");
             if pool_id_bytes.len() != 32 {
@@ -309,21 +333,102 @@ impl V4BaseMetricsHandler {
             let mut pool_id = [0u8; 32];
             pool_id.copy_from_slice(&pool_id_bytes);
 
-            if !pool_ids.contains(&pool_id) {
-                continue;
-            }
-
             let proceeds_str: String = row.get("total_proceeds");
             let tokens_str: String = row.get("total_tokens_sold");
 
-            let proceeds =
-                U256::from_str_radix(proceeds_str.trim(), 10).unwrap_or(U256::ZERO);
+            let proceeds = U256::from_str_radix(proceeds_str.trim(), 10).unwrap_or(U256::ZERO);
             let tokens = U256::from_str_radix(tokens_str.trim(), 10).unwrap_or(U256::ZERO);
 
-            result.insert(pool_id, (proceeds, tokens));
+            state.insert(pool_id, (proceeds, tokens));
         }
 
-        Ok(result)
+        tracing::debug!(
+            "V4BaseMetricsHandler: loaded {} proceeds checkpoints",
+            state.len()
+        );
+        Ok(())
+    }
+
+    /// Fetch proceeds state from DB for any pool IDs missing from the in-memory cache.
+    ///
+    /// Pools without a checkpoint row are still marked present in the cache with (0, 0),
+    /// so subsequent calls for the same pool don't re-query the DB.
+    async fn refresh_proceeds_state_for_pools(
+        &self,
+        pool_ids: &[[u8; 32]],
+    ) -> Result<(), TransformationError> {
+        // Find pools not already in the cache.
+        let missing: Vec<[u8; 32]> = {
+            let state = self.proceeds_state.read().unwrap();
+            pool_ids
+                .iter()
+                .copied()
+                .filter(|id| !state.contains_key(id))
+                .collect()
+        };
+
+        if missing.is_empty() {
+            return Ok(());
+        }
+
+        let Some(pool) = self.db_pool.get() else {
+            // No DB pool — seed missing entries with zero so we don't loop.
+            let mut state = self.proceeds_state.write().unwrap();
+            for id in &missing {
+                state.entry(*id).or_insert((U256::ZERO, U256::ZERO));
+            }
+            return Ok(());
+        };
+
+        let client = pool
+            .get()
+            .await
+            .map_err(|e| TransformationError::DatabaseError(e.into()))?;
+
+        // Use a BYTEA[] parameter so the query stays bounded.
+        let missing_bytes: Vec<&[u8]> = missing.iter().map(|id| id.as_slice()).collect();
+        let rows = client
+            .query(
+                "SELECT pool_id, total_proceeds::text, total_tokens_sold::text \
+                 FROM v4_base_proceeds_state \
+                 WHERE chain_id = $1 \
+                   AND source = $2 \
+                   AND source_version = $3 \
+                   AND pool_id = ANY($4)",
+                &[
+                    &(self.chain_id as i64),
+                    &self.name(),
+                    &(self.version() as i32),
+                    &missing_bytes,
+                ],
+            )
+            .await
+            .map_err(|e| TransformationError::DatabaseError(e.into()))?;
+
+        let mut state = self.proceeds_state.write().unwrap();
+        for row in &rows {
+            let pool_id_bytes: Vec<u8> = row.get("pool_id");
+            if pool_id_bytes.len() != 32 {
+                continue;
+            }
+            let mut pool_id = [0u8; 32];
+            pool_id.copy_from_slice(&pool_id_bytes);
+
+            let proceeds_str: String = row.get("total_proceeds");
+            let tokens_str: String = row.get("total_tokens_sold");
+            let proceeds = U256::from_str_radix(proceeds_str.trim(), 10).unwrap_or(U256::ZERO);
+            let tokens = U256::from_str_radix(tokens_str.trim(), 10).unwrap_or(U256::ZERO);
+
+            state.insert(pool_id, (proceeds, tokens));
+        }
+
+        // Any pool that still isn't in the cache has no checkpoint yet; seed with (0, 0)
+        // so we don't re-query for it on every subsequent handle().
+        for id in &missing {
+            state.entry(*id).or_insert((U256::ZERO, U256::ZERO));
+        }
+
+        Ok(())
     }
 
     /// Extract swap inputs from V4 base Swap events, computing per-swap deltas.
@@ -545,6 +650,7 @@ pub fn register_handlers(
         chain_id,
         db_pool: OnceLock::new(),
         hook_pool_map: RwLock::new(HashMap::new()),
+        proceeds_state: RwLock::new(HashMap::new()),
     });
 }
 
@@ -592,6 +698,7 @@ mod tests {
             chain_id,
             db_pool: OnceLock::new(),
             hook_pool_map: RwLock::new(HashMap::new()),
+            proceeds_state: RwLock::new(HashMap::new()),
         }
     }
 
@@ -775,6 +882,46 @@ mod tests {
 
         assert!(swaps.is_empty());
         assert!(new_cum.is_empty());
+    }
+
+    #[test]
+    fn test_proceeds_state_cache_used_instead_of_db_on_hit() {
+        // After a write to the in-memory proceeds_state, the next extract_swaps
+        // call should use those cached values rather than treating the pool as
+        // having no prior state.
+        let handler = make_handler(8453);
+        let hook_addr = make_hook_addr(0xEE);
+        let pool_id = make_pool_id(0x04);
+        setup_handler_with_pool(&handler, hook_addr, pool_id, true);
+
+        // Simulate an earlier handle() that populated the cache.
+        handler
+            .proceeds_state
+            .write()
+            .unwrap()
+            .insert(pool_id, (U256::from(700u64), U256::from(350u64)));
+
+        // A new event arrives with a higher cumulative total.
+        let event = make_decoded_event(hook_addr, 150, 0, 0, 1000, 500);
+        let events = vec![&event];
+
+        // Simulate handle()'s snapshot read from the in-memory state:
+        let prev_state: HashMap<[u8; 32], (U256, U256)> = {
+            let state = handler.proceeds_state.read().unwrap();
+            [pool_id]
+                .iter()
+                .filter_map(|id| state.get(id).map(|&v| (*id, v)))
+                .collect()
+        };
+
+        let (swaps, new_cum) = handler.extract_swaps(&events, &prev_state).unwrap();
+
+        assert_eq!(swaps.len(), 1);
+        // delta = (1000 - 700, 500 - 350) = (300, 150)
+        // is_token_0 = true: amount0 = -150, amount1 = +300
+        assert_eq!(swaps[0].amount0, I256::try_from(-150i64).unwrap());
+        assert_eq!(swaps[0].amount1, I256::try_from(300i64).unwrap());
+        assert_eq!(new_cum[&pool_id], (U256::from(1000u64), U256::from(500u64)));
     }
 
     #[test]

--- a/src/transformations/event/v4/mod.rs
+++ b/src/transformations/event/v4/mod.rs
@@ -1,1 +1,2 @@
 pub mod create;
+pub mod metrics;

--- a/src/transformations/executor.rs
+++ b/src/transformations/executor.rs
@@ -219,16 +219,26 @@ pub(crate) async fn run_handler_task(
                 .map_err(TransformationError::DatabaseError),
         };
 
-        if let Err(e) = result {
-            tracing::error!(
-                "Handler {} transaction failed for range {}-{}: {:?}",
-                handler_key,
-                range_start,
-                range_end,
-                e
-            );
-            return Err(e);
+        match result {
+            Ok(()) => {
+                handler.on_commit_success((range_start, range_end)).await?;
+            }
+            Err(e) => {
+                tracing::error!(
+                    "Handler {} transaction failed for range {}-{}: {:?}",
+                    handler_key,
+                    range_start,
+                    range_end,
+                    e
+                );
+                handler.on_commit_failure((range_start, range_end)).await?;
+                return Err(e);
+            }
         }
+    } else {
+        // Empty ops = nothing to commit, but still notify the handler so it
+        // can drain any per-range state it may track.
+        handler.on_commit_success((range_start, range_end)).await?;
     }
 
     Ok(HandlerOutcome {

--- a/src/transformations/finalizer.rs
+++ b/src/transformations/finalizer.rs
@@ -13,7 +13,7 @@ use super::error::TransformationError;
 use super::live_state::LiveProcessingState;
 use super::registry::TransformationRegistry;
 use crate::db::{DbOperation, DbPool, DbValue, WhereClause};
-use crate::live::{LiveProgressTracker, LiveStorage, StorageError};
+use crate::live::{LiveProgressTracker, LiveStorage, LiveUpsertSnapshot, StorageError};
 
 /// Handles range finalization, reorg cleanup, and progress tracking.
 pub(crate) struct RangeFinalizer {
@@ -336,6 +336,12 @@ impl RangeFinalizer {
         // Phase 2: Delete committed rows from database tables
         self.cleanup_reorg_tables(orphaned).await?;
 
+        // Phase 2.5: Notify handlers so they can invalidate in-memory caches
+        // that mirror rolled-back DB state.
+        for handler in self.registry.all_handlers() {
+            handler.on_reorg(orphaned).await?;
+        }
+
         // Phase 3: Clean up _live_progress entries
         self.cleanup_live_progress(orphaned).await?;
 
@@ -355,61 +361,18 @@ impl RangeFinalizer {
         }
 
         let storage = LiveStorage::new(&self.chain_name);
-        let mut restore_ops = Vec::new();
         // Maps table_name -> set of block numbers for which we have snapshots.
         let mut tables_covered: HashMap<String, HashSet<u64>> = HashMap::new();
 
-        // Phase 2a: Read snapshots and generate restore operations
+        // Phase 2a: Read snapshots and dedupe per (table, source, source_version,
+        // key_columns). Keep the OLDEST snapshot seen for each key so the
+        // restored row reflects the pre-rollback state, not the most recent
+        // orphaned write.
+        let mut per_block_snapshots: Vec<(u64, Vec<LiveUpsertSnapshot>)> = Vec::new();
         for &block_number in orphaned {
             match storage.read_snapshots(block_number) {
                 Ok(snapshots) => {
-                    for snapshot in snapshots {
-                        tables_covered
-                            .entry(snapshot.table.clone())
-                            .or_default()
-                            .insert(block_number);
-
-                        match snapshot.previous_row {
-                            Some(previous) => {
-                                let columns: Vec<String> =
-                                    previous.iter().map(|(k, _)| k.clone()).collect();
-                                let values: Vec<DbValue> =
-                                    previous.iter().map(|(_, v)| v.to_db_value()).collect();
-                                let conflict_cols: Vec<String> = snapshot
-                                    .key_columns
-                                    .iter()
-                                    .map(|(k, _)| k.clone())
-                                    .collect();
-
-                                let update_cols: Vec<String> = columns
-                                    .iter()
-                                    .filter(|c| !conflict_cols.contains(c))
-                                    .cloned()
-                                    .collect();
-
-                                restore_ops.push(DbOperation::Upsert {
-                                    table: snapshot.table,
-                                    columns,
-                                    values,
-                                    conflict_columns: conflict_cols,
-                                    update_columns: update_cols,
-                                    update_condition: None,
-                                });
-                            }
-                            None => {
-                                let key_conditions: Vec<(String, DbValue)> = snapshot
-                                    .key_columns
-                                    .into_iter()
-                                    .map(|(k, v)| (k, v.to_db_value()))
-                                    .collect();
-
-                                restore_ops.push(DbOperation::Delete {
-                                    table: snapshot.table,
-                                    where_clause: WhereClause::And(key_conditions),
-                                });
-                            }
-                        }
-                    }
+                    per_block_snapshots.push((block_number, snapshots));
                 }
                 Err(StorageError::NotFound(_)) => {
                     tracing::debug!(
@@ -423,6 +386,51 @@ impl RangeFinalizer {
                         block_number,
                         e
                     );
+                }
+            }
+        }
+
+        let deduped = dedupe_restore_snapshots(per_block_snapshots, &mut tables_covered);
+
+        let mut restore_ops = Vec::new();
+        for snapshot in deduped {
+            match snapshot.previous_row {
+                Some(previous) => {
+                    let columns: Vec<String> = previous.iter().map(|(k, _)| k.clone()).collect();
+                    let values: Vec<DbValue> =
+                        previous.iter().map(|(_, v)| v.to_db_value()).collect();
+                    let conflict_cols: Vec<String> = snapshot
+                        .key_columns
+                        .iter()
+                        .map(|(k, _)| k.clone())
+                        .collect();
+
+                    let update_cols: Vec<String> = columns
+                        .iter()
+                        .filter(|c| !conflict_cols.contains(c))
+                        .cloned()
+                        .collect();
+
+                    restore_ops.push(DbOperation::Upsert {
+                        table: snapshot.table,
+                        columns,
+                        values,
+                        conflict_columns: conflict_cols,
+                        update_columns: update_cols,
+                        update_condition: None,
+                    });
+                }
+                None => {
+                    let key_conditions: Vec<(String, DbValue)> = snapshot
+                        .key_columns
+                        .into_iter()
+                        .map(|(k, v)| (k, v.to_db_value()))
+                        .collect();
+
+                    restore_ops.push(DbOperation::Delete {
+                        table: snapshot.table,
+                        where_clause: WhereClause::And(key_conditions),
+                    });
                 }
             }
         }
@@ -516,6 +524,47 @@ impl RangeFinalizer {
     }
 }
 
+/// Dedupe rollback snapshots so only the OLDEST snapshot per
+/// `(table, source, source_version, key_columns)` is kept. Updates
+/// `tables_covered` with the set of blocks that had a snapshot per table.
+///
+/// `per_block_snapshots` must be ordered ascending by block number; the
+/// function relies on this so the first snapshot seen for a given key is
+/// the one whose `previous_row` holds the truly pre-rollback state.
+pub(crate) fn dedupe_restore_snapshots(
+    per_block_snapshots: Vec<(u64, Vec<LiveUpsertSnapshot>)>,
+    tables_covered: &mut HashMap<String, HashSet<u64>>,
+) -> Vec<LiveUpsertSnapshot> {
+    type DedupKey = (String, String, u32, Vec<(String, Vec<u8>)>);
+    fn dedup_key(s: &LiveUpsertSnapshot) -> DedupKey {
+        let serialized_keys: Vec<(String, Vec<u8>)> = s
+            .key_columns
+            .iter()
+            .map(|(name, v)| (name.clone(), bincode::serialize(v).unwrap_or_default()))
+            .collect();
+        (
+            s.table.clone(),
+            s.source.clone(),
+            s.source_version,
+            serialized_keys,
+        )
+    }
+
+    let mut first_snapshot_by_key: HashMap<DedupKey, LiveUpsertSnapshot> = HashMap::new();
+    for (block_number, snapshots) in per_block_snapshots {
+        for snapshot in snapshots {
+            tables_covered
+                .entry(snapshot.table.clone())
+                .or_default()
+                .insert(block_number);
+            first_snapshot_by_key
+                .entry(dedup_key(&snapshot))
+                .or_insert(snapshot);
+        }
+    }
+    first_snapshot_by_key.into_values().collect()
+}
+
 /// Compute per-table fallback delete block lists.
 ///
 /// For each table in `tables_to_clean`, returns `(table_name, uncovered_blocks)`
@@ -545,6 +594,133 @@ pub(crate) fn compute_fallback_deletes<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::live::LiveDbValue;
+
+    fn make_snapshot(
+        table: &str,
+        pool_id_byte: u8,
+        previous_value: Option<i64>,
+    ) -> LiveUpsertSnapshot {
+        LiveUpsertSnapshot {
+            table: table.to_string(),
+            source: "TestHandler".to_string(),
+            source_version: 1,
+            key_columns: vec![(
+                "pool_id".to_string(),
+                LiveDbValue::Bytes32([pool_id_byte; 32]),
+            )],
+            previous_row: previous_value.map(|v| {
+                vec![
+                    (
+                        "pool_id".to_string(),
+                        LiveDbValue::Bytes32([pool_id_byte; 32]),
+                    ),
+                    ("value".to_string(), LiveDbValue::Int64(v)),
+                ]
+            }),
+        }
+    }
+
+    /// When two orphaned blocks each snapshot the same (table, key), the
+    /// dedupe must keep the OLDEST block's snapshot — that snapshot's
+    /// `previous_row` holds the true pre-rollback state.
+    #[test]
+    fn test_dedupe_restore_snapshots_keeps_oldest_per_key() {
+        // Simulate: blocks 100 and 101 both touched the same pool row.
+        // Block 100's snapshot says "before me, value was 50".
+        // Block 101's snapshot says "before me, value was 60" (post-block-100).
+        // Reorg of [100, 101] should restore value=50, so dedupe must
+        // keep the snapshot from block 100.
+        let per_block = vec![
+            (100u64, vec![make_snapshot("pool_state", 0xAA, Some(50))]),
+            (101u64, vec![make_snapshot("pool_state", 0xAA, Some(60))]),
+        ];
+
+        let mut tables_covered: HashMap<String, HashSet<u64>> = HashMap::new();
+        let deduped = dedupe_restore_snapshots(per_block, &mut tables_covered);
+
+        assert_eq!(deduped.len(), 1, "expected one snapshot after dedup");
+        let kept = &deduped[0];
+        assert_eq!(kept.table, "pool_state");
+
+        // Verify the kept snapshot is the oldest one (value=50).
+        let row = kept
+            .previous_row
+            .as_ref()
+            .expect("snapshot should have previous_row");
+        let value_cell = row
+            .iter()
+            .find(|(k, _)| k == "value")
+            .expect("value column should exist");
+        match &value_cell.1 {
+            LiveDbValue::Int64(n) => assert_eq!(*n, 50, "expected oldest snapshot (value=50)"),
+            other => panic!("unexpected value type: {:?}", other),
+        }
+
+        // tables_covered should record both block numbers for pool_state.
+        let covered = tables_covered
+            .get("pool_state")
+            .expect("pool_state should be covered");
+        assert!(covered.contains(&100));
+        assert!(covered.contains(&101));
+    }
+
+    /// Snapshots for different pools in the same block remain separate.
+    #[test]
+    fn test_dedupe_restore_snapshots_different_keys_preserved() {
+        let per_block = vec![(
+            100u64,
+            vec![
+                make_snapshot("pool_state", 0xAA, Some(50)),
+                make_snapshot("pool_state", 0xBB, Some(60)),
+            ],
+        )];
+
+        let mut tables_covered: HashMap<String, HashSet<u64>> = HashMap::new();
+        let deduped = dedupe_restore_snapshots(per_block, &mut tables_covered);
+
+        assert_eq!(deduped.len(), 2, "two distinct pool rows should both be kept");
+    }
+
+    /// Snapshots for different tables (same key) remain separate.
+    #[test]
+    fn test_dedupe_restore_snapshots_different_tables_preserved() {
+        let per_block = vec![(
+            100u64,
+            vec![
+                make_snapshot("pool_state", 0xAA, Some(50)),
+                make_snapshot("pool_snapshots", 0xAA, Some(50)),
+            ],
+        )];
+
+        let mut tables_covered: HashMap<String, HashSet<u64>> = HashMap::new();
+        let deduped = dedupe_restore_snapshots(per_block, &mut tables_covered);
+
+        assert_eq!(deduped.len(), 2, "two distinct tables should both be kept");
+    }
+
+    /// Insert-case snapshot (previous_row = None) is still deduped.
+    #[test]
+    fn test_dedupe_restore_snapshots_delete_case_keeps_oldest() {
+        // Block 100: row was just inserted (previous_row = None → DELETE on reorg).
+        // Block 101: same row was updated (previous_row = Some).
+        // Dedupe should keep block 100's snapshot (the DELETE) since that's
+        // the correct rollback: the row didn't exist before block 100.
+        let per_block = vec![
+            (100u64, vec![make_snapshot("pool_state", 0xAA, None)]),
+            (101u64, vec![make_snapshot("pool_state", 0xAA, Some(60))]),
+        ];
+
+        let mut tables_covered: HashMap<String, HashSet<u64>> = HashMap::new();
+        let deduped = dedupe_restore_snapshots(per_block, &mut tables_covered);
+
+        assert_eq!(deduped.len(), 1);
+        assert!(
+            deduped[0].previous_row.is_none(),
+            "expected the DELETE snapshot (previous_row = None) from block 100"
+        );
+    }
+
 
     /// Fix C test: when block 100 has a snapshot but block 101 does not,
     /// the fallback DELETE should target only block 101.

--- a/src/transformations/retry.rs
+++ b/src/transformations/retry.rs
@@ -580,9 +580,9 @@ impl RetryProcessor {
 
             match rh.handler.handle(&ctx).await {
                 Ok(ops) => {
-                    if !ops.is_empty() {
+                    let commit_result = if !ops.is_empty() {
                         let ops = inject_source_version(ops, handler_name, handler_version);
-                        if let Err(e) = execute_with_snapshot_capture(
+                        execute_with_snapshot_capture(
                             ops,
                             &self.db_pool,
                             Some(&live_storage),
@@ -591,27 +591,58 @@ impl RetryProcessor {
                             handler_version,
                         )
                         .await
-                        {
+                    } else {
+                        Ok(())
+                    };
+
+                    match commit_result {
+                        Ok(()) => {
+                            if let Err(e) = rh
+                                .handler
+                                .on_commit_success((range_start, range_end))
+                                .await
+                            {
+                                tracing::error!(
+                                    "Handler {} on_commit_success failed for block {}: {}",
+                                    handler_key,
+                                    block_number,
+                                    e
+                                );
+                                continue;
+                            }
+                            self.record_handler_retry_success(
+                                &handler_key,
+                                handler_name,
+                                range_start,
+                                range_end,
+                                block_number,
+                                &mut succeeded_keys,
+                                &mut succeeded_names,
+                            )
+                            .await;
+                        }
+                        Err(e) => {
                             tracing::error!(
                                 "Handler {} DB write failed during live retry for block {}: {}",
                                 handler_key,
                                 block_number,
                                 e
                             );
+                            if let Err(hook_err) = rh
+                                .handler
+                                .on_commit_failure((range_start, range_end))
+                                .await
+                            {
+                                tracing::error!(
+                                    "Handler {} on_commit_failure hook also failed for block {}: {}",
+                                    handler_key,
+                                    block_number,
+                                    hook_err
+                                );
+                            }
                             continue;
                         }
                     }
-
-                    self.record_handler_retry_success(
-                        &handler_key,
-                        handler_name,
-                        range_start,
-                        range_end,
-                        block_number,
-                        &mut succeeded_keys,
-                        &mut succeeded_names,
-                    )
-                    .await;
                 }
                 Err(e) => {
                     tracing::error!(

--- a/src/transformations/traits.rs
+++ b/src/transformations/traits.rs
@@ -97,6 +97,34 @@ pub trait TransformationHandler: Send + Sync + 'static {
     fn requires_sequential(&self) -> bool {
         false
     }
+
+    /// Called after the finalizer has rolled back DB rows for orphaned blocks.
+    /// Handlers that cache stateful DB-derived values in memory should invalidate
+    /// or reload the affected entries here. Default is a no-op.
+    #[allow(unused_variables)]
+    async fn on_reorg(&self, orphaned: &[u64]) -> Result<(), TransformationError> {
+        Ok(())
+    }
+
+    /// Called after the ops returned by `handle()` committed successfully.
+    /// Lets handlers promote any in-flight optimistic state.
+    #[allow(unused_variables)]
+    async fn on_commit_success(
+        &self,
+        range: (u64, u64),
+    ) -> Result<(), TransformationError> {
+        Ok(())
+    }
+
+    /// Called after the ops returned by `handle()` failed to commit.
+    /// Lets handlers revert optimistic state and mark the range for retry.
+    #[allow(unused_variables)]
+    async fn on_commit_failure(
+        &self,
+        range: (u64, u64),
+    ) -> Result<(), TransformationError> {
+        Ok(())
+    }
 }
 
 /// Trigger for event-based handlers.

--- a/src/transformations/traits.rs
+++ b/src/transformations/traits.rs
@@ -86,6 +86,17 @@ pub trait TransformationHandler: Send + Sync + 'static {
     fn reorg_tables(&self) -> Vec<&'static str> {
         vec![]
     }
+
+    /// Whether this handler must process block ranges sequentially (one at a time, in order).
+    ///
+    /// When true, the catchup engine limits concurrency to 1 for this handler, relying on
+    /// Tokio's FIFO semaphore to guarantee ranges execute in ascending block order.
+    ///
+    /// Required for handlers that maintain cumulative in-memory state that depends on
+    /// block ordering (e.g., tracking running totals across block ranges).
+    fn requires_sequential(&self) -> bool {
+        false
+    }
 }
 
 /// Trigger for event-based handlers.


### PR DESCRIPTION
## Summary

- Adds `V4BaseMetricsHandler` for `DopplerV4Hook` pools — processes `Swap(int24 currentTick, uint256 totalProceeds, uint256 totalTokensSold)` events into `pool_state` and `pool_snapshots`
- Adds `migrations/tables/v4_base_proceeds_state.sql` — per-pool checkpoint table that stores the latest cumulative `totalProceeds`/`totalTokensSold` for restart recovery
- Adds `requires_sequential()` to `TransformationHandler` trait; the catchup engine creates a capacity-1 FIFO semaphore for sequential handlers, guaranteeing block-range ordering

## Design notes

**Sequential processing**: The V4 base Swap event emits cumulative running totals. To compute per-swap deltas correctly, ranges must be processed in ascending order. `requires_sequential() = true` causes the engine to use a capacity-1 semaphore (FIFO by Tokio guarantee), so each range commits before the next one reads the checkpoint.

**DB-read approach**: Rather than purely in-memory state (wrong after a retry), each `handle()` reads the previous checkpoint from `v4_base_proceeds_state` and writes the updated totals in the same atomic transaction. Retries re-read the last committed values.

**Pool ID lookup**: The event has no pool ID field. `hook_address → pool_id` is resolved via `v4_pool_configs` (loaded at init, refreshed on miss). `handler_dependencies = ["V4CreateHandler"]` ensures the config exists before metrics run.

**amount0/amount1**: `proceeds_delta` = quote inflow (positive), `tokens_delta` = base outflow (negative). Signs derived from `is_token_0` in the metadata cache.

**liquidity**: set to `U256::ZERO` — not present in the V4 base Swap event.

8 new unit tests covering delta computation, is_token_0 sign conventions, multi-event same-block ordering, and missing pool ID handling.