### PR TITLE
feat: add block collection metrics tracking

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -155,6 +155,7 @@ async fn main() -> anyhow::Result<()> {
             .context("Invalid metrics.addr in config")?;
         metrics::init_metrics_server(addr);
         metrics::describe_rpc_metrics();
+        metrics::describe_collection_metrics();
     }
 
     // Create retry queue before StorageManager if S3 is configured

--- a/src/metrics/collection.rs
+++ b/src/metrics/collection.rs
@@ -1,0 +1,59 @@
+use std::path::Path;
+
+use metrics::{counter, describe_counter, describe_histogram, histogram};
+
+/// Register metric descriptions for block/receipt/log/eth_call collection
+/// (call once at startup).
+pub fn describe_collection_metrics() {
+    describe_counter!(
+        "collection_blocks_processed_total",
+        "Total blocks processed during collection"
+    );
+    describe_histogram!(
+        "collection_block_processing_duration_seconds",
+        "Duration to process a range of blocks"
+    );
+    describe_histogram!(
+        "collection_block_transactions",
+        "Number of transactions per block"
+    );
+    describe_histogram!(
+        "collection_parquet_write_duration_seconds",
+        "Duration of parquet file writes"
+    );
+    describe_histogram!(
+        "collection_parquet_file_size_bytes",
+        "Size of written parquet files in bytes"
+    );
+    describe_counter!(
+        "collection_eth_calls_total",
+        "Total eth_call results collected"
+    );
+    describe_histogram!(
+        "collection_eth_call_batch_duration_seconds",
+        "Duration of eth_call RPC batch execution"
+    );
+    describe_counter!(
+        "collection_receipts_processed_total",
+        "Total receipts processed"
+    );
+}
+
+/// Record metrics for a parquet file write: duration and file size.
+pub fn record_parquet_write(chain: &str, data_type: &str, duration_secs: f64, file_path: &Path) {
+    histogram!(
+        "collection_parquet_write_duration_seconds",
+        "chain" => chain.to_string(),
+        "data_type" => data_type.to_string()
+    )
+    .record(duration_secs);
+
+    if let Ok(metadata) = std::fs::metadata(file_path) {
+        histogram!(
+            "collection_parquet_file_size_bytes",
+            "chain" => chain.to_string(),
+            "data_type" => data_type.to_string()
+        )
+        .record(metadata.len() as f64);
+    }
+}

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -1,5 +1,7 @@
+mod collection;
 mod rpc;
 
+pub use collection::{describe_collection_metrics, record_parquet_write};
 pub use rpc::{chain_label_from_url, describe_rpc_metrics, with_metrics, RpcMethod};
 
 use std::net::SocketAddr;

--- a/src/raw_data/historical/catchup/blocks.rs
+++ b/src/raw_data/historical/catchup/blocks.rs
@@ -1,10 +1,12 @@
 use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Instant;
 
 use alloy::primitives::B256;
 use alloy::rpc::types::BlockNumberOrTag;
 use arrow::datatypes::Schema;
+use metrics::{counter, histogram};
 use tokio::sync::mpsc::{self, Sender};
 
 use crate::raw_data::historical::blocks::{
@@ -26,11 +28,13 @@ enum PendingBlockWrite {
         schema: Arc<Schema>,
         fields: Vec<BlockField>,
         output_path: PathBuf,
+        chain_name: String,
     },
     Full {
         records: Vec<FullBlockRecord>,
         schema: Arc<Schema>,
         output_path: PathBuf,
+        chain_name: String,
     },
 }
 
@@ -154,6 +158,7 @@ pub async fn collect_blocks(
             &output_dir,
             &tx_sender,
             &eth_call_sender,
+            &chain.name,
         )
         .await?;
 
@@ -194,7 +199,9 @@ async fn collect_blocks_streaming(
     output_dir: &Path,
     tx_sender: &Option<Sender<(u64, u64, Vec<B256>)>>,
     eth_call_sender: &Option<Sender<(u64, u64)>>,
+    chain_name: &str,
 ) -> Result<(usize, PendingBlockWrite), BlockCollectionError> {
+    let range_start_time = Instant::now();
     let block_numbers: Vec<BlockNumberOrTag> = (range.start..range.end)
         .map(BlockNumberOrTag::Number)
         .collect();
@@ -296,12 +303,36 @@ async fn collect_blocks_streaming(
                 );
             }
 
+            // Record collection metrics
+            counter!(
+                "collection_blocks_processed_total",
+                "chain" => chain_name.to_string(),
+                "mode" => "historical"
+            )
+            .increment(count as u64);
+
+            for record in &all_records {
+                histogram!(
+                    "collection_block_transactions",
+                    "chain" => chain_name.to_string()
+                )
+                .record(record.transaction_count as f64);
+            }
+
+            histogram!(
+                "collection_block_processing_duration_seconds",
+                "chain" => chain_name.to_string(),
+                "mode" => "historical"
+            )
+            .record(range_start_time.elapsed().as_secs_f64());
+
             // Return data for deferred parquet write
             let pending = PendingBlockWrite::Minimal {
                 records: all_records,
                 schema: schema.clone(),
                 fields: fields.to_vec(),
                 output_path: output_dir.join(range.file_name("blocks")),
+                chain_name: chain_name.to_string(),
             };
 
             Ok((count, pending))
@@ -374,11 +405,35 @@ async fn collect_blocks_streaming(
             let all_records: Vec<FullBlockRecord> = records_map.into_values().collect();
             let count = all_records.len();
 
+            // Record collection metrics
+            counter!(
+                "collection_blocks_processed_total",
+                "chain" => chain_name.to_string(),
+                "mode" => "historical"
+            )
+            .increment(count as u64);
+
+            for record in &all_records {
+                histogram!(
+                    "collection_block_transactions",
+                    "chain" => chain_name.to_string()
+                )
+                .record(record.transaction_count as f64);
+            }
+
+            histogram!(
+                "collection_block_processing_duration_seconds",
+                "chain" => chain_name.to_string(),
+                "mode" => "historical"
+            )
+            .record(range_start_time.elapsed().as_secs_f64());
+
             // Return data for deferred parquet write
             let pending = PendingBlockWrite::Full {
                 records: all_records,
                 schema: schema.clone(),
                 output_path: output_dir.join(range.file_name("blocks")),
+                chain_name: chain_name.to_string(),
             };
 
             Ok((count, pending))
@@ -389,21 +444,37 @@ async fn collect_blocks_streaming(
 /// Execute a deferred parquet write using async wrappers (which internally
 /// use `spawn_blocking`).
 async fn execute_block_write(write: PendingBlockWrite) -> Result<(), BlockCollectionError> {
+    let write_start = Instant::now();
     match write {
         PendingBlockWrite::Minimal {
             records,
             schema,
             fields,
             output_path,
+            chain_name,
         } => {
-            write_minimal_blocks_to_parquet_async(records, schema, fields, output_path).await?;
+            write_minimal_blocks_to_parquet_async(records, schema, fields, output_path.clone())
+                .await?;
+            crate::metrics::record_parquet_write(
+                &chain_name,
+                "blocks",
+                write_start.elapsed().as_secs_f64(),
+                &output_path,
+            );
         }
         PendingBlockWrite::Full {
             records,
             schema,
             output_path,
+            chain_name,
         } => {
-            write_full_blocks_to_parquet_async(records, schema, output_path).await?;
+            write_full_blocks_to_parquet_async(records, schema, output_path.clone()).await?;
+            crate::metrics::record_parquet_write(
+                &chain_name,
+                "blocks",
+                write_start.elapsed().as_secs_f64(),
+                &output_path,
+            );
         }
     }
     Ok(())

--- a/src/raw_data/historical/eth_calls/event_triggers.rs
+++ b/src/raw_data/historical/eth_calls/event_triggers.rs
@@ -1106,7 +1106,8 @@ pub(crate) async fn process_event_triggers_multicall(
 
     // Execute all multicalls
     let results =
-        execute_multicalls_generic(ctx.client, multicall3_address, block_multicalls).await?;
+        execute_multicalls_generic(ctx.client, multicall3_address, block_multicalls, ctx.chain_name)
+            .await?;
 
     // Distribute results back to groups
     let mut group_results: HashMap<(String, String), Vec<EventCallResult>> = HashMap::new();

--- a/src/raw_data/historical/eth_calls/multicall.rs
+++ b/src/raw_data/historical/eth_calls/multicall.rs
@@ -1,5 +1,9 @@
 //! Multicall3 infrastructure: types, calldata encoding/decoding, and generic executor.
 
+use std::time::Instant;
+
+use metrics::histogram;
+
 use super::config::compute_function_selector;
 use super::types::{BlockInfo, EthCallCollectionError};
 use crate::rpc::UnifiedRpcClient;
@@ -182,6 +186,7 @@ pub(crate) async fn execute_multicalls_generic<M: Clone + Send + Sync>(
     client: &UnifiedRpcClient,
     multicall3_address: Address,
     block_multicalls: Vec<BlockMulticall<M>>,
+    chain_name: &str,
 ) -> Result<Vec<(M, Vec<u8>, bool)>, EthCallCollectionError> {
     struct FailedCall {
         result_index: usize,
@@ -208,7 +213,13 @@ pub(crate) async fn execute_multicalls_generic<M: Clone + Send + Sync>(
         })
         .collect();
 
+    let batch_start = Instant::now();
     let results = client.call_batch(calls).await?;
+    histogram!(
+        "collection_eth_call_batch_duration_seconds",
+        "chain" => chain_name.to_string()
+    )
+    .record(batch_start.elapsed().as_secs_f64());
 
     let mut all_results: Vec<(M, Vec<u8>, bool)> = Vec::new();
     let mut failed_retries: Vec<FailedCall> = Vec::new();
@@ -284,7 +295,13 @@ pub(crate) async fn execute_multicalls_generic<M: Clone + Send + Sync>(
             })
             .collect();
 
+        let retry_start = Instant::now();
         let retry_results = client.call_batch(retry_batch).await?;
+        histogram!(
+            "collection_eth_call_batch_duration_seconds",
+            "chain" => chain_name.to_string()
+        )
+        .record(retry_start.elapsed().as_secs_f64());
 
         for (i, result) in retry_results.into_iter().enumerate() {
             let failed = &failed_retries[i];

--- a/src/raw_data/historical/eth_calls/once_calls.rs
+++ b/src/raw_data/historical/eth_calls/once_calls.rs
@@ -1219,7 +1219,8 @@ pub(crate) async fn process_once_calls_multicall(
 
     // Execute multicall
     let results =
-        execute_multicalls_generic(ctx.client, multicall3_address, block_multicalls).await?;
+        execute_multicalls_generic(ctx.client, multicall3_address, block_multicalls, ctx.chain_name)
+            .await?;
 
     // Group results by contract_name -> address -> function_name -> value
     let mut results_by_contract: HashMap<String, HashMap<Address, HashMap<String, Vec<u8>>>> =
@@ -1734,8 +1735,13 @@ pub(crate) async fn process_factory_once_calls_multicall(
         );
 
         // Execute multicalls
-        let results =
-            execute_multicalls_generic(ctx.client, multicall3_address, block_multicalls).await?;
+        let results = execute_multicalls_generic(
+            ctx.client,
+            multicall3_address,
+            block_multicalls,
+            ctx.chain_name,
+        )
+        .await?;
 
         for (meta, return_data, _success) in results {
             let entry = results_by_collection
@@ -1941,6 +1947,7 @@ pub(crate) async fn process_factory_once_calls_multicall(
                             ctx.client,
                             multicall3_address,
                             backfill_multicalls,
+                            ctx.chain_name,
                         )
                         .await?;
 

--- a/src/raw_data/historical/eth_calls/postprocessing.rs
+++ b/src/raw_data/historical/eth_calls/postprocessing.rs
@@ -2,7 +2,9 @@
 
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Instant;
 
+use metrics::counter;
 use tokio::sync::mpsc::Sender;
 use tokio::task::JoinHandle;
 
@@ -89,14 +91,27 @@ pub(crate) async fn finalize_regular_results(
     // 1. Parquet write via async wrapper
     let max_params = params.max_params;
     let results = params.results;
-    #[cfg(feature = "bench")]
-    let write_start = std::time::Instant::now();
+    let write_start = Instant::now();
     write_results_to_parquet_async(results, output_path.clone(), max_params).await?;
+    let write_elapsed = write_start.elapsed();
+
+    // Record eth_call collection metrics
+    counter!(
+        "collection_eth_calls_total",
+        "chain" => params.chain_name.to_string()
+    )
+    .increment(result_count as u64);
+
+    crate::metrics::record_parquet_write(
+        params.chain_name,
+        "eth_calls",
+        write_elapsed.as_secs_f64(),
+        &output_path,
+    );
 
     // 2. Bench recording
     #[cfg(feature = "bench")]
     {
-        let write_time = write_start.elapsed();
         if let Some((bench_label, rpc_time, process_time)) = params.bench {
             crate::bench::record(
                 &bench_label,
@@ -105,7 +120,7 @@ pub(crate) async fn finalize_regular_results(
                 result_count,
                 rpc_time,
                 process_time,
-                write_time,
+                write_elapsed,
             );
         }
     }
@@ -228,14 +243,27 @@ pub(crate) async fn finalize_regular_results_deferred(
 
     let handle = tokio::spawn(async move {
         // 1. Parquet write
-        #[cfg(feature = "bench")]
-        let write_start = std::time::Instant::now();
+        let write_start = Instant::now();
         write_results_to_parquet_async(results, output_path.clone(), max_params).await?;
+        let write_elapsed = write_start.elapsed();
+
+        // Record eth_call collection metrics
+        counter!(
+            "collection_eth_calls_total",
+            "chain" => chain_name.clone()
+        )
+        .increment(result_count as u64);
+
+        crate::metrics::record_parquet_write(
+            &chain_name,
+            "eth_calls",
+            write_elapsed.as_secs_f64(),
+            &output_path,
+        );
 
         // 2. Bench recording
         #[cfg(feature = "bench")]
         {
-            let write_time = write_start.elapsed();
             if let Some((bench_label, rpc_time, process_time)) = bench {
                 crate::bench::record(
                     &bench_label,
@@ -244,7 +272,7 @@ pub(crate) async fn finalize_regular_results_deferred(
                     result_count,
                     rpc_time,
                     process_time,
-                    write_time,
+                    write_elapsed,
                 );
             }
         }

--- a/src/raw_data/historical/eth_calls/regular_calls.rs
+++ b/src/raw_data/historical/eth_calls/regular_calls.rs
@@ -545,7 +545,8 @@ pub(crate) async fn process_factory_range_multicall(
 
     // Execute all multicalls
     let results =
-        execute_multicalls_generic(ctx.client, multicall3_address, block_multicalls).await?;
+        execute_multicalls_generic(ctx.client, multicall3_address, block_multicalls, ctx.chain_name)
+            .await?;
 
     // Distribute results back to groups
     let mut group_results: HashMap<(String, String), Vec<CallResult>> = HashMap::new();
@@ -984,7 +985,8 @@ pub(crate) async fn process_range_multicall(
 
     // Execute all multicalls
     let results =
-        execute_multicalls_generic(ctx.client, multicall3_address, block_multicalls).await?;
+        execute_multicalls_generic(ctx.client, multicall3_address, block_multicalls, ctx.chain_name)
+            .await?;
 
     // Distribute results back to groups
     let mut group_results: HashMap<(String, String), Vec<CallResult>> = HashMap::new();

--- a/src/raw_data/historical/logs.rs
+++ b/src/raw_data/historical/logs.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Instant;
 
 use arrow::array::{
     ArrayRef, BinaryArray, FixedSizeBinaryArray, FixedSizeBinaryBuilder, ListBuilder, UInt32Array,
@@ -192,6 +193,7 @@ pub(crate) async fn process_range(
         range.end - 1
     );
 
+    let write_start = Instant::now();
     match log_fields {
         Some(fields) => {
             let records: Vec<MinimalLogRecord> = logs
@@ -234,6 +236,14 @@ pub(crate) async fn process_range(
     }
 
     let output_path = output_dir.join(range.file_name("logs"));
+
+    crate::metrics::record_parquet_write(
+        chain_name,
+        "logs",
+        write_start.elapsed().as_secs_f64(),
+        &output_path,
+    );
+
     tracing::info!("Wrote logs to {}", output_path.display());
 
     // Upload to S3 if configured

--- a/src/raw_data/historical/receipts.rs
+++ b/src/raw_data/historical/receipts.rs
@@ -13,6 +13,7 @@ use alloy::rpc::types::Log;
 use arrow::array::{ArrayRef, FixedSizeBinaryArray, UInt32Array, UInt64Array};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
+use metrics::counter;
 use thiserror::Error;
 use tokio::sync::mpsc::Sender;
 
@@ -935,6 +936,20 @@ pub(crate) async fn process_range(
         }
     };
     let total_write_time = write_start.elapsed();
+
+    // Record receipt collection metrics
+    counter!(
+        "collection_receipts_processed_total",
+        "chain" => chain_name.to_string()
+    )
+    .increment(total_receipts as u64);
+
+    crate::metrics::record_parquet_write(
+        chain_name,
+        "receipts",
+        total_write_time.as_secs_f64(),
+        &output_path,
+    );
 
     // Upload to S3 if configured
     if let Some(sm) = storage_manager {


### PR DESCRIPTION
## Summary
- Adds Prometheus metrics for the block collection / raw data pipeline: block processing counts and duration, parquet write timing and file sizes, receipt and eth_call collection counts
- Provides `record_parquet_write()` helper for consistent parquet write metrics across all data types
- Instruments block, receipt, log, and eth_call collection paths in `src/raw_data/historical/`

## Metrics added
- `collection_blocks_processed_total` (counter)
- `collection_block_processing_duration_seconds` (histogram)
- `collection_block_transactions` (histogram)
- `collection_parquet_write_duration_seconds` (histogram)
- `collection_parquet_file_size_bytes` (histogram)
- `collection_eth_calls_total` (counter)
- `collection_eth_call_batch_duration_seconds` (histogram)
- `collection_receipts_processed_total` (counter)

## Note
Part of a metrics rollout across all subsystems. Expect merge conflicts in `src/metrics/mod.rs` and `src/main.rs` with sibling PRs (#102, #103, #104, #105).