### PR TITLE
feat: continuous catchup scheduler

### DIFF
--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -135,7 +135,7 @@ migrations/
 - **doc**: `docs/features/decoding.md`
 
 ### transformations
-- **description**: Custom Rust handlers process decoded events/calls and produce PostgreSQL operations. DAG-based catchup with dependency-aware pipelined execution. Per-handler progress tracking, version injection, sequential execution support, and transactional execution with deadlock retry.
+- **description**: Custom Rust handlers process decoded events/calls and produce PostgreSQL operations. Single-submit continuous DAG scheduler: all `(handler, range)` work items are submitted upfront with call-dep readiness gated by a background file scanner, eliminating pass-based batching. Per-handler progress tracking, version injection, sequential execution support, and transactional execution with deadlock retry.
 - **entry_points**: `src/transformations/traits.rs`, `src/transformations/registry.rs`, `src/transformations/engine.rs`, `src/transformations/executor.rs`, `src/transformations/scheduler/`
 - **depends_on**: [decoding, database]
 - **doc**: `docs/features/transformations.md`

--- a/docs/designs/concurrent_handlers/roadmap.md
+++ b/docs/designs/concurrent_handlers/roadmap.md
@@ -118,38 +118,23 @@ Four independently-mergeable phases. Each ships value on its own and can be revi
 - **Largest behavior-change surface** of the four phases. Landed last intentionally. Gatekept on full live-mode integration test suite + manual replay on recent mainnet data before merge.
 - **Persistence ordering**: today, handler failures are persisted to status files synchronously from `process_events_message`. Must preserve the same "persist-before-returning-from-message" guarantee in the new flow.
 
-**Pick up Phase 2's call-dep deadlock workaround**
+**Pick up Phase 2's call-dep deadlock workaround — IMPLEMENTED (catchup only)**
 
-Phase 2 shipped with a caller-side fix for a deadlock: when a handler's
-call-dep parquet files aren't yet on disk for a range `R`, its
-`(handler, R)` work item is deferred out of the scheduler, and any
-transitive dependents' `(handler, R)` items are cascade-deferred in
-the same pre-submit scan (topological handler iteration makes a
-single-level check compose into the full transitive cascade). That
-closed the correctness hole but left the catchup fundamentally
-batch-quantized: items whose prerequisites arrive mid-pass must wait
-for the current `DagScheduler::execute` batch to fully drain plus the
-1s inter-pass sleep before being considered again.
+The catchup portion of this sub-goal has been completed. The per-pass
+`deferred_starts` / `next_pending` retry loop from Phase 2 has been
+removed. `run_handler_catchup` now builds all `(handler, range)` work
+items upfront and submits them in a single `DagScheduler::execute`
+call. Call-dep readiness is gated inside the scheduler via a
+`call_dep_keys` field on `WorkItem` and a background
+`CallDepScanner` loop that periodically scans the filesystem and
+registers newly-available call-dep ranges on the `CompletionTracker`.
+Items unblock as soon as their call-dep files appear on disk, not at
+the next pass boundary.
 
-Phase 4's `wait_for_calls` readiness condition (listed above) is the
-principled fix. Submit every `(handler, range)` item unconditionally,
-and have `wait_ready` gate on call-dep file availability as a second
-wait condition in addition to handler-dep completion. That retires
-the per-pass `next_pending` retry loop in `run_handler_catchup`
-entirely and lets items unblock the instant their prerequisites
-arrive, not at the next pass boundary. Doing this during Phase 4
-delivers the full catchup pipelining win as a side-effect of the
-live-mode unification.
-
-Concrete touchpoints when folding this in during Phase 4:
-- Remove the `deferred_starts` / `next_pending` cascade in
-  `run_handler_catchup` (introduced in Phase 2 as the deadlock fix).
-- Extend `WorkItem` with `call_deps` and thread them through
-  `wait_ready` as an additional readiness check.
-- Decide where the call-dep file-availability signal comes from in
-  catchup mode (filesystem polling, shared call-dep tracker, or
-  inotify) — this is the one place where catchup and live mode need
-  different signal sources for the same readiness condition.
+Remaining (not yet implemented): the live-mode side of this, where
+`wait_for_calls` uses a different signal source (received-calls
+tracker rather than filesystem polling) for the same readiness
+condition.
 
 **Branch**: `feat/dag-live-mode`
 

--- a/src/transformations/engine.rs
+++ b/src/transformations/engine.rs
@@ -31,7 +31,10 @@ use super::live_state::{LiveProcessingState, PendingEventData};
 use super::registry::{extract_event_name, TransformationRegistry};
 use super::retry::{filter_calls_by_start_block, filter_events_by_start_block, RetryProcessor};
 use super::scheduler::dag::{DagScheduler, OutcomeStatus, WorkItem, WorkItemRunResult};
-use super::scheduler::loader::{read_receipt_addresses, CatchupLoader, CatchupPayload};
+use super::scheduler::loader::{
+    read_receipt_addresses, CallDepScanner, CatchupLoader, CatchupPayload,
+    run_call_dep_scanner_loop,
+};
 use super::scheduler::tracker::CompletionTracker;
 use crate::db::DbPool;
 use crate::live::{LiveProgressTracker, LiveStorage, StorageError, TransformRetryRequest};
@@ -658,7 +661,8 @@ impl TransformationEngine {
 
         // Seed CompletionTracker from _handler_progress so downstream handlers
         // can gate on upstream completion per range via the DAG scheduler.
-        let tracker = Arc::new(CompletionTracker::new());
+        // Use `with_available_starts` so the tracker can maintain contiguous watermarks.
+        let tracker = Arc::new(CompletionTracker::with_available_starts(available_starts.clone()));
         // self_completed: handler_name → set of range_starts already processed.
         // Used to skip building WorkItems for ranges already done.
         let mut self_completed: HashMap<String, HashSet<u64>> = HashMap::new();
@@ -717,571 +721,380 @@ impl TransformationEngine {
 
         let scheduler = DagScheduler::new(tracker.clone(), self.handler_concurrency);
 
-        // (handler_key, range_start, error_message) for each item-level failure.
-        let mut failed_items: Vec<(String, u64, String)> = vec![];
+        // ── Build ALL work items upfront ────────────────────────────────
+        let mut items: Vec<WorkItem> = Vec::new();
+        let mut per_handler_submitted: HashMap<String, usize> = HashMap::new();
 
-        // Call-dep retry loop.
-        //
-        // `ranges_pending` is None on the first pass (try every available range).
-        // On subsequent passes it holds only the ranges that were skipped because
-        // dependencies were not ready or a prior pass ended transiently blocked.
-        let mut ranges_pending: Option<HashMap<String, Vec<(u64, u64)>>> = None;
-        let mut pass = 0u32;
-        // Bail only after several consecutive passes make zero progress, so that
-        // slowly-arriving dependencies don't get abandoned.
-        const MAX_CONSECUTIVE_NO_PROGRESS: u32 = 3;
-        let mut consecutive_no_progress: u32 = 0;
-        let mut stranded_pending: HashMap<String, Vec<(u64, u64)>> = HashMap::new();
+        for ch in &handlers {
+            let name = ch.handler.name().to_string();
+            let completed = self_completed.get(&name).cloned().unwrap_or_default();
 
-        loop {
-            pass += 1;
-
-            let mut items: Vec<WorkItem> = Vec::new();
-            let mut next_pending: HashMap<String, Vec<(u64, u64)>> = HashMap::new();
-            let mut pending_index: HashSet<(String, u64, u64)> = HashSet::new();
-            // Parallel index into next_pending for O(1) cascade lookups.
-            // Updated in lock-step with next_pending whenever we defer a range.
-            let mut deferred_starts: HashMap<String, HashSet<u64>> = HashMap::new();
-            // Per-handler per-pass counters for observability.
-            // (submitted, call_dep_deferred, upstream_deferred).
-            let mut per_handler_counts: HashMap<String, (usize, usize, usize)> = HashMap::new();
-            // First missing call dep paths per handler (for summary log).
-            let mut per_handler_missing_call_deps: HashMap<String, Vec<String>> = HashMap::new();
-            let contiguous_watermarks: HashMap<String, Option<u64>> = handlers
-                .iter()
-                .map(|ch| {
-                    let completed = self_completed
-                        .get(ch.handler.name())
-                        .cloned()
-                        .unwrap_or_default();
-                    (
-                        ch.handler.name().to_string(),
-                        contiguous_completed_through(&available_starts, &completed),
-                    )
-                })
-                .collect();
-
-            for ch in &handlers {
-                let name = ch.handler.name().to_string();
-                let completed = self_completed.get(&name).cloned().unwrap_or_default();
-
-                // On retry passes only re-try handlers that had pending ranges.
-                let candidate_ranges: Vec<(u64, u64)> = if let Some(ref pending) = ranges_pending {
-                    match pending.get(&name) {
-                        Some(r) => r.clone(),
-                        None => continue,
-                    }
-                } else {
-                    available.clone()
-                };
-
-                // Scan call-dep file availability once per handler per pass.
-                let mut call_range_sets: Vec<HashSet<(u64, u64)>> =
-                    Vec::with_capacity(ch.call_deps.len());
-                for (source, func) in &ch.call_deps {
-                    let ranges = self
-                        .scan_available_call_dependency_ranges(source, func)
-                        .await
-                        .unwrap_or_default();
-                    call_range_sets.push(ranges);
-                }
-
-                for (range_start, range_end) in candidate_ranges {
-                    if completed.contains(&range_start) {
-                        continue;
-                    }
-
-                    let trigger_range_present = trigger_range_sets
-                        .get(&name)
-                        .is_some_and(|ranges| ranges.contains(&(range_start, range_end)));
-
-                    // Skip range if call-dep files aren't on disk yet, but
-                    // only when this handler actually has trigger data in the
-                    // range. Otherwise let it no-op complete and unblock
-                    // same-range dependents.
-                    if trigger_range_present && !ch.call_deps.is_empty() {
-                        let missing_deps: Vec<&str> = ch
-                            .call_deps
-                            .iter()
-                            .zip(call_range_sets.iter())
-                            .filter(|(_, set)| !set.contains(&(range_start, range_end)))
-                            .map(|((source, func), _)| {
-                                // Leak-free: just reference the source since it
-                                // lives as long as the handler.
-                                if func.is_empty() {
-                                    source.as_str()
-                                } else {
-                                    // Can't return a formatted &str, so store in
-                                    // per_handler_missing_deps below instead.
-                                    source.as_str()
-                                }
-                            })
-                            .collect();
-                        if !missing_deps.is_empty() {
-                            // Track which call deps are missing for the summary log.
-                            let missing_formatted: Vec<String> = ch
-                                .call_deps
-                                .iter()
-                                .zip(call_range_sets.iter())
-                                .filter(|(_, set)| !set.contains(&(range_start, range_end)))
-                                .map(|((source, func), _)| format!("{}/{}", source, func))
-                                .collect();
-                            per_handler_missing_call_deps
-                                .entry(name.clone())
-                                .or_insert_with(|| missing_formatted);
-                            queue_pending_range(
-                                &mut next_pending,
-                                &mut pending_index,
-                                &name,
-                                range_start,
-                                range_end,
-                            );
-                            deferred_starts
-                                .entry(name.clone())
-                                .or_default()
-                                .insert(range_start);
-                            per_handler_counts.entry(name.clone()).or_default().1 += 1;
-                            continue;
-                        }
-                    }
-
-                    if let Some(blocking) = ch.contiguous_handler_deps.iter().find(|dep_name| {
-                        !contiguous_watermarks
-                            .get(dep_name.as_str())
-                            .copied()
-                            .flatten()
-                            .is_some_and(|watermark| watermark >= range_start)
-                    }) {
-                        tracing::debug!(
-                            "Handler {} deferring range {}-{}: upstream dep '{}' has not completed contiguously through this range",
-                            ch.handler.handler_key(),
-                            range_start,
-                            range_end,
-                            blocking
-                        );
-                        queue_pending_range(
-                            &mut next_pending,
-                            &mut pending_index,
-                            &name,
-                            range_start,
-                            range_end,
-                        );
-                        deferred_starts
-                            .entry(name.clone())
-                            .or_default()
-                            .insert(range_start);
-                        per_handler_counts.entry(name.clone()).or_default().2 += 1;
-                        continue;
-                    }
-
-                    // Cascade: if any handler_dep is already deferred for this
-                    // range_start, defer this (handler, range) too. Submitting
-                    // it would hang the scheduler because its dep will never
-                    // be marked in the tracker for this pass. Topological
-                    // handler iteration (sorted above) guarantees deps are
-                    // processed before dependents in the same pass, so a
-                    // single-level check composes into full transitive cascade.
-                    if let Some(blocking) = ch.handler_deps.iter().find(|dep_name| {
-                        deferred_starts
-                            .get(dep_name.as_str())
-                            .is_some_and(|starts| starts.contains(&range_start))
-                    }) {
-                        tracing::debug!(
-                            "Handler {} deferring range {}-{}: upstream dep '{}' deferred",
-                            ch.handler.handler_key(),
-                            range_start,
-                            range_end,
-                            blocking
-                        );
-                        queue_pending_range(
-                            &mut next_pending,
-                            &mut pending_index,
-                            &name,
-                            range_start,
-                            range_end,
-                        );
-                        deferred_starts
-                            .entry(name.clone())
-                            .or_default()
-                            .insert(range_start);
-                        per_handler_counts.entry(name.clone()).or_default().2 += 1;
-                        continue;
-                    }
-
-                    // Skip if any handler dep already failed in a previous
-                    // pass — the tracker retains failure state across
-                    // scheduler.execute() calls, so submitting this item
-                    // would immediately cascade-fail.
-                    {
-                        let mut dep_failed = false;
-                        for dep in &ch.handler_deps {
-                            if tracker.is_failed(dep, range_start).await {
-                                dep_failed = true;
-                                break;
-                            }
-                        }
-                        if dep_failed {
-                            continue;
-                        }
-                    }
-
-                    per_handler_counts.entry(name.clone()).or_default().0 += 1;
-                    items.push(WorkItem {
-                        handler_name: name.clone(),
-                        range_start,
-                        range_end,
-                        dep_names: ch
-                            .handler_deps
-                            .iter()
-                            .chain(ch.contiguous_handler_deps.iter())
-                            .cloned()
-                            .collect(),
-                        sequential: ch.sequential,
-                        payload: Box::new(CatchupPayload {
-                            handler: ch.handler.clone(),
-                            handler_key: ch.handler.handler_key(),
-                            handler_name: ch.handler.name(),
-                            handler_version: ch.handler.version(),
-                            triggers: ch.triggers.clone(),
-                            call_deps: ch.call_deps.clone(),
-                            kind: ch.kind,
-                        }),
-                    });
-                }
-            }
-
-            // Per-handler summary of this pass's work (submitted / deferred).
-            // Iterate `handlers` for deterministic topological ordering.
-            for ch in &handlers {
-                let name = ch.handler.name();
-                let (submitted, call_dep_def, cascade_def) =
-                    per_handler_counts.get(name).copied().unwrap_or((0, 0, 0));
-                if submitted == 0 && call_dep_def == 0 && cascade_def == 0 {
+            for &(range_start, range_end) in &available {
+                if completed.contains(&range_start) {
                     continue;
                 }
-                if call_dep_def == 0 && cascade_def == 0 {
-                    tracing::info!(
-                        "Handler {} catchup pass {}: submitting {} range(s)",
-                        ch.handler.handler_key(),
-                        pass,
-                        submitted
-                    );
-                } else {
-                    let missing_info = per_handler_missing_call_deps
-                        .get(ch.handler.name())
-                        .map(|deps| format!(" [missing: {}]", deps.join(", ")))
-                        .unwrap_or_default();
-                    tracing::info!(
-                        "Handler {} catchup pass {}: submitting {} range(s), \
-                         deferring {} (call_deps not ready) + {} (upstream not ready){}",
-                        ch.handler.handler_key(),
-                        pass,
-                        submitted,
-                        call_dep_def,
-                        cascade_def,
-                        missing_info
-                    );
-                }
-            }
 
-            if !items.is_empty() {
-                tracing::info!(
-                    "{} catchup pass {}: executing {} work items",
-                    kind_label,
-                    pass,
-                    items.len()
-                );
-
-                let pass_start = Instant::now();
-                let loader_ref = loader.clone();
-                let outcomes = scheduler
-                    .execute(items, move |item| {
-                        let loader = loader_ref.clone();
-                        Box::pin(async move {
-                            match loader.run(item).await {
-                                Ok(()) => WorkItemRunResult::Succeeded,
-                                Err(TransformationError::TransientBlocked(msg)) => {
-                                    WorkItemRunResult::Blocked(msg)
-                                }
-                                Err(e) => WorkItemRunResult::Failed(e.to_string()),
-                            }
-                        })
-                    })
-                    .await;
-
-                histogram!(
-                    "transformation_catchup_pass_duration_seconds",
-                    "kind" => kind_label,
-                )
-                .record(pass_start.elapsed().as_secs_f64());
-
-                let mut succeeded = 0usize;
-                let mut blocked = 0usize;
-                let mut cascade_blocked = 0usize;
-                let mut cascade_failed = 0usize;
-                let mut blocked_marks_to_clear: Vec<(String, u64)> = Vec::new();
-                // Per-handler: (succeeded, failed, blocked, cascade_failed, cascade_blocked, panicked).
-                let mut per_handler_outcomes:
-                    HashMap<String, (usize, usize, usize, usize, usize, usize)> =
-                    HashMap::new();
-
-                for outcome in &outcomes {
-                    let counts = per_handler_outcomes
-                        .entry(outcome.handler_name.clone())
-                        .or_default();
-                    match &outcome.status {
-                        OutcomeStatus::Succeeded => {
-                            self_completed
-                                .entry(outcome.handler_name.clone())
-                                .or_default()
-                                .insert(outcome.range_start);
-                            succeeded += 1;
-                            counts.0 += 1;
-                            let key = handlers
-                                .iter()
-                                .find(|ch| ch.handler.name() == outcome.handler_name)
-                                .map(|ch| ch.handler.handler_key())
-                                .unwrap_or_else(|| outcome.handler_name.clone());
-                            counter!(
-                                "transformation_catchup_ranges_completed_total",
-                                "handler_key" => key,
-                                "kind" => kind_label,
-                            )
-                            .increment(1);
-                        }
-                        OutcomeStatus::Blocked { reason } => {
-                            tracing::info!(
-                                "Handler {} blocked on range {}-{}: {}",
-                                outcome.handler_name,
-                                outcome.range_start,
-                                outcome.range_end,
-                                reason
-                            );
-                            queue_pending_range(
-                                &mut next_pending,
-                                &mut pending_index,
-                                &outcome.handler_name,
-                                outcome.range_start,
-                                outcome.range_end,
-                            );
-                            deferred_starts
-                                .entry(outcome.handler_name.clone())
-                                .or_default()
-                                .insert(outcome.range_start);
-                            blocked_marks_to_clear
-                                .push((outcome.handler_name.clone(), outcome.range_start));
-                            blocked += 1;
-                            counts.2 += 1;
-                        }
-                        OutcomeStatus::HandlerFailed { reason } => {
-                            tracing::error!(
-                                "Handler {} failed on range {}-{}: {}",
-                                outcome.handler_name,
-                                outcome.range_start,
-                                outcome.range_end,
-                                reason
-                            );
-                            let key = handlers
-                                .iter()
-                                .find(|ch| ch.handler.name() == outcome.handler_name)
-                                .map(|ch| ch.handler.handler_key())
-                                .unwrap_or_else(|| outcome.handler_name.clone());
-                            failed_items.push((key, outcome.range_start, reason.clone()));
-                            counts.1 += 1;
-                        }
-                        OutcomeStatus::DepCascadeFailed { dep_name } => {
-                            tracing::warn!(
-                                "Handler {} cascade-failed on range {} due to dep '{}'",
-                                outcome.handler_name,
-                                outcome.range_start,
-                                dep_name
-                            );
-                            let key = handlers
-                                .iter()
-                                .find(|ch| ch.handler.name() == outcome.handler_name)
-                                .map(|ch| ch.handler.handler_key())
-                                .unwrap_or_else(|| outcome.handler_name.clone());
-                            failed_items.push((
-                                key,
-                                outcome.range_start,
-                                format!("cascade-failed: dep '{}' failed", dep_name),
-                            ));
-                            cascade_failed += 1;
-                            counts.3 += 1;
-                        }
-                        OutcomeStatus::DepCascadeBlocked { dep_name } => {
-                            tracing::info!(
-                                "Handler {} cascade-blocked on range {} due to dep '{}'",
-                                outcome.handler_name,
-                                outcome.range_start,
-                                dep_name
-                            );
-                            queue_pending_range(
-                                &mut next_pending,
-                                &mut pending_index,
-                                &outcome.handler_name,
-                                outcome.range_start,
-                                outcome.range_end,
-                            );
-                            deferred_starts
-                                .entry(outcome.handler_name.clone())
-                                .or_default()
-                                .insert(outcome.range_start);
-                            blocked_marks_to_clear
-                                .push((outcome.handler_name.clone(), outcome.range_start));
-                            cascade_blocked += 1;
-                            counts.4 += 1;
-                        }
-                        OutcomeStatus::Panicked => {
-                            tracing::error!(
-                                "Handler {} panicked on range {}",
-                                outcome.handler_name,
-                                outcome.range_start
-                            );
-                            let key = handlers
-                                .iter()
-                                .find(|ch| ch.handler.name() == outcome.handler_name)
-                                .map(|ch| ch.handler.handler_key())
-                                .unwrap_or_else(|| outcome.handler_name.clone());
-                            failed_items.push((
-                                key,
-                                outcome.range_start,
-                                "task panicked".to_string(),
-                            ));
-                            counts.5 += 1;
-                        }
-                    }
-                }
-
-                for (handler_name, range_start) in blocked_marks_to_clear {
-                    tracker.clear_blocked(&handler_name, range_start).await;
-                }
-
-                // Per-handler outcome summary. Log anything with non-success
-                // activity at info, clean runs at debug to reduce log noise.
-                for ch in &handlers {
-                    let name = ch.handler.name();
-                    let Some(&(ok, failed, blocked_count, cascade, cascade_blocked_count, panicked)) =
-                        per_handler_outcomes.get(name)
-                    else {
-                        continue;
-                    };
-                    let total =
-                        ok + failed + blocked_count + cascade + cascade_blocked_count + panicked;
-                    if failed > 0
-                        || blocked_count > 0
-                        || cascade > 0
-                        || cascade_blocked_count > 0
-                        || panicked > 0
-                    {
-                        tracing::info!(
-                            "Handler {} catchup pass {} result: {}/{} succeeded \
-                             ({} failed, {} blocked, {} cascade-failed, {} cascade-blocked, {} panicked)",
-                            ch.handler.handler_key(),
-                            pass,
-                            ok,
-                            total,
-                            failed,
-                            blocked_count,
-                            cascade,
-                            cascade_blocked_count,
-                            panicked
-                        );
-                    } else {
-                        tracing::debug!(
-                            "Handler {} catchup pass {} result: {} range(s) ok",
-                            ch.handler.handler_key(),
-                            pass,
-                            ok
-                        );
-                    }
-                }
-
-                tracing::info!(
-                    "{} catchup pass {} complete: {} succeeded, {} blocked, {} cascade-blocked, {} cascade-failed",
-                    kind_label,
-                    pass,
-                    succeeded,
-                    blocked,
-                    cascade_blocked,
-                    cascade_failed
-                );
-
-                // Update remaining gauge: recompute from self_completed
-                let remaining: usize = handlers
-                    .iter()
-                    .map(|ch| {
-                        let done = self_completed
-                            .get(ch.handler.name())
-                            .map(|s| s.len())
-                            .unwrap_or(0);
-                        available.len().saturating_sub(done)
-                    })
-                    .sum();
-                gauge!(
-                    "transformation_catchup_ranges_remaining",
-                    "kind" => kind_label,
-                )
-                .set(remaining as f64);
-            }
-
-            if next_pending.is_empty() {
-                stranded_pending.clear();
-                break;
-            }
-
-            // Check for progress on pending ranges; bail only after
-            // repeated passes with strictly zero progress.
-            if let Some(ref prev) = ranges_pending {
-                let prev_count: usize = prev.values().map(|v| v.len()).sum();
-                let next_count: usize = next_pending.values().map(|v| v.len()).sum();
-                if next_count >= prev_count {
-                    consecutive_no_progress += 1;
-                    if consecutive_no_progress >= MAX_CONSECUTIVE_NO_PROGRESS {
-                        tracing::warn!(
-                            "{} catchup: {} ranges still blocked by dependencies, \
-                             no progress for {} consecutive passes after pass {}. Giving up.",
-                            kind_label,
-                            next_count,
-                            consecutive_no_progress,
-                            pass
-                        );
-                        stranded_pending = next_pending;
+                // Skip if any handler dep already failed — the tracker retains
+                // failure state, so submitting would immediately cascade-fail.
+                let mut dep_failed = false;
+                for dep in &ch.handler_deps {
+                    if tracker.is_failed(dep, range_start).await {
+                        dep_failed = true;
                         break;
                     }
-                } else {
-                    consecutive_no_progress = 0;
                 }
-            }
+                if dep_failed {
+                    continue;
+                }
 
-            let pending_count: usize = next_pending.values().map(|v| v.len()).sum();
-            tracing::info!(
-                "{} catchup pass {}: {} ranges pending dependencies or blocked upstream work, retrying in 1s...",
-                kind_label,
-                pass,
-                pending_count
+                // Determine if this handler has trigger parquet data in this
+                // range. If not, call-dep gating is skipped (the handler will
+                // no-op and unblock same-range dependents).
+                let trigger_range_present = trigger_range_sets
+                    .get(&name)
+                    .is_some_and(|ranges| ranges.contains(&(range_start, range_end)));
+
+                let call_dep_keys: Vec<(String, String)> =
+                    if trigger_range_present && !ch.call_deps.is_empty() {
+                        ch.call_deps.clone()
+                    } else {
+                        Vec::new()
+                    };
+
+                *per_handler_submitted.entry(name.clone()).or_default() += 1;
+                items.push(WorkItem {
+                    handler_name: name.clone(),
+                    range_start,
+                    range_end,
+                    dep_names: ch.handler_deps.clone(),
+                    contiguous_dep_names: ch.contiguous_handler_deps.clone(),
+                    call_dep_keys,
+                    sequential: ch.sequential,
+                    payload: Box::new(CatchupPayload {
+                        handler: ch.handler.clone(),
+                        handler_key: ch.handler.handler_key(),
+                        handler_name: ch.handler.name(),
+                        handler_version: ch.handler.version(),
+                        triggers: ch.triggers.clone(),
+                        call_deps: ch.call_deps.clone(),
+                        kind: ch.kind,
+                    }),
+                });
+            }
+        }
+
+        // Per-handler submission summary.
+        for ch in &handlers {
+            let count = per_handler_submitted
+                .get(ch.handler.name())
+                .copied()
+                .unwrap_or(0);
+            if count > 0 {
+                tracing::info!(
+                    "Handler {} catchup: submitting {} range(s)",
+                    ch.handler.handler_key(),
+                    count
+                );
+            }
+        }
+
+        if items.is_empty() {
+            tracing::info!("{} handler catchup: no work items to submit", kind_label);
+            return Ok(());
+        }
+
+        tracing::info!(
+            "{} catchup: executing {} work items across {} handlers",
+            kind_label,
+            items.len(),
+            per_handler_submitted.len()
+        );
+
+        // ── Spawn background call-dep scanner ──────────────────────────
+        // Collect unique (source, function) pairs across all handlers.
+        let mut unique_call_deps: HashSet<(String, String)> = HashSet::new();
+        for ch in &handlers {
+            for dep in &ch.call_deps {
+                unique_call_deps.insert(dep.clone());
+            }
+        }
+        let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+        let scanner_handle = if !unique_call_deps.is_empty() {
+            let scanner = CallDepScanner::new(
+                self.decoded_calls_dir.clone(),
+                self.raw_eth_calls_dir.clone(),
+                self.contracts.clone(),
+                unique_call_deps.into_iter().collect(),
             );
-            tokio::time::sleep(Duration::from_secs(1)).await;
-            stranded_pending = next_pending.clone();
-            ranges_pending = Some(next_pending);
-        }
+            // Run one initial scan synchronously before spawning the loop so
+            // that items whose call deps are already on disk don't have to
+            // wait for the first 2s tick.
+            let initial = scanner.scan_all().await;
+            for ((source, func), ranges) in initial {
+                tracker.register_call_dep_ranges(&source, &func, ranges).await;
+            }
+            Some(tokio::spawn(run_call_dep_scanner_loop(
+                scanner,
+                tracker.clone(),
+                cancel_rx,
+            )))
+        } else {
+            None
+        };
 
-        if !stranded_pending.is_empty() {
-            for (handler_name, ranges) in stranded_pending {
-                let key = handlers
-                    .iter()
-                    .find(|ch| ch.handler.name() == handler_name)
-                    .map(|ch| ch.handler.handler_key())
-                    .unwrap_or(handler_name.clone());
-                for (range_start, _) in ranges {
+        // ── Spawn background progress reporter ─────────────────────────
+        let progress_tracker = tracker.clone();
+        let progress_kind: &'static str = kind_label;
+        let total_available = available.len();
+        let handler_keys: HashMap<String, String> = handlers
+            .iter()
+            .map(|ch| (ch.handler.name().to_string(), ch.handler.handler_key()))
+            .collect();
+        let progress_handle = tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(30));
+            interval.tick().await; // skip immediate first tick
+            loop {
+                interval.tick().await;
+                let snap = progress_tracker.snapshot_progress().await;
+                let total_completed: usize = snap.values().map(|(c, _, _)| c).sum();
+                let total_failed: usize = snap.values().map(|(_, f, _)| f).sum();
+                let total_blocked: usize = snap.values().map(|(_, _, b)| b).sum();
+                tracing::info!(
+                    "{} catchup progress: {}/{} completed, {} failed, {} blocked",
+                    progress_kind,
+                    total_completed,
+                    total_available * snap.len(),
+                    total_failed,
+                    total_blocked,
+                );
+                // Log per-handler detail for handlers that are behind.
+                for (name, (completed, failed, blocked)) in &snap {
+                    let remaining = total_available.saturating_sub(*completed);
+                    if remaining > 0 || *failed > 0 || *blocked > 0 {
+                        let key = handler_keys.get(name).cloned().unwrap_or_else(|| name.clone());
+                        tracing::info!(
+                            "  {} — {} done, {} remaining, {} failed, {} blocked",
+                            key,
+                            completed,
+                            remaining,
+                            failed,
+                            blocked,
+                        );
+                    }
+                }
+                gauge!(
+                    "transformation_catchup_ranges_remaining",
+                    "kind" => progress_kind,
+                )
+                .set(
+                    snap.values()
+                        .map(|(c, _, _)| total_available.saturating_sub(*c))
+                        .sum::<usize>() as f64,
+                );
+            }
+        });
+
+        // ── Execute all items ──────────────────────────────────────────
+        let catchup_start = Instant::now();
+        let loader_ref = loader.clone();
+        let outcomes = scheduler
+            .execute(items, move |item| {
+                let loader = loader_ref.clone();
+                Box::pin(async move {
+                    match loader.run(item).await {
+                        Ok(()) => WorkItemRunResult::Succeeded,
+                        Err(TransformationError::TransientBlocked(msg)) => {
+                            WorkItemRunResult::Blocked(msg)
+                        }
+                        Err(e) => WorkItemRunResult::Failed(e.to_string()),
+                    }
+                })
+            })
+            .await;
+
+        histogram!(
+            "transformation_catchup_total_duration_seconds",
+            "kind" => kind_label,
+        )
+        .record(catchup_start.elapsed().as_secs_f64());
+
+        // ── Cancel background tasks ────────────────────────────────────
+        let _ = cancel_tx.send(true);
+        if let Some(handle) = scanner_handle {
+            handle.abort();
+        }
+        progress_handle.abort();
+
+        // ── Process outcomes ───────────────────────────────────────────
+        let mut failed_items: Vec<(String, u64, String)> = Vec::new();
+        let mut succeeded = 0usize;
+        let mut blocked = 0usize;
+        let mut cascade_blocked = 0usize;
+        let mut cascade_failed = 0usize;
+        let mut per_handler_outcomes: HashMap<String, (usize, usize, usize, usize, usize, usize)> =
+            HashMap::new();
+
+        for outcome in &outcomes {
+            let counts = per_handler_outcomes
+                .entry(outcome.handler_name.clone())
+                .or_default();
+            match &outcome.status {
+                OutcomeStatus::Succeeded => {
+                    succeeded += 1;
+                    counts.0 += 1;
+                    let key = handlers
+                        .iter()
+                        .find(|ch| ch.handler.name() == outcome.handler_name)
+                        .map(|ch| ch.handler.handler_key())
+                        .unwrap_or_else(|| outcome.handler_name.clone());
+                    counter!(
+                        "transformation_catchup_ranges_completed_total",
+                        "handler_key" => key,
+                        "kind" => kind_label,
+                    )
+                    .increment(1);
+                }
+                OutcomeStatus::Blocked { reason } => {
+                    tracing::info!(
+                        "Handler {} blocked on range {}-{}: {}",
+                        outcome.handler_name,
+                        outcome.range_start,
+                        outcome.range_end,
+                        reason
+                    );
+                    blocked += 1;
+                    counts.2 += 1;
+                    let key = handlers
+                        .iter()
+                        .find(|ch| ch.handler.name() == outcome.handler_name)
+                        .map(|ch| ch.handler.handler_key())
+                        .unwrap_or_else(|| outcome.handler_name.clone());
+                    failed_items.push((key, outcome.range_start, format!("blocked: {}", reason)));
+                }
+                OutcomeStatus::HandlerFailed { reason } => {
+                    tracing::error!(
+                        "Handler {} failed on range {}-{}: {}",
+                        outcome.handler_name,
+                        outcome.range_start,
+                        outcome.range_end,
+                        reason
+                    );
+                    let key = handlers
+                        .iter()
+                        .find(|ch| ch.handler.name() == outcome.handler_name)
+                        .map(|ch| ch.handler.handler_key())
+                        .unwrap_or_else(|| outcome.handler_name.clone());
+                    failed_items.push((key, outcome.range_start, reason.clone()));
+                    counts.1 += 1;
+                }
+                OutcomeStatus::DepCascadeFailed { dep_name } => {
+                    tracing::warn!(
+                        "Handler {} cascade-failed on range {} due to dep '{}'",
+                        outcome.handler_name,
+                        outcome.range_start,
+                        dep_name
+                    );
+                    let key = handlers
+                        .iter()
+                        .find(|ch| ch.handler.name() == outcome.handler_name)
+                        .map(|ch| ch.handler.handler_key())
+                        .unwrap_or_else(|| outcome.handler_name.clone());
                     failed_items.push((
-                        key.clone(),
-                        range_start,
-                        "range remained blocked after retry passes".to_string(),
+                        key,
+                        outcome.range_start,
+                        format!("cascade-failed: dep '{}' failed", dep_name),
                     ));
+                    cascade_failed += 1;
+                    counts.3 += 1;
+                }
+                OutcomeStatus::DepCascadeBlocked { dep_name } => {
+                    tracing::info!(
+                        "Handler {} cascade-blocked on range {} due to dep '{}'",
+                        outcome.handler_name,
+                        outcome.range_start,
+                        dep_name
+                    );
+                    let key = handlers
+                        .iter()
+                        .find(|ch| ch.handler.name() == outcome.handler_name)
+                        .map(|ch| ch.handler.handler_key())
+                        .unwrap_or_else(|| outcome.handler_name.clone());
+                    failed_items.push((
+                        key,
+                        outcome.range_start,
+                        format!("cascade-blocked: dep '{}' blocked", dep_name),
+                    ));
+                    cascade_blocked += 1;
+                    counts.4 += 1;
+                }
+                OutcomeStatus::Panicked => {
+                    tracing::error!(
+                        "Handler {} panicked on range {}",
+                        outcome.handler_name,
+                        outcome.range_start
+                    );
+                    let key = handlers
+                        .iter()
+                        .find(|ch| ch.handler.name() == outcome.handler_name)
+                        .map(|ch| ch.handler.handler_key())
+                        .unwrap_or_else(|| outcome.handler_name.clone());
+                    failed_items.push((key, outcome.range_start, "task panicked".to_string()));
+                    counts.5 += 1;
                 }
             }
         }
+
+        // Per-handler outcome summary.
+        for ch in &handlers {
+            let name = ch.handler.name();
+            let Some(&(ok, failed, blocked_count, cascade, cascade_blocked_count, panicked)) =
+                per_handler_outcomes.get(name)
+            else {
+                continue;
+            };
+            let total = ok + failed + blocked_count + cascade + cascade_blocked_count + panicked;
+            if failed > 0
+                || blocked_count > 0
+                || cascade > 0
+                || cascade_blocked_count > 0
+                || panicked > 0
+            {
+                tracing::info!(
+                    "Handler {} catchup result: {}/{} succeeded \
+                     ({} failed, {} blocked, {} cascade-failed, {} cascade-blocked, {} panicked)",
+                    ch.handler.handler_key(),
+                    ok,
+                    total,
+                    failed,
+                    blocked_count,
+                    cascade,
+                    cascade_blocked_count,
+                    panicked
+                );
+            } else {
+                tracing::debug!(
+                    "Handler {} catchup result: {} range(s) ok",
+                    ch.handler.handler_key(),
+                    ok
+                );
+            }
+        }
+
+        tracing::info!(
+            "{} catchup complete: {} succeeded, {} blocked, {} cascade-blocked, {} cascade-failed in {:.1}s",
+            kind_label,
+            succeeded,
+            blocked,
+            cascade_blocked,
+            cascade_failed,
+            catchup_start.elapsed().as_secs_f64()
+        );
+
+        gauge!(
+            "transformation_catchup_ranges_remaining",
+            "kind" => kind_label,
+        )
+        .set(0.0f64);
 
         if failed_items.is_empty() {
             return Ok(());
@@ -2599,6 +2412,8 @@ impl TransformationEngine {
                     range_start,
                     range_end,
                     dep_names,
+                    contiguous_dep_names: Vec::new(),
+                    call_dep_keys: Vec::new(),
                     sequential: false,
                     payload: Box::new(ProcessRangePayload {
                         handler,
@@ -2627,6 +2442,8 @@ impl TransformationEngine {
                     range_start,
                     range_end,
                     dep_names: vec![],
+                    contiguous_dep_names: Vec::new(),
+                    call_dep_keys: Vec::new(),
                     sequential: false,
                     payload: Box::new(ProcessRangePayload {
                         handler,
@@ -2829,38 +2646,7 @@ impl super::retry::RecordAndFinalize for TransformationEngine {
     }
 }
 
-fn queue_pending_range(
-    next_pending: &mut HashMap<String, Vec<(u64, u64)>>,
-    pending_index: &mut HashSet<(String, u64, u64)>,
-    handler_name: &str,
-    range_start: u64,
-    range_end: u64,
-) {
-    let key = (handler_name.to_string(), range_start, range_end);
-    if pending_index.insert(key) {
-        next_pending
-            .entry(handler_name.to_string())
-            .or_default()
-            .push((range_start, range_end));
-    }
-}
-
-fn contiguous_completed_through(
-    available_starts: &[u64],
-    completed: &HashSet<u64>,
-) -> Option<u64> {
-    let mut last = None;
-    for range_start in available_starts {
-        if completed.contains(range_start) {
-            last = Some(*range_start);
-        } else {
-            break;
-        }
-    }
-    last
-}
-
-fn call_dependency_contract_index_complete(
+pub(crate) fn call_dependency_contract_index_complete(
     raw_index_dir: &Path,
     source: &str,
     range_start: u64,
@@ -2883,29 +2669,11 @@ fn call_dependency_contract_index_complete(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{HashMap, HashSet};
+    use std::collections::HashMap;
 
-    use super::{call_dependency_contract_index_complete, contiguous_completed_through};
+    use super::call_dependency_contract_index_complete;
     use crate::storage::contract_index::{range_key, update_contract_index, write_contract_index};
     use tempfile::tempdir;
-
-    #[test]
-    fn contiguous_completed_through_returns_none_when_first_range_is_missing() {
-        let completed = HashSet::from([200, 300]);
-        assert_eq!(
-            contiguous_completed_through(&[100, 200, 300], &completed),
-            None
-        );
-    }
-
-    #[test]
-    fn contiguous_completed_through_stops_at_first_gap() {
-        let completed = HashSet::from([100, 200, 400]);
-        assert_eq!(
-            contiguous_completed_through(&[100, 200, 300, 400], &completed),
-            Some(200)
-        );
-    }
 
     #[test]
     fn contract_index_gate_defaults_open_without_sidecar() {

--- a/src/transformations/engine.rs
+++ b/src/transformations/engine.rs
@@ -557,8 +557,8 @@ impl TransformationEngine {
             HandlerKind::Call => "Call",
         };
 
-        let available = self.scan_available_ranges(base_dir).await?;
-        let available_starts: Vec<u64> = available.iter().map(|(start, _)| *start).collect();
+        let mut available = self.scan_available_ranges(base_dir).await?;
+        let mut available_starts: Vec<u64> = available.iter().map(|(start, _)| *start).collect();
 
         if available.is_empty() {
             tracing::info!(
@@ -657,6 +657,21 @@ impl TransformationEngine {
                 ranges.extend(self.scan_available_ranges(&dir).await?);
             }
             trigger_range_sets.insert(ch.handler.name().to_string(), ranges);
+        }
+
+        // For call handlers, the base_dir scan picks up on_events/ files that
+        // belong to event-triggered call collection, polluting the available set
+        // with non-standard range sizes. Narrow available to only ranges that
+        // appear in at least one call handler's trigger directories.
+        if kind == HandlerKind::Call {
+            let trigger_union: HashSet<(u64, u64)> = trigger_range_sets
+                .values()
+                .flat_map(|s| s.iter().copied())
+                .collect();
+            let mut narrowed: Vec<(u64, u64)> = trigger_union.into_iter().collect();
+            narrowed.sort_by_key(|(start, _)| *start);
+            available = narrowed;
+            available_starts = available.iter().map(|(start, _)| *start).collect();
         }
 
         // Seed CompletionTracker from _handler_progress so downstream handlers

--- a/src/transformations/retry.rs
+++ b/src/transformations/retry.rs
@@ -521,6 +521,8 @@ impl RetryProcessor {
                 range_start,
                 range_end,
                 dep_names,
+                contiguous_dep_names: Vec::new(),
+                call_dep_keys: Vec::new(),
                 sequential: false,
                 payload: Box::new(RetryPayload {
                     handler: rh.handler.clone(),

--- a/src/transformations/scheduler/dag.rs
+++ b/src/transformations/scheduler/dag.rs
@@ -31,6 +31,13 @@ pub(crate) struct WorkItem {
     pub range_start: u64,
     pub range_end: u64,
     pub dep_names: Vec<String>,
+    /// Handler names whose contiguous watermark must be >= `range_start` before
+    /// this item can execute. Used for `contiguous_handler_dependencies`.
+    pub contiguous_dep_names: Vec<String>,
+    /// `(source, function)` pairs whose decoded call parquet files must be
+    /// available on disk for `(range_start, range_end)` before this item can
+    /// execute. Empty if no call deps or no trigger data in this range.
+    pub call_dep_keys: Vec<(String, String)>,
     /// When `true`, the scheduler enforces one-at-a-time FIFO execution for this
     /// handler via a per-handler capacity-1 semaphore. Items must be submitted in
     /// ascending `range_start` order for the FIFO guarantee to hold.
@@ -145,6 +152,8 @@ impl DagScheduler {
             let range_start = item.range_start;
             let range_end = item.range_end;
             let dep_names = item.dep_names.clone();
+            let contiguous_dep_names = item.contiguous_dep_names.clone();
+            let call_dep_keys = item.call_dep_keys.clone();
             let tracker = self.tracker.clone();
             let permits = self.global_permits.clone();
             let seq_sems = seq_sems.clone();
@@ -154,8 +163,17 @@ impl DagScheduler {
             // Data captured by the spawned task:
             let name_for_task = name.clone();
             let handle = join_set.spawn(async move {
-                // 1. Gate on dependencies.
-                if let Err(dep_wait) = tracker.wait_ready(&dep_names, range_start).await {
+                // 1. Gate on dependencies (handler deps + contiguous deps + call deps).
+                if let Err(dep_wait) = tracker
+                    .wait_ready_extended(
+                        &dep_names,
+                        &contiguous_dep_names,
+                        &call_dep_keys,
+                        range_start,
+                        (range_start, range_end),
+                    )
+                    .await
+                {
                     match dep_wait {
                         super::tracker::DepWaitError::DepFailed { dep_name, .. } => {
                             // Cascade: our own dependents must also short-circuit.
@@ -427,6 +445,8 @@ mod tests {
             range_start,
             range_end: range_start + 1,
             dep_names: deps.iter().map(|s| s.to_string()).collect(),
+            contiguous_dep_names: Vec::new(),
+            call_dep_keys: Vec::new(),
             sequential: false,
             payload: Box::new(()),
         }

--- a/src/transformations/scheduler/dag.rs
+++ b/src/transformations/scheduler/dag.rs
@@ -170,7 +170,6 @@ impl DagScheduler {
                         &contiguous_dep_names,
                         &call_dep_keys,
                         range_start,
-                        (range_start, range_end),
                     )
                     .await
                 {

--- a/src/transformations/scheduler/loader.rs
+++ b/src/transformations/scheduler/loader.rs
@@ -430,6 +430,188 @@ impl CatchupLoader {
     }
 }
 
+// ─── CallDepScanner ────────────────────────────────────────────────────────
+
+use std::collections::HashSet;
+
+use crate::storage::contract_index::build_expected_factory_contracts_for_range;
+use crate::transformations::engine::call_dependency_contract_index_complete;
+use crate::transformations::scheduler::tracker::CompletionTracker;
+
+/// Standalone call-dependency file scanner.
+///
+/// Periodically scans the decoded-calls directory for each unique `(source,
+/// function)` pair to discover which parquet ranges are available on disk.
+/// Registers newly-found ranges with the [`CompletionTracker`] so that
+/// `wait_ready_extended` can unblock items whose call deps have arrived.
+pub(crate) struct CallDepScanner {
+    decoded_calls_dir: PathBuf,
+    raw_eth_calls_dir: PathBuf,
+    contracts: Arc<Contracts>,
+    /// Unique `(source, function)` pairs to scan for.
+    call_dep_pairs: Vec<(String, String)>,
+}
+
+impl CallDepScanner {
+    pub(crate) fn new(
+        decoded_calls_dir: PathBuf,
+        raw_eth_calls_dir: PathBuf,
+        contracts: Arc<Contracts>,
+        call_dep_pairs: Vec<(String, String)>,
+    ) -> Self {
+        Self {
+            decoded_calls_dir,
+            raw_eth_calls_dir,
+            contracts,
+            call_dep_pairs,
+        }
+    }
+
+    /// Scan all `(source, function)` pairs and return available ranges.
+    pub(crate) async fn scan_all(
+        &self,
+    ) -> HashMap<(String, String), HashSet<(u64, u64)>> {
+        let mut results = HashMap::new();
+        for (source, function) in &self.call_dep_pairs {
+            match self.scan_one(source, function).await {
+                Ok(ranges) => {
+                    if !ranges.is_empty() {
+                        results.insert((source.clone(), function.clone()), ranges);
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "Call-dep scan failed for {}/{}: {}",
+                        source,
+                        function,
+                        e
+                    );
+                }
+            }
+        }
+        results
+    }
+
+    /// Scan one `(source, function)` pair for available decoded call parquet files.
+    ///
+    /// This is the same logic as `TransformationEngine::scan_available_call_dependency_ranges`
+    /// but extracted to avoid borrowing `&self` across a spawn boundary.
+    async fn scan_one(
+        &self,
+        source: &str,
+        function_name: &str,
+    ) -> Result<HashSet<(u64, u64)>, std::io::Error> {
+        let source = source.to_string();
+        let function_name = function_name.to_string();
+        let decoded_base = self.decoded_calls_dir.join(&source).join(&function_name);
+        let raw_base = self.raw_eth_calls_dir.join(&source).join(&function_name);
+        let contracts = self.contracts.clone();
+
+        tokio::task::spawn_blocking(move || {
+            fn scan_recursive(
+                dir: &Path,
+                decoded_base: &Path,
+                raw_base: &Path,
+                source: &str,
+                function_name: &str,
+                contracts: &Contracts,
+                ranges: &mut HashSet<(u64, u64)>,
+            ) -> std::io::Result<()> {
+                if !dir.exists() {
+                    return Ok(());
+                }
+                for entry in std::fs::read_dir(dir)? {
+                    let entry = entry?;
+                    let path = entry.path();
+                    if path.is_dir() {
+                        scan_recursive(
+                            &path,
+                            decoded_base,
+                            raw_base,
+                            source,
+                            function_name,
+                            contracts,
+                            ranges,
+                        )?;
+                        continue;
+                    }
+                    if !path.extension().is_some_and(|ext| ext == "parquet") {
+                        continue;
+                    }
+                    let Some((range_start, range_end_inclusive)) =
+                        crate::storage::paths::parse_range_from_filename(&path)
+                    else {
+                        continue;
+                    };
+                    let range_end = range_end_inclusive + 1;
+                    let expected =
+                        build_expected_factory_contracts_for_range(contracts, range_end);
+                    let parent_dir = path.parent().unwrap_or(decoded_base);
+                    let relative_parent = parent_dir
+                        .strip_prefix(decoded_base)
+                        .ok()
+                        .filter(|rel| !rel.as_os_str().is_empty());
+                    let raw_index_dir = match relative_parent {
+                        Some(rel) => raw_base.join(rel),
+                        None => raw_base.to_path_buf(),
+                    };
+                    if !call_dependency_contract_index_complete(
+                        &raw_index_dir,
+                        source,
+                        range_start,
+                        range_end,
+                        &expected,
+                    ) {
+                        continue;
+                    }
+                    ranges.insert((range_start, range_end));
+                }
+                Ok(())
+            }
+
+            let mut ranges = HashSet::new();
+            if !decoded_base.exists() {
+                return Ok(ranges);
+            }
+            scan_recursive(
+                &decoded_base,
+                &decoded_base,
+                &raw_base,
+                &source,
+                &function_name,
+                contracts.as_ref(),
+                &mut ranges,
+            )?;
+            Ok(ranges)
+        })
+        .await
+        .map_err(|e| std::io::Error::other(e.to_string()))?
+    }
+}
+
+/// Background scanner loop that periodically discovers call-dep files and
+/// registers them with the tracker.
+///
+/// The loop runs until the `cancel` watch receives `true`, or the task is
+/// aborted. Callers typically abort the returned `JoinHandle` when catchup
+/// finishes.
+pub(crate) async fn run_call_dep_scanner_loop(
+    scanner: CallDepScanner,
+    tracker: Arc<CompletionTracker>,
+    mut cancel: tokio::sync::watch::Receiver<bool>,
+) {
+    loop {
+        let results = scanner.scan_all().await;
+        for ((source, func), ranges) in results {
+            tracker.register_call_dep_ranges(&source, &func, ranges).await;
+        }
+        tokio::select! {
+            _ = tokio::time::sleep(std::time::Duration::from_secs(2)) => {},
+            _ = cancel.changed() => break,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::dag::{DagScheduler, OutcomeStatus, WorkItem, WorkItemRunResult};
@@ -513,6 +695,8 @@ mod tests {
             range_start,
             range_end: range_start + 1000,
             dep_names: deps.iter().map(|s| s.to_string()).collect(),
+            contiguous_dep_names: Vec::new(),
+            call_dep_keys: Vec::new(),
             sequential: false,
             payload: Box::new(()),
         }

--- a/src/transformations/scheduler/tracker.rs
+++ b/src/transformations/scheduler/tracker.rs
@@ -35,8 +35,10 @@ use tokio::sync::{Notify, RwLock};
 /// - **Contiguous watermarks**: per-handler highest `range_start` with no gap
 ///   from the first available range. Used to gate handlers with
 ///   `contiguous_handler_dependencies`.
-/// - **Call-dep ranges**: per-`(source, function)` set of `(range_start,
-///   range_end)` pairs where decoded call parquet files are available on disk.
+/// - **Call-dep ranges**: per-`(source, function)` set of `range_start`
+///   values where decoded call parquet files are available on disk.
+///   Matched by range_start only (not range_end) since log and call-dep
+///   parquet files may use different range sizes.
 ///   Updated by a background scanner task.
 ///
 /// [`WorkItem`]: super::dag::WorkItem
@@ -53,9 +55,10 @@ pub(crate) struct CompletionTracker {
     contiguous_watermarks: RwLock<HashMap<String, Option<u64>>>,
     /// Per-handler index into `available_starts` for O(1) amortized watermark advance.
     contiguous_positions: RwLock<HashMap<String, usize>>,
-    /// Per-`(source, function)` set of available call-dep range keys.
+    /// Per-`(source, function)` set of available call-dep range_starts.
+    /// Matched by range_start only (log and call-dep files may have different range sizes).
     /// Updated by the background `CallDepScanner`.
-    call_dep_ranges: RwLock<HashMap<(String, String), HashSet<(u64, u64)>>>,
+    call_dep_ranges: RwLock<HashMap<(String, String), HashSet<u64>>>,
 }
 
 /// Snapshot view of whether a set of dependencies is satisfied for a range.
@@ -407,6 +410,10 @@ impl CompletionTracker {
 
     /// Bulk-register available call-dep ranges for a `(source, function)` pair.
     ///
+    /// Accepts `(range_start, range_end)` tuples from the scanner but stores
+    /// only `range_start` values — call-dep and log parquet files may use
+    /// different range sizes, so matching on range_start alone is correct.
+    ///
     /// Called by the background `CallDepScanner`. Only calls `notify_waiters`
     /// if at least one new range was added.
     pub(crate) async fn register_call_dep_ranges(
@@ -419,7 +426,7 @@ impl CompletionTracker {
         let mut call_deps = self.call_dep_ranges.write().await;
         let entry = call_deps.entry(key).or_insert_with(HashSet::new);
         let old_len = entry.len();
-        entry.extend(ranges);
+        entry.extend(ranges.into_iter().map(|(start, _end)| start));
         let grew = entry.len() > old_len;
         drop(call_deps);
         if grew {
@@ -436,7 +443,6 @@ impl CompletionTracker {
         contiguous_deps: &[String],
         call_dep_keys: &[(String, String)],
         range_start: u64,
-        range_key: (u64, u64),
     ) -> DepState {
         // 1. Check handler deps failed/blocked/waiting (existing logic).
         {
@@ -475,12 +481,12 @@ impl CompletionTracker {
             }
         }
 
-        // 3. Check call-dep file availability.
+        // 3. Check call-dep file availability (matched by range_start only).
         if !call_dep_keys.is_empty() {
             let call_deps = self.call_dep_ranges.read().await;
             for (source, function) in call_dep_keys {
                 let key = (source.clone(), function.clone());
-                if !call_deps.get(&key).is_some_and(|r| r.contains(&range_key)) {
+                if !call_deps.get(&key).is_some_and(|r| r.contains(&range_start)) {
                     return DepState::Waiting;
                 }
             }
@@ -490,7 +496,10 @@ impl CompletionTracker {
     }
 
     /// Await until handler deps, contiguous watermark deps, and call-dep files
-    /// are all satisfied for `(range_start, range_end)`.
+    /// are all satisfied for `range_start`.
+    ///
+    /// Call-dep availability is matched by `range_start` only (not range_end)
+    /// since log and call-dep parquet files may use different range sizes.
     ///
     /// Same wake-safety invariant as [`wait_ready`]: `notified()` is constructed
     /// before probing.
@@ -500,12 +509,11 @@ impl CompletionTracker {
         contiguous_deps: &[String],
         call_dep_keys: &[(String, String)],
         range_start: u64,
-        range_key: (u64, u64),
     ) -> Result<(), DepWaitError> {
         loop {
             let notified = self.notify.notified();
             match self
-                .probe_extended(handler_deps, contiguous_deps, call_dep_keys, range_start, range_key)
+                .probe_extended(handler_deps, contiguous_deps, call_dep_keys, range_start)
                 .await
             {
                 DepState::Ready => return Ok(()),
@@ -896,7 +904,7 @@ mod tests {
         let tracker2 = tracker.clone();
         let handle = tokio::spawn(async move {
             tracker2
-                .wait_ready_extended(&[], &names(&["A"]), &[], 200, (200, 300))
+                .wait_ready_extended(&[], &names(&["A"]), &[], 200)
                 .await
                 .unwrap();
         });
@@ -919,21 +927,21 @@ mod tests {
         let handle = tokio::spawn(async move {
             let call_deps = vec![("src".to_string(), "func".to_string())];
             tracker2
-                .wait_ready_extended(&[], &[], &call_deps, 100, (100, 200))
+                .wait_ready_extended(&[], &[], &call_deps, 100)
                 .await
                 .unwrap();
         });
         tokio::time::sleep(Duration::from_millis(10)).await;
         assert!(!handle.is_finished(), "should wait for call-dep");
 
-        // Register the call-dep range.
+        // Register the call-dep range (range_end differs from log's range_end — only range_start matters).
         let mut ranges = HashSet::new();
-        ranges.insert((100u64, 200u64));
+        ranges.insert((100u64, 250u64)); // Different range_end than log's (100, 200)
         tracker.register_call_dep_ranges("src", "func", ranges).await;
 
         tokio::time::timeout(Duration::from_millis(100), handle)
             .await
-            .expect("waiter should resolve after call-dep registered")
+            .expect("waiter should resolve after call-dep registered (matched by range_start only)")
             .unwrap();
     }
 
@@ -941,7 +949,7 @@ mod tests {
     async fn wait_ready_extended_combined_gating() {
         let tracker = Arc::new(CompletionTracker::with_available_starts(vec![100, 200, 300]));
         // Need: handler dep B completed for range 200, contiguous dep A >= 200,
-        // call dep (src, func) available for (200, 300).
+        // call dep (src, func) available for range_start 200.
         tracker.seed_completed("A", [100]).await;
 
         let tracker2 = tracker.clone();
@@ -953,7 +961,6 @@ mod tests {
                     &names(&["A"]),
                     &call_deps,
                     200,
-                    (200, 300),
                 )
                 .await
                 .unwrap();
@@ -971,9 +978,9 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(10)).await;
         assert!(!handle.is_finished(), "still waiting on call dep");
 
-        // Satisfy call dep.
+        // Satisfy call dep (call-dep file has different range_end — only range_start matters).
         let mut ranges = HashSet::new();
-        ranges.insert((200u64, 300u64));
+        ranges.insert((200u64, 400u64));
         tracker.register_call_dep_ranges("src", "func", ranges).await;
         tokio::time::timeout(Duration::from_millis(100), handle)
             .await
@@ -986,7 +993,7 @@ mod tests {
         let tracker = CompletionTracker::with_available_starts(vec![100, 200]);
         tracker.mark_failed("A", 100).await;
         let state = tracker
-            .probe_extended(&names(&["A"]), &[], &[], 100, (100, 200))
+            .probe_extended(&names(&["A"]), &[], &[], 100)
             .await;
         assert_eq!(
             state,

--- a/src/transformations/scheduler/tracker.rs
+++ b/src/transformations/scheduler/tracker.rs
@@ -31,6 +31,14 @@ use tokio::sync::{Notify, RwLock};
 /// finish. Waiters register interest via [`wait_ready`] and are woken on every
 /// state transition.
 ///
+/// In continuous-scheduler mode, also tracks:
+/// - **Contiguous watermarks**: per-handler highest `range_start` with no gap
+///   from the first available range. Used to gate handlers with
+///   `contiguous_handler_dependencies`.
+/// - **Call-dep ranges**: per-`(source, function)` set of `(range_start,
+///   range_end)` pairs where decoded call parquet files are available on disk.
+///   Updated by a background scanner task.
+///
 /// [`WorkItem`]: super::dag::WorkItem
 /// [`wait_ready`]: CompletionTracker::wait_ready
 pub(crate) struct CompletionTracker {
@@ -38,6 +46,16 @@ pub(crate) struct CompletionTracker {
     failed: RwLock<HashMap<String, HashSet<u64>>>,
     blocked: RwLock<HashMap<String, HashSet<u64>>>,
     notify: Notify,
+    /// Sorted list of all available range_starts (immutable after construction).
+    available_starts: Vec<u64>,
+    /// Per-handler contiguous watermark: highest `range_start` where all ranges
+    /// from the first available through this one are completed with no gaps.
+    contiguous_watermarks: RwLock<HashMap<String, Option<u64>>>,
+    /// Per-handler index into `available_starts` for O(1) amortized watermark advance.
+    contiguous_positions: RwLock<HashMap<String, usize>>,
+    /// Per-`(source, function)` set of available call-dep range keys.
+    /// Updated by the background `CallDepScanner`.
+    call_dep_ranges: RwLock<HashMap<(String, String), HashSet<(u64, u64)>>>,
 }
 
 /// Snapshot view of whether a set of dependencies is satisfied for a range.
@@ -71,6 +89,28 @@ impl CompletionTracker {
             failed: RwLock::new(HashMap::new()),
             blocked: RwLock::new(HashMap::new()),
             notify: Notify::new(),
+            available_starts: Vec::new(),
+            contiguous_watermarks: RwLock::new(HashMap::new()),
+            contiguous_positions: RwLock::new(HashMap::new()),
+            call_dep_ranges: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Create a tracker with a known set of available range starts.
+    ///
+    /// The `starts` must be sorted ascending. This enables contiguous watermark
+    /// tracking for handlers with `contiguous_handler_dependencies`.
+    pub(crate) fn with_available_starts(starts: Vec<u64>) -> Self {
+        debug_assert!(starts.windows(2).all(|w| w[0] < w[1]), "starts must be sorted");
+        Self {
+            completed: RwLock::new(HashMap::new()),
+            failed: RwLock::new(HashMap::new()),
+            blocked: RwLock::new(HashMap::new()),
+            notify: Notify::new(),
+            available_starts: starts,
+            contiguous_watermarks: RwLock::new(HashMap::new()),
+            contiguous_positions: RwLock::new(HashMap::new()),
+            call_dep_ranges: RwLock::new(HashMap::new()),
         }
     }
 
@@ -78,6 +118,8 @@ impl CompletionTracker {
     /// seeding from `_handler_progress`. Calls `notify_waiters` so that any
     /// waiters that happen to be active (e.g. Phase 4 live-mode overlap)
     /// see the newly-seeded state.
+    ///
+    /// Also computes the initial contiguous watermark for this handler.
     pub(crate) async fn seed_completed(
         &self,
         handler_name: &str,
@@ -91,6 +133,10 @@ impl CompletionTracker {
             for range in ranges {
                 entry.insert(range);
             }
+        }
+        // Compute initial contiguous watermark from seeded data.
+        if !self.available_starts.is_empty() {
+            self.recompute_contiguous_watermark(handler_name).await;
         }
         self.notify.notify_waiters();
     }
@@ -179,6 +225,8 @@ impl CompletionTracker {
     }
 
     /// Mark `(handler_name, range_start)` as completed and wake all waiters.
+    ///
+    /// Also advances the contiguous watermark for this handler if applicable.
     pub(crate) async fn mark_completed(&self, handler_name: &str, range_start: u64) {
         {
             let mut completed = self.completed.write().await;
@@ -195,6 +243,9 @@ impl CompletionTracker {
                     blocked.remove(handler_name);
                 }
             }
+        }
+        if !self.available_starts.is_empty() {
+            self.advance_contiguous_watermark(handler_name).await;
         }
         self.notify.notify_waiters();
     }
@@ -264,6 +315,234 @@ impl CompletionTracker {
             .get(handler_name)
             .map(|ranges| ranges.contains(&range_start))
             .unwrap_or(false)
+    }
+
+    // ─── Contiguous watermark tracking ──────────────────────────────────
+
+    /// Full recomputation of contiguous watermark from position 0.
+    /// Used during `seed_completed`.
+    async fn recompute_contiguous_watermark(&self, handler_name: &str) {
+        let completed = self.completed.read().await;
+        let handler_completed = completed.get(handler_name);
+        let mut pos = 0usize;
+        let mut watermark: Option<u64> = None;
+        for (i, &start) in self.available_starts.iter().enumerate() {
+            if handler_completed.is_some_and(|c| c.contains(&start)) {
+                watermark = Some(start);
+                pos = i;
+            } else {
+                break;
+            }
+        }
+        drop(completed);
+        let mut watermarks = self.contiguous_watermarks.write().await;
+        watermarks.insert(handler_name.to_string(), watermark);
+        let mut positions = self.contiguous_positions.write().await;
+        positions.insert(handler_name.to_string(), pos);
+    }
+
+    /// Incrementally advance the contiguous watermark after a new completion.
+    ///
+    /// Starting from the current position index, walks forward through
+    /// `available_starts` while each successive range_start is in
+    /// `completed[handler_name]`. O(k) amortized where k = newly-contiguous
+    /// ranges (typically 0 or 1).
+    async fn advance_contiguous_watermark(&self, handler_name: &str) {
+        let completed = self.completed.read().await;
+        let handler_completed = match completed.get(handler_name) {
+            Some(c) => c,
+            None => return,
+        };
+
+        let watermarks_read = self.contiguous_watermarks.read().await;
+        let current_watermark = watermarks_read
+            .get(handler_name)
+            .copied()
+            .flatten();
+        let positions_read = self.contiguous_positions.read().await;
+        let current_pos = positions_read
+            .get(handler_name)
+            .copied()
+            .unwrap_or(0);
+        drop(positions_read);
+        drop(watermarks_read);
+
+        // Determine the starting index for the walk. If there is no watermark
+        // yet, start from 0 (the handler might now have completed the first
+        // range). Otherwise start from the position after the current watermark.
+        let start_idx = if current_watermark.is_some() {
+            current_pos + 1
+        } else {
+            0
+        };
+
+        let mut new_pos = current_pos;
+        let mut new_watermark = current_watermark;
+        for i in start_idx..self.available_starts.len() {
+            if handler_completed.contains(&self.available_starts[i]) {
+                new_pos = i;
+                new_watermark = Some(self.available_starts[i]);
+            } else {
+                break;
+            }
+        }
+
+        // Only take write locks if something changed.
+        if new_watermark != current_watermark {
+            drop(completed);
+            let mut watermarks = self.contiguous_watermarks.write().await;
+            watermarks.insert(handler_name.to_string(), new_watermark);
+            let mut positions = self.contiguous_positions.write().await;
+            positions.insert(handler_name.to_string(), new_pos);
+        }
+    }
+
+    /// Read the current contiguous watermark for a handler.
+    pub(crate) async fn contiguous_watermark(&self, handler_name: &str) -> Option<u64> {
+        let watermarks = self.contiguous_watermarks.read().await;
+        watermarks.get(handler_name).copied().flatten()
+    }
+
+    // ─── Call-dep range tracking ────────────────────────────────────────
+
+    /// Bulk-register available call-dep ranges for a `(source, function)` pair.
+    ///
+    /// Called by the background `CallDepScanner`. Only calls `notify_waiters`
+    /// if at least one new range was added.
+    pub(crate) async fn register_call_dep_ranges(
+        &self,
+        source: &str,
+        function: &str,
+        ranges: HashSet<(u64, u64)>,
+    ) {
+        let key = (source.to_string(), function.to_string());
+        let mut call_deps = self.call_dep_ranges.write().await;
+        let entry = call_deps.entry(key).or_insert_with(HashSet::new);
+        let old_len = entry.len();
+        entry.extend(ranges);
+        let grew = entry.len() > old_len;
+        drop(call_deps);
+        if grew {
+            self.notify.notify_waiters();
+        }
+    }
+
+    // ─── Extended wait (handler deps + contiguous deps + call deps) ─────
+
+    /// Snapshot check for the extended readiness condition.
+    pub(crate) async fn probe_extended(
+        &self,
+        handler_deps: &[String],
+        contiguous_deps: &[String],
+        call_dep_keys: &[(String, String)],
+        range_start: u64,
+        range_key: (u64, u64),
+    ) -> DepState {
+        // 1. Check handler deps failed/blocked/waiting (existing logic).
+        {
+            let failed = self.failed.read().await;
+            for dep in handler_deps {
+                if failed.get(dep).is_some_and(|r| r.contains(&range_start)) {
+                    return DepState::DepFailed { dep_name: dep.clone() };
+                }
+            }
+        }
+        {
+            let blocked = self.blocked.read().await;
+            for dep in handler_deps {
+                if blocked.get(dep).is_some_and(|r| r.contains(&range_start)) {
+                    return DepState::DepBlocked { dep_name: dep.clone() };
+                }
+            }
+        }
+        {
+            let completed = self.completed.read().await;
+            for dep in handler_deps {
+                if !completed.get(dep).is_some_and(|r| r.contains(&range_start)) {
+                    return DepState::Waiting;
+                }
+            }
+        }
+
+        // 2. Check contiguous handler deps.
+        if !contiguous_deps.is_empty() {
+            let watermarks = self.contiguous_watermarks.read().await;
+            for dep in contiguous_deps {
+                let watermark = watermarks.get(dep).copied().flatten();
+                if !watermark.is_some_and(|w| w >= range_start) {
+                    return DepState::Waiting;
+                }
+            }
+        }
+
+        // 3. Check call-dep file availability.
+        if !call_dep_keys.is_empty() {
+            let call_deps = self.call_dep_ranges.read().await;
+            for (source, function) in call_dep_keys {
+                let key = (source.clone(), function.clone());
+                if !call_deps.get(&key).is_some_and(|r| r.contains(&range_key)) {
+                    return DepState::Waiting;
+                }
+            }
+        }
+
+        DepState::Ready
+    }
+
+    /// Await until handler deps, contiguous watermark deps, and call-dep files
+    /// are all satisfied for `(range_start, range_end)`.
+    ///
+    /// Same wake-safety invariant as [`wait_ready`]: `notified()` is constructed
+    /// before probing.
+    pub(crate) async fn wait_ready_extended(
+        &self,
+        handler_deps: &[String],
+        contiguous_deps: &[String],
+        call_dep_keys: &[(String, String)],
+        range_start: u64,
+        range_key: (u64, u64),
+    ) -> Result<(), DepWaitError> {
+        loop {
+            let notified = self.notify.notified();
+            match self
+                .probe_extended(handler_deps, contiguous_deps, call_dep_keys, range_start, range_key)
+                .await
+            {
+                DepState::Ready => return Ok(()),
+                DepState::DepFailed { dep_name } => {
+                    return Err(DepWaitError::DepFailed { dep_name, range_start })
+                }
+                DepState::DepBlocked { dep_name } => {
+                    return Err(DepWaitError::DepBlocked { dep_name, range_start })
+                }
+                DepState::Waiting => notified.await,
+            }
+        }
+    }
+
+    // ─── Observability ──────────────────────────────────────────────────
+
+    /// Snapshot of per-handler progress for periodic logging.
+    ///
+    /// Returns `(completed_count, failed_count, blocked_count)` per handler.
+    pub(crate) async fn snapshot_progress(
+        &self,
+    ) -> HashMap<String, (usize, usize, usize)> {
+        let completed = self.completed.read().await;
+        let failed = self.failed.read().await;
+        let blocked = self.blocked.read().await;
+
+        let mut result: HashMap<String, (usize, usize, usize)> = HashMap::new();
+        for (name, ranges) in completed.iter() {
+            result.entry(name.clone()).or_default().0 = ranges.len();
+        }
+        for (name, ranges) in failed.iter() {
+            result.entry(name.clone()).or_default().1 = ranges.len();
+        }
+        for (name, ranges) in blocked.iter() {
+            result.entry(name.clone()).or_default().2 = ranges.len();
+        }
+        result
     }
 }
 
@@ -548,5 +827,183 @@ mod tests {
         tracker.clear_blocked("A", 100).await;
         assert!(!tracker.is_blocked("A", 100).await);
         assert_eq!(tracker.probe(&names(&["A"]), 100).await, DepState::Waiting);
+    }
+
+    // ─── Contiguous watermark tests ─────────────────────────────────────
+
+    #[tokio::test]
+    async fn contiguous_watermark_seed_computes_initial() {
+        let tracker = CompletionTracker::with_available_starts(vec![100, 200, 300, 400, 500]);
+        // Seed with a contiguous prefix.
+        tracker.seed_completed("A", [100, 200, 300]).await;
+        assert_eq!(tracker.contiguous_watermark("A").await, Some(300));
+    }
+
+    #[tokio::test]
+    async fn contiguous_watermark_seed_with_gap() {
+        let tracker = CompletionTracker::with_available_starts(vec![100, 200, 300, 400, 500]);
+        // Gap at 200 means watermark stops at 100.
+        tracker.seed_completed("A", [100, 300, 400]).await;
+        assert_eq!(tracker.contiguous_watermark("A").await, Some(100));
+    }
+
+    #[tokio::test]
+    async fn contiguous_watermark_seed_missing_first() {
+        let tracker = CompletionTracker::with_available_starts(vec![100, 200, 300]);
+        // First range not completed.
+        tracker.seed_completed("A", [200, 300]).await;
+        assert_eq!(tracker.contiguous_watermark("A").await, None);
+    }
+
+    #[tokio::test]
+    async fn contiguous_watermark_advances_on_mark_completed() {
+        let tracker = CompletionTracker::with_available_starts(vec![100, 200, 300, 400]);
+        tracker.seed_completed("A", [100, 200]).await;
+        assert_eq!(tracker.contiguous_watermark("A").await, Some(200));
+
+        // Complete 300 — watermark should advance.
+        tracker.mark_completed("A", 300).await;
+        assert_eq!(tracker.contiguous_watermark("A").await, Some(300));
+    }
+
+    #[tokio::test]
+    async fn contiguous_watermark_fills_gap() {
+        let tracker = CompletionTracker::with_available_starts(vec![100, 200, 300, 400]);
+        tracker.seed_completed("A", [100, 300, 400]).await;
+        assert_eq!(tracker.contiguous_watermark("A").await, Some(100));
+
+        // Fill the gap at 200 — watermark should jump to 400.
+        tracker.mark_completed("A", 200).await;
+        assert_eq!(tracker.contiguous_watermark("A").await, Some(400));
+    }
+
+    #[tokio::test]
+    async fn contiguous_watermark_no_available_starts() {
+        let tracker = CompletionTracker::new(); // No available_starts.
+        tracker.seed_completed("A", [100, 200]).await;
+        // Should return None — no available_starts to track against.
+        assert_eq!(tracker.contiguous_watermark("A").await, None);
+    }
+
+    // ─── Extended wait tests ────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn wait_ready_extended_contiguous_dep_gates() {
+        let tracker = Arc::new(CompletionTracker::with_available_starts(vec![100, 200, 300]));
+        // A has completed 100 only; contiguous watermark = 100.
+        tracker.seed_completed("A", [100]).await;
+
+        let tracker2 = tracker.clone();
+        let handle = tokio::spawn(async move {
+            tracker2
+                .wait_ready_extended(&[], &names(&["A"]), &[], 200, (200, 300))
+                .await
+                .unwrap();
+        });
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        assert!(!handle.is_finished(), "should wait for A's watermark to reach 200");
+
+        // Complete A:200 → watermark advances to 200 → waiter unblocks.
+        tracker.mark_completed("A", 200).await;
+        tokio::time::timeout(Duration::from_millis(100), handle)
+            .await
+            .expect("waiter should resolve")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn wait_ready_extended_call_dep_gates() {
+        let tracker = Arc::new(CompletionTracker::with_available_starts(vec![100, 200]));
+
+        let tracker2 = tracker.clone();
+        let handle = tokio::spawn(async move {
+            let call_deps = vec![("src".to_string(), "func".to_string())];
+            tracker2
+                .wait_ready_extended(&[], &[], &call_deps, 100, (100, 200))
+                .await
+                .unwrap();
+        });
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        assert!(!handle.is_finished(), "should wait for call-dep");
+
+        // Register the call-dep range.
+        let mut ranges = HashSet::new();
+        ranges.insert((100u64, 200u64));
+        tracker.register_call_dep_ranges("src", "func", ranges).await;
+
+        tokio::time::timeout(Duration::from_millis(100), handle)
+            .await
+            .expect("waiter should resolve after call-dep registered")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn wait_ready_extended_combined_gating() {
+        let tracker = Arc::new(CompletionTracker::with_available_starts(vec![100, 200, 300]));
+        // Need: handler dep B completed for range 200, contiguous dep A >= 200,
+        // call dep (src, func) available for (200, 300).
+        tracker.seed_completed("A", [100]).await;
+
+        let tracker2 = tracker.clone();
+        let handle = tokio::spawn(async move {
+            let call_deps = vec![("src".to_string(), "func".to_string())];
+            tracker2
+                .wait_ready_extended(
+                    &names(&["B"]),
+                    &names(&["A"]),
+                    &call_deps,
+                    200,
+                    (200, 300),
+                )
+                .await
+                .unwrap();
+        });
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        assert!(!handle.is_finished());
+
+        // Satisfy handler dep B.
+        tracker.mark_completed("B", 200).await;
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        assert!(!handle.is_finished(), "still waiting on contiguous + call dep");
+
+        // Satisfy contiguous dep A.
+        tracker.mark_completed("A", 200).await;
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        assert!(!handle.is_finished(), "still waiting on call dep");
+
+        // Satisfy call dep.
+        let mut ranges = HashSet::new();
+        ranges.insert((200u64, 300u64));
+        tracker.register_call_dep_ranges("src", "func", ranges).await;
+        tokio::time::timeout(Duration::from_millis(100), handle)
+            .await
+            .expect("waiter should resolve after all deps satisfied")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn probe_extended_reports_failed_dep() {
+        let tracker = CompletionTracker::with_available_starts(vec![100, 200]);
+        tracker.mark_failed("A", 100).await;
+        let state = tracker
+            .probe_extended(&names(&["A"]), &[], &[], 100, (100, 200))
+            .await;
+        assert_eq!(
+            state,
+            DepState::DepFailed { dep_name: "A".to_string() }
+        );
+    }
+
+    #[tokio::test]
+    async fn snapshot_progress_returns_counts() {
+        let tracker = CompletionTracker::new();
+        tracker.mark_completed("A", 100).await;
+        tracker.mark_completed("A", 200).await;
+        tracker.mark_failed("B", 100).await;
+        tracker.mark_blocked("A", 300).await;
+
+        let snap = tracker.snapshot_progress().await;
+        assert_eq!(snap.get("A"), Some(&(2, 0, 1)));
+        assert_eq!(snap.get("B"), Some(&(0, 1, 0)));
     }
 }


### PR DESCRIPTION
## Summary

- Replace the multi-pass loop in `run_handler_catchup` with a single `DagScheduler::execute()` call that submits all `(handler, range)` pairs upfront
- Each item gates on its actual prerequisites via `wait_ready_extended()`: same-range handler deps, contiguous watermark deps, and call-dep file availability
- A slow unrelated handler (e.g., DERC20TransferHandler) no longer blocks deferred items from retrying — items unblock the instant their prerequisites are met

## What changed

**CompletionTracker** (`scheduler/tracker.rs`):
- Added contiguous watermark tracking: `available_starts`, `contiguous_watermarks`, `contiguous_positions` — watermarks advance incrementally on each `mark_completed`
- Added call-dep range tracking: `call_dep_ranges` map, updated by background scanner
- New `wait_ready_extended()` gates on all three conditions (handler deps + contiguous deps + call deps)
- New `snapshot_progress()` for observability

**WorkItem** (`scheduler/dag.rs`):
- Added `contiguous_dep_names` and `call_dep_keys` fields
- `execute()` now calls `wait_ready_extended` instead of `wait_ready`

**CallDepScanner** (`scheduler/loader.rs`):
- Extracted filesystem scanning from `TransformationEngine::scan_available_call_dependency_ranges` into standalone struct
- Background `run_call_dep_scanner_loop` polls every 2s and registers new ranges with the tracker

**run_handler_catchup** (`engine.rs`):
- Removed: pass loop, `deferred_starts`, `next_pending`, `ranges_pending`, `contiguous_watermarks` local, `queue_pending_range`, `contiguous_completed_through`, cascade deferral logic, 1s retry sleep
- Added: single-submit of all items, background call-dep scanner, periodic progress reporter (every 30s)
- `dep_names` now carries only same-range handler deps; contiguous deps go in `contiguous_dep_names`