### PR TITLE
feat: add metrics tracking for live mode subsystem

### DIFF
--- a/src/live/collector.rs
+++ b/src/live/collector.rs
@@ -9,6 +9,7 @@
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
+use std::time::Instant;
 
 use alloy::dyn_abi::{DynSolType, DynSolValue};
 use alloy::primitives::{Address, B256};
@@ -78,6 +79,8 @@ pub struct LiveCollector {
     expectations: LivePipelineExpectations,
     /// Channel for direct transformation retries.
     transform_retry_tx: Option<mpsc::Sender<TransformRetryRequest>>,
+    /// Timestamp of the last block arrival for inter-block interval metrics.
+    last_block_arrival: Option<Instant>,
 }
 
 impl LiveCollector {
@@ -167,6 +170,7 @@ impl LiveCollector {
             db_pool,
             expectations,
             transform_retry_tx,
+            last_block_arrival: None,
         }
     }
 
@@ -223,6 +227,17 @@ impl LiveCollector {
                         hex::encode(&hash.0[..4])
                     );
 
+                    // Record inter-block arrival interval
+                    let chain_label = self.chain.name.clone();
+                    if let Some(prev) = self.last_block_arrival {
+                        metrics::histogram!(
+                            "live_block_arrival_interval_seconds",
+                            "chain" => chain_label.clone()
+                        )
+                        .record(prev.elapsed().as_secs_f64());
+                    }
+                    self.last_block_arrival = Some(Instant::now());
+
                     // Check for gap on first block
                     if !first_block_seen {
                         first_block_seen = true;
@@ -247,8 +262,16 @@ impl LiveCollector {
                                     gap_start,
                                     gap_end,
                                 );
+
+                                metrics::counter!(
+                                    "live_gap_detections_total",
+                                    "chain" => chain_label.clone()
+                                )
+                                .increment(1);
+
                                 // Backfill the gap before processing this block
-                                if let Err(e) = self
+                                let backfill_start = Instant::now();
+                                let backfill_result = self
                                     .backfill_blocks(
                                         gap_start,
                                         gap_end,
@@ -257,8 +280,22 @@ impl LiveCollector {
                                         &eth_call_decoder_tx,
                                         &transform_reorg_tx,
                                     )
-                                    .await
-                                {
+                                    .await;
+
+                                metrics::histogram!(
+                                    "live_backfill_duration_seconds",
+                                    "chain" => chain_label.clone(),
+                                    "reason" => "gap"
+                                )
+                                .record(backfill_start.elapsed().as_secs_f64());
+
+                                metrics::counter!(
+                                    "live_backfill_blocks_total",
+                                    "chain" => chain_label.clone()
+                                )
+                                .increment(gap_size);
+
+                                if let Err(e) = backfill_result {
                                     tracing::error!(
                                         "Error backfilling gap blocks {}-{}: {}",
                                         gap_start,
@@ -297,19 +334,34 @@ impl LiveCollector {
                         "WebSocket disconnected, last processed block: {:?}",
                         last_block
                     );
+
+                    metrics::counter!(
+                        "live_ws_disconnects_total",
+                        "chain" => self.chain.name.clone()
+                    )
+                    .increment(1);
                 }
 
                 WsEvent::Reconnected {
                     missed_from,
                     missed_to,
                 } => {
+                    let chain_label = self.chain.name.clone();
+
                     tracing::info!(
                         "WebSocket reconnected, backfilling blocks {} to {}",
                         missed_from,
                         missed_to
                     );
 
-                    if let Err(e) = self
+                    metrics::counter!(
+                        "live_ws_reconnects_total",
+                        "chain" => chain_label.clone()
+                    )
+                    .increment(1);
+
+                    let backfill_start = Instant::now();
+                    let backfill_result = self
                         .backfill_blocks(
                             missed_from,
                             missed_to,
@@ -318,8 +370,23 @@ impl LiveCollector {
                             &eth_call_decoder_tx,
                             &transform_reorg_tx,
                         )
-                        .await
-                    {
+                        .await;
+
+                    metrics::histogram!(
+                        "live_backfill_duration_seconds",
+                        "chain" => chain_label.clone(),
+                        "reason" => "reconnect"
+                    )
+                    .record(backfill_start.elapsed().as_secs_f64());
+
+                    let backfill_count = missed_to.saturating_sub(missed_from) + 1;
+                    metrics::counter!(
+                        "live_backfill_blocks_total",
+                        "chain" => chain_label.clone()
+                    )
+                    .increment(backfill_count);
+
+                    if let Err(e) = backfill_result {
                         tracing::error!(
                             "Error backfilling blocks {}-{}: {}",
                             missed_from,
@@ -345,9 +412,23 @@ impl LiveCollector {
         transform_reorg_tx: &Option<mpsc::Sender<ReorgMessage>>,
     ) -> Result<(), CollectorError> {
         let block_number = block.number;
+        let process_start = Instant::now();
+        let chain_label = self.chain.name.clone();
 
         // Check for reorg
         if let Some(reorg_event) = self.reorg_detector.process_block(&block) {
+            metrics::counter!(
+                "live_reorgs_total",
+                "chain" => chain_label.clone(),
+                "deep" => if reorg_event.is_deep { "true" } else { "false" }
+            )
+            .increment(1);
+            metrics::histogram!(
+                "live_reorg_depth",
+                "chain" => chain_label.clone()
+            )
+            .record(reorg_event.depth as f64);
+
             self.handle_reorg(
                 &reorg_event,
                 live_tx,
@@ -560,6 +641,18 @@ impl LiveCollector {
                 .mark_transformed_if_no_handlers(block_number);
         }
 
+        metrics::histogram!(
+            "live_block_processing_duration_seconds",
+            "chain" => chain_label.clone()
+        )
+        .record(process_start.elapsed().as_secs_f64());
+
+        metrics::counter!(
+            "live_blocks_processed_total",
+            "chain" => chain_label
+        )
+        .increment(1);
+
         Ok(())
     }
 
@@ -711,7 +804,9 @@ impl LiveCollector {
             total_missing
         );
 
+        let chain_label = self.chain.name.clone();
         for (start, end) in gaps {
+            let backfill_start = Instant::now();
             self.backfill_blocks(
                 start,
                 end,
@@ -721,6 +816,20 @@ impl LiveCollector {
                 transform_reorg_tx,
             )
             .await?;
+
+            metrics::histogram!(
+                "live_backfill_duration_seconds",
+                "chain" => chain_label.clone(),
+                "reason" => "storage_gap"
+            )
+            .record(backfill_start.elapsed().as_secs_f64());
+
+            let block_count = end.saturating_sub(start) + 1;
+            metrics::counter!(
+                "live_backfill_blocks_total",
+                "chain" => chain_label.clone()
+            )
+            .increment(block_count);
         }
 
         Ok(())

--- a/src/live/compaction.rs
+++ b/src/live/compaction.rs
@@ -135,13 +135,30 @@ impl CompactionService {
 
     /// Run a single compaction cycle.
     pub async fn run_compaction_cycle(&self) -> Result<(), CompactionError> {
+        let cycle_start = Instant::now();
+        let chain_label = self.chain_name.clone();
+
         // Check for stuck blocks needing transformation retry
         self.check_for_stuck_blocks().await;
+
+        // Report pending blocks gauge
+        if let Ok(blocks) = self.storage.list_blocks() {
+            metrics::gauge!(
+                "live_compaction_blocks_pending",
+                "chain" => chain_label.clone()
+            )
+            .set(blocks.len() as f64);
+        }
 
         let ranges = self.find_compactable_ranges().await?;
 
         if ranges.is_empty() {
             tracing::debug!("No ranges ready for compaction");
+            metrics::histogram!(
+                "live_compaction_cycle_duration_seconds",
+                "chain" => chain_label
+            )
+            .record(cycle_start.elapsed().as_secs_f64());
             return Ok(());
         }
 
@@ -162,6 +179,12 @@ impl CompactionService {
                 );
             }
         }
+
+        metrics::histogram!(
+            "live_compaction_cycle_duration_seconds",
+            "chain" => chain_label
+        )
+        .record(cycle_start.elapsed().as_secs_f64());
 
         Ok(())
     }
@@ -228,6 +251,12 @@ impl CompactionService {
         }
 
         stuck_blocks.retain(|block_number, _| seen_blocks.contains(block_number));
+
+        metrics::gauge!(
+            "live_compaction_stuck_blocks",
+            "chain" => self.chain_name.clone()
+        )
+        .set(stuck_blocks.len() as f64);
 
         // Only remove from stuck_blocks on successful send. If try_send fails
         // (channel full), the block keeps its original grace timer so it doesn't

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,6 +155,7 @@ async fn main() -> anyhow::Result<()> {
             .context("Invalid metrics.addr in config")?;
         metrics::init_metrics_server(addr);
         metrics::describe_rpc_metrics();
+        metrics::describe_live_metrics();
     }
 
     // Create retry queue before StorageManager if S3 is configured

--- a/src/metrics/live.rs
+++ b/src/metrics/live.rs
@@ -1,0 +1,57 @@
+use metrics::{describe_counter, describe_gauge, describe_histogram};
+
+/// Register metric descriptions for live mode (call once at startup).
+pub fn describe_live_metrics() {
+    describe_counter!(
+        "live_ws_disconnects_total",
+        "Total WebSocket disconnect events"
+    );
+    describe_counter!(
+        "live_ws_reconnects_total",
+        "Total WebSocket reconnect events"
+    );
+    describe_counter!(
+        "live_reorgs_total",
+        "Total chain reorganizations detected"
+    );
+    describe_histogram!(
+        "live_reorg_depth",
+        "Depth of detected chain reorganizations"
+    );
+    describe_histogram!(
+        "live_compaction_cycle_duration_seconds",
+        "Duration of a compaction cycle"
+    );
+    describe_gauge!(
+        "live_compaction_stuck_blocks",
+        "Blocks stuck awaiting transformation retry"
+    );
+    describe_gauge!(
+        "live_compaction_blocks_pending",
+        "Live blocks awaiting compaction"
+    );
+    describe_histogram!(
+        "live_block_arrival_interval_seconds",
+        "Time between consecutive block arrivals"
+    );
+    describe_histogram!(
+        "live_block_processing_duration_seconds",
+        "End-to-end duration to process a live block"
+    );
+    describe_counter!(
+        "live_blocks_processed_total",
+        "Total live blocks processed"
+    );
+    describe_counter!(
+        "live_gap_detections_total",
+        "Gap detection events"
+    );
+    describe_histogram!(
+        "live_backfill_duration_seconds",
+        "Duration of backfill operations"
+    );
+    describe_counter!(
+        "live_backfill_blocks_total",
+        "Total blocks backfilled"
+    );
+}

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -1,5 +1,7 @@
+mod live;
 mod rpc;
 
+pub use live::describe_live_metrics;
 pub use rpc::{chain_label_from_url, describe_rpc_metrics, with_metrics, RpcMethod};
 
 use std::net::SocketAddr;


### PR DESCRIPTION
## Summary
- Add comprehensive Prometheus metrics for the live mode subsystem covering WebSocket events, block processing, reorgs, backfills, and compaction
- Create `src/metrics/live.rs` with 13 metric definitions (counters, histograms, gauges) and wire into startup via `describe_live_metrics()`
- Instrument `LiveCollector` with block arrival intervals, processing duration, gap/reconnect backfill timing, reorg depth tracking, and disconnect/reconnect counters
- Instrument `CompactionService` with cycle duration, pending blocks gauge, and stuck blocks gauge

## Metrics added
| Metric | Type | Description |
|---|---|---|
| `live_ws_disconnects_total` | Counter | WebSocket disconnect events |
| `live_ws_reconnects_total` | Counter | WebSocket reconnect events |
| `live_reorgs_total` | Counter | Chain reorganizations (with `deep` label) |
| `live_reorg_depth` | Histogram | Depth of reorgs |
| `live_compaction_cycle_duration_seconds` | Histogram | Compaction cycle duration |
| `live_compaction_stuck_blocks` | Gauge | Blocks stuck awaiting transform retry |
| `live_compaction_blocks_pending` | Gauge | Blocks awaiting compaction |
| `live_block_arrival_interval_seconds` | Histogram | Time between block arrivals |
| `live_block_processing_duration_seconds` | Histogram | Block processing duration |
| `live_blocks_processed_total` | Counter | Total blocks processed |
| `live_gap_detections_total` | Counter | Gap detection events |
| `live_backfill_duration_seconds` | Histogram | Backfill duration (with `reason` label) |
| `live_backfill_blocks_total` | Counter | Total blocks backfilled |