### PR TITLE
perf: speed up catchup decoding

### DIFF
--- a/src/decoding/catchup/eth_calls.rs
+++ b/src/decoding/catchup/eth_calls.rs
@@ -58,7 +58,11 @@ pub async fn catchup_decode_eth_calls(
     raw_data_config: &RawDataCollectionConfig,
     transform_tx: Option<&Sender<DecodedCallsMessage>>,
 ) -> Result<(), EthCallDecodingError> {
-    let concurrency = raw_data_config.decoding_concurrency.unwrap_or(4);
+    let concurrency = raw_data_config.decoding_concurrency.unwrap_or_else(|| {
+        std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(8)
+    });
 
     // Scan existing decoded files
     let existing_decoded = scan_existing_decoded_files(output_base);
@@ -418,7 +422,11 @@ pub async fn catchup_decode_eth_calls(
                     range_end,
                     config,
                 } => {
-                    let results = read_regular_calls_from_parquet(&file_path)?;
+                    let results = tokio::task::spawn_blocking(move || {
+                        read_regular_calls_from_parquet(&file_path)
+                    })
+                    .await
+                    .expect("parquet read task panicked")?;
                     process_regular_calls(
                         &results,
                         range_start,
@@ -428,7 +436,6 @@ pub async fn catchup_decode_eth_calls(
                         transform_tx.as_ref(),
                     )
                     .await?;
-                    // Regular calls don't need index updates
                     Ok(None)
                 }
                 CatchupWorkItem::Once {
@@ -438,9 +445,14 @@ pub async fn catchup_decode_eth_calls(
                     contract_name,
                     configs,
                 } => {
+                    let configs_for_read = configs.clone();
+                    let results = tokio::task::spawn_blocking(move || {
+                        let config_refs: Vec<&CallDecodeConfig> = configs_for_read.iter().collect();
+                        read_once_calls_from_parquet(&file_path, &config_refs)
+                    })
+                    .await
+                    .expect("parquet read task panicked")?;
                     let config_refs: Vec<&CallDecodeConfig> = configs.iter().collect();
-                    let results = read_once_calls_from_parquet(&file_path, &config_refs)?;
-                    // Return index info for batch update (avoids race condition)
                     process_once_calls(
                         &results,
                         range_start,
@@ -449,7 +461,7 @@ pub async fn catchup_decode_eth_calls(
                         &config_refs,
                         &output_base,
                         transform_tx.as_ref(),
-                        true, // return_index_info: batch update after all tasks complete
+                        true,
                     )
                     .await
                 }
@@ -459,7 +471,11 @@ pub async fn catchup_decode_eth_calls(
                     range_end,
                     config,
                 } => {
-                    let results = read_event_calls_from_parquet(&file_path)?;
+                    let results = tokio::task::spawn_blocking(move || {
+                        read_event_calls_from_parquet(&file_path)
+                    })
+                    .await
+                    .expect("parquet read task panicked")?;
                     process_event_calls(
                         &results,
                         range_start,
@@ -469,7 +485,6 @@ pub async fn catchup_decode_eth_calls(
                         transform_tx.as_ref(),
                     )
                     .await?;
-                    // Event calls don't need index updates
                     Ok(None)
                 }
             };

--- a/src/decoding/catchup/logs.rs
+++ b/src/decoding/catchup/logs.rs
@@ -35,7 +35,11 @@ pub async fn catchup_decode_logs(
 ) -> Result<(), LogDecodingError> {
     let regular_matchers = matchers.regular_matchers;
     let factory_matchers = matchers.factory_matchers;
-    let concurrency = raw_data_config.decoding_concurrency.unwrap_or(4);
+    let concurrency = raw_data_config.decoding_concurrency.unwrap_or_else(|| {
+        std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(8)
+    });
 
     // Scan existing decoded files
     let existing_decoded = Arc::new(scan_existing_decoded_files(output_base));
@@ -200,9 +204,15 @@ pub async fn catchup_decode_logs(
                 range_end - 1
             );
 
-            // Read raw logs from parquet
+            // Read raw logs from parquet — use spawn_blocking to avoid starving
+            // the tokio runtime with synchronous file I/O + decompression
             let file_path_for_read = file_path.clone();
-            let logs = match read_raw_logs_from_parquet(&file_path_for_read) {
+            let logs = match tokio::task::spawn_blocking(move || {
+                read_raw_logs_from_parquet(&file_path_for_read)
+            })
+            .await
+            .expect("parquet read task panicked")
+            {
                 Ok(logs) => logs,
                 Err(e) => {
                     tracing::warn!(

--- a/src/decoding/logs.rs
+++ b/src/decoding/logs.rs
@@ -273,6 +273,26 @@ pub(crate) async fn process_logs(
     let factory_matchers = matchers.factory_matchers;
     let build_transform = outputs.transform_tx.is_some();
 
+    // Build topic0 index for O(1) matcher lookup instead of O(matchers) linear scan per log.
+    // This is the key optimization for catchup with many configured events.
+    let mut regular_by_topic: HashMap<[u8; 32], Vec<&EventMatcher>> = HashMap::new();
+    for matcher in regular_matchers {
+        regular_by_topic
+            .entry(matcher.event.topic0)
+            .or_default()
+            .push(matcher);
+    }
+
+    let mut factory_by_topic: HashMap<[u8; 32], Vec<(&str, &EventMatcher)>> = HashMap::new();
+    for (collection_name, matchers) in factory_matchers {
+        for matcher in matchers {
+            factory_by_topic
+                .entry(matcher.event.topic0)
+                .or_default()
+                .push((collection_name.as_str(), matcher));
+        }
+    }
+
     // Group decoded logs by (contract_name, event_name) — for parquet storage
     let mut decoded_by_event: HashMap<(String, String), (Vec<DecodedLogRecord>, &ParsedEvent)> =
         HashMap::new();
@@ -287,58 +307,52 @@ pub(crate) async fn process_logs(
         }
         let topic0 = log.topics[0];
 
-        // Try regular matchers
-        for matcher in regular_matchers {
-            // Skip if block is before contract's start_block
-            if let Some(sb) = matcher.start_block {
-                if log.block_number < sb {
+        // Regular matchers via topic0 index
+        if let Some(matchers) = regular_by_topic.get(&topic0) {
+            for matcher in matchers {
+                if let Some(sb) = matcher.start_block {
+                    if log.block_number < sb {
+                        continue;
+                    }
+                }
+                if !matcher.addresses.contains(&log.address) {
                     continue;
                 }
-            }
-            if !matcher.addresses.contains(&log.address) {
-                continue;
-            }
-            if topic0 != matcher.event.topic0 {
-                continue;
-            }
 
-            if let Some(decoded) = decode_log(log, &matcher.event)? {
-                if build_transform {
-                    let transform_event = convert_to_transform_event(
-                        &decoded,
-                        &matcher.event,
-                        &matcher.name,
-                        &matcher.event_name,
-                    );
+                if let Some(decoded) = decode_log(log, &matcher.event)? {
+                    if build_transform {
+                        let transform_event = convert_to_transform_event(
+                            &decoded,
+                            &matcher.event,
+                            &matcher.name,
+                            &matcher.event_name,
+                        );
+                        let key = (matcher.name.clone(), matcher.event_name.clone());
+                        transform_events_by_type
+                            .entry(key)
+                            .or_default()
+                            .push(transform_event);
+                    }
+
                     let key = (matcher.name.clone(), matcher.event_name.clone());
-                    transform_events_by_type
+                    decoded_by_event
                         .entry(key)
-                        .or_default()
-                        .push(transform_event);
+                        .or_insert_with(|| (Vec::new(), &matcher.event))
+                        .0
+                        .push(decoded);
                 }
-
-                let key = (matcher.name.clone(), matcher.event_name.clone());
-                decoded_by_event
-                    .entry(key)
-                    .or_insert_with(|| (Vec::new(), &matcher.event))
-                    .0
-                    .push(decoded);
             }
         }
 
-        // Try factory matchers
-        for (collection_name, matchers) in factory_matchers {
-            let addrs = match factory_addresses.get(collection_name) {
-                Some(addrs) => addrs,
-                None => continue,
-            };
+        // Factory matchers via topic0 index
+        if let Some(entries) = factory_by_topic.get(&topic0) {
+            for (collection_name, matcher) in entries {
+                let addrs = match factory_addresses.get(*collection_name) {
+                    Some(addrs) => addrs,
+                    None => continue,
+                };
 
-            if !addrs.contains(&log.address) {
-                continue;
-            }
-
-            for matcher in matchers {
-                if topic0 != matcher.event.topic0 {
+                if !addrs.contains(&log.address) {
                     continue;
                 }
 
@@ -350,14 +364,14 @@ pub(crate) async fn process_logs(
                             collection_name,
                             &matcher.event_name,
                         );
-                        let key = (collection_name.clone(), matcher.event_name.clone());
+                        let key = (collection_name.to_string(), matcher.event_name.clone());
                         transform_events_by_type
                             .entry(key)
                             .or_default()
                             .push(transform_event);
                     }
 
-                    let key = (collection_name.clone(), matcher.event_name.clone());
+                    let key = (collection_name.to_string(), matcher.event_name.clone());
                     decoded_by_event
                         .entry(key)
                         .or_insert_with(|| (Vec::new(), &matcher.event))


### PR DESCRIPTION
## Summary

- **Topic0 HashMap index**: Build `HashMap<[u8;32], Vec<&EventMatcher>>` before the log processing loop in `process_logs`, turning matcher lookup from O(matchers) per log to O(1). This is the key algorithmic win for configs with many events/contracts.
- **`spawn_blocking` for parquet reads**: Wrap all catchup parquet reads (`read_raw_logs_from_parquet`, `read_regular_calls_from_parquet`, `read_once_calls_from_parquet`, `read_event_calls_from_parquet`) in `tokio::task::spawn_blocking` to avoid starving the tokio runtime with synchronous file I/O and decompression.
- **Higher default concurrency**: Bump `decoding_concurrency` default from hardcoded 4 to `std::thread::available_parallelism()` (falls back to 8) so catchup saturates available CPU cores.