### PR TITLE
feat: deeper metrics for rate limiter and RPC internals

### DIFF
--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -1,6 +1,10 @@
 mod rpc;
 
-pub use rpc::{chain_label_from_url, describe_rpc_metrics, with_metrics, RpcMethod};
+pub use rpc::{
+    chain_label_from_url, describe_rpc_metrics, record_batch_size, record_rate_limit_wait,
+    record_retries_exhausted, record_retry_attempt, set_cu_usage, set_semaphore_utilization,
+    with_metrics, RpcMethod,
+};
 
 use std::net::SocketAddr;
 

--- a/src/metrics/rpc.rs
+++ b/src/metrics/rpc.rs
@@ -93,6 +93,106 @@ pub fn describe_rpc_metrics() {
         "rpc_requests_in_flight",
         "Number of RPC requests currently in progress"
     );
+    describe_gauge!(
+        "rpc_rate_limiter_cu_used",
+        "Current compute units consumed in sliding window"
+    );
+    describe_gauge!(
+        "rpc_rate_limiter_cu_capacity",
+        "Max compute units for the window"
+    );
+    describe_histogram!(
+        "rpc_rate_limit_wait_seconds",
+        "Time waiting for rate limiter capacity"
+    );
+    describe_counter!(
+        "rpc_retry_attempts_total",
+        "Each retry attempt"
+    );
+    describe_counter!(
+        "rpc_retries_exhausted_total",
+        "Retries fully exhausted"
+    );
+    describe_gauge!(
+        "rpc_semaphore_acquired",
+        "Currently held semaphore permits"
+    );
+    describe_gauge!(
+        "rpc_semaphore_capacity",
+        "Total semaphore permits configured"
+    );
+    describe_histogram!(
+        "rpc_batch_size",
+        "Items per batch execution"
+    );
+}
+
+/// Record time spent waiting for rate limiter capacity.
+pub fn record_rate_limit_wait(chain: &str, duration_secs: f64) {
+    histogram!(
+        "rpc_rate_limit_wait_seconds",
+        "chain" => chain.to_string()
+    )
+    .record(duration_secs);
+}
+
+/// Record a retry attempt with its outcome.
+pub fn record_retry_attempt(chain: &str, operation: &str, outcome: &str) {
+    counter!(
+        "rpc_retry_attempts_total",
+        "chain" => chain.to_string(),
+        "operation" => operation.to_string(),
+        "outcome" => outcome.to_string()
+    )
+    .increment(1);
+}
+
+/// Record that retries were fully exhausted for an operation.
+pub fn record_retries_exhausted(chain: &str, operation: &str) {
+    counter!(
+        "rpc_retries_exhausted_total",
+        "chain" => chain.to_string(),
+        "operation" => operation.to_string()
+    )
+    .increment(1);
+}
+
+/// Record the size of a batch execution.
+pub fn record_batch_size(chain: &str, method: &str, size: usize) {
+    histogram!(
+        "rpc_batch_size",
+        "chain" => chain.to_string(),
+        "method" => method.to_string()
+    )
+    .record(size as f64);
+}
+
+/// Set current compute unit usage and capacity gauges.
+pub fn set_cu_usage(chain: &str, current: f64, capacity: f64) {
+    gauge!(
+        "rpc_rate_limiter_cu_used",
+        "chain" => chain.to_string()
+    )
+    .set(current);
+    gauge!(
+        "rpc_rate_limiter_cu_capacity",
+        "chain" => chain.to_string()
+    )
+    .set(capacity);
+}
+
+/// Set semaphore utilization gauges.
+pub fn set_semaphore_utilization(chain: &str, acquired: f64, capacity: f64) {
+    gauge!(
+        "rpc_semaphore_acquired",
+        "chain" => chain.to_string()
+    )
+    .set(acquired);
+    gauge!(
+        "rpc_semaphore_capacity",
+        "chain" => chain.to_string()
+    )
+    .set(capacity);
 }
 
 /// Extract a sanitized chain identifier from an RPC URL.

--- a/src/rpc/alchemy.rs
+++ b/src/rpc/alchemy.rs
@@ -13,7 +13,9 @@ use async_trait::async_trait;
 use tokio::sync::{Mutex, Semaphore};
 use url::Url;
 
-use crate::metrics::{chain_label_from_url, with_metrics, RpcMethod};
+use crate::metrics::{
+    chain_label_from_url, record_batch_size, set_semaphore_utilization, with_metrics, RpcMethod,
+};
 use crate::rpc::provider::{
     error_chain, with_retry, RetryConfig, RpcClient, RpcClientConfig, RpcError, RpcProvider,
 };
@@ -162,6 +164,28 @@ impl SlidingWindowRateLimiter {
         let history = self.history.lock().await;
         Self::current_usage(&history, Instant::now(), self.window)
     }
+
+    /// Get the maximum compute units allowed in the sliding window.
+    pub fn max_in_window(&self) -> u32 {
+        self.max_in_window
+    }
+
+    /// Acquire compute units with metrics instrumentation.
+    ///
+    /// Wraps `acquire` with timing and reports the wait duration and CU usage
+    /// to the metrics system.
+    pub async fn acquire_with_metrics(&self, units: u32, chain: &str) {
+        let start = Instant::now();
+        self.acquire(units).await;
+        let elapsed = start.elapsed();
+
+        if elapsed > Duration::from_millis(1) {
+            crate::metrics::record_rate_limit_wait(chain, elapsed.as_secs_f64());
+        }
+
+        let current = self.current_usage_async().await;
+        crate::metrics::set_cu_usage(chain, current as f64, self.max_in_window as f64);
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -247,6 +271,8 @@ struct ConcurrentExecutor {
     /// Tasks beyond this limit are spawned only as earlier tasks complete,
     /// preventing unbounded task creation for large request sets.
     max_in_flight: usize,
+    /// Chain label for metrics.
+    chain: String,
 }
 
 impl ConcurrentExecutor {
@@ -264,14 +290,17 @@ impl ConcurrentExecutor {
         let semaphore = self.semaphore.clone();
         let rate_limiter = self.rate_limiter.clone();
         let cost = self.cost_per_request;
+        let chain = self.chain.clone();
 
         join_set.spawn(async move {
             let permit = semaphore
                 .acquire_owned()
                 .await
                 .expect("semaphore should never be closed during operation");
-            rate_limiter.acquire(cost).await;
+            metrics::gauge!("rpc_semaphore_acquired", "chain" => chain.clone()).increment(1.0);
+            rate_limiter.acquire_with_metrics(cost, &chain).await;
             let result = fut.await;
+            metrics::gauge!("rpc_semaphore_acquired", "chain" => chain.clone()).decrement(1.0);
             drop(permit);
             (idx, result)
         });
@@ -290,14 +319,17 @@ impl ConcurrentExecutor {
         let semaphore = self.semaphore.clone();
         let rate_limiter = self.rate_limiter.clone();
         let cost = self.cost_per_request;
+        let chain = self.chain.clone();
 
         join_set.spawn(async move {
             let permit = semaphore
                 .acquire_owned()
                 .await
                 .expect("semaphore should never be closed during operation");
-            rate_limiter.acquire(cost).await;
+            metrics::gauge!("rpc_semaphore_acquired", "chain" => chain.clone()).increment(1.0);
+            rate_limiter.acquire_with_metrics(cost, &chain).await;
             let result = fut.await;
+            metrics::gauge!("rpc_semaphore_acquired", "chain" => chain.clone()).decrement(1.0);
             drop(permit);
             let _ = result_tx.send(result).await;
         });
@@ -375,22 +407,31 @@ impl AlchemyClient {
     /// Consume compute units, waiting if necessary.
     /// Uses sliding window rate limiting to prevent burst accumulation.
     async fn consume_compute_units(&self, cost: ComputeUnitCost) {
-        self.rate_limiter.acquire(cost.cost()).await;
+        let chain = self.chain_label();
+        self.rate_limiter
+            .acquire_with_metrics(cost.cost(), &chain)
+            .await;
     }
 
     /// Consume a raw number of compute units, waiting if necessary.
     async fn consume_compute_units_raw(&self, units: u32) {
-        self.rate_limiter.acquire(units).await;
+        let chain = self.chain_label();
+        self.rate_limiter
+            .acquire_with_metrics(units, &chain)
+            .await;
     }
 
     /// Create a bounded concurrent executor with semaphore and rate limiter.
     /// This captures the common setup for both ordered and streaming execution.
     fn create_concurrent_executor(&self, cost_per_request: u32) -> ConcurrentExecutor {
+        let chain = self.chain_label();
+        set_semaphore_utilization(&chain, 0.0, self.config.rpc_concurrency as f64);
         ConcurrentExecutor {
             semaphore: Arc::new(Semaphore::new(self.config.rpc_concurrency)),
             rate_limiter: self.rate_limiter.clone(),
             cost_per_request,
             max_in_flight: (self.config.rpc_concurrency * 2).max(1),
+            chain,
         }
     }
 
@@ -564,6 +605,8 @@ impl AlchemyClient {
                 return Ok(vec![]);
             }
 
+            record_batch_size(&chain, method.as_str(), requests.len());
+
             if !self.config.batching_enabled {
                 return fallback(requests).await;
             }
@@ -598,6 +641,8 @@ impl AlchemyClient {
                 return Ok(vec![]);
             }
 
+            record_batch_size(&chain, method.as_str(), requests.len());
+
             if !self.config.batching_enabled {
                 return fallback(requests).await;
             }
@@ -623,7 +668,7 @@ impl AlchemyClient {
         self.consume_compute_units(ComputeUnitCost::BLOCK_NUMBER)
             .await;
         with_metrics(RpcMethod::GetBlockNumber, &chain, || async {
-            with_retry(&retry_config, "get_block_number", || async {
+            with_retry(&retry_config, "get_block_number", &chain, || async {
                 provider
                     .get_block_number()
                     .await
@@ -650,7 +695,7 @@ impl AlchemyClient {
 
         self.consume_compute_units(cost).await;
         with_metrics(RpcMethod::GetBlock, &chain, || async {
-            with_retry(&retry_config, &op_name, || async {
+            with_retry(&retry_config, &op_name, &chain, || async {
                 let builder = provider.get_block(block_id);
                 if full_transactions {
                     builder
@@ -685,7 +730,7 @@ impl AlchemyClient {
         self.consume_compute_units(ComputeUnitCost::GET_TRANSACTION_BY_HASH)
             .await;
         with_metrics(RpcMethod::GetTransaction, &chain, || async {
-            with_retry(&retry_config, &op_name, || async {
+            with_retry(&retry_config, &op_name, &chain, || async {
                 provider
                     .get_transaction_by_hash(hash)
                     .await
@@ -707,7 +752,7 @@ impl AlchemyClient {
         self.consume_compute_units(ComputeUnitCost::GET_TRANSACTION_RECEIPT)
             .await;
         with_metrics(RpcMethod::GetTransactionReceipt, &chain, || async {
-            with_retry(&retry_config, &op_name, || async {
+            with_retry(&retry_config, &op_name, &chain, || async {
                 provider
                     .get_transaction_receipt(hash)
                     .await
@@ -783,7 +828,7 @@ impl AlchemyClient {
         let provider = self.inner.provider().clone();
         self.consume_compute_units(ComputeUnitCost::GET_LOGS).await;
         with_metrics(RpcMethod::GetLogs, &chain, || async {
-            with_retry(&retry_config, &op_name, || async {
+            with_retry(&retry_config, &op_name, &chain, || async {
                 provider
                     .get_logs(&filter)
                     .await
@@ -806,7 +851,7 @@ impl AlchemyClient {
         self.consume_compute_units(ComputeUnitCost::GET_BALANCE)
             .await;
         with_metrics(RpcMethod::GetBalance, &chain, || async {
-            with_retry(&retry_config, &op_name, || async {
+            with_retry(&retry_config, &op_name, &chain, || async {
                 provider
                     .get_balance(address)
                     .block_id(block.unwrap_or(BlockId::latest()))
@@ -829,7 +874,7 @@ impl AlchemyClient {
         let provider = self.inner.provider().clone();
         self.consume_compute_units(ComputeUnitCost::GET_CODE).await;
         with_metrics(RpcMethod::GetCode, &chain, || async {
-            with_retry(&retry_config, &op_name, || async {
+            with_retry(&retry_config, &op_name, &chain, || async {
                 provider
                     .get_code_at(address)
                     .block_id(block.unwrap_or(BlockId::latest()))
@@ -853,7 +898,7 @@ impl AlchemyClient {
         let provider = self.inner.provider().clone();
         self.consume_compute_units(ComputeUnitCost::ETH_CALL).await;
         with_metrics(RpcMethod::EthCall, &chain, || async {
-            with_retry(&retry_config, &op_name, || async {
+            with_retry(&retry_config, &op_name, &chain, || async {
                 provider
                     .call(tx.clone())
                     .block(block.unwrap_or(BlockId::latest()))
@@ -872,6 +917,7 @@ impl AlchemyClient {
     ) -> Result<Vec<Option<Block>>, RpcError> {
         let provider = self.inner.provider().clone();
         let retry_config = self.config.retry.clone();
+        let chain = self.chain_label();
 
         self.execute_batch_collecting_results(
             RpcMethod::GetBlocksBatch,
@@ -880,9 +926,10 @@ impl AlchemyClient {
             move |number| {
                 let provider = provider.clone();
                 let retry_config = retry_config.clone();
+                let chain = chain.clone();
                 async move {
                     let op_name = format!("eth_getBlockByNumber({:?})", number);
-                    with_retry(&retry_config, &op_name, || async {
+                    with_retry(&retry_config, &op_name, &chain, || async {
                         let builder = provider.get_block(BlockId::Number(number));
                         if full_transactions {
                             builder
@@ -921,13 +968,15 @@ impl AlchemyClient {
         let provider = self.inner.provider().clone();
         let retry_config = self.config.retry.clone();
         let cost_per_block = ComputeUnitCost::GET_BLOCK_BY_NUMBER.cost();
+        let chain = self.chain_label();
 
         self.execute_streaming(block_numbers, cost_per_block, result_tx, move |number| {
             let provider = provider.clone();
             let retry_config = retry_config.clone();
+            let chain = chain.clone();
             async move {
                 let op_name = format!("eth_getBlockByNumber({:?})", number);
-                let result = with_retry(&retry_config, &op_name, || async {
+                let result = with_retry(&retry_config, &op_name, &chain, || async {
                     let builder = provider.get_block(BlockId::Number(number));
                     if full_transactions {
                         builder
@@ -990,6 +1039,7 @@ impl AlchemyClient {
     pub async fn get_logs_batch(&self, filters: Vec<Filter>) -> Result<Vec<Vec<Log>>, RpcError> {
         let provider = self.inner.provider().clone();
         let retry_config = self.config.retry.clone();
+        let chain = self.chain_label();
 
         self.execute_batch_collecting_results(
             RpcMethod::GetLogsBatch,
@@ -998,13 +1048,14 @@ impl AlchemyClient {
             move |filter| {
                 let provider = provider.clone();
                 let retry_config = retry_config.clone();
+                let chain = chain.clone();
                 async move {
                     let op_name = format!(
                         "eth_getLogs(blocks {:?}-{:?})",
                         filter.get_from_block(),
                         filter.get_to_block()
                     );
-                    with_retry(&retry_config, &op_name, || async {
+                    with_retry(&retry_config, &op_name, &chain, || async {
                         provider
                             .get_logs(&filter)
                             .await
@@ -1030,6 +1081,7 @@ impl AlchemyClient {
     ) -> Result<Vec<Result<Bytes, RpcError>>, RpcError> {
         let provider = self.inner.provider().clone();
         let retry_config = self.config.retry.clone();
+        let chain = self.chain_label();
 
         // call_batch returns Vec<Result<Bytes, RpcError>> directly, so we use
         // execute_batch_with_metrics (no result unwrapping)
@@ -1040,9 +1092,10 @@ impl AlchemyClient {
             move |(tx, block)| {
                 let provider = provider.clone();
                 let retry_config = retry_config.clone();
+                let chain = chain.clone();
                 async move {
                     let op_name = format!("eth_call(to={:?}, block={:?})", tx.to, block);
-                    with_retry(&retry_config, &op_name, || async {
+                    with_retry(&retry_config, &op_name, &chain, || async {
                         provider
                             .call(tx.clone())
                             .block(block)

--- a/src/rpc/provider.rs
+++ b/src/rpc/provider.rs
@@ -17,6 +17,11 @@ use governor::{Jitter, Quota, RateLimiter};
 use thiserror::Error;
 use url::Url;
 
+use crate::metrics::{
+    chain_label_from_url, record_rate_limit_wait, record_retries_exhausted, record_retry_attempt,
+    set_cu_usage,
+};
+
 use super::alchemy::SlidingWindowRateLimiter;
 
 /// Trait for RPC providers that can execute Ethereum JSON-RPC calls.
@@ -243,15 +248,20 @@ impl RetryConfig {
 ///
 /// Retries the operation up to `config.max_retries` times with exponential backoff
 /// for retryable errors. All retry attempts are logged for debugging.
+///
+/// The `chain` parameter is used for metrics labeling. Pass an empty string to skip
+/// metrics recording.
 pub async fn with_retry<F, Fut, T>(
     config: &RetryConfig,
     operation_name: &str,
+    chain: &str,
     mut operation: F,
 ) -> Result<T, RpcError>
 where
     F: FnMut() -> Fut,
     Fut: Future<Output = Result<T, RpcError>>,
 {
+    let has_chain = !chain.is_empty();
     let mut errors: Vec<String> = Vec::new();
 
     for attempt in 0..=config.max_retries {
@@ -276,6 +286,9 @@ where
                         operation_name,
                         attempt
                     );
+                    if has_chain {
+                        record_retry_attempt(chain, operation_name, "success_after_retry");
+                    }
                 }
                 return Ok(result);
             }
@@ -291,6 +304,9 @@ where
                         error_msg
                     );
                     errors.push(format!("attempt {}: {}", attempt + 1, error_msg));
+                    if has_chain {
+                        record_retry_attempt(chain, operation_name, "retry");
+                    }
                 } else {
                     // Non-retryable error or exhausted retries
                     errors.push(format!("attempt {}: {}", attempt + 1, error_msg));
@@ -303,6 +319,9 @@ where
                             attempt + 1,
                             errors.join("; ")
                         );
+                        if has_chain {
+                            record_retries_exhausted(chain, operation_name);
+                        }
                     }
                     return Err(e);
                 }
@@ -311,6 +330,9 @@ where
     }
 
     // This should be unreachable, but provide a meaningful error if it happens
+    if has_chain {
+        record_retries_exhausted(chain, operation_name);
+    }
     Err(RpcError::ProviderError(format!(
         "RPC '{}' exhausted retries. Errors: [{}]",
         operation_name,
@@ -393,12 +415,14 @@ pub struct RpcClient {
     rate_limiter: Option<Arc<StandardRateLimiter>>,
     jitter: Option<Jitter>,
     sliding_limiter: Option<Arc<SlidingWindowRateLimiter>>,
+    chain: String,
 }
 
 #[allow(dead_code)]
 impl RpcClient {
     pub fn new(config: RpcClientConfig) -> Result<Self, RpcError> {
         let provider = RootProvider::<Ethereum>::new_http(config.url.clone());
+        let chain = chain_label_from_url(&config.url);
 
         let (rate_limiter, jitter) = if let Some(ref rate_config) = config.rate_limit {
             let quota = Quota::per_second(rate_config.requests_per_second);
@@ -418,6 +442,7 @@ impl RpcClient {
             rate_limiter,
             jitter,
             sliding_limiter: None,
+            chain,
         })
     }
 
@@ -426,12 +451,14 @@ impl RpcClient {
         limiter: Arc<SlidingWindowRateLimiter>,
     ) -> Result<Self, RpcError> {
         let provider = RootProvider::<Ethereum>::new_http(config.url.clone());
+        let chain = chain_label_from_url(&config.url);
         Ok(Self {
             provider,
             config,
             rate_limiter: None,
             jitter: None,
             sliding_limiter: Some(limiter),
+            chain,
         })
     }
 
@@ -457,15 +484,26 @@ impl RpcClient {
     }
 
     async fn wait_for_rate_limit(&self) {
+        let start = std::time::Instant::now();
         if let Some(ref limiter) = self.sliding_limiter {
             limiter.acquire(1).await;
+            let current = limiter.current_usage_async().await;
+            set_cu_usage(
+                &self.chain,
+                current as f64,
+                limiter.max_in_window() as f64,
+            );
         } else if let (Some(limiter), Some(jitter)) = (&self.rate_limiter, &self.jitter) {
             limiter.until_ready_with_jitter(*jitter).await;
+        }
+        let elapsed = start.elapsed();
+        if elapsed > Duration::from_millis(1) {
+            record_rate_limit_wait(&self.chain, elapsed.as_secs_f64());
         }
     }
 
     pub async fn get_block_number(&self) -> Result<BlockNumber, RpcError> {
-        with_retry(&self.config.retry, "get_block_number", || async {
+        with_retry(&self.config.retry, "get_block_number", &self.chain, || async {
             self.wait_for_rate_limit().await;
             self.provider
                 .get_block_number()
@@ -481,7 +519,7 @@ impl RpcClient {
         full_transactions: bool,
     ) -> Result<Option<Block>, RpcError> {
         let op_name = format!("eth_getBlockByNumber({:?})", block_id);
-        with_retry(&self.config.retry, &op_name, || async {
+        with_retry(&self.config.retry, &op_name, &self.chain, || async {
             self.wait_for_rate_limit().await;
             let builder = self.provider.get_block(block_id);
             if full_transactions {
@@ -509,7 +547,7 @@ impl RpcClient {
 
     pub async fn get_transaction(&self, hash: B256) -> Result<Option<Transaction>, RpcError> {
         let op_name = format!("eth_getTransactionByHash({:?})", hash);
-        with_retry(&self.config.retry, &op_name, || async {
+        with_retry(&self.config.retry, &op_name, &self.chain, || async {
             self.wait_for_rate_limit().await;
             self.provider
                 .get_transaction_by_hash(hash)
@@ -524,7 +562,7 @@ impl RpcClient {
         hash: B256,
     ) -> Result<Option<TransactionReceipt>, RpcError> {
         let op_name = format!("eth_getTransactionReceipt({:?})", hash);
-        with_retry(&self.config.retry, &op_name, || async {
+        with_retry(&self.config.retry, &op_name, &self.chain, || async {
             self.wait_for_rate_limit().await;
             self.provider
                 .get_transaction_receipt(hash)
@@ -552,6 +590,7 @@ impl RpcClient {
         let raw_receipts: Vec<serde_json::Value> = with_retry(
             &self.config.retry,
             &format!("{}({:?})", method_name, block_number),
+            &self.chain,
             || async {
                 self.wait_for_rate_limit().await;
                 self.provider
@@ -635,7 +674,7 @@ impl RpcClient {
             filter.get_from_block(),
             filter.get_to_block()
         );
-        with_retry(&self.config.retry, &op_name, || async {
+        with_retry(&self.config.retry, &op_name, &self.chain, || async {
             self.wait_for_rate_limit().await;
             self.provider
                 .get_logs(&filter)
@@ -651,7 +690,7 @@ impl RpcClient {
         block: Option<BlockId>,
     ) -> Result<U256, RpcError> {
         let op_name = format!("eth_getBalance({:?}, {:?})", address, block);
-        with_retry(&self.config.retry, &op_name, || async {
+        with_retry(&self.config.retry, &op_name, &self.chain, || async {
             self.wait_for_rate_limit().await;
             self.provider
                 .get_balance(address)
@@ -668,7 +707,7 @@ impl RpcClient {
         block: Option<BlockId>,
     ) -> Result<Bytes, RpcError> {
         let op_name = format!("eth_getCode({:?}, {:?})", address, block);
-        with_retry(&self.config.retry, &op_name, || async {
+        with_retry(&self.config.retry, &op_name, &self.chain, || async {
             self.wait_for_rate_limit().await;
             self.provider
                 .get_code_at(address)
@@ -686,7 +725,7 @@ impl RpcClient {
     ) -> Result<Bytes, RpcError> {
         let tx = tx.clone();
         let op_name = format!("eth_call(to={:?}, block={:?})", tx.to, block);
-        with_retry(&self.config.retry, &op_name, || async {
+        with_retry(&self.config.retry, &op_name, &self.chain, || async {
             self.wait_for_rate_limit().await;
             self.provider
                 .call(tx.clone())
@@ -727,7 +766,7 @@ impl RpcClient {
                 chunk_idx, first_block, last_block
             );
             let chunk_results: Vec<Option<Block>> =
-                with_retry(&self.config.retry, &op_name, || async {
+                with_retry(&self.config.retry, &op_name, &self.chain, || async {
                     self.wait_for_rate_limit().await;
 
                     let futures: Vec<_> = chunk_vec
@@ -823,7 +862,7 @@ impl RpcClient {
                 chunk_idx,
                 chunk_vec.len()
             );
-            let chunk_results: Vec<Vec<Log>> = with_retry(&self.config.retry, &op_name, || async {
+            let chunk_results: Vec<Vec<Log>> = with_retry(&self.config.retry, &op_name, &self.chain, || async {
                 self.wait_for_rate_limit().await;
 
                 let futures: Vec<_> = chunk_vec
@@ -886,7 +925,7 @@ impl RpcClient {
                 chunk_vec.len()
             );
             let chunk_results: Vec<Result<Bytes, RpcError>> =
-                with_retry(&self.config.retry, &op_name, || async {
+                with_retry(&self.config.retry, &op_name, &self.chain, || async {
                     self.wait_for_rate_limit().await;
 
                     let futures: Vec<_> = chunk_vec


### PR DESCRIPTION
## Summary
- Add 8 new Prometheus metrics covering rate limiter CU usage/capacity, rate limit wait times, retry attempts/exhaustion, semaphore utilization, and batch sizing
- Instrument `SlidingWindowRateLimiter` with `acquire_with_metrics()` and `max_in_window()` getter
- Add `chain` parameter to `with_retry()` for per-chain retry/exhaustion tracking across all ~23 call sites in `provider.rs` and `alchemy.rs`
- Emit semaphore acquired/capacity gauges from `ConcurrentExecutor` spawn methods
- Record batch sizes in `execute_batch_with_metrics()` and `execute_batch_collecting_results()`

## New metrics
| Metric | Type | Labels |
|---|---|---|
| `rpc_rate_limiter_cu_used` | Gauge | chain |
| `rpc_rate_limiter_cu_capacity` | Gauge | chain |
| `rpc_rate_limit_wait_seconds` | Histogram | chain |
| `rpc_retry_attempts_total` | Counter | chain, operation, outcome |
| `rpc_retries_exhausted_total` | Counter | chain, operation |
| `rpc_semaphore_acquired` | Gauge | chain |
| `rpc_semaphore_capacity` | Gauge | chain |
| `rpc_batch_size` | Histogram | chain, method |