### PR TITLE
feat: add migration pool metrics handlers (Phase 5)

### DIFF
--- a/docs/pool-metrics/metrics_implementation_phases.md
+++ b/docs/pool-metrics/metrics_implementation_phases.md
@@ -298,21 +298,25 @@ multicurve::metrics::register_handlers(registry, chain_id, multicurve_cache);
 
 ---
 
-## Phase 5: Migration Pool Handler
+## Phase 5: Migration Pool Handler ✅
+
+**Status**: Complete
 
 **Goal**: Handle swaps and liquidity on graduated (migrated) V4 pools.
 
-### Tasks
-1. Create `src/transformations/event/migration_pool/` module
-2. Implement `migration_pool/metrics.rs` — MigrationPoolMetricsHandler
-3. Register in `event/mod.rs`
+**Delivered**:
+- `src/transformations/event/migration_pool/mod.rs`
+- `src/transformations/event/migration_pool/create.rs` — MigrationPoolCreateHandler
+- `src/transformations/event/migration_pool/metrics.rs` — MigrationPoolSwapMetricsHandler, MigrationPoolLiquidityMetricsHandler
+- `src/transformations/util/db/pool.rs` — `MigrationPoolData` + `insert_migration_pool()`
+- All 3 handlers registered in `event/mod.rs`
 
-### Handler specifics
-- Swap source: `UniswapV4PoolManager` — Swap event has sqrtPriceX96/tick/liquidity directly
-- Liquidity source: `UniswapV4MigratorHook` — ModifyLiquidity (tuple format)
-- **Must filter PoolManager Swaps**: PoolManager emits Swap for ALL V4 pools. Use in-memory `RwLock<HashSet<Vec<u8>>>` of migration pool IDs. Rebuild on init from `pools WHERE migrated_from IS NOT NULL`.
-- Also scan for Migrate events in current context to add newly graduated pools inline
-- call_dependencies: none (all data in events)
+**Key design decisions**:
+- **Create handler required**: no existing handler inserted migration pool rows into `pools`. `MigrationPoolCreateHandler` handles `UniswapV4Migrator.Migrate`, queries the original Doppler pool via `migration_pool = poolId`, and inserts a new row with `migrated_from` set. This enables `PoolMetadataCache` to work normally for migration pools.
+- **Swap filtering**: `MigrationPoolSwapMetricsHandler` holds `RwLock<HashSet<Vec<u8>>>` of migration pool IDs. Seeded at init from `pools WHERE migrated_from IS NOT NULL`. Inline scan of `Migrate` events in the current context handles same-range Migrate+Swap edge cases.
+- **Liquidity**: `MigrationPoolLiquidityMetricsHandler` triggers on `UniswapV4MigratorHook.ModifyLiquidity` (tuple format). No filter needed — MigratorHook only handles migration pools. Uses `extract_tuple_modify_liquidity()`.
+- **Dependencies**: both metrics handlers depend on `MigrationPoolCreateHandler` so the pool row and metadata exist before metrics handlers run.
+- **Chains**: 5 chains have Migrator + MigratorHook (base, baseSepolia, mainnet, unichain, sepolia). ink and monad have PoolManager but no migration infrastructure — handlers simply find no events on those chains.
 
 ---
 

--- a/src/transformations/event/migration_pool/create.rs
+++ b/src/transformations/event/migration_pool/create.rs
@@ -1,0 +1,162 @@
+//! Migration pool create handler.
+//!
+//! Inserts a `pools` row for each Doppler V4 pool that graduates to a standard
+//! UniswapV4 pool via `UniswapV4Migrator.Migrate`. The new row carries
+//! `migrated_from` pointing to the original Doppler pool's bytes32 address,
+//! which is how `MigrationPoolSwapMetricsHandler` discovers the migration pool
+//! ID set at startup.
+//!
+//! ## Dependencies
+//!
+//! Depends on `V4CreateHandler` so the original Doppler V4 pool row exists in
+//! the DB before this handler queries for it.
+
+use std::sync::OnceLock;
+
+use async_trait::async_trait;
+use deadpool_postgres::Pool;
+
+use crate::db::{DbOperation, DbPool};
+use crate::transformations::context::{FieldExtractor, TransformationContext};
+use crate::transformations::error::TransformationError;
+use crate::transformations::registry::TransformationRegistry;
+use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
+use crate::transformations::util::db::pool::{insert_migration_pool, MigrationPoolData};
+
+const MIGRATOR_SOURCE: &str = "UniswapV4Migrator";
+
+pub struct MigrationPoolCreateHandler {
+    db_pool: OnceLock<Pool>,
+}
+
+#[async_trait]
+impl TransformationHandler for MigrationPoolCreateHandler {
+    fn name(&self) -> &'static str {
+        "MigrationPoolCreateHandler"
+    }
+
+    fn version(&self) -> u32 {
+        1
+    }
+
+    fn migration_paths(&self) -> Vec<&'static str> {
+        vec!["migrations/tables/pools.sql"]
+    }
+
+    fn reorg_tables(&self) -> Vec<&'static str> {
+        vec!["pools"]
+    }
+
+    async fn handle(
+        &self,
+        ctx: &TransformationContext,
+    ) -> Result<Vec<DbOperation>, TransformationError> {
+        let mut ops = Vec::new();
+
+        for event in ctx.events_of_type(MIGRATOR_SOURCE, "Migrate") {
+            let pool_id = event.extract_bytes32("poolId")?;
+
+            let client = self
+                .db_pool
+                .get()
+                .expect("db_pool must be set before handle()")
+                .get()
+                .await?;
+
+            let rows = client
+                .query(
+                    "SELECT address, base_token, quote_token, is_token_0, fee, \
+                     integrator, initializer \
+                     FROM pools \
+                     WHERE chain_id = $1 AND migration_pool = $2 \
+                     ORDER BY source_version DESC \
+                     LIMIT 1",
+                    &[&(ctx.chain_id as i64), &pool_id.to_vec()],
+                )
+                .await?;
+
+            let Some(row) = rows.first() else {
+                tracing::warn!(
+                    pool_id = hex::encode(pool_id),
+                    block = event.block_number,
+                    "no original pool found for migration pool; skipping"
+                );
+                continue;
+            };
+
+            let base_token_bytes: Vec<u8> = row.get("base_token");
+            let quote_token_bytes: Vec<u8> = row.get("quote_token");
+            let integrator_bytes: Vec<u8> = row.get("integrator");
+            let initializer_bytes: Vec<u8> = row.get("initializer");
+            let original_address: Vec<u8> = row.get("address");
+
+            if base_token_bytes.len() != 20
+                || quote_token_bytes.len() != 20
+                || integrator_bytes.len() != 20
+                || initializer_bytes.len() != 20
+            {
+                tracing::warn!(
+                    pool_id = hex::encode(pool_id),
+                    block = event.block_number,
+                    "malformed address bytes in original pool row; skipping"
+                );
+                continue;
+            }
+
+            let mut base_token = [0u8; 20];
+            let mut quote_token = [0u8; 20];
+            let mut integrator = [0u8; 20];
+            let mut initializer = [0u8; 20];
+            base_token.copy_from_slice(&base_token_bytes);
+            quote_token.copy_from_slice(&quote_token_bytes);
+            integrator.copy_from_slice(&integrator_bytes);
+            initializer.copy_from_slice(&initializer_bytes);
+
+            let is_token_0: bool = row.get("is_token_0");
+            let fee: i32 = row.get("fee");
+
+            ops.push(insert_migration_pool(
+                &MigrationPoolData {
+                    block_number: event.block_number,
+                    block_timestamp: event.block_timestamp,
+                    pool_id: &pool_id,
+                    base_token,
+                    quote_token,
+                    is_token_0,
+                    integrator,
+                    initializer,
+                    fee: fee as u32,
+                    migrated_from: &original_address,
+                },
+                ctx,
+            ));
+        }
+
+        Ok(ops)
+    }
+
+    async fn initialize(&self, db_pool: &DbPool) -> Result<(), TransformationError> {
+        self.db_pool.set(db_pool.inner().clone()).ok();
+        tracing::info!("MigrationPoolCreateHandler initialized");
+        Ok(())
+    }
+}
+
+impl EventHandler for MigrationPoolCreateHandler {
+    fn triggers(&self) -> Vec<EventTrigger> {
+        vec![EventTrigger::new(
+            MIGRATOR_SOURCE,
+            "Migrate(bytes32,uint160,int24,int24,uint256,uint256,uint256)",
+        )]
+    }
+
+    fn handler_dependencies(&self) -> Vec<&'static str> {
+        vec!["V4CreateHandler"]
+    }
+}
+
+pub fn register_handlers(registry: &mut TransformationRegistry) {
+    registry.register_event_handler(MigrationPoolCreateHandler {
+        db_pool: OnceLock::new(),
+    });
+}

--- a/src/transformations/event/migration_pool/create.rs
+++ b/src/transformations/event/migration_pool/create.rs
@@ -8,8 +8,9 @@
 //!
 //! ## Dependencies
 //!
-//! Depends on `V4CreateHandler` so the original Doppler V4 pool row exists in
-//! the DB before this handler queries for it.
+//! Depends on every Doppler pool create handler that can populate
+//! `pools.migration_pool`, so the original pool row exists in the DB before
+//! this handler queries for it during catchup.
 
 use std::sync::OnceLock;
 
@@ -151,7 +152,13 @@ impl EventHandler for MigrationPoolCreateHandler {
     }
 
     fn handler_dependencies(&self) -> Vec<&'static str> {
-        vec!["V4CreateHandler"]
+        vec![
+            "V4CreateHandler",
+            "V4MulticurveCreateHandler",
+            "V4ScheduledMulticurveCreateHandler",
+            "V4DecayMulticurveCreateHandler",
+            "DopplerHookCreateHandler",
+        ]
     }
 }
 

--- a/src/transformations/event/migration_pool/metrics.rs
+++ b/src/transformations/event/migration_pool/metrics.rs
@@ -7,10 +7,10 @@
 //! ## Swap filtering
 //!
 //! `UniswapV4PoolManager` emits `Swap` for every V4 pool on the chain. The swap
-//! handler maintains an in-memory `HashSet` of known migration pool IDs loaded at
-//! init from `pools WHERE migrated_from IS NOT NULL`. `Migrate` events observed
-//! in the current context are also added inline so that a pool's first swap in
-//! the same range as its graduation is not missed.
+//! handler maintains an in-memory `HashSet` of known migration pool IDs seeded at
+//! init from `pools WHERE migrated_from IS NOT NULL` and refreshed from the DB on
+//! each `handle()` invocation to pick up pools that graduated since init (e.g.
+//! during catchup processing).
 //!
 //! ## Liquidity
 //!
@@ -37,7 +37,6 @@ use crate::transformations::util::pool_metadata::PoolMetadataCache;
 
 const POOL_MANAGER_SOURCE: &str = "UniswapV4PoolManager";
 const MIGRATOR_HOOK_SOURCE: &str = "UniswapV4MigratorHook";
-const MIGRATOR_SOURCE: &str = "UniswapV4Migrator";
 
 // ─── Swap handler ─────────────────────────────────────────────────────────────
 
@@ -47,9 +46,48 @@ pub struct MigrationPoolSwapMetricsHandler {
     chain_id: u64,
     db_pool: OnceLock<Pool>,
     /// bytes32 pool IDs of known migration pools.
-    /// Loaded at init from `pools WHERE migrated_from IS NOT NULL`;
-    /// augmented inline per-handle() from Migrate events in the current context.
+    /// Seeded at init from `pools WHERE migrated_from IS NOT NULL`;
+    /// refreshed from DB on each `handle()` to discover newly graduated pools.
     migration_pool_ids: RwLock<HashSet<Vec<u8>>>,
+}
+
+impl MigrationPoolSwapMetricsHandler {
+    /// Re-query the DB for migration pool IDs to pick up pools that graduated
+    /// since initialization (e.g. committed by MigrationPoolCreateHandler during
+    /// catchup).
+    async fn refresh_migration_pool_ids(&self) -> Result<(), TransformationError> {
+        let Some(pool) = self.db_pool.get() else {
+            return Ok(());
+        };
+        let client = pool.get().await?;
+        let rows = client
+            .query(
+                "SELECT p.address \
+                 FROM pools p \
+                 JOIN active_versions av \
+                   ON p.source = av.source AND p.source_version = av.active_version \
+                 WHERE p.chain_id = $1 AND p.migrated_from IS NOT NULL",
+                &[&(self.chain_id as i64)],
+            )
+            .await?;
+
+        let mut ids = self.migration_pool_ids.write().unwrap();
+        let before = ids.len();
+        for row in &rows {
+            let address: Vec<u8> = row.get("address");
+            ids.insert(address);
+        }
+        let added = ids.len() - before;
+        if added > 0 {
+            tracing::info!(
+                added,
+                total = ids.len(),
+                chain_id = self.chain_id,
+                "Refreshed migration pool ID set"
+            );
+        }
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -81,28 +119,9 @@ impl TransformationHandler for MigrationPoolSwapMetricsHandler {
             self.metadata_cache.resolve_quote_decimals(&ctx.contracts);
         });
 
-        // Add any newly graduated pools from Migrate events in this context so that
-        // a pool's first swap in the same range as its graduation is not missed.
-        {
-            let migrate_events: Vec<_> =
-                ctx.events_of_type(MIGRATOR_SOURCE, "Migrate").collect();
-            if !migrate_events.is_empty() {
-                let mut ids = self.migration_pool_ids.write().unwrap();
-                for event in migrate_events {
-                    match event.extract_bytes32("poolId") {
-                        Ok(pool_id) => {
-                            ids.insert(pool_id.to_vec());
-                        }
-                        Err(e) => {
-                            tracing::warn!(
-                                block = event.block_number,
-                                "failed to extract poolId from Migrate event: {e}"
-                            );
-                        }
-                    }
-                }
-            }
-        }
+        // Refresh the migration pool ID set from DB to pick up any pools
+        // graduated since init (e.g. by MigrationPoolCreateHandler during catchup).
+        self.refresh_migration_pool_ids().await?;
 
         // Extract PoolManager Swap events, filtering to known migration pool IDs.
         let mut swaps: Vec<SwapInput> = Vec::new();

--- a/src/transformations/event/migration_pool/metrics.rs
+++ b/src/transformations/event/migration_pool/metrics.rs
@@ -138,6 +138,7 @@ impl TransformationHandler for MigrationPoolSwapMetricsHandler {
 
             swaps.push(SwapInput {
                 pool_id: pool_id.to_vec(),
+                transaction_hash: event.transaction_hash,
                 block_number: event.block_number,
                 block_timestamp: event.block_timestamp,
                 log_index: event.log_index,

--- a/src/transformations/event/migration_pool/metrics.rs
+++ b/src/transformations/event/migration_pool/metrics.rs
@@ -1,0 +1,257 @@
+//! Migration pool metrics handlers.
+//!
+//! Processes swaps and liquidity changes on graduated (migrated) Doppler V4 pools.
+//! After migration, swaps flow through `UniswapV4PoolManager` and initial liquidity
+//! through `UniswapV4MigratorHook`.
+//!
+//! ## Swap filtering
+//!
+//! `UniswapV4PoolManager` emits `Swap` for every V4 pool on the chain. The swap
+//! handler maintains an in-memory `HashSet` of known migration pool IDs loaded at
+//! init from `pools WHERE migrated_from IS NOT NULL`. `Migrate` events observed
+//! in the current context are also added inline so that a pool's first swap in
+//! the same range as its graduation is not missed.
+//!
+//! ## Liquidity
+//!
+//! `UniswapV4MigratorHook` only emits `ModifyLiquidity` for migration pools, so
+//! no filtering is needed. Pool ID is computed from the tuple PoolKey via keccak256,
+//! matching the same approach used by V4 hook liquidity handlers.
+
+use std::collections::HashSet;
+use std::sync::{Arc, Once, OnceLock, RwLock};
+
+use async_trait::async_trait;
+use deadpool_postgres::Pool;
+
+use crate::db::{DbOperation, DbPool};
+use crate::transformations::context::{FieldExtractor, TransformationContext};
+use crate::transformations::error::TransformationError;
+use crate::transformations::event::metrics::swap_data::{
+    process_liquidity_deltas, process_swaps, refresh_cache_if_needed, SwapInput,
+};
+use crate::transformations::event::metrics::v4_hook_extract::extract_tuple_modify_liquidity;
+use crate::transformations::registry::TransformationRegistry;
+use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
+use crate::transformations::util::pool_metadata::PoolMetadataCache;
+
+const POOL_MANAGER_SOURCE: &str = "UniswapV4PoolManager";
+const MIGRATOR_HOOK_SOURCE: &str = "UniswapV4MigratorHook";
+const MIGRATOR_SOURCE: &str = "UniswapV4Migrator";
+
+// ─── Swap handler ─────────────────────────────────────────────────────────────
+
+pub struct MigrationPoolSwapMetricsHandler {
+    metadata_cache: Arc<PoolMetadataCache>,
+    decimals_init: Once,
+    chain_id: u64,
+    db_pool: OnceLock<Pool>,
+    /// bytes32 pool IDs of known migration pools.
+    /// Loaded at init from `pools WHERE migrated_from IS NOT NULL`;
+    /// augmented inline per-handle() from Migrate events in the current context.
+    migration_pool_ids: RwLock<HashSet<Vec<u8>>>,
+}
+
+#[async_trait]
+impl TransformationHandler for MigrationPoolSwapMetricsHandler {
+    fn name(&self) -> &'static str {
+        "MigrationPoolSwapMetricsHandler"
+    }
+
+    fn version(&self) -> u32 {
+        1
+    }
+
+    fn migration_paths(&self) -> Vec<&'static str> {
+        vec![
+            "migrations/tables/pool_state.sql",
+            "migrations/tables/pool_snapshots.sql",
+        ]
+    }
+
+    fn reorg_tables(&self) -> Vec<&'static str> {
+        vec!["pool_state", "pool_snapshots"]
+    }
+
+    async fn handle(
+        &self,
+        ctx: &TransformationContext,
+    ) -> Result<Vec<DbOperation>, TransformationError> {
+        self.decimals_init.call_once(|| {
+            self.metadata_cache.resolve_quote_decimals(&ctx.contracts);
+        });
+
+        // Add any newly graduated pools from Migrate events in this context so that
+        // a pool's first swap in the same range as its graduation is not missed.
+        {
+            let migrate_events: Vec<_> =
+                ctx.events_of_type(MIGRATOR_SOURCE, "Migrate").collect();
+            if !migrate_events.is_empty() {
+                let mut ids = self.migration_pool_ids.write().unwrap();
+                for event in migrate_events {
+                    match event.extract_bytes32("poolId") {
+                        Ok(pool_id) => {
+                            ids.insert(pool_id.to_vec());
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                block = event.block_number,
+                                "failed to extract poolId from Migrate event: {e}"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        // Extract PoolManager Swap events, filtering to known migration pool IDs.
+        let mut swaps: Vec<SwapInput> = Vec::new();
+        for event in ctx.events_of_type(POOL_MANAGER_SOURCE, "Swap") {
+            let pool_id = event.extract_bytes32("id")?;
+
+            let known = {
+                let ids = self.migration_pool_ids.read().unwrap();
+                ids.contains(pool_id.as_slice())
+            };
+            if !known {
+                continue;
+            }
+
+            swaps.push(SwapInput {
+                pool_id: pool_id.to_vec(),
+                block_number: event.block_number,
+                block_timestamp: event.block_timestamp,
+                log_index: event.log_index,
+                amount0: event.extract_int256("amount0")?,
+                amount1: event.extract_int256("amount1")?,
+                sqrt_price_x96: event.extract_uint256("sqrtPriceX96")?,
+                tick: event.extract_i32_flexible("tick")?,
+                liquidity: event.extract_uint256("liquidity")?,
+            });
+        }
+
+        if swaps.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        refresh_cache_if_needed(
+            swaps.iter().map(|s| &s.pool_id),
+            &self.metadata_cache,
+            &self.db_pool,
+            self.chain_id,
+            &ctx.contracts,
+        )
+        .await?;
+
+        Ok(process_swaps(&swaps, &self.metadata_cache, ctx.chain_id))
+    }
+
+    async fn initialize(&self, db_pool: &DbPool) -> Result<(), TransformationError> {
+        self.db_pool.set(db_pool.inner().clone()).ok();
+        self.metadata_cache
+            .load_into(db_pool, self.chain_id)
+            .await?;
+
+        // Seed the migration pool ID set from pools that have already graduated.
+        let client = db_pool.inner().get().await?;
+        let rows = client
+            .query(
+                "SELECT p.address \
+                 FROM pools p \
+                 JOIN active_versions av \
+                   ON p.source = av.source AND p.source_version = av.active_version \
+                 WHERE p.chain_id = $1 AND p.migrated_from IS NOT NULL",
+                &[&(self.chain_id as i64)],
+            )
+            .await?;
+
+        let mut ids = self.migration_pool_ids.write().unwrap();
+        for row in &rows {
+            let address: Vec<u8> = row.get("address");
+            ids.insert(address);
+        }
+
+        tracing::info!(
+            count = ids.len(),
+            chain_id = self.chain_id,
+            "MigrationPoolSwapMetricsHandler initialized"
+        );
+        Ok(())
+    }
+}
+
+impl EventHandler for MigrationPoolSwapMetricsHandler {
+    fn triggers(&self) -> Vec<EventTrigger> {
+        vec![EventTrigger::new(
+            POOL_MANAGER_SOURCE,
+            "Swap(bytes32,address,int128,int128,uint160,uint128,int24,uint24)",
+        )]
+    }
+
+    fn handler_dependencies(&self) -> Vec<&'static str> {
+        vec!["MigrationPoolCreateHandler"]
+    }
+}
+
+// ─── Liquidity handler ─────────────────────────────────────────────────────────
+
+pub struct MigrationPoolLiquidityMetricsHandler {
+    chain_id: u64,
+}
+
+#[async_trait]
+impl TransformationHandler for MigrationPoolLiquidityMetricsHandler {
+    fn name(&self) -> &'static str {
+        "MigrationPoolLiquidityMetricsHandler"
+    }
+
+    fn version(&self) -> u32 {
+        1
+    }
+
+    fn migration_paths(&self) -> Vec<&'static str> {
+        vec!["migrations/tables/liquidity_deltas.sql"]
+    }
+
+    fn reorg_tables(&self) -> Vec<&'static str> {
+        vec!["liquidity_deltas"]
+    }
+
+    async fn handle(
+        &self,
+        ctx: &TransformationContext,
+    ) -> Result<Vec<DbOperation>, TransformationError> {
+        let deltas = extract_tuple_modify_liquidity(ctx, MIGRATOR_HOOK_SOURCE)?;
+        Ok(process_liquidity_deltas(&deltas, self.chain_id))
+    }
+}
+
+impl EventHandler for MigrationPoolLiquidityMetricsHandler {
+    fn triggers(&self) -> Vec<EventTrigger> {
+        vec![EventTrigger::new(
+            MIGRATOR_HOOK_SOURCE,
+            "ModifyLiquidity((address,address,uint24,int24,address),(int24,int24,int256,bytes32))",
+        )]
+    }
+
+    fn handler_dependencies(&self) -> Vec<&'static str> {
+        vec!["MigrationPoolCreateHandler"]
+    }
+}
+
+// ─── Registration ──────────────────────────────────────────────────────────────
+
+pub fn register_handlers(
+    registry: &mut TransformationRegistry,
+    chain_id: u64,
+    cache: Arc<PoolMetadataCache>,
+) {
+    registry.register_event_handler(MigrationPoolSwapMetricsHandler {
+        metadata_cache: cache,
+        decimals_init: Once::new(),
+        chain_id,
+        db_pool: OnceLock::new(),
+        migration_pool_ids: RwLock::new(HashSet::new()),
+    });
+    registry.register_event_handler(MigrationPoolLiquidityMetricsHandler { chain_id });
+}

--- a/src/transformations/event/migration_pool/mod.rs
+++ b/src/transformations/event/migration_pool/mod.rs
@@ -1,0 +1,2 @@
+pub mod create;
+pub mod metrics;

--- a/src/transformations/event/mod.rs
+++ b/src/transformations/event/mod.rs
@@ -16,9 +16,27 @@ use std::sync::Arc;
 
 use super::registry::TransformationRegistry;
 use super::util::pool_metadata::PoolMetadataCache;
+use crate::types::config::contract::Contracts;
 
 /// Register all event handlers with the registry.
 pub fn register_handlers(registry: &mut TransformationRegistry, chain_id: u64) {
+    register_handlers_inner(registry, chain_id, None);
+}
+
+/// Register event handlers filtered by the chain's configured contracts.
+pub fn register_handlers_for_chain(
+    registry: &mut TransformationRegistry,
+    chain_id: u64,
+    contracts: &Contracts,
+) {
+    register_handlers_inner(registry, chain_id, Some(contracts));
+}
+
+fn register_handlers_inner(
+    registry: &mut TransformationRegistry,
+    chain_id: u64,
+    contracts: Option<&Contracts>,
+) {
     derc20_transfer::register_handlers(registry);
     v4::create::register_handlers(registry);
     multicurve::create::register_handlers(registry);
@@ -54,8 +72,16 @@ pub fn register_handlers(registry: &mut TransformationRegistry, chain_id: u64) {
     let v4_base_cache = Arc::new(PoolMetadataCache::new());
     v4::metrics::register_handlers(registry, chain_id, v4_base_cache);
 
-    // Migration pool (graduated Doppler V4 pools on UniswapV4PoolManager)
-    migration_pool::create::register_handlers(registry);
-    let migration_pool_cache = Arc::new(PoolMetadataCache::new());
-    migration_pool::metrics::register_handlers(registry, chain_id, migration_pool_cache);
+    // Register migration pool handlers as a group only on chains with a V4
+    // migrator. The swap handler depends on MigrationPoolCreateHandler, so
+    // letting source filtering split them apart can leave a dangling dependency
+    // on PoolManager-only chains.
+    let register_migration_pool_handlers = contracts
+        .map(|contracts| contracts.contains_key("UniswapV4Migrator"))
+        .unwrap_or(true);
+    if register_migration_pool_handlers {
+        migration_pool::create::register_handlers(registry);
+        let migration_pool_cache = Arc::new(PoolMetadataCache::new());
+        migration_pool::metrics::register_handlers(registry, chain_id, migration_pool_cache);
+    }
 }

--- a/src/transformations/event/mod.rs
+++ b/src/transformations/event/mod.rs
@@ -6,6 +6,7 @@ pub mod decay_multicurve;
 pub mod derc20_transfer;
 pub mod dhook;
 pub mod metrics;
+pub mod migration_pool;
 pub mod multicurve;
 pub mod scheduled_multicurve;
 pub mod v3;
@@ -52,4 +53,9 @@ pub fn register_handlers(registry: &mut TransformationRegistry, chain_id: u64) {
     // V4 base (DopplerV4Hook) — sequential handler, own cache
     let v4_base_cache = Arc::new(PoolMetadataCache::new());
     v4::metrics::register_handlers(registry, chain_id, v4_base_cache);
+
+    // Migration pool (graduated Doppler V4 pools on UniswapV4PoolManager)
+    migration_pool::create::register_handlers(registry);
+    let migration_pool_cache = Arc::new(PoolMetadataCache::new());
+    migration_pool::metrics::register_handlers(registry, chain_id, migration_pool_cache);
 }

--- a/src/transformations/registry.rs
+++ b/src/transformations/registry.rs
@@ -726,7 +726,7 @@ pub fn build_registry_for_chain(
     let mut registry = TransformationRegistry::with_source_filter(available);
 
     // Register event handlers (filtered by available sources)
-    super::event::register_handlers(&mut registry, chain_id);
+    super::event::register_handlers_for_chain(&mut registry, chain_id, contracts);
 
     // Register eth_call handlers (filtered by available sources)
     super::eth_call::register_handlers(&mut registry);
@@ -1262,5 +1262,55 @@ mod tests {
         let mut registry = TransformationRegistry::new();
         registry.register_event_handler(mock_handler("X", vec![]));
         registry.register_call_handler(MockCallHandler { name: "X" });
+    }
+
+    #[test]
+    fn build_registry_for_chain_skips_migration_pool_handlers_without_migrator() {
+        use crate::types::config::contract::{AddressOrAddresses, ContractConfig};
+        use alloy_primitives::Address;
+
+        let mut contracts = Contracts::new();
+        contracts.insert(
+            "UniswapV4PoolManager".to_string(),
+            ContractConfig {
+                address: AddressOrAddresses::Single(Address::ZERO),
+                start_block: None,
+                calls: None,
+                factories: None,
+                events: None,
+            },
+        );
+
+        let registry = build_registry_for_chain(1, &contracts, &empty_factory_collections());
+
+        assert!(registry
+            .handler_key_for_name("MigrationPoolCreateHandler")
+            .is_none());
+        assert!(registry
+            .handler_key_for_name("MigrationPoolSwapMetricsHandler")
+            .is_none());
+        assert!(registry
+            .handler_key_for_name("MigrationPoolLiquidityMetricsHandler")
+            .is_none());
+    }
+
+    #[test]
+    fn build_registry_declares_all_migration_pool_create_dependencies() {
+        let registry = build_registry(1);
+        let deps = registry
+            .handler_dependency_graph()
+            .get("MigrationPoolCreateHandler")
+            .expect("MigrationPoolCreateHandler should be registered");
+
+        assert_eq!(
+            deps,
+            &vec![
+                "V4CreateHandler".to_string(),
+                "V4MulticurveCreateHandler".to_string(),
+                "V4ScheduledMulticurveCreateHandler".to_string(),
+                "V4DecayMulticurveCreateHandler".to_string(),
+                "DopplerHookCreateHandler".to_string(),
+            ]
+        );
     }
 }

--- a/src/transformations/util/db/pool.rs
+++ b/src/transformations/util/db/pool.rs
@@ -130,3 +130,88 @@ pub fn insert_pool(data: &PoolData, ctx: &TransformationContext) -> DbOperation 
         ],
     }
 }
+
+/// Domain data for inserting a migration pool record into the database.
+///
+/// Migration pools are graduated Doppler V4 pools that now trade as standard
+/// UniswapV4 pools. Their metadata (tokens, fee, integrator) is inherited from
+/// the original Doppler pool.
+pub struct MigrationPoolData<'a> {
+    pub block_number: u64,
+    pub block_timestamp: u64,
+    /// The new migration pool's bytes32 pool ID.
+    pub pool_id: &'a [u8; 32],
+    pub base_token: [u8; 20],
+    pub quote_token: [u8; 20],
+    pub is_token_0: bool,
+    pub integrator: [u8; 20],
+    pub initializer: [u8; 20],
+    pub fee: u32,
+    /// The original Doppler V4 pool's bytes32 address stored in `pools.address`.
+    pub migrated_from: &'a [u8],
+}
+
+/// Insert a migration pool row into the `pools` table.
+///
+/// Uses ON CONFLICT DO NOTHING so reprocessing is idempotent.
+pub fn insert_migration_pool(
+    data: &MigrationPoolData<'_>,
+    ctx: &crate::transformations::TransformationContext,
+) -> DbOperation {
+    DbOperation::Upsert {
+        table: "pools".to_string(),
+        conflict_columns: vec!["chain_id".to_string(), "address".to_string()],
+        update_columns: vec![],
+        update_condition: None,
+        columns: vec![
+            "chain_id".to_string(),
+            "block_number".to_string(),
+            "created_at".to_string(),
+            "address".to_string(),
+            "base_token".to_string(),
+            "quote_token".to_string(),
+            "is_token_0".to_string(),
+            "type".to_string(),
+            "integrator".to_string(),
+            "initializer".to_string(),
+            "fee".to_string(),
+            "min_threshold".to_string(),
+            "max_threshold".to_string(),
+            "migrator".to_string(),
+            "migrated_at".to_string(),
+            "migration_pool".to_string(),
+            "migrated_from".to_string(),
+            "migration_type".to_string(),
+            "lock_duration".to_string(),
+            "beneficiaries".to_string(),
+            "pool_key".to_string(),
+            "starting_time".to_string(),
+            "ending_time".to_string(),
+        ],
+        values: vec![
+            DbValue::Int64(ctx.chain_id as i64),
+            DbValue::Uint64(data.block_number),
+            DbValue::Timestamp(data.block_timestamp as i64),
+            DbValue::Bytes32(*data.pool_id),
+            DbValue::Address(data.base_token),
+            DbValue::Address(data.quote_token),
+            DbValue::Bool(data.is_token_0),
+            DbValue::VarChar("migration_v4".to_string()),
+            DbValue::Address(data.integrator),
+            DbValue::Address(data.initializer),
+            DbValue::Int32(data.fee as i32),
+            DbValue::Null, // min_threshold
+            DbValue::Null, // max_threshold
+            DbValue::Null, // migrator
+            DbValue::Null, // migrated_at
+            DbValue::Null, // migration_pool
+            DbValue::Bytes(data.migrated_from.to_vec()),
+            DbValue::VarChar("v4".to_string()), // migration_type
+            DbValue::Null,                       // lock_duration
+            DbValue::Null,                       // beneficiaries
+            DbValue::Null,                       // pool_key
+            DbValue::Timestamp(data.block_timestamp as i64), // starting_time = migration time
+            DbValue::Timestamp(data.block_timestamp as i64), // ending_time = migration time
+        ],
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `MigrationPoolCreateHandler`, `MigrationPoolSwapMetricsHandler`, and `MigrationPoolLiquidityMetricsHandler` for graduated Doppler V4 pools that trade as standard UniswapV4 pools after migration.
- Create handler processes `UniswapV4Migrator.Migrate` events, queries the original Doppler pool metadata, and inserts a new `pools` row with `migrated_from` set.
- Swap handler filters `UniswapV4PoolManager.Swap` events to known migration pool IDs. The ID set is seeded at init and refreshed from the DB on each `handle()` invocation to discover pools that graduate during catchup.
- Liquidity handler processes `UniswapV4MigratorHook.ModifyLiquidity` (tuple format) using the shared `extract_tuple_modify_liquidity` extractor.
- Adds `MigrationPoolData` and `insert_migration_pool()` to `util/db/pool.rs`.

## Why

Graduated pools were previously invisible to the metrics pipeline — no price snapshots, no OHLC, no liquidity deltas. This completes Phase 5 of the pool metrics roadmap.