### PR TITLE
fix: db jitter, compaction lock, collector config, orphaned locks

### DIFF
--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -1,5 +1,6 @@
 use bytes::BytesMut;
 use deadpool_postgres::{Manager, ManagerConfig, Pool, RecyclingMethod, Runtime};
+use rand::Rng;
 use tokio_postgres::error::SqlState;
 use tokio_postgres::types::ToSql;
 use tokio_postgres::NoTls;
@@ -59,12 +60,16 @@ impl DbPool {
             match self.try_execute_transaction(&operations).await {
                 Ok(()) => return Ok(()),
                 Err(e) if is_deadlock(&e) && attempt < DEADLOCK_MAX_RETRIES => {
-                    let delay_ms = DEADLOCK_BASE_DELAY_MS * (1u64 << attempt);
+                    let base_delay_ms = DEADLOCK_BASE_DELAY_MS * (1u64 << attempt);
+                    let jitter_range = base_delay_ms / 5; // ±20%
+                    let jitter_offset = rand::rng().random_range(0..=(jitter_range * 2));
+                    let delay_ms = base_delay_ms - jitter_range + jitter_offset;
                     tracing::warn!(
-                        "Deadlock detected (attempt {}/{}), retrying in {}ms",
+                        "Deadlock detected (attempt {}/{}), retrying in {}ms (base={}ms)",
                         attempt + 1,
                         DEADLOCK_MAX_RETRIES + 1,
                         delay_ms,
+                        base_delay_ms,
                     );
                     tokio::time::sleep(tokio::time::Duration::from_millis(delay_ms)).await;
                 }

--- a/src/live/collector.rs
+++ b/src/live/collector.rs
@@ -53,6 +53,19 @@ pub enum CollectorError {
     ReorgCleanupFailed(Vec<u64>),
 }
 
+/// Configuration for creating a `LiveCollector`.
+pub struct LiveCollectorConfig {
+    pub chain: Arc<ChainConfig>,
+    pub http_client: Arc<UnifiedRpcClient>,
+    pub config: LiveModeConfig,
+    pub progress_tracker: Option<Arc<Mutex<LiveProgressTracker>>>,
+    pub factory_matchers: Arc<Vec<FactoryMatcher>>,
+    pub eth_call_collector: Option<LiveEthCallCollector>,
+    pub db_pool: Option<Arc<DbPool>>,
+    pub expectations: LivePipelineExpectations,
+    pub transform_retry_tx: Option<mpsc::Sender<TransformRetryRequest>>,
+}
+
 /// Collects live blocks from WebSocket and processes them.
 pub struct LiveCollector {
     chain: Arc<ChainConfig>,
@@ -82,18 +95,19 @@ pub struct LiveCollector {
 
 impl LiveCollector {
     /// Create a new LiveCollector.
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        chain: Arc<ChainConfig>,
-        http_client: Arc<UnifiedRpcClient>,
-        config: LiveModeConfig,
-        progress_tracker: Option<Arc<Mutex<LiveProgressTracker>>>,
-        factory_matchers: Arc<Vec<FactoryMatcher>>,
-        eth_call_collector: Option<LiveEthCallCollector>,
-        db_pool: Option<Arc<DbPool>>,
-        expectations: LivePipelineExpectations,
-        transform_retry_tx: Option<mpsc::Sender<TransformRetryRequest>>,
-    ) -> Self {
+    pub fn new(cfg: LiveCollectorConfig) -> Self {
+        let LiveCollectorConfig {
+            chain,
+            http_client,
+            config,
+            progress_tracker,
+            factory_matchers,
+            eth_call_collector,
+            db_pool,
+            expectations,
+            transform_retry_tx,
+        } = cfg;
+
         let storage = LiveStorage::new(&chain.name);
         let mut reorg_detector = ReorgDetector::new(config.reorg_depth);
 

--- a/src/live/compaction.rs
+++ b/src/live/compaction.rs
@@ -176,81 +176,93 @@ impl CompactionService {
             return;
         }
 
+        // Phase 1 (no locks): gather block list and read status files from storage
         let blocks = match self.storage.list_blocks() {
             Ok(b) => b,
             Err(_) => return,
         };
 
         let now = Instant::now();
-        let mut pending_retries = Vec::new();
-        let mut seen_blocks = HashSet::new();
-        let mut stuck_blocks = self.stuck_blocks.lock().await;
+        let seen_blocks: HashSet<u64> = blocks.iter().copied().collect();
 
+        // Collect blocks that are transform-ready but not yet transformed,
+        // along with their failed handlers from the status file.
+        let mut candidates: Vec<(u64, HashSet<String>)> = Vec::new();
         for block_number in blocks {
-            seen_blocks.insert(block_number);
-
             let status = match self.storage.read_status(block_number) {
                 Ok(s) => s,
-                Err(_) => {
-                    stuck_blocks.remove(&block_number);
-                    continue;
-                }
+                Err(_) => continue,
             };
 
             if status.transformed || !status.transform_inputs_ready_with(&self.expectations) {
-                stuck_blocks.remove(&block_number);
                 continue;
             }
 
-            let progress = self.progress_tracker.lock().await;
-            if progress.is_block_complete(block_number) {
-                stuck_blocks.remove(&block_number);
-                continue;
-            }
-
-            // Combine handlers that are pending in the progress tracker with
-            // handlers that explicitly failed (stored in status file)
-            let mut missing_handlers = progress.get_pending_handlers(block_number);
-            drop(progress);
-
-            // Include failed handlers from status file - these need retry
-            missing_handlers.extend(status.failed_handlers.iter().cloned());
-
-            if missing_handlers.is_empty() {
-                stuck_blocks.remove(&block_number);
-                continue;
-            }
-
-            let first_seen = stuck_blocks.entry(block_number).or_insert(now);
-            if now.duration_since(*first_seen) >= self.retry_grace_period {
-                pending_retries.push((block_number, missing_handlers));
-            }
-        }
-
-        stuck_blocks.retain(|block_number, _| seen_blocks.contains(block_number));
-
-        // Only remove from stuck_blocks on successful send. If try_send fails
-        // (channel full), the block keeps its original grace timer so it doesn't
-        // restart the grace period on the next cycle.
-        for (block_number, missing_handlers) in pending_retries {
-            match retry_tx.try_send(TransformRetryRequest {
+            candidates.push((
                 block_number,
-                missing_handlers: Some(missing_handlers),
-            }) {
-                Ok(()) => {
-                    stuck_blocks.remove(&block_number);
-                    tracing::info!(
-                        "Requested transformation retry for stuck block {}",
-                        block_number
-                    );
-                }
-                Err(e) => {
-                    tracing::debug!("Retry channel full for block {}: {}", block_number, e);
-                }
-            }
+                status.failed_handlers.iter().cloned().collect(),
+            ));
         }
 
-        drop(stuck_blocks);
+        // Phase 2a (progress_tracker lock only): collect complete blocks and pending handlers
+        let mut blocks_with_missing: Vec<(u64, HashSet<String>)> = Vec::new();
+        {
+            let progress = self.progress_tracker.lock().await;
+            for (block_number, mut failed_handlers) in candidates {
+                if progress.is_block_complete(block_number) {
+                    continue;
+                }
+
+                // Combine handlers pending in the progress tracker with
+                // handlers that explicitly failed (stored in status file)
+                let mut missing_handlers = progress.get_pending_handlers(block_number);
+                missing_handlers.extend(failed_handlers.drain());
+
+                if !missing_handlers.is_empty() {
+                    blocks_with_missing.push((block_number, missing_handlers));
+                }
+            }
+        } // progress_tracker lock dropped
+
+        // Phase 2b (stuck_blocks lock only): update stuck state and build retry list
+        let mut pending_retries = Vec::new();
+        {
+            let mut stuck_blocks = self.stuck_blocks.lock().await;
+
+            for (block_number, missing_handlers) in blocks_with_missing {
+                let first_seen = stuck_blocks.entry(block_number).or_insert(now);
+                if now.duration_since(*first_seen) >= self.retry_grace_period {
+                    pending_retries.push((block_number, missing_handlers));
+                }
+            }
+
+            stuck_blocks.retain(|block_number, _| seen_blocks.contains(block_number));
+
+            // Only remove from stuck_blocks on successful send. If try_send fails
+            // (channel full), the block keeps its original grace timer so it doesn't
+            // restart the grace period on the next cycle.
+            for (block_number, missing_handlers) in pending_retries {
+                match retry_tx.try_send(TransformRetryRequest {
+                    block_number,
+                    missing_handlers: Some(missing_handlers),
+                }) {
+                    Ok(()) => {
+                        stuck_blocks.remove(&block_number);
+                        tracing::info!(
+                            "Requested transformation retry for stuck block {}",
+                            block_number
+                        );
+                    }
+                    Err(e) => {
+                        tracing::debug!(
+                            "Retry channel full for block {}: {}",
+                            block_number,
+                            e
+                        );
+                    }
+                }
+            }
+        } // stuck_blocks lock dropped
     }
 
     /// Find ranges that are ready for compaction.

--- a/src/live/mod.rs
+++ b/src/live/mod.rs
@@ -17,7 +17,7 @@ mod reorg;
 mod storage;
 mod types;
 
-pub use collector::LiveCollector;
+pub use collector::{LiveCollector, LiveCollectorConfig};
 pub use compaction::{CompactionService, TransformRetryRequest};
 pub use eth_calls::LiveEthCallCollector;
 pub use progress::LiveProgressTracker;

--- a/src/live/storage.rs
+++ b/src/live/storage.rs
@@ -122,15 +122,20 @@ pub struct LiveStorage {
 
 impl LiveStorage {
     /// Create a new LiveStorage for the given chain.
+    ///
+    /// On construction, removes any orphaned `.lock` files left by a
+    /// previous process crash (file locks are process-scoped).
     pub fn new(chain_name: &str) -> Self {
         let base_dir = PathBuf::from(format!("data/{}/live", chain_name));
         let durable_writes = std::env::var("DOPPLER_DURABLE_WRITES")
             .map(|v| v != "false" && v != "0")
             .unwrap_or(true);
-        Self {
+        let storage = Self {
             base_dir,
             durable_writes,
-        }
+        };
+        storage.cleanup_orphaned_locks();
+        storage
     }
 
     /// Create a new LiveStorage with a custom base directory.
@@ -146,6 +151,41 @@ impl LiveStorage {
     #[allow(dead_code)]
     pub fn base_dir(&self) -> &Path {
         &self.base_dir
+    }
+
+    /// Remove orphaned `.lock` files from the status directory.
+    ///
+    /// File locks are process-scoped and released on exit, so any `.lock`
+    /// files present at startup are orphans from a previous crash.
+    pub fn cleanup_orphaned_locks(&self) {
+        let status_dir = self.base_dir.join("status");
+        if !status_dir.exists() {
+            return;
+        }
+
+        let entries = match fs::read_dir(&status_dir) {
+            Ok(e) => e,
+            Err(_) => return,
+        };
+
+        let mut count = 0u64;
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) == Some("lock") {
+                if let Err(e) = fs::remove_file(&path) {
+                    tracing::warn!("Failed to remove orphaned lock file {:?}: {}", path, e);
+                } else {
+                    count += 1;
+                }
+            }
+        }
+
+        if count > 0 {
+            tracing::info!(
+                count,
+                "Cleaned up orphaned lock files from status directory"
+            );
+        }
     }
 
     /// Ensure all subdirectories exist and clean up leftover .tmp files.

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,8 +24,8 @@ use tracing_subscriber::EnvFilter;
 use db::DbPool;
 use decoding::{decode_eth_calls, decode_logs, DecoderMessage};
 use live::{
-    CompactionService, LiveCollector, LiveEthCallCollector, LiveMessage, LiveModeConfig,
-    LivePipelineExpectations, LiveProgressTracker, TransformRetryRequest,
+    CompactionService, LiveCollector, LiveCollectorConfig, LiveEthCallCollector, LiveMessage,
+    LiveModeConfig, LivePipelineExpectations, LiveProgressTracker, TransformRetryRequest,
 };
 use raw_data::historical::catchup::blocks::collect_blocks;
 use raw_data::historical::factories::{
@@ -1900,17 +1900,17 @@ async fn spawn_live_mode(
     );
 
     // Start live collector
-    let collector = LiveCollector::new(
-        chain.clone(),
-        http_client.clone(),
-        live_config.clone(),
-        Some(progress_tracker.clone()),
+    let collector = LiveCollector::new(LiveCollectorConfig {
+        chain: chain.clone(),
+        http_client: http_client.clone(),
+        config: live_config.clone(),
+        progress_tracker: Some(progress_tracker.clone()),
         factory_matchers,
         eth_call_collector,
-        db_pool.clone(),
-        live_expectations,
-        live_channels.transform_retry_tx.clone(),
-    );
+        db_pool: db_pool.clone(),
+        expectations: live_expectations,
+        transform_retry_tx: live_channels.transform_retry_tx.clone(),
+    });
     tasks.spawn(async move {
         collector
             .run(

--- a/src/raw_data/historical/logs.rs
+++ b/src/raw_data/historical/logs.rs
@@ -136,14 +136,12 @@ pub(crate) async fn process_completed_range(
     }
 
     // Send logs to decoder before processing (decoder will receive them for decoding).
-    // Wrap in Arc so we can share without cloning when process_range also needs ownership.
     if let Some(tx) = decoder_tx {
-        let logs = std::sync::Arc::new(logs);
         let _ = tx
             .send(DecoderMessage::LogsReady {
                 range_start,
                 range_end,
-                logs: std::sync::Arc::clone(&logs),
+                logs: logs.clone(),
                 live_mode: false,            // Historical mode: write to parquet
                 has_factory_matchers: false, // Factory addresses handled separately in historical mode
             })
@@ -151,7 +149,7 @@ pub(crate) async fn process_completed_range(
 
         process_range(
             &range,
-            logs.as_ref(),
+            &logs,
             log_fields,
             schema,
             output_dir,


### PR DESCRIPTION
## Summary

- **Deadlock retry jitter**: Added +/-20% random jitter to the exponential backoff delay in `execute_transaction` to prevent synchronized retries when multiple transactions deadlock simultaneously.
- **Compaction nested mutex elimination**: Restructured `check_for_stuck_blocks` into three lock-free/single-lock phases, eliminating the nested `stuck_blocks` + `progress_tracker` mutex acquisition pattern that risked deadlock.
- **`LiveCollectorConfig` struct**: Replaced the 9-parameter `LiveCollector::new` constructor with a config struct for clarity and extensibility.
- **Orphaned lock file cleanup**: `LiveStorage::new()` now removes stale `.json.lock` files from the status directory on startup, since file locks are process-scoped and any leftovers are crash orphans.
- **Pre-existing compile fix**: Corrected `Arc<Vec<LogData>>` vs `Vec<LogData>` type mismatch in historical log decoder message path.

Expected merge conflict with sibling PR `refactor/main-orchestration` at LiveCollector call sites in main.rs — trivial to resolve.