### PR TITLE
refactor: config types and storage data structure quality improvements

### DIFF
--- a/src/storage/manifest.rs
+++ b/src/storage/manifest.rs
@@ -6,11 +6,13 @@
 //! - S3Manifest: Aggregated view of all available data ranges
 //! - ManifestManager: Handles manifest refresh and caching
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::path::PathBuf;
 use std::sync::RwLock;
 use std::time::{Duration, Instant};
 
+use serde::de::Deserializer;
+use serde::ser::Serializer;
 use serde::{Deserialize, Serialize};
 
 use super::s3::S3Backend;
@@ -19,32 +21,44 @@ use crate::types::config::storage::SyncConfig;
 
 /// A sorted, deduplicated set of `(start, end)` block ranges.
 ///
-/// Serializes transparently as `Vec<(u64, u64)>` for backward compatibility
-/// with existing S3 manifest JSON.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct RangeSet(Vec<(u64, u64)>);
+/// Backed by a `BTreeSet` for O(log n) lookup and insertion with
+/// automatic ordering. Serializes as `Vec<(u64, u64)>` for backward
+/// compatibility with existing S3 manifest JSON.
+#[derive(Debug, Clone, Default)]
+pub struct RangeSet(BTreeSet<(u64, u64)>);
+
+impl Serialize for RangeSet {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let vec: Vec<&(u64, u64)> = self.0.iter().collect();
+        vec.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for RangeSet {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let vec = Vec::<(u64, u64)>::deserialize(deserializer)?;
+        Ok(RangeSet(vec.into_iter().collect()))
+    }
+}
 
 impl RangeSet {
     pub fn new() -> Self {
-        Self(Vec::new())
+        Self(BTreeSet::new())
     }
 
-    /// Check if a specific `(start, end)` range exists in the set.
+    /// Check if a specific `(start, end)` range exists in the set — O(log n).
     pub fn has(&self, start: u64, end: u64) -> bool {
-        self.0.iter().any(|(s, e)| *s == start && *e == end)
+        self.0.contains(&(start, end))
     }
 
-    /// Add a range. Duplicates are ignored and the set stays sorted by start.
+    /// Add a range — O(log n). Duplicates are ignored; order is maintained
+    /// by the BTreeSet.
     pub fn add(&mut self, start: u64, end: u64) {
-        if !self.has(start, end) {
-            self.0.push((start, end));
-            self.0.sort_by_key(|(s, _)| *s);
-        }
+        self.0.insert((start, end));
     }
 
-    /// Iterate over all ranges.
-    pub fn iter(&self) -> impl Iterator<Item = &(u64, u64)> {
+    /// Iterate over all ranges in sorted order.
+    pub fn iter(&self) -> std::collections::btree_set::Iter<'_, (u64, u64)> {
         self.0.iter()
     }
 
@@ -61,7 +75,7 @@ impl RangeSet {
 
 impl<'a> IntoIterator for &'a RangeSet {
     type Item = &'a (u64, u64);
-    type IntoIter = std::slice::Iter<'a, (u64, u64)>;
+    type IntoIter = std::collections::btree_set::Iter<'a, (u64, u64)>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.iter()

--- a/src/types/config/defaults.rs
+++ b/src/types/config/defaults.rs
@@ -69,6 +69,33 @@ pub mod rpc {
     pub const ALCHEMY_CU_PER_SECOND: u32 = 7500;
 }
 
+/// Storage and S3 defaults
+pub mod storage {
+    /// Default AWS region for S3-compatible storage
+    pub const REGION: &str = "us-east-1";
+
+    /// Default maximum cache size in gigabytes
+    pub const MAX_SIZE_GB: u64 = 100;
+
+    /// Default eviction threshold as a fraction of max_size_gb
+    pub const EVICTION_THRESHOLD: f64 = 0.8;
+
+    /// Default number of recent ranges to check markers directly
+    pub const MARKER_FRESHNESS_RANGES: u64 = 10;
+
+    /// Default manifest refresh interval in seconds
+    pub const MANIFEST_REFRESH_SECS: u64 = 60;
+
+    /// Default retry interval for failed uploads in seconds
+    pub const RETRY_INTERVAL_SECS: u64 = 30;
+
+    /// Default maximum number of retry attempts
+    pub const MAX_RETRIES: u32 = 10;
+
+    /// Default prefixes that are pinned (never evicted from cache)
+    pub const PINNED_PREFIXES: &[&str] = &["factories", "decoded"];
+}
+
 /// Database pool defaults
 #[allow(dead_code)]
 pub mod db_pool {
@@ -119,5 +146,17 @@ mod tests {
     #[test]
     fn test_db_pool_defaults() {
         assert_eq!(db_pool::MAX_SIZE, 32);
+    }
+
+    #[test]
+    fn test_storage_defaults() {
+        assert_eq!(storage::REGION, "us-east-1");
+        assert_eq!(storage::MAX_SIZE_GB, 100);
+        assert!((storage::EVICTION_THRESHOLD - 0.8).abs() < f64::EPSILON);
+        assert_eq!(storage::MARKER_FRESHNESS_RANGES, 10);
+        assert_eq!(storage::MANIFEST_REFRESH_SECS, 60);
+        assert_eq!(storage::RETRY_INTERVAL_SECS, 30);
+        assert_eq!(storage::MAX_RETRIES, 10);
+        assert_eq!(storage::PINNED_PREFIXES, &["factories", "decoded"]);
     }
 }

--- a/src/types/config/eth_call.rs
+++ b/src/types/config/eth_call.rs
@@ -3,6 +3,7 @@ use alloy::primitives::{Address, Bytes, B256, I256, U256};
 use arrow::datatypes::{DataType, Field};
 use serde::de::{self, Visitor};
 use serde::Deserialize;
+use std::borrow::Cow;
 use std::fmt;
 use std::sync::Arc;
 use thiserror::Error;
@@ -27,11 +28,14 @@ pub enum EventFieldLocation {
 
 impl EventFieldLocation {
     /// Convert back to the canonical string representation.
-    pub fn as_str_repr(&self) -> String {
+    ///
+    /// Returns `Cow::Borrowed` for the `Address` variant (zero-alloc) and
+    /// `Cow::Owned` for indexed variants that require formatting.
+    pub fn as_str_repr(&self) -> Cow<'static, str> {
         match self {
-            Self::Address => "address".to_string(),
-            Self::Topic(idx) => format!("topics[{}]", idx),
-            Self::Data(idx) => format!("data[{}]", idx),
+            Self::Address => Cow::Borrowed("address"),
+            Self::Topic(idx) => Cow::Owned(format!("topics[{}]", idx)),
+            Self::Data(idx) => Cow::Owned(format!("data[{}]", idx)),
         }
     }
 }

--- a/src/types/config/generic.rs
+++ b/src/types/config/generic.rs
@@ -26,8 +26,22 @@ pub enum InlineOrPath<T> {
     Path(String),
 }
 
+impl<T> From<T> for InlineOrPath<T> {
+    fn from(value: T) -> Self {
+        InlineOrPath::Inline(value)
+    }
+}
+
 #[allow(dead_code)]
 impl<T> InlineOrPath<T> {
+    /// Create an `InlineOrPath::Path` from anything convertible to `String`.
+    ///
+    /// A named constructor avoids a blanket `From<String>` that would conflict
+    /// when `T = String`.
+    pub fn from_path(path: impl Into<String>) -> Self {
+        InlineOrPath::Path(path.into())
+    }
+
     /// Returns true if this is an inline value
     pub fn is_inline(&self) -> bool {
         matches!(self, InlineOrPath::Inline(_))
@@ -160,6 +174,18 @@ impl<T> SingleOrMultiple<T> {
             SingleOrMultiple::Single(item) => vec![item],
             SingleOrMultiple::Multiple(items) => items.iter().collect(),
         }
+    }
+}
+
+impl<T> From<T> for SingleOrMultiple<T> {
+    fn from(item: T) -> Self {
+        SingleOrMultiple::Single(item)
+    }
+}
+
+impl<T> From<Vec<T>> for SingleOrMultiple<T> {
+    fn from(items: Vec<T>) -> Self {
+        SingleOrMultiple::Multiple(items)
     }
 }
 
@@ -315,6 +341,21 @@ mod tests {
                 InlineOrPath::Path("./test".to_string());
             assert!(path.into_inline().is_none());
         }
+
+        #[test]
+        fn test_from_inline() {
+            let map: HashMap<String, String> = HashMap::new();
+            let iop: InlineOrPath<HashMap<String, String>> = map.into();
+            assert!(iop.is_inline());
+        }
+
+        #[test]
+        fn test_from_path() {
+            let iop: InlineOrPath<HashMap<String, String>> =
+                InlineOrPath::from_path("./config.json");
+            assert!(iop.is_path());
+            assert_eq!(iop.as_path(), Some("./config.json"));
+        }
     }
 
     // Tests for SingleOrMultiple
@@ -411,6 +452,43 @@ mod tests {
             assert_eq!(iter.size_hint(), (3, Some(3)));
             iter.next();
             assert_eq!(iter.size_hint(), (2, Some(2)));
+        }
+
+        #[test]
+        fn test_from_single() {
+            let config = TestConfig {
+                name: "test".to_string(),
+                value: 42,
+            };
+            let som: SingleOrMultiple<TestConfig> = config.into();
+            assert_eq!(som.len(), 1);
+            if let SingleOrMultiple::Single(c) = &som {
+                assert_eq!(c.name, "test");
+            } else {
+                panic!("expected Single variant");
+            }
+        }
+
+        #[test]
+        fn test_from_vec() {
+            let configs = vec![
+                TestConfig {
+                    name: "a".to_string(),
+                    value: 1,
+                },
+                TestConfig {
+                    name: "b".to_string(),
+                    value: 2,
+                },
+            ];
+            let som: SingleOrMultiple<TestConfig> = configs.into();
+            assert_eq!(som.len(), 2);
+            if let SingleOrMultiple::Multiple(items) = &som {
+                assert_eq!(items[0].name, "a");
+                assert_eq!(items[1].name, "b");
+            } else {
+                panic!("expected Multiple variant");
+            }
         }
     }
 }

--- a/src/types/config/storage.rs
+++ b/src/types/config/storage.rs
@@ -2,6 +2,8 @@
 
 use serde::Deserialize;
 
+use super::defaults::storage as defaults;
+
 /// Top-level storage configuration.
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct StorageConfig {
@@ -41,7 +43,7 @@ pub struct S3Config {
 }
 
 fn default_region() -> String {
-    "us-east-1".to_string()
+    defaults::REGION.to_string()
 }
 
 /// Local cache configuration.
@@ -73,15 +75,18 @@ impl Default for CacheConfig {
 }
 
 fn default_max_size_gb() -> u64 {
-    100
+    defaults::MAX_SIZE_GB
 }
 
 fn default_pinned_prefixes() -> Vec<String> {
-    vec!["factories".to_string(), "decoded".to_string()]
+    defaults::PINNED_PREFIXES
+        .iter()
+        .map(|s| s.to_string())
+        .collect()
 }
 
 fn default_eviction_threshold() -> f64 {
-    0.8
+    defaults::EVICTION_THRESHOLD
 }
 
 /// Synchronization configuration for S3.
@@ -119,17 +124,17 @@ impl Default for SyncConfig {
 }
 
 fn default_marker_freshness_ranges() -> u64 {
-    10
+    defaults::MARKER_FRESHNESS_RANGES
 }
 
 fn default_manifest_refresh_secs() -> u64 {
-    60
+    defaults::MANIFEST_REFRESH_SECS
 }
 
 fn default_retry_interval_secs() -> u64 {
-    30
+    defaults::RETRY_INTERVAL_SECS
 }
 
 fn default_max_retries() -> u32 {
-    10
+    defaults::MAX_RETRIES
 }


### PR DESCRIPTION
## Summary

- **`EventFieldLocation::as_str_repr()`** now returns `Cow<'static, str>` instead of `String`, eliminating an allocation for the `Address` variant while remaining transparent to callers via `Display` and `==` on `Cow<str>`.
- **Storage defaults consolidated** into `defaults::storage` constants (REGION, MAX_SIZE_GB, EVICTION_THRESHOLD, etc.), matching the existing pattern for database, transformations, and RPC defaults. The serde default functions in `storage.rs` now reference these constants.
- **`From` impls** added for `SingleOrMultiple<T>` (from `T` and `Vec<T>`) and `InlineOrPath<T>` (from `T`), plus a `from_path()` named constructor that avoids `From<String>` conflicts when `T = String`.
- **`RangeSet`** internals changed from `Vec<(u64, u64)>` to `BTreeSet<(u64, u64)>`, giving O(log n) `has()` and `add()` instead of O(n). Custom `Serialize`/`Deserialize` impls preserve the existing JSON array format for backward compatibility.

No expected conflicts with sibling PRs.

Note: Tests could not be run because `main` has a pre-existing compile error in `src/raw_data/historical/logs.rs:146` (Arc/Vec type mismatch from commit 14ec1b8).