### PR TITLE
feat: add metrics tracking for transformation engine

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -155,6 +155,7 @@ async fn main() -> anyhow::Result<()> {
             .context("Invalid metrics.addr in config")?;
         metrics::init_metrics_server(addr);
         metrics::describe_rpc_metrics();
+        metrics::describe_transformation_metrics();
     }
 
     // Create retry queue before StorageManager if S3 is configured

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -1,6 +1,8 @@
 mod rpc;
+mod transformations;
 
 pub use rpc::{chain_label_from_url, describe_rpc_metrics, with_metrics, RpcMethod};
+pub use transformations::{describe_transformation_metrics, HandlerMetricsGuard};
 
 use std::net::SocketAddr;
 

--- a/src/metrics/transformations.rs
+++ b/src/metrics/transformations.rs
@@ -1,0 +1,127 @@
+//! Metrics for the transformation engine subsystem.
+//!
+//! Tracks handler execution duration, errors, event/call throughput,
+//! retry outcomes, range finalization, and concurrency gauges.
+
+use std::time::Instant;
+
+use metrics::{
+    counter, describe_counter, describe_gauge, describe_histogram, gauge, histogram,
+};
+
+/// Register metric descriptions (call once at startup).
+pub fn describe_transformation_metrics() {
+    describe_histogram!(
+        "transformation_handler_duration_seconds",
+        "Duration of individual handler executions in seconds"
+    );
+    describe_counter!(
+        "transformation_handler_errors_total",
+        "Total handler execution errors and rollbacks"
+    );
+    describe_counter!(
+        "transformation_events_processed_total",
+        "Total decoded events processed through the engine"
+    );
+    describe_counter!(
+        "transformation_calls_processed_total",
+        "Total decoded calls processed through the engine"
+    );
+    describe_counter!(
+        "transformation_retry_attempts_total",
+        "Total retry attempts per handler"
+    );
+    describe_histogram!(
+        "transformation_range_finalization_duration_seconds",
+        "Duration of range finalization in seconds"
+    );
+    describe_gauge!(
+        "transformation_pending_events",
+        "Pending event batches waiting for dependencies"
+    );
+    describe_gauge!(
+        "transformation_handlers_in_flight",
+        "Handler tasks currently executing"
+    );
+}
+
+/// RAII guard for recording handler execution metrics.
+///
+/// Increments the in-flight gauge on creation and decrements it when the
+/// guard is consumed via [`success`](Self::success) or
+/// [`failure`](Self::failure), or when dropped without completion (e.g.
+/// panic).
+pub struct HandlerMetricsGuard {
+    handler_key: String,
+    mode: &'static str,
+    start: Instant,
+    completed: bool,
+}
+
+impl HandlerMetricsGuard {
+    /// Create a new guard, incrementing `transformation_handlers_in_flight`.
+    pub fn new(handler_key: &str, mode: &'static str) -> Self {
+        gauge!(
+            "transformation_handlers_in_flight",
+            "handler_key" => handler_key.to_string(),
+        )
+        .increment(1.0);
+
+        Self {
+            handler_key: handler_key.to_string(),
+            mode,
+            start: Instant::now(),
+            completed: false,
+        }
+    }
+
+    /// Record successful completion.
+    pub fn success(mut self) {
+        self.completed = true;
+        self.record_completion("success");
+    }
+
+    /// Record failure with an error type category.
+    pub fn failure(mut self, error_type: &'static str) {
+        self.completed = true;
+
+        counter!(
+            "transformation_handler_errors_total",
+            "handler_key" => self.handler_key.clone(),
+            "error_type" => error_type,
+        )
+        .increment(1);
+
+        self.record_completion("error");
+    }
+
+    fn record_completion(&self, status: &'static str) {
+        let duration = self.start.elapsed().as_secs_f64();
+
+        histogram!(
+            "transformation_handler_duration_seconds",
+            "handler_key" => self.handler_key.clone(),
+            "status" => status,
+            "mode" => self.mode,
+        )
+        .record(duration);
+
+        gauge!(
+            "transformation_handlers_in_flight",
+            "handler_key" => self.handler_key.clone(),
+        )
+        .decrement(1.0);
+    }
+}
+
+impl Drop for HandlerMetricsGuard {
+    fn drop(&mut self) {
+        if !self.completed {
+            gauge!(
+                "transformation_handlers_in_flight",
+                "handler_key" => self.handler_key.clone(),
+            )
+            .decrement(1.0);
+        }
+    }
+}

--- a/src/transformations/engine.rs
+++ b/src/transformations/engine.rs
@@ -15,6 +15,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use metrics::{counter, gauge};
 use tokio::sync::mpsc::Receiver;
 use tokio::sync::oneshot;
 use tokio::sync::Mutex;
@@ -1074,6 +1075,16 @@ impl TransformationEngine {
         }
 
         let filtered_events = filter_events_by_start_block(&self.contracts, msg.events.clone());
+
+        if !filtered_events.is_empty() {
+            counter!(
+                "transformation_events_processed_total",
+                "source_name" => msg.source_name.clone(),
+                "event_name" => msg.event_name.clone(),
+            )
+            .increment(filtered_events.len() as u64);
+        }
+
         let events = Arc::new(filtered_events.clone());
 
         // Categorize handlers: ready to run vs needs buffering
@@ -1210,9 +1221,14 @@ impl TransformationEngine {
                         .or_insert_with(Instant::now);
                     state
                         .pending_events
-                        .entry(handler_key)
+                        .entry(handler_key.clone())
                         .or_default()
                         .push(pending);
+                    gauge!(
+                        "transformation_pending_events",
+                        "handler_key" => handler_key,
+                    )
+                    .increment(1.0);
                 }
             }
         } // lock released
@@ -1511,6 +1527,16 @@ impl TransformationEngine {
         }
 
         let filtered_calls = filter_calls_by_start_block(&self.contracts, msg.calls);
+
+        if !filtered_calls.is_empty() {
+            counter!(
+                "transformation_calls_processed_total",
+                "source_name" => msg.source_name.clone(),
+                "function_name" => msg.function_name.clone(),
+            )
+            .increment(filtered_calls.len() as u64);
+        }
+
         self.process_range(msg.range_start, msg.range_end, Vec::new(), filtered_calls)
             .await?;
 
@@ -1597,7 +1623,16 @@ impl TransformationEngine {
                     if handler_failed {
                         let remove_entry =
                             if let Some(pending) = state.pending_events.get_mut(&handler_key) {
+                                let before = pending.len();
                                 pending.retain(|p| (p.range_start, p.range_end) != range_key);
+                                let removed = before - pending.len();
+                                if removed > 0 {
+                                    gauge!(
+                                        "transformation_pending_events",
+                                        "handler_key" => handler_key.clone(),
+                                    )
+                                    .decrement(removed as f64);
+                                }
                                 pending.is_empty()
                             } else {
                                 false
@@ -1653,6 +1688,11 @@ impl TransformationEngine {
                         let pending = state.pending_events.get_mut(&handler_key).unwrap();
                         for i in ready_indices.into_iter().rev() {
                             let event_data = pending.remove(i);
+                            gauge!(
+                                "transformation_pending_events",
+                                "handler_key" => handler_key.clone(),
+                            )
+                            .decrement(1.0);
                             let handlers = self.registry.handlers_for_event(
                                 &event_data.source_name,
                                 &event_data.event_name,

--- a/src/transformations/executor.rs
+++ b/src/transformations/executor.rs
@@ -7,6 +7,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use metrics::counter;
 use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
 
@@ -16,6 +17,7 @@ use super::historical::HistoricalDataReader;
 use super::traits::TransformationHandler;
 use crate::db::{DbOperation, DbPool, DbValue, WhereClause};
 use crate::live::{LiveDbValue, LiveStorage, LiveUpsertSnapshot};
+use crate::metrics::HandlerMetricsGuard;
 use crate::rpc::UnifiedRpcClient;
 use crate::types::config::contract::Contracts;
 
@@ -131,6 +133,12 @@ impl HandlerExecutor {
                 }
                 Err(e) => {
                     tracing::error!("Handler task panicked: {}", e);
+                    counter!(
+                        "transformation_handler_errors_total",
+                        "handler_key" => "unknown",
+                        "error_type" => "panic",
+                    )
+                    .increment(1);
                 }
             }
         }
@@ -170,6 +178,12 @@ pub(crate) async fn run_handler_task(
     let handler_version = handler.version();
     let handler_key = handler.handler_key();
 
+    let mode_label = match db_exec_mode {
+        DbExecMode::WithSnapshotCapture { .. } => "live",
+        DbExecMode::Direct => "catchup",
+    };
+    let guard = HandlerMetricsGuard::new(&handler_key, mode_label);
+
     let ctx = TransformationContext::new(
         chain_name,
         chain_id,
@@ -193,6 +207,7 @@ pub(crate) async fn run_handler_task(
                 range_end,
                 e
             );
+            guard.failure("handler_error");
             return Err(e);
         }
     };
@@ -231,6 +246,7 @@ pub(crate) async fn run_handler_task(
                     range_end,
                     e
                 );
+                guard.failure("db_error");
                 handler.on_commit_failure((range_start, range_end)).await?;
                 return Err(e);
             }
@@ -240,6 +256,8 @@ pub(crate) async fn run_handler_task(
         // can drain any per-range state it may track.
         handler.on_commit_success((range_start, range_end)).await?;
     }
+
+    guard.success();
 
     Ok(HandlerOutcome {
         handler_key,

--- a/src/transformations/finalizer.rs
+++ b/src/transformations/finalizer.rs
@@ -6,7 +6,9 @@
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::time::Instant;
 
+use metrics::histogram;
 use tokio::sync::Mutex;
 
 use super::error::TransformationError;
@@ -185,6 +187,7 @@ impl RangeFinalizer {
         range_end: u64,
         live_state: &Mutex<LiveProcessingState>,
     ) -> Result<(), TransformationError> {
+        let finalize_start = Instant::now();
         let range_key = (range_start, range_end);
 
         // Prevent double finalization
@@ -292,6 +295,9 @@ impl RangeFinalizer {
                 }
             }
         }
+
+        histogram!("transformation_range_finalization_duration_seconds")
+            .record(finalize_start.elapsed().as_secs_f64());
 
         Ok(())
     }

--- a/src/transformations/retry.rs
+++ b/src/transformations/retry.rs
@@ -7,12 +7,14 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+use metrics::counter;
 use tokio::sync::Mutex;
 
 use super::context::{DecodedCall, DecodedEvent, TransactionAddresses, TransformationContext};
 use super::engine::HandlerKind;
 use super::error::TransformationError;
 use super::executor::{execute_with_snapshot_capture, inject_source_version};
+use crate::metrics::HandlerMetricsGuard;
 use super::historical::HistoricalDataReader;
 use super::live_state::LiveProcessingState;
 use super::registry::{extract_event_name, TransformationRegistry};
@@ -522,6 +524,12 @@ impl RetryProcessor {
                         block_number,
                         unmet
                     );
+                    counter!(
+                        "transformation_retry_attempts_total",
+                        "handler_key" => handler_key.clone(),
+                        "outcome" => "blocked",
+                    )
+                    .increment(1);
                     blocked_handlers.insert(handler_key);
                     continue;
                 }
@@ -537,6 +545,12 @@ impl RetryProcessor {
                         block_number,
                         missing_deps
                     );
+                    counter!(
+                        "transformation_retry_attempts_total",
+                        "handler_key" => handler_key.clone(),
+                        "outcome" => "blocked",
+                    )
+                    .increment(1);
                     blocked_handlers.insert(handler_key);
                     continue;
                 }
@@ -578,6 +592,8 @@ impl RetryProcessor {
                 self.contracts.clone(),
             );
 
+            let guard = HandlerMetricsGuard::new(&handler_key, "retry");
+
             match rh.handler.handle(&ctx).await {
                 Ok(ops) => {
                     let commit_result = if !ops.is_empty() {
@@ -608,8 +624,22 @@ impl RetryProcessor {
                                     block_number,
                                     e
                                 );
+                                guard.failure("handler_error");
+                                counter!(
+                                    "transformation_retry_attempts_total",
+                                    "handler_key" => handler_key.clone(),
+                                    "outcome" => "failure",
+                                )
+                                .increment(1);
                                 continue;
                             }
+                            guard.success();
+                            counter!(
+                                "transformation_retry_attempts_total",
+                                "handler_key" => handler_key.clone(),
+                                "outcome" => "success",
+                            )
+                            .increment(1);
                             self.record_handler_retry_success(
                                 &handler_key,
                                 handler_name,
@@ -628,6 +658,13 @@ impl RetryProcessor {
                                 block_number,
                                 e
                             );
+                            guard.failure("db_error");
+                            counter!(
+                                "transformation_retry_attempts_total",
+                                "handler_key" => handler_key.clone(),
+                                "outcome" => "failure",
+                            )
+                            .increment(1);
                             if let Err(hook_err) = rh
                                 .handler
                                 .on_commit_failure((range_start, range_end))
@@ -651,6 +688,13 @@ impl RetryProcessor {
                         block_number,
                         e
                     );
+                    guard.failure("handler_error");
+                    counter!(
+                        "transformation_retry_attempts_total",
+                        "handler_key" => handler_key.clone(),
+                        "outcome" => "failure",
+                    )
+                    .increment(1);
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Adds `src/metrics/transformations.rs` with 8 metrics (histograms, counters, gauges) covering handler execution duration, errors, event/call throughput, retry outcomes, range finalization, pending events, and in-flight handlers
- `HandlerMetricsGuard` RAII guard tracks handler execution timing and in-flight count, modeled after existing `RpcMetricsGuard`
- Instruments `executor.rs` (handler success/failure/DB error/panic), `engine.rs` (events/calls processed, pending event buffering/draining), `retry.rs` (retry attempts with outcome labels, inline handler execution), and `finalizer.rs` (range finalization duration)

## Metrics added

| Metric | Type | Labels |
|---|---|---|
| `transformation_handler_duration_seconds` | Histogram | handler_key, status, mode |
| `transformation_handler_errors_total` | Counter | handler_key, error_type |
| `transformation_events_processed_total` | Counter | source_name, event_name |
| `transformation_calls_processed_total` | Counter | source_name, function_name |
| `transformation_retry_attempts_total` | Counter | handler_key, outcome |
| `transformation_range_finalization_duration_seconds` | Histogram | (none) |
| `transformation_pending_events` | Gauge | handler_key |
| `transformation_handlers_in_flight` | Gauge | handler_key |