### PR TITLE
docs: add database and metrics feature docs, update for DAG scheduler

### DIFF
--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -14,7 +14,7 @@ Operating modes: Full (historical + live), Decode-Only (`--decode-only`), Live-O
 |-----------|-------------|
 | **Raw Data Collection** | Fetches blocks, receipts, logs, factory addresses, and eth_call results from EVM chains |
 | **Decoding** | Parses raw log and eth_call data into typed columns using Solidity ABI signatures |
-| **Transformations** | Custom Rust handlers process decoded data and write to PostgreSQL with per-handler progress |
+| **Transformations** | Custom Rust handlers process decoded data and write to PostgreSQL with DAG-based dependency scheduling and per-handler progress |
 | **Live Mode** | Real-time block processing via WebSocket with reorg detection and bincode-to-parquet compaction |
 | **RPC Layer** | Unified RPC client with sliding-window rate limiting, streaming, and batch support |
 | **S3 Storage** | Optional S3-compatible storage with write-through caching and manifest management |
@@ -135,8 +135,8 @@ migrations/
 - **doc**: `docs/features/decoding.md`
 
 ### transformations
-- **description**: Custom Rust handlers process decoded events/calls and produce PostgreSQL operations. Per-handler progress tracking, version injection, and transactional execution.
-- **entry_points**: `src/transformations/traits.rs`, `src/transformations/registry.rs`, `src/transformations/engine.rs`, `src/transformations/executor.rs`
+- **description**: Custom Rust handlers process decoded events/calls and produce PostgreSQL operations. DAG-based catchup with dependency-aware pipelined execution. Per-handler progress tracking, version injection, sequential execution support, and transactional execution with deadlock retry.
+- **entry_points**: `src/transformations/traits.rs`, `src/transformations/registry.rs`, `src/transformations/engine.rs`, `src/transformations/executor.rs`, `src/transformations/scheduler/`
 - **depends_on**: [decoding, database]
 - **doc**: `docs/features/transformations.md`
 
@@ -183,16 +183,16 @@ migrations/
 - **doc**: `docs/features/parallelism.md`
 
 ### database
-- **description**: PostgreSQL connection pool (deadpool_postgres), migration runner, typed DbOperation/DbValue/WhereClause abstractions, and structured error types.
+- **description**: PostgreSQL connection pool (deadpool_postgres), migration runner, typed DbOperation/DbValue/WhereClause abstractions, deadlock retry, and structured error types.
 - **entry_points**: `src/db/`
 - **depends_on**: []
-- **doc**: *(no feature doc yet)*
+- **doc**: `docs/features/database.md`
 
 ### metrics
-- **description**: Prometheus metrics server exposing RPC counters, histograms, and pipeline observability metrics via HTTP endpoint.
+- **description**: Prometheus metrics server exposing RPC, live mode, collection, and transformation observability metrics via HTTP endpoint. RAII guards for safe in-flight tracking.
 - **entry_points**: `src/metrics/`
 - **depends_on**: [rpc]
-- **doc**: *(no feature doc yet)*
+- **doc**: `docs/features/metrics.md`
 
 ---
 
@@ -209,7 +209,7 @@ src/
 ├── live/                # Live mode (collector, storage, compaction, reorg, progress)
 ├── storage/             # S3 storage (local, s3, cached, manifest, upload, retry, contract_index)
 ├── metrics/             # Prometheus metrics server and RPC metrics
-├── transformations/     # Transformation engine, handlers, registry, utils
+├── transformations/     # Transformation engine, handlers, registry, scheduler, utils
 └── types/               # Config types, shared types, decoded value types
 ```
 

--- a/docs/features/database.md
+++ b/docs/features/database.md
@@ -1,0 +1,312 @@
+# Database Module
+
+The database module provides a PostgreSQL connection pool, typed operation builder, migration system, and deadlock-resilient transaction execution. It is the sole interface through which the indexer persists transformed blockchain data.
+
+## Scope
+
+- Connection pool management via `deadpool_postgres`
+- Typed SQL operation construction (insert, upsert, update, delete, raw SQL)
+- Atomic transaction execution with automatic deadlock retry
+- Snapshot reads within a transaction (pre-modification state)
+- System and handler migration management
+- Structured error types with detailed PostgreSQL error formatting
+
+## Non-Scope
+
+- Query planning or ORM functionality -- SQL is generated from typed operations, not a query DSL
+- Schema design -- table schemas are defined in migration files, not in Rust types
+- Connection encryption -- connections use `NoTls` (TLS is not configured)
+- Read replicas or multi-database routing
+
+## Module Structure
+
+```
+src/db/
+├── mod.rs         # Public exports: DbError, DbPool, DbOperation, DbValue, WhereClause
+├── pool.rs        # DbPool struct, transaction execution, SQL generation, deadlock retry
+├── types.rs       # DbOperation, DbValue, WhereClause enums
+├── error.rs       # DbError enum with detailed PostgreSQL formatting
+└── migrations.rs  # System and handler migration runner
+
+migrations/
+├── 000_handler_progress.sql   # _handler_progress tracking table
+├── 001_active_versions.sql    # _active_versions tracking table
+└── 002_live_progress.sql      # _live_progress tracking table
+```
+
+## Data Flow
+
+### Write Path
+
+1. Transformation handlers produce `Vec<DbOperation>` from decoded blockchain data.
+2. The transformation engine calls `DbPool::execute_transaction(operations)`.
+3. `execute_transaction` delegates to `try_execute_transaction`, which:
+   a. Acquires a connection from the pool.
+   b. Opens a PostgreSQL transaction.
+   c. For each `DbOperation`, calls `build_operation_sql()` to produce a SQL string and `Vec<SqlParam>`.
+   d. Executes each statement within the transaction.
+   e. Commits the transaction.
+4. If step 3 fails with PostgreSQL error code `40P01` (deadlock detected), the entire transaction is retried up to `DEADLOCK_MAX_RETRIES` (3) times with exponential backoff starting at 50ms.
+
+### Snapshot Read Path
+
+1. The metrics/snapshot system calls `execute_transaction_with_snapshot_reads(snapshot_specs, operations)`.
+2. Inside a single transaction:
+   a. Snapshot queries run first, reading committed state before any modifications.
+   b. Write operations execute, each returning an affected row count.
+3. The transaction commits and returns `(Vec<Option<Vec<(String, DbValue)>>>, Vec<u64>)` -- snapshot results and per-operation affected row counts.
+4. This method does not have deadlock retry (it is expected to be called from contexts where deadlocks are unlikely).
+
+### Migration Path
+
+1. On startup, `DbPool::run_migrations()` is called:
+   a. Creates `_migrations` table if it does not exist (id, name, applied_at).
+   b. Reads all `.sql` files from `migrations/` directory, sorted by filename.
+   c. Skips already-applied migrations (tracked by name in `_migrations`).
+   d. Each new migration runs in its own transaction and is recorded in `_migrations`.
+2. Then `DbPool::run_handler_migrations(registry)` is called:
+   a. Iterates all handlers in the registry, collecting `migration_paths()`.
+   b. Deduplicates paths via `HashSet` to prevent double-execution when multiple handlers share migration files.
+   c. Supports both individual `.sql` files and directories of `.sql` files (sorted by filename within each directory).
+   d. Each migration runs in its own transaction and is recorded in `_migrations` using the full path as the name.
+   e. Missing paths produce a warning log but do not fail.
+3. All handler migrations run globally (once) before any per-chain engine spawning.
+
+## DbPool
+
+### Constructor
+
+```rust
+pub async fn new(database_url: &str) -> Result<Self, DbError>
+```
+
+- Parses the connection string into `tokio_postgres::Config`.
+- Creates a `deadpool_postgres` pool with `RecyclingMethod::Fast`.
+- Pool size: `DB_POOL_SIZE` env var, default 16.
+- Validates the connection by acquiring and releasing one connection immediately.
+- Fails fast on invalid connection strings with `DbError::InvalidConnectionString`.
+
+### Key Methods
+
+| Method | Description |
+|--------|-------------|
+| `execute_transaction(ops)` | Atomic multi-operation execution with deadlock retry |
+| `execute_transaction_with_snapshot_reads(specs, ops)` | Reads pre-modification state inside transaction, returns snapshots and affected row counts |
+| `query(sql, params)` | Raw parameterized query returning `Vec<Row>` |
+| `query_row(table, key_columns)` | Single row lookup by key columns, returns `Option<Vec<(String, DbValue)>>` |
+| `run_migrations()` | Runs system migrations from `migrations/` directory |
+| `run_handler_migrations(registry)` | Runs handler-declared migrations from the transformation registry |
+| `inner()` | Returns a reference to the underlying `deadpool_postgres::Pool` |
+
+### Deadlock Retry
+
+- Triggered only by PostgreSQL error code `40P01` (`T_R_DEADLOCK_DETECTED`).
+- Maximum 3 retries (4 total attempts including the initial one).
+- Exponential backoff: 50ms, 100ms, 200ms.
+- The `is_deadlock()` helper inspects `DbError::PostgresError` variants for the specific SQL state.
+
+## DbValue
+
+Typed representation of values that can be stored in PostgreSQL. Each variant maps to a specific PostgreSQL type.
+
+| Variant | Rust Type | PostgreSQL Type | SQL Placeholder |
+|---------|-----------|----------------|-----------------|
+| `Null` | -- | NULL | `$N` |
+| `Bool(bool)` | `bool` | BOOLEAN | `$N` |
+| `Int64(i64)` | `i64` | BIGINT | `$N` |
+| `Int32(i32)` | `i32` | INTEGER | `$N` |
+| `Int2(i16)` | `i16` | SMALLINT | `$N` |
+| `Uint64(u64)` | `u64` | BIGINT (cast to i64) | `$N` |
+| `Text(String)` | `String` | TEXT | `$N` |
+| `VarChar(String)` | `String` | VARCHAR | `$N` |
+| `Bytes(Vec<u8>)` | `Vec<u8>` | BYTEA | `$N` |
+| `Address([u8; 20])` | `[u8; 20]` | BYTEA | `$N` |
+| `Bytes32([u8; 32])` | `[u8; 32]` | BYTEA | `$N` |
+| `Numeric(String)` | `String` | NUMERIC | `$N::text::numeric` |
+| `Timestamp(i64)` | `i64` (unix seconds) | TIMESTAMP | `to_timestamp($N)` |
+| `Json(Value)` | `serde_json::Value` | JSON | `$N` |
+| `JsonB(Value)` | `serde_json::Value` | JSONB | `$N::jsonb` |
+| `Float64(f64)` | `f64` | FLOAT8 | `$N` |
+
+### Convenience Constructors
+
+- `DbValue::jsonb<T: Serialize>(value)` -- serializes any `Serialize` type into a `JsonB` variant.
+- `DbValue::json<T: Serialize>(value)` -- serializes any `Serialize` type into a `Json` variant.
+
+### Value Conversion
+
+`DbValue` is converted to `SqlParam` (an internal enum that implements `ToSql`) before being passed to `tokio_postgres`. Notable conversions:
+
+- `Uint64(v)` is cast to `i64` (potential overflow for values > `i64::MAX`).
+- `Address` and `Bytes32` are converted to `Vec<u8>`.
+- `Numeric` is sent as text and cast by PostgreSQL via `::text::numeric`.
+- `Timestamp` is sent as `f64` and wrapped in `to_timestamp()`.
+
+### Row Extraction
+
+When reading rows back from PostgreSQL (via `query_row` or snapshot reads), the `extract_db_value_from_row` function maps PostgreSQL column types back to `DbValue` variants:
+
+- `BOOL` -> `Bool`
+- `INT8` -> `Int64`
+- `INT4` -> `Int32`
+- `INT2` -> `Int2`
+- `FLOAT8` -> `Float64`
+- `TEXT`, `VARCHAR` -> `Text`
+- `BYTEA` -> `Bytes`
+- `NUMERIC` -> `Numeric` (via `rust_decimal::Decimal` with string fallback)
+- `TIMESTAMP`, `TIMESTAMPTZ` -> `Timestamp` (unix seconds via `SystemTime`)
+- `JSON`, `JSONB` -> `JsonB`
+- Unknown types -> attempts `Bytes`, then `Text`, then `Null`
+
+## DbOperation
+
+Typed enum representing SQL write operations.
+
+### Variants
+
+**Upsert** -- `INSERT ... ON CONFLICT DO UPDATE`:
+```rust
+Upsert {
+    table: String,
+    columns: Vec<String>,
+    values: Vec<DbValue>,
+    conflict_columns: Vec<String>,    // Unique constraint columns
+    update_columns: Vec<String>,      // Columns to update on conflict
+    update_condition: Option<String>,  // Optional WHERE on DO UPDATE
+}
+```
+- If `update_columns` is empty, generates `ON CONFLICT DO NOTHING`.
+- If `update_condition` is provided, adds a `WHERE` clause to the `DO UPDATE SET` (e.g., conditional updates based on block number).
+
+**Insert** -- simple `INSERT INTO`:
+```rust
+Insert {
+    table: String,
+    columns: Vec<String>,
+    values: Vec<DbValue>,
+}
+```
+
+**Update** -- `UPDATE ... SET ... WHERE`:
+```rust
+Update {
+    table: String,
+    set_columns: Vec<(String, DbValue)>,
+    where_clause: WhereClause,
+}
+```
+
+**Delete** -- `DELETE FROM ... WHERE`:
+```rust
+Delete {
+    table: String,
+    where_clause: WhereClause,
+}
+```
+
+**RawSql** -- arbitrary parameterized SQL:
+```rust
+RawSql {
+    query: String,
+    params: Vec<DbValue>,
+}
+```
+
+## WhereClause
+
+Typed enum for building WHERE conditions.
+
+| Variant | SQL Output |
+|---------|-----------|
+| `Eq(col, val)` | `"col" = $N` |
+| `And(vec)` | `"col1" = $N AND "col2" = $M AND ...` |
+| `Raw { condition, params }` | Raw SQL condition with parameterized values |
+
+## SQL Generation
+
+All SQL is generated by internal `build_*_sql` functions using a `QueryBuilder` struct that tracks parameter indices automatically.
+
+Key properties:
+- **All column names are double-quoted** via `quote_ident()` to handle PostgreSQL reserved keywords.
+- **Parameter indices are 1-based** and managed automatically by `QueryBuilder`.
+- **Type-specific placeholders** are generated by `placeholder_for()` (see the DbValue table above).
+- Upsert uses `EXCLUDED.column` references in the `DO UPDATE SET` clause.
+
+## DbError
+
+Structured error type using `thiserror`.
+
+| Variant | Source | Description |
+|---------|--------|-------------|
+| `PoolError` | `deadpool_postgres::PoolError` | Connection pool exhaustion or checkout failure |
+| `PostgresError` | `tokio_postgres::Error` | SQL execution errors with detailed formatting |
+| `BuildError` | `deadpool_postgres::BuildError` | Pool construction failure |
+| `ConfigError` | `String` | Configuration errors |
+| `MigrationError` | `String` | Migration execution or tracking errors |
+| `IoError` | `std::io::Error` | File I/O errors (reading migration files) |
+| `InvalidConnectionString` | `String` | Malformed database URL |
+
+### PostgreSQL Error Formatting
+
+`PostgresError` uses a custom `format_pg_error` function that extracts structured details from `tokio_postgres::Error`:
+- Error code (e.g., `23505` for unique violation)
+- Message
+- Detail (if present)
+- Hint (if present)
+- Table name (if present)
+- Column name (if present)
+- Constraint name (if present)
+
+Example output:
+```
+PostgreSQL error [23505]: duplicate key value violates unique constraint "pools_pkey"
+  Detail: Key (chain_id, pool_address)=(1, \x1234...) already exists.
+  Table: v3_pools_v1
+  Constraint: pools_pkey
+```
+
+## Migration System
+
+### System Migrations
+
+Located in `migrations/` directory. Tracked in the `_migrations` table with columns:
+- `id SERIAL PRIMARY KEY`
+- `name VARCHAR(255) NOT NULL UNIQUE`
+- `applied_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()`
+
+Current system migrations:
+- `000_handler_progress.sql` -- creates `_handler_progress` table for per-handler transformation progress tracking
+- `001_active_versions.sql` -- creates `_active_versions` table for tracking active handler versions
+- `002_live_progress.sql` -- creates `_live_progress` table for live mode progress tracking
+
+### Handler Migrations
+
+Declared by transformation handlers via `migration_paths()` method. Each handler can return paths to individual `.sql` files or directories containing `.sql` files.
+
+Properties:
+- Deduplication via `HashSet<PathBuf>` prevents the same migration from running twice when multiple handlers reference the same path.
+- Directory entries are sorted by filename for deterministic ordering.
+- Missing paths log a warning but do not cause failure.
+- Migration names in `_migrations` use the full filesystem path (e.g., `migrations/handlers/v3/000_create_pools.sql`).
+- All handler migrations execute globally at startup, not per-chain.
+
+## Invariants and Constraints
+
+1. **Column quoting**: All column names in generated SQL are double-quoted. This is unconditional and applies to all operations.
+2. **Transaction atomicity**: All operations within a single `execute_transaction` call succeed or fail together.
+3. **Deadlock retry scope**: Only PostgreSQL `40P01` errors trigger retry. All other errors propagate immediately.
+4. **Snapshot consistency**: Snapshot reads in `execute_transaction_with_snapshot_reads` see committed state before any writes in the same transaction because reads execute first.
+5. **Migration idempotency**: Migrations are tracked by name and skipped if already applied. Re-running migrations is safe.
+6. **Migration deduplication**: Handler migration paths are deduplicated before execution. Two handlers declaring the same migration path will not cause double-execution.
+7. **Pool validation**: `DbPool::new` acquires and releases a connection immediately, failing fast on unreachable databases or invalid credentials.
+8. **Uint64 overflow**: `DbValue::Uint64` is cast to `i64` for PostgreSQL `BIGINT`. Values exceeding `i64::MAX` will overflow silently.
+9. **No TLS**: Connections use `NoTls`. This is appropriate for localhost or VPC-internal databases but not for connections over the public internet.
+
+## Dependencies
+
+- `deadpool-postgres` -- async connection pool
+- `tokio-postgres` -- async PostgreSQL driver
+- `rust_decimal` -- NUMERIC column extraction
+- `serde_json` -- JSON/JSONB value handling
+- `thiserror` -- structured error derivation
+- `bytes` -- `BytesMut` for `ToSql` implementation

--- a/docs/features/metrics.md
+++ b/docs/features/metrics.md
@@ -1,0 +1,260 @@
+# Metrics / Observability
+
+Prometheus-based observability subsystem that exposes operational metrics about the indexer pipeline via an HTTP endpoint.
+
+**Important disambiguation:** This document covers the *infrastructure observability* module at `src/metrics/`. The similarly named files at `src/transformations/event/*/metrics.rs` are *domain-specific transformation handlers* that compute pool state, snapshots, and liquidity deltas from on-chain swap/mint/burn events. Those are documented in the [transformations](transformations.md) feature doc.
+
+## Scope
+
+- Prometheus metric registration and HTTP exposition via `metrics-exporter-prometheus`
+- RPC request instrumentation: duration histograms, request/error counters, in-flight gauges
+- Live mode instrumentation: WebSocket disconnects, reorg depth, compaction cycles, block arrival intervals
+- Collection instrumentation: parquet writes, block processing, eth_call batches
+- Transformation instrumentation: handler duration, events/calls processed, retry tracking, handler concurrency
+- RAII guard pattern for safe metric lifecycle (in-flight tracking, duration recording)
+- Convenience `with_metrics()` async wrapper for ergonomic instrumentation
+- Chain label extraction and sanitization from RPC URLs
+- Configuration: optional metrics server enabled via `MetricsConfig` in the indexer config
+
+## Non-scope
+
+- Pool metrics handlers (swap metrics, liquidity deltas, OHLC snapshots) -- those are transformation handlers, not observability
+- Application-level dashboards or alerting rules
+
+## Data / Control Flow
+
+### Initialization
+
+```
+main.rs
+  |
+  +--> config.metrics is Some?
+         |
+         +--> metrics::init_metrics_server(addr)
+         |      |
+         |      +--> PrometheusBuilder::new()
+         |             .with_http_listener(addr)
+         |             .install()
+         |
+         +--> metrics::describe_rpc_metrics()
+                |
+                +--> describe_histogram!("rpc_request_duration_seconds", ...)
+                +--> describe_counter!("rpc_requests_total", ...)
+                +--> describe_counter!("rpc_errors_total", ...)
+                +--> describe_gauge!("rpc_requests_in_flight", ...)
+```
+
+`init_metrics_server` installs the global Prometheus recorder and spawns an HTTP server that serves metrics at the `/metrics` endpoint. `describe_rpc_metrics` registers human-readable descriptions for all RPC metric names. Both are called exactly once during startup, before any RPC calls occur.
+
+### RPC Request Instrumentation
+
+Every RPC call in `AlchemyClient` (the primary production client) is wrapped with `with_metrics()`:
+
+```
+AlchemyClient::get_block(block_number)
+  |
+  +--> with_metrics(RpcMethod::GetBlock, &chain_label, || async { ... })
+         |
+         +--> RpcMetricsGuard::new(method, chain)
+         |      |
+         |      +--> gauge!("rpc_requests_in_flight").increment(1.0)
+         |
+         +--> operation().await
+         |
+         +--> match result:
+                Ok(_)  => guard.success()
+                           |
+                           +--> histogram!("rpc_request_duration_seconds", status="success").record(duration)
+                           +--> counter!("rpc_requests_total", status="success").increment(1)
+                           +--> gauge!("rpc_requests_in_flight").decrement(1.0)
+                |
+                Err(e) => guard.failure(&e)
+                           |
+                           +--> counter!("rpc_errors_total", error_type=category).increment(1)
+                           +--> histogram!("rpc_request_duration_seconds", status="error").record(duration)
+                           +--> counter!("rpc_requests_total", status="error").increment(1)
+                           +--> gauge!("rpc_requests_in_flight").decrement(1.0)
+```
+
+If the guard is dropped without calling `success()` or `failure()` (e.g., due to a panic), the `Drop` impl still decrements the in-flight gauge, preventing counter leaks.
+
+### Chain Label Extraction
+
+`chain_label_from_url(url)` produces sanitized Prometheus-safe label values from RPC endpoint URLs:
+
+| URL pattern | Label |
+|---|---|
+| `https://eth-mainnet.g.alchemy.com/v2/...` | `alchemy_eth_mainnet` |
+| `https://base-mainnet.g.alchemy.com/v2/...` | `alchemy_base_mainnet` |
+| `https://mainnet.infura.io/v3/...` | `infura_mainnet` |
+| `https://rpc.ankr.com/eth` | `rpc_ankr_com` |
+
+Dots and hyphens in hostnames are replaced with underscores. For Alchemy and Infura, the subdomain is extracted and prefixed with the provider name.
+
+## Live Mode Metrics
+
+`describe_live_metrics()` registers metrics for the WebSocket-based live processing pipeline:
+
+| Name | Type | Labels | Description |
+|---|---|---|---|
+| `live_ws_disconnects_total` | counter | `chain` | WebSocket disconnection count |
+| `live_ws_reconnects_total` | counter | `chain` | WebSocket reconnection count |
+| `live_reorgs_total` | counter | `chain` | Chain reorganizations detected |
+| `live_reorg_depth` | histogram | `chain` | Depth of detected reorgs (blocks rolled back) |
+| `live_compaction_cycle_duration_seconds` | histogram | `chain` | Duration of compaction cycles |
+| `live_compaction_stuck_blocks` | gauge | `chain` | Blocks stuck awaiting transformation |
+| `live_compaction_blocks_pending` | gauge | `chain` | Blocks pending compaction |
+| `live_block_arrival_interval_seconds` | histogram | `chain` | Time between consecutive block arrivals |
+| `live_block_processing_duration_seconds` | histogram | `chain` | Time to process a single live block |
+| `live_blocks_processed_total` | counter | `chain` | Total live blocks processed |
+| `live_gap_detections_total` | counter | `chain` | Gap detections (missing block sequences) |
+| `live_backfill_duration_seconds` | histogram | `chain` | Duration of gap backfill operations |
+| `live_backfill_blocks_total` | counter | `chain` | Total blocks backfilled |
+
+## Collection Metrics
+
+`describe_collection_metrics()` registers metrics for raw data collection:
+
+| Name | Type | Labels | Description |
+|---|---|---|---|
+| `collection_blocks_processed_total` | counter | `chain` | Blocks processed during collection |
+| `collection_block_processing_duration_seconds` | histogram | `chain` | Per-block processing time |
+| `collection_block_transactions` | histogram | `chain` | Transaction count per block |
+| `collection_parquet_write_duration_seconds` | histogram | `chain`, `data_type` | Parquet file write duration |
+| `collection_parquet_file_size_bytes` | histogram | `chain`, `data_type` | Parquet file sizes |
+| `collection_eth_calls_total` | counter | `chain` | Total eth_calls executed |
+| `collection_eth_call_batch_duration_seconds` | histogram | `chain` | Eth_call batch duration |
+| `collection_receipts_processed_total` | counter | `chain` | Receipts processed |
+
+`record_parquet_write(chain, data_type, duration_secs, file_path)` records both the write duration and the resulting file size by reading file metadata.
+
+## Transformation Metrics
+
+`describe_transformation_metrics()` registers metrics for the handler execution pipeline:
+
+| Name | Type | Labels | Description |
+|---|---|---|---|
+| `transformation_handler_duration_seconds` | histogram | `handler_key`, `mode`, `status` | Handler execution time |
+| `transformation_handler_errors_total` | counter | `handler_key`, `error_type` | Handler error count |
+| `transformation_events_processed_total` | counter | `handler_key` | Events processed by handler |
+| `transformation_calls_processed_total` | counter | `handler_key` | Calls processed by handler |
+| `transformation_retry_attempts_total` | counter | `chain` | Live mode retry attempts |
+| `transformation_range_finalization_duration_seconds` | histogram | `chain` | Range finalization time |
+| `transformation_pending_events` | gauge | `chain` | Events buffered pending call dependencies |
+| `transformation_handlers_in_flight` | gauge | `handler_key`, `mode` | Handlers currently executing |
+
+**HandlerMetricsGuard** - RAII guard for handler execution: increments `transformation_handlers_in_flight` on creation, records `transformation_handler_duration_seconds` with status label on `success()`/`failure()`, decrements the gauge on drop. Labels include `handler_key` and `mode` (either `"catchup"` or `"live"`).
+
+## Related Files
+
+### Core metrics module
+
+| File | Role | Key exports |
+|---|---|---|
+| `src/metrics/mod.rs` | Module root, Prometheus server initialization | `init_metrics_server(addr: SocketAddr)`, re-exports from submodules |
+| `src/metrics/rpc.rs` | RPC request metrics: registration, RAII guard, async wrapper | `RpcMethod`, `RpcMetricsGuard`, `with_metrics()`, `describe_rpc_metrics()`, `chain_label_from_url()` |
+| `src/metrics/live.rs` | Live mode metrics registration | `describe_live_metrics()` |
+| `src/metrics/collection.rs` | Collection metrics registration and recording | `describe_collection_metrics()`, `record_parquet_write()` |
+| `src/metrics/transformations.rs` | Transformation metrics registration, RAII guard | `describe_transformation_metrics()`, `HandlerMetricsGuard` |
+
+### Configuration
+
+| File | Role | Key exports |
+|---|---|---|
+| `src/types/config/metrics.rs` | Metrics config deserialization | `MetricsConfig { addr: String }` |
+| `src/types/config/indexer.rs` | Top-level config, holds optional `MetricsConfig` | `IndexerConfig.metrics: Option<MetricsConfig>` |
+
+### Consumer (RPC client)
+
+| File | Role | Key exports |
+|---|---|---|
+| `src/rpc/alchemy.rs` | Primary production RPC client; wraps every RPC method with `with_metrics()` | `AlchemyClient` |
+
+### Pool metrics handlers (domain logic, not observability)
+
+These files are named `metrics.rs` but implement `TransformationHandler`/`EventHandler` traits to compute pool state from on-chain events. They are listed here only for disambiguation.
+
+| File | Role |
+|---|---|
+| `src/transformations/event/v3/metrics.rs` | V3 pool swap/liquidity metrics handlers |
+| `src/transformations/event/v4/metrics.rs` | V4 base hook cumulative swap metrics handler |
+| `src/transformations/event/multicurve/metrics.rs` | Multicurve swap/liquidity metrics handlers |
+| `src/transformations/event/dhook/metrics.rs` | Doppler hook swap/liquidity metrics handlers |
+| `src/transformations/event/scheduled_multicurve/metrics.rs` | Scheduled multicurve swap/liquidity metrics handlers |
+| `src/transformations/event/decay_multicurve/metrics.rs` | Decay multicurve swap/liquidity metrics handlers |
+| `src/transformations/event/metrics/mod.rs` | Shared metrics processing module root |
+| `src/transformations/event/metrics/swap_data.rs` | Normalized `SwapInput`/`LiquidityInput` types, `process_swaps()`, `process_liquidity_deltas()` |
+| `src/transformations/event/metrics/v4_hook_extract.rs` | Shared V4 hook event extraction (`extract_v4_hook_swaps()`, `extract_*_modify_liquidity()`) |
+| `src/transformations/event/metrics/accumulator.rs` | `BlockAccumulator` for OHLC and volume aggregation within a single block |
+
+## RPC Metrics Reference
+
+### Registered metrics
+
+| Name | Type | Labels | Description |
+|---|---|---|---|
+| `rpc_request_duration_seconds` | histogram | `method`, `chain`, `status` | Duration of RPC requests in seconds |
+| `rpc_requests_total` | counter | `method`, `chain`, `status` | Total number of RPC requests |
+| `rpc_errors_total` | counter | `method`, `chain`, `error_type` | Total number of RPC errors |
+| `rpc_requests_in_flight` | gauge | `method`, `chain` | Number of RPC requests currently in progress |
+
+### RpcMethod variants
+
+Each variant maps to a string label value used in `method`:
+
+| Variant | Label value |
+|---|---|
+| `GetBlockNumber` | `eth_blockNumber` |
+| `GetBlock` | `eth_getBlockByNumber` |
+| `GetTransaction` | `eth_getTransactionByHash` |
+| `GetTransactionReceipt` | `eth_getTransactionReceipt` |
+| `GetBlockReceipts` | `eth_getBlockReceipts` |
+| `GetLogs` | `eth_getLogs` |
+| `GetBalance` | `eth_getBalance` |
+| `GetCode` | `eth_getCode` |
+| `EthCall` | `eth_call` |
+| `GetBlocksBatch` | `eth_getBlockByNumber_batch` |
+| `GetTransactionReceiptsBatch` | `eth_getTransactionReceipt_batch` |
+| `GetLogsBatch` | `eth_getLogs_batch` |
+| `EthCallBatch` | `eth_call_batch` |
+| `GetBlockReceiptsConcurrent` | `eth_getBlockReceipts_concurrent` |
+
+### RpcErrorCategory variants
+
+Errors are categorized into label values used in `error_type`:
+
+| Variant | Label value | Source error |
+|---|---|---|
+| `Transport` | `transport` | `RpcError::Transport` |
+| `RateLimit` | `rate_limit` | `RpcError::RateLimitExceeded` |
+| `InvalidUrl` | `invalid_url` | `RpcError::InvalidUrl` |
+| `Batch` | `batch` | `RpcError::BatchError` |
+| `Provider` | `provider` | `RpcError::ProviderError` |
+
+## Configuration
+
+Metrics are optional. When the `metrics` key is absent from the indexer config, no metrics server is started and no metrics are recorded (the global `metrics` crate recorder remains a no-op).
+
+```json
+{
+  "metrics": {
+    "addr": "0.0.0.0:9090"
+  }
+}
+```
+
+The `addr` field is a `SocketAddr` string parsed at startup. The Prometheus exporter serves metrics at `http://{addr}/metrics`.
+
+## Invariants and Constraints
+
+1. **Single initialization**: `init_metrics_server` must be called at most once. The underlying `PrometheusBuilder::install()` sets a global recorder; calling it twice will panic.
+
+2. **Describe before record**: `describe_rpc_metrics()` must be called before any RPC metrics are recorded. This is enforced by startup ordering in `main.rs` -- the describe call happens immediately after `init_metrics_server`, before any chain workers or RPC clients are created.
+
+3. **RAII in-flight safety**: `RpcMetricsGuard` guarantees that the `rpc_requests_in_flight` gauge is always decremented, even on panic. The `Drop` impl checks a `completed` flag; if the guard was dropped without an explicit `success()`/`failure()` call, it still decrements the gauge. This prevents in-flight counter leaks that would produce incorrect dashboard values.
+
+4. **Label sanitization**: `chain_label_from_url` replaces dots and hyphens with underscores in URL hostnames. This produces labels safe for Prometheus (which restricts label values to `[a-zA-Z0-9_]` for best compatibility). API keys in URL paths are never included in labels.
+
+5. **Optional metrics**: When no `MetricsConfig` is provided, no Prometheus recorder is installed. The `metrics` crate's macros (`counter!`, `gauge!`, `histogram!`) become no-ops in this case, so instrumented code paths incur negligible overhead.
+
+6. **No cross-thread state**: The `metrics` crate uses a global atomic recorder. All metric operations are lock-free and safe to call from any async task or thread without synchronization.

--- a/docs/features/parallelism.md
+++ b/docs/features/parallelism.md
@@ -454,7 +454,7 @@ All RPC tasks share the same rate limiter (`SlidingWindowRateLimiter`), which ma
 The system uses `oneshot` channels as barriers to coordinate catchup ordering:
 
 1. **Factory catchup barrier**: Factory catchup must complete before factory-dependent eth_call catchup begins.
-2. **Eth_call decode catchup barrier**: Eth_call decode catchup must complete before the transformation engine runs its own catchup, ensuring decoded parquet files are available.
+2. **Eth_call decode catchup barrier**: Eth_call decode catchup must complete before the transformation engine runs its own catchup, ensuring decoded parquet files are available. After this barrier is released, the transformation engine uses the DAG scheduler (see [DAG-Based Catchup Execution](#dag-based-catchup-execution)) rather than sequential execution, enabling pipelined, dependency-aware handler processing across all pending ranges.
 
 ## Transformation Engine Parallelism
 
@@ -501,6 +501,41 @@ This ensures:
 - **Independent progress**: Each handler tracks its own progress in `_handler_progress`
 - **Independent transactions**: Each handler's operations execute in their own transaction
 - **Fault isolation**: One handler's failure doesn't affect others
+
+### DAG-Based Catchup Execution
+
+The transformation engine uses a DAG (Directed Acyclic Graph) scheduler for catchup processing that enables pipelined, dependency-aware execution:
+
+```
+┌─────────────────────────────────────────────────┐
+│              CompletionTracker                    │
+│   Tracks per-(handler, range) completion state   │
+│   Seeded from _handler_progress on startup       │
+└─────────────────────────┬───────────────────────┘
+                          │
+┌─────────────────────────▼───────────────────────┐
+│              DagScheduler                         │
+│   1. Spawn task per WorkItem                     │
+│   2. Await dependency satisfaction               │
+│   3. Acquire sequential semaphore (if needed)    │
+│   4. Acquire global concurrency permit           │
+│   5. Execute handler                             │
+│   6. Mark completed/failed, wake dependents      │
+└─────────────────────────────────────────────────┘
+```
+
+Key properties:
+- **Pipelined execution**: Range R+1 for handler A can start while R is still running for dependent handler B
+- **Cascade failures**: If handler A fails on range R, all dependents immediately cascade-fail on that range
+- **Sequential handlers**: Per-handler FIFO semaphore (capacity 1) ensures strict range ordering for state-dependent handlers
+- **Multi-pass deferral**: Catchup runs multiple passes, deferring ranges where call-dependency files don't yet exist
+
+Configuration:
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `handler_concurrency` | 4 | Global concurrency limit for DAG scheduler |
+
+The DAG scheduler replaces the previous sequential per-handler catchup, enabling much higher throughput when handlers have independent dependency chains.
 
 ## Performance Tuning
 

--- a/docs/features/s3_storage.md
+++ b/docs/features/s3_storage.md
@@ -243,6 +243,40 @@ The S3 storage system is composed of several modules in `src/storage/`:
 | `data_loader.rs` | `DataLoader` for on-demand S3 download with local caching |
 | `error.rs` | `StorageError` enum (Io, ObjectStore, NotFound, Config, Serialization, Cache, Manifest) |
 
+### Contract Index Tracking
+
+The storage system maintains per-directory `contract_index.json` files to track which factory-discovered contracts were included in each processed range. This enables reprocessing when configuration changes add new contracts.
+
+**Types** (`src/storage/contract_index.rs`):
+```rust
+pub type ContractIndex = HashMap<String, HashMap<String, Vec<String>>>
+// range_key -> source_name -> [contract_addresses]
+
+pub type ExpectedContracts = HashMap<String, Vec<String>>
+// source_name -> [contract_addresses]
+```
+
+**Key functions**:
+- `range_key(start, end)` - generates range key string
+- `build_expected_factory_contracts(contracts)` - computes expected contracts from config
+- `get_missing_contracts(index, range_key, expected)` - finds contracts not yet in index
+- `update_contract_index(index, range_key, contracts)` - adds contracts to index
+- `read_contract_index(dir)` / `write_contract_index(dir, index)` - atomic file I/O
+- `detect_contracts_in_log_parquet(path, address_maps)` - scans parquet for contract presence
+
+**Migration helpers**: When the contract index is first introduced, existing data is migrated from the factory layer to downstream indices (eth_calls, decoded logs) without requiring a full reprocess.
+
+### Atomic Parquet Writes
+
+All parquet file writes use `atomic_write_parquet()` (`src/storage/parquet_writer.rs`):
+
+1. Write to a temporary file (`.tmp` suffix)
+2. Apply Snappy compression
+3. Call `sync_all()` to ensure data is flushed to disk
+4. Atomic `rename()` to final path
+
+This prevents corrupt parquet files from partial writes or crashes. Parquet files have their metadata footer written last, so a partial write produces an unreadable file. The atomic rename guarantees readers always see a complete file.
+
 ### DataLoader
 
 The `DataLoader` provides transparent on-demand fetching from S3. When a file is needed locally but missing, it downloads from S3 and writes it to the local filesystem atomically (via tmp file + rename). This is used by catchup collectors to fetch data that may have been produced by another service.

--- a/docs/features/transformations.md
+++ b/docs/features/transformations.md
@@ -27,6 +27,106 @@ Decoded Events/Calls ──► TransformationEngine ──► Handlers ──►
 
 The transformation engine receives decoded data via channels from the decoders, invokes registered handlers, collects database operations, injects `source`/`source_version` columns automatically, and executes them transactionally.
 
+### DAG Scheduler
+
+The DAG-based execution scheduler lives in `src/transformations/scheduler/` (dag.rs, tracker.rs, loader.rs) and orchestrates handler execution respecting dependency ordering and concurrency limits.
+
+**DagScheduler** takes a `CompletionTracker` and a concurrency limit, then executes work items in dependency order:
+
+```
+DagScheduler::new(tracker: CompletionTracker, concurrency: usize)
+  └─ execute(items: Vec<WorkItem>, runner) -> Vec<WorkItemOutcome>
+```
+
+`execute(items, runner)` spawns one tokio task per `WorkItem`. Each task follows this flow:
+
+1. **Await dependencies** via `CompletionTracker` -- block until all `dep_names` report completed for this range
+2. **Acquire sequential semaphore** (if `sequential=true`) -- per-handler capacity-1 FIFO semaphore
+3. **Acquire global concurrency permit** -- bounded by the scheduler's concurrency limit
+4. **Run** the work item via the provided runner
+5. **Mark completed or failed** in the `CompletionTracker`
+
+Waits happen BEFORE permit acquisition to prevent permit-deadlock (holding a permit while waiting on a dependency that needs one).
+
+Returns outcomes for ALL items, including those that were cascade-failed due to a dependency failure.
+
+**WorkItem** struct:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `handler_name` | `String` | Handler identity |
+| `range_start` | `u64` | Block range start |
+| `range_end` | `u64` | Block range end |
+| `dep_names` | `Vec<String>` | Handler names that must complete first |
+| `sequential` | `bool` | Whether to acquire the per-handler sequential semaphore |
+| `payload` | generic | Data needed to execute the item |
+
+**OutcomeStatus** enum:
+
+| Variant | Description |
+|---------|-------------|
+| `Succeeded` | Handler completed successfully |
+| `HandlerFailed` | Handler returned an error |
+| `DepCascadeFailed` | A dependency failed, so this item was not attempted |
+| `Panicked` | The handler task panicked |
+
+**CompletionTracker** provides per-(handler_name, range_start) completion and failure tracking. Uses `tokio::sync::Notify` to wake blocked dependents. Supports `seed_completed()` to pre-mark ranges as done, enabling phase overlap (e.g., seeding from `_handler_progress` so catchup does not re-execute already-completed work).
+
+**CatchupLoader** executes one `WorkItem` end-to-end for catchup mode: load parquet data, build `TransformationContext`, invoke the handler, execute the resulting database transaction, and record progress in `_handler_progress`.
+
+### Handler Dependency Chains
+
+Handlers declare ordering constraints via `handler_dependencies()`, which returns `Vec<&'static str>` of handler names that must complete for a given block range before this handler can execute.
+
+**Cascade failures:** If handler A fails on range R, all handlers that depend (directly or transitively) on A immediately cascade-fail for range R without being attempted.
+
+**Startup validation** uses Kahn's algorithm to verify the dependency graph:
+
+- **Missing names**: If a declared dependency does not resolve to a registered handler, the process panics at startup
+- **Cycles**: If the dependency graph contains a cycle, the process panics with a diagnostic trace showing the cycle path
+- **Dep type validation**: All declared dependencies must be event handlers
+
+**Topological sort** of the validated graph determines execution order for both catchup and live processing.
+
+### Sequential Execution
+
+Handlers can opt into strictly ordered execution across block ranges by implementing `requires_sequential() -> bool` (default `false`).
+
+When a handler returns `true`:
+
+- Its `WorkItem`s are created with `sequential = true`
+- The DAG scheduler uses a per-handler capacity-1 FIFO semaphore
+- Items are submitted in ascending `range_start` order and acquire permits in FIFO order
+
+**Guarantee:** Within a handler that requires sequential execution, block ranges execute in strictly ascending order. This is useful for handlers that maintain cumulative state (e.g., running totals, position tracking) where processing range N depends on the result of range N-1.
+
+### Multi-Trigger Handler Completion
+
+Some handlers respond to multiple event triggers (e.g., a metrics handler that processes both Swap and Mint events).
+
+- The registry tracks multi-trigger handler keys via `is_multi_trigger(handler_key)`
+- In live mode, handler success is NOT persisted until all trigger batches for that block have been dispatched
+- This is coordinated by the engine's batching logic and the `RangeFinalizer` to prevent marking a handler as complete before all of its trigger sources have been processed
+
+### Catchup Execution with DAG
+
+Catchup uses the DAG scheduler in a multi-phase approach:
+
+**Phase 1 -- Initialization:**
+- Collect handlers by kind (event, eth_call), sort by topological order
+- Seed the `CompletionTracker` from `_handler_progress` so already-completed ranges are pre-marked
+
+**Phase 2 -- Multi-pass item building loop:**
+1. Build `WorkItem`s for each handler and block range
+2. Skip ranges already completed (seeded in Phase 1)
+3. Defer ranges where call-dependency files are unavailable (parquet not yet produced)
+4. Cascade defer: if a handler's dependency was deferred, the handler is also deferred
+5. Submit non-deferred items to the DAG scheduler
+6. Repeat from step 1 until no deferrals remain
+
+**Phase 3 -- Live processing:**
+- Transition to live mode with pending event buffering for handlers whose call dependencies have not yet arrived
+
 The engine delegates to sub-components:
 - **HandlerExecutor** (`executor.rs`): Concurrent handler spawn-loop, context construction, source/version injection, optional snapshot capture
 - **RangeFinalizer** (`finalizer.rs`): Range finalization, reorg cleanup, progress tracking
@@ -729,10 +829,11 @@ DbOperation::RawSql {
 |---------|-----------|-----------------|
 | `Null` | - | NULL |
 | `Bool(bool)` | `bool` | BOOLEAN |
-| `Int2(u8)` | `u8` | SMALLINT (INT2) |
+| `Int2(i16)` | `i16` | SMALLINT (INT2) |
 | `Int32(i32)` | `i32` | INTEGER |
 | `Int64(i64)` | `i64` | BIGINT |
 | `Uint64(u64)` | `u64` | BIGINT |
+| `Float64(f64)` | `f64` | DOUBLE PRECISION |
 | `Text(String)` | `String` | TEXT |
 | `VarChar(String)` | `String` | VARCHAR |
 | `Bytes(Vec<u8>)` | `Vec<u8>` | BYTEA |
@@ -763,13 +864,19 @@ pub enum TransformationError {
     TypeConversion(String),
     ConfigError(String),
     ChannelError(String),
-    IncludesPrecompileError(String),
+    TransientBlocked(String),       // Call-dep blocking — range deferred, not failed
+    IncludesPrecompileError(String), // Handler's asset or numeraire is a precompile address
     LiveStorage(StorageError),      // Live storage read/write failures
 }
 
 // Create a handler error with context
 TransformationError::handler("MyHandler", "Failed to process swap event")
 ```
+
+Notable variants:
+
+- **`TransientBlocked(String)`**: Returned when a handler's call-dependency files are not yet available. During catchup, this causes the range to be deferred to a later pass rather than treated as a failure.
+- **`IncludesPrecompileError(String)`**: Returned when a handler detects that an asset or numeraire address is a precompile (addresses 0x01-0x09). These handlers are skipped rather than errored.
 
 When a handler returns an error:
 
@@ -778,7 +885,7 @@ When a handler returns an error:
 3. Other handlers continue processing independently
 4. In live mode, failed handler keys are persisted to the block's status file for retry
 
-During catchup, a handler error stops catchup for that specific handler but does not affect other handlers.
+During catchup, a handler error stops catchup for that specific handler and propagates via cascade to all dependent handlers (see [Handler Dependency Chains](#handler-dependency-chains)). Independent handlers are unaffected.
 
 ## Execution Modes
 
@@ -855,6 +962,11 @@ src/transformations/
 ├── registry.rs      # Handler registration and build_registry()
 ├── historical.rs    # HistoricalDataReader for parquet queries
 ├── error.rs         # TransformationError enum
+├── scheduler/       # DAG-based execution scheduling
+│   ├── mod.rs           # Public exports
+│   ├── dag.rs           # DagScheduler, WorkItem, WorkItemOutcome
+│   ├── tracker.rs       # CompletionTracker (dependency satisfaction)
+│   └── loader.rs        # CatchupLoader (end-to-end WorkItem execution)
 ├── event/           # Event handlers
 │   ├── mod.rs           # register_handlers() for all event handlers
 │   ├── derc20_transfer.rs  # ERC20 Transfer handler
@@ -870,8 +982,14 @@ src/transformations/
 │   │   └── create.rs
 │   ├── decay_multicurve/  # Decay multicurve handlers
 │   │   └── mod.rs
-│   └── dhook/           # DHook handlers
-│       └── (scaffolded)
+│   ├── dhook/           # DHook handlers
+│   │   └── (scaffolded)
+│   └── metrics/         # Shared metrics utilities
+│       ├── mod.rs
+│       ├── accumulator.rs    # BlockAccumulator
+│       ├── swap_data.rs      # Swap processing
+│       ├── v4_hook_extract.rs # V4 hook extraction
+│       └── metrics.rs        # Metric calculations
 ├── eth_call/        # Call handlers
 │   └── mod.rs           # register_handlers() for all call handlers
 └── util/            # Shared utilities
@@ -885,7 +1003,9 @@ src/transformations/
         ├── users.rs     # upsert_user helper
         ├── transfers.rs # insert_transfer helper
         ├── v4_pool_configs.rs  # insert_pool_config helper
-        └── dhook_pool_configs.rs  # insert_dhook_pool_config helper
+        ├── dhook_pool_configs.rs  # insert_dhook_pool_config helper
+        ├── skipped_addresses.rs  # Skipped address filtering
+        └── pool_metrics.rs       # Pool metrics queries
 
 migrations/
 ├── 000_handler_progress.sql  # _handler_progress table


### PR DESCRIPTION
## Summary

- Created `docs/features/database.md` covering DbPool, DbOperation/DbValue types, deadlock retry, snapshot reads, and the migration system
- Created `docs/features/metrics.md` covering Prometheus server, RPC/live/collection/transformation metrics, RAII guards, and metric reference tables
- Updated `docs/features/transformations.md` with DAG scheduler, handler dependency chains, cascade failures, sequential execution, multi-trigger completion, and catchup execution sections
- Updated `docs/features/parallelism.md` with DAG-based catchup execution subsection
- Updated `docs/features/s3_storage.md` with contract index tracking and atomic parquet writes sections
- Updated `docs/OVERVIEW.md` with database/metrics doc links and updated descriptions