### PR TITLE
refactor: extract shared eth_calls helpers to reduce duplication

### DIFF
--- a/src/raw_data/historical/eth_calls/config.rs
+++ b/src/raw_data/historical/eth_calls/config.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 use alloy::dyn_abi::DynSolValue;
 use alloy::primitives::Bytes;
 
+use super::helpers::parse_function_name;
 use super::types::{
     CallConfig, EncodedParam, EthCallCollectionError, OnceCallConfig, ParamCombinations,
 };
@@ -91,12 +92,7 @@ pub fn build_call_configs(
                 };
 
                 let selector = compute_function_selector(&call.function);
-                let function_name = call
-                    .function
-                    .split('(')
-                    .next()
-                    .unwrap_or(&call.function)
-                    .to_string();
+                let function_name = parse_function_name(&call.function);
 
                 let param_combinations = generate_param_combinations(&call.params)?;
 
@@ -144,12 +140,7 @@ pub fn build_once_call_configs(contracts: &Contracts) -> HashMap<String, Vec<Onc
             for call in calls {
                 if call.frequency.is_once() {
                     let selector = compute_function_selector(&call.function);
-                    let function_name = call
-                        .function
-                        .split('(')
-                        .next()
-                        .unwrap_or(&call.function)
-                        .to_string();
+                    let function_name = parse_function_name(&call.function);
 
                     // Check if call has self-address params (requires dynamic encoding per address)
                     let (preencoded_calldata, params) = if call.has_self_address_param() {
@@ -233,12 +224,7 @@ pub fn build_factory_once_call_configs(
         for call in call_configs {
             if call.frequency.is_once() {
                 let selector = compute_function_selector(&call.function);
-                let function_name = call
-                    .function
-                    .split('(')
-                    .next()
-                    .unwrap_or(&call.function)
-                    .to_string();
+                let function_name = parse_function_name(&call.function);
 
                 // Resolve target override if specified (resolves to first address only for factory calls)
                 let target_addresses = call.target.as_ref().and_then(|t| {

--- a/src/raw_data/historical/eth_calls/event_triggers.rs
+++ b/src/raw_data/historical/eth_calls/event_triggers.rs
@@ -15,6 +15,7 @@ use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 
 use super::config::compute_function_selector;
+use super::helpers::parse_function_name;
 use super::types::{
     EthCallCollectionError, EthCallContext, EventCallKey, EventCallResult, EventTriggeredCallConfig,
 };
@@ -86,12 +87,7 @@ pub fn build_event_triggered_call_configs(
                     let key = (trigger_config.source.clone(), event_hash);
 
                     let selector = compute_function_selector(&call.function);
-                    let function_name = call
-                        .function
-                        .split('(')
-                        .next()
-                        .unwrap_or(&call.function)
-                        .to_string();
+                    let function_name = parse_function_name(&call.function);
 
                     // Resolve target override if specified, otherwise use contract addresses
                     let target_addrs = if let Some(target) = &call.target {
@@ -139,12 +135,7 @@ pub fn build_event_triggered_call_configs(
                             let key = (trigger_config.source.clone(), event_hash);
 
                             let selector = compute_function_selector(&call.function);
-                            let function_name = call
-                                .function
-                                .split('(')
-                                .next()
-                                .unwrap_or(&call.function)
-                                .to_string();
+                            let function_name = parse_function_name(&call.function);
 
                             // If target is specified, use resolved target; otherwise use event emitter at runtime
                             let target_address = call.target.as_ref().and_then(|t| {

--- a/src/raw_data/historical/eth_calls/helpers.rs
+++ b/src/raw_data/historical/eth_calls/helpers.rs
@@ -1,0 +1,392 @@
+//! Shared helper functions for eth_call collection modules.
+//!
+//! These helpers extract common patterns duplicated across `once_calls.rs`,
+//! `regular_calls.rs`, and `event_triggers.rs`.
+
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+use alloy::primitives::Address;
+
+use super::parquet_io::{
+    read_once_column_index_async, read_once_parquet_state_async, write_once_column_index_async,
+    write_once_results_to_parquet_async, OnceParquetState,
+};
+use super::types::{EthCallCollectionError, OnceCallConfig};
+use crate::raw_data::historical::factories::FactoryAddressData;
+use crate::storage::contract_index::{
+    get_missing_contracts, range_key, read_contract_index, ExpectedContracts,
+};
+
+/// Extract function names from a slice of `OnceCallConfig`.
+///
+/// Replaces the recurring pattern:
+/// ```ignore
+/// call_configs.iter().map(|c| c.function_name.clone()).collect()
+/// ```
+pub(crate) fn extract_fn_names(call_configs: &[OnceCallConfig]) -> Vec<String> {
+    call_configs
+        .iter()
+        .map(|c| c.function_name.clone())
+        .collect()
+}
+
+/// Parse the bare function name from a Solidity function signature.
+///
+/// Given `"balanceOf(address)"`, returns `"balanceOf"`.
+/// Given `"totalSupply"`, returns `"totalSupply"`.
+///
+/// Replaces the recurring pattern:
+/// ```ignore
+/// call.function.split('(').next().unwrap_or(&call.function).to_string()
+/// ```
+pub(crate) fn parse_function_name(function_signature: &str) -> String {
+    function_signature
+        .split('(')
+        .next()
+        .unwrap_or(function_signature)
+        .to_string()
+}
+
+/// Result of checking the parquet state for a regular (non-factory) once-call file.
+///
+/// When `check_regular_once_file_state` returns `None`, the caller should skip
+/// this contract (all columns present and no nulls to patch).
+pub(crate) struct OnceFileState {
+    /// Function names that are missing from the existing parquet file.
+    pub missing_fn_names: Vec<String>,
+    /// Whether an existing file was found.
+    pub has_existing_file: bool,
+    /// Per-column null entries: fn_name -> set of addresses with null values.
+    pub null_entries: HashMap<String, HashSet<[u8; 20]>>,
+    /// Pre-read parquet state (batches for merge). Only `Some` when `has_existing_file` is true.
+    pub parquet_state: Option<OnceParquetState>,
+}
+
+/// Check the parquet file state for a regular (non-factory) once-call file.
+///
+/// Reads the column index and parquet state in a single pass, determines which
+/// columns are missing and which have null entries that need patching.
+///
+/// Returns `None` when the file exists and is already complete (skip this contract).
+/// Returns `Some(OnceFileState)` when work needs to be done.
+///
+/// This encapsulates the pattern found in `process_once_calls_regular` and
+/// `process_once_calls_multicall`.
+pub(crate) async fn check_regular_once_file_state(
+    rel_path: &str,
+    file_name: &str,
+    sub_dir: &Path,
+    output_path: &Path,
+    all_fn_names: &[String],
+    existing_files: &HashSet<String>,
+    contract_name: &str,
+    range_start: u64,
+    range_end: u64,
+) -> Result<Option<OnceFileState>, EthCallCollectionError> {
+    if existing_files.contains(rel_path) {
+        let index = read_once_column_index_async(sub_dir.to_path_buf()).await;
+        let mut state = read_once_parquet_state_async(output_path.to_path_buf()).await?;
+        let existing_cols: HashSet<String> = if let Some(cols) = index.get(file_name) {
+            cols.iter().cloned().collect()
+        } else {
+            tracing::debug!(
+                "File {} exists but not in index, using schema from parquet state",
+                output_path.display()
+            );
+            state.column_names.clone()
+        };
+        let missing: Vec<String> = all_fn_names
+            .iter()
+            .filter(|f| !existing_cols.contains(*f))
+            .cloned()
+            .collect();
+        // Filter null entries to only existing (non-missing) columns
+        let null_entries: HashMap<String, HashSet<[u8; 20]>> = state
+            .null_entries
+            .drain()
+            .filter(|(k, _)| existing_cols.contains(k) && !missing.contains(k))
+            .collect();
+        if missing.is_empty() && null_entries.is_empty() {
+            tracing::debug!(
+                "Skipping once eth_calls for {} blocks {}-{} (all columns present, no nulls)",
+                contract_name,
+                range_start,
+                range_end - 1
+            );
+            return Ok(None);
+        }
+        if !missing.is_empty() {
+            tracing::info!(
+                "Found {} missing once columns for {} blocks {}-{}: {:?}",
+                missing.len(),
+                contract_name,
+                range_start,
+                range_end - 1,
+                missing
+            );
+        }
+        if !null_entries.is_empty() {
+            let null_count: usize = null_entries.values().map(|s| s.len()).sum();
+            tracing::info!(
+                "Found {} null entries across {} columns for {} blocks {}-{}, will re-fetch",
+                null_count,
+                null_entries.len(),
+                contract_name,
+                range_start,
+                range_end - 1,
+            );
+        }
+        Ok(Some(OnceFileState {
+            missing_fn_names: missing,
+            has_existing_file: true,
+            null_entries,
+            parquet_state: Some(state),
+        }))
+    } else {
+        Ok(Some(OnceFileState {
+            missing_fn_names: all_fn_names.to_vec(),
+            has_existing_file: false,
+            null_entries: HashMap::new(),
+            parquet_state: None,
+        }))
+    }
+}
+
+/// Result of checking the parquet state for a factory once-call file.
+pub(crate) struct FactoryOnceFileState {
+    /// Function names that are missing from the existing parquet file.
+    pub missing_fn_names: Vec<String>,
+    /// Whether an existing file was found.
+    pub has_existing_file: bool,
+    /// Per-column null entries: fn_name -> set of addresses with null values.
+    pub null_entries: HashMap<String, HashSet<[u8; 20]>>,
+    /// Pre-read parquet state (batches for merge). Only `Some` when `has_existing_file` is true.
+    pub parquet_state: Option<OnceParquetState>,
+}
+
+/// Check the parquet file state for a factory once-call file.
+///
+/// Similar to `check_regular_once_file_state` but uses a pre-loaded column
+/// index map, checks contract-index completeness, and verifies row count
+/// against factory address count.
+///
+/// Returns `None` when the file exists and is already complete (skip this collection).
+/// Returns `Some(FactoryOnceFileState)` when work needs to be done.
+///
+/// This encapsulates the pattern found in `process_factory_once_calls` and
+/// `process_factory_once_calls_multicall`.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn check_factory_once_file_state(
+    rel_path: &str,
+    file_name: &str,
+    sub_dir: &Path,
+    output_path: &Path,
+    all_fn_names: &[String],
+    existing_files: &HashSet<String>,
+    column_indexes: &HashMap<String, HashMap<String, Vec<String>>>,
+    collection_name: &str,
+    range: &super::types::BlockRange,
+    factory_data: &FactoryAddressData,
+    expected_contracts: Option<&HashMap<String, ExpectedContracts>>,
+    repair: bool,
+) -> Result<Option<FactoryOnceFileState>, EthCallCollectionError> {
+    if existing_files.contains(rel_path) {
+        let index = column_indexes.get(collection_name);
+        let indexed_cols: HashSet<String> = index
+            .and_then(|idx| idx.get(file_name))
+            .map(|cols| cols.iter().cloned().collect())
+            .unwrap_or_default();
+
+        // Single read: get schema, null entries, row count, and batches
+        let mut state = read_once_parquet_state_async(output_path.to_path_buf()).await?;
+        let parquet_cols = &state.column_names;
+
+        // Missing: in config but not in the parquet file
+        let missing: Vec<String> = all_fn_names
+            .iter()
+            .filter(|f| !parquet_cols.contains(*f))
+            .cloned()
+            .collect();
+
+        // Only try to fill null results if:
+        // 1) there is no column index file (indexed_cols is empty)
+        // 2) the block range file is not in the column index
+        // 3) the column with nulls is not in the column index for that file
+        // If a column IS in the index, nulls are considered permanent.
+        let null_entries: HashMap<String, HashSet<[u8; 20]>> = {
+            let has_unindexed = all_fn_names
+                .iter()
+                .any(|f| parquet_cols.contains(f) && !indexed_cols.contains(f));
+            if !has_unindexed {
+                HashMap::new()
+            } else {
+                state
+                    .null_entries
+                    .drain()
+                    .filter(|(k, _)| !indexed_cols.contains(k))
+                    .collect()
+            }
+        };
+
+        if missing.is_empty() && null_entries.is_empty() {
+            // Column check passes. Also verify contract-index completeness.
+            let index_complete = match expected_contracts.and_then(|m| m.get(collection_name)) {
+                None => true,
+                Some(expected) => {
+                    let ci = read_contract_index(sub_dir);
+                    let rk = range_key(range.start, range.end - 1);
+                    get_missing_contracts(&ci, &rk, expected).is_empty()
+                }
+            };
+            let factory_addr_count =
+                unique_factory_address_count(factory_data, collection_name);
+            let rows_complete =
+                factory_addr_count == 0 || state.row_count >= factory_addr_count;
+
+            if index_complete && rows_complete {
+                return Ok(None);
+            }
+
+            if !rows_complete {
+                tracing::info!(
+                    "Factory once {} blocks {}-{}: file has {} rows but factory has {} unique addresses, re-checking",
+                    collection_name, range.start, range.end - 1,
+                    state.row_count, factory_addr_count,
+                );
+            } else if !repair {
+                return Ok(None);
+            }
+            if !index_complete {
+                tracing::info!(
+                    "Factory once {} blocks {}-{}: columns complete but contract index incomplete, re-checking",
+                    collection_name,
+                    range.start,
+                    range.end - 1
+                );
+            }
+        }
+        if !missing.is_empty() {
+            tracing::info!(
+                "Found {} missing factory once columns for {} blocks {}-{}: {:?}",
+                missing.len(),
+                collection_name,
+                range.start,
+                range.end - 1,
+                missing
+            );
+        }
+        if !null_entries.is_empty() {
+            let null_count: usize = null_entries.values().map(|s| s.len()).sum();
+            tracing::info!(
+                "Found {} null entries across {} unindexed factory columns for {} blocks {}-{}, will re-fetch",
+                null_count,
+                null_entries.len(),
+                collection_name,
+                range.start,
+                range.end - 1,
+            );
+        }
+        Ok(Some(FactoryOnceFileState {
+            missing_fn_names: missing,
+            has_existing_file: true,
+            null_entries,
+            parquet_state: Some(state),
+        }))
+    } else {
+        Ok(Some(FactoryOnceFileState {
+            missing_fn_names: all_fn_names.to_vec(),
+            has_existing_file: false,
+            null_entries: HashMap::new(),
+            parquet_state: None,
+        }))
+    }
+}
+
+/// Read-update-write the once column index in a single operation.
+///
+/// Replaces the recurring three-line pattern:
+/// ```ignore
+/// let mut index = read_once_column_index_async(sub_dir.clone()).await;
+/// index.insert(file_name.clone(), cols.clone());
+/// write_once_column_index_async(sub_dir.to_path_buf(), index).await?;
+/// ```
+pub(crate) async fn update_column_index(
+    sub_dir: &Path,
+    file_name: &str,
+    cols: &[String],
+) -> Result<(), EthCallCollectionError> {
+    let mut index = read_once_column_index_async(sub_dir.to_path_buf()).await;
+    index.insert(file_name.to_string(), cols.to_vec());
+    write_once_column_index_async(sub_dir.to_path_buf(), index).await
+}
+
+/// Create an empty once-call parquet file with the given schema and update the column index.
+///
+/// Replaces the recurring pattern:
+/// ```ignore
+/// tokio::fs::create_dir_all(&sub_dir).await?;
+/// write_once_results_to_parquet_async(vec![], output_path.clone(), all_fn_names.clone()).await?;
+/// update_column_index(&sub_dir, &file_name, &all_fn_names).await?;
+/// ```
+pub(crate) async fn write_empty_once_file(
+    sub_dir: &Path,
+    output_path: &Path,
+    file_name: &str,
+    all_fn_names: &[String],
+) -> Result<(), EthCallCollectionError> {
+    tokio::fs::create_dir_all(sub_dir).await?;
+    write_once_results_to_parquet_async(
+        vec![],
+        output_path.to_path_buf(),
+        all_fn_names.to_vec(),
+    )
+    .await?;
+    update_column_index(sub_dir, file_name, all_fn_names).await
+}
+
+/// Collect factory addresses grouped by collection name.
+///
+/// Replaces the recurring pattern:
+/// ```ignore
+/// let mut addresses_by_collection: HashMap<String, HashSet<Address>> = HashMap::new();
+/// for addrs in factory_data.addresses_by_block.values() {
+///     for (_, addr, collection_name) in addrs {
+///         addresses_by_collection
+///             .entry(collection_name.clone())
+///             .or_default()
+///             .insert(*addr);
+///     }
+/// }
+/// ```
+pub(crate) fn collect_factory_addresses_by_collection(
+    factory_data: &FactoryAddressData,
+) -> HashMap<String, HashSet<Address>> {
+    let mut result: HashMap<String, HashSet<Address>> = HashMap::new();
+    for addrs in factory_data.addresses_by_block.values() {
+        for (_, addr, collection_name) in addrs {
+            result
+                .entry(collection_name.clone())
+                .or_default()
+                .insert(*addr);
+        }
+    }
+    result
+}
+
+/// Count unique factory addresses for a given collection.
+///
+/// Used by factory once-call file state checks to verify row completeness.
+pub(crate) fn unique_factory_address_count(
+    factory_data: &FactoryAddressData,
+    collection_name: &str,
+) -> u64 {
+    factory_data
+        .addresses_by_block
+        .values()
+        .flat_map(|addrs| addrs.iter())
+        .filter(|(_, _, coll)| coll == collection_name)
+        .map(|(_, addr, _)| addr.0 .0)
+        .collect::<HashSet<[u8; 20]>>()
+        .len() as u64
+}

--- a/src/raw_data/historical/eth_calls/mod.rs
+++ b/src/raw_data/historical/eth_calls/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod config;
 pub(crate) mod event_triggers;
 pub(crate) mod factory;
 pub(crate) mod frequency;
+pub(crate) mod helpers;
 pub(crate) mod multicall;
 pub(crate) mod once_calls;
 pub(crate) mod parquet_io;

--- a/src/raw_data/historical/eth_calls/once_calls.rs
+++ b/src/raw_data/historical/eth_calls/once_calls.rs
@@ -7,13 +7,19 @@ use alloy::primitives::Address;
 use alloy::rpc::types::{BlockId, BlockNumberOrTag, TransactionRequest};
 
 use super::event_triggers::encode_once_call_params;
+use super::helpers::{
+    check_factory_once_file_state, check_regular_once_file_state, extract_fn_names,
+    update_column_index, write_empty_once_file,
+};
+// Re-imported for test accessibility via `super::unique_factory_address_count`
+#[cfg(test)]
+use super::helpers::unique_factory_address_count;
 use super::multicall::{
     execute_multicalls_generic, BlockMulticall, FactoryOnceSlotMeta, MulticallSlotGeneric,
     OnceCallMeta,
 };
 use super::parquet_io::{
     extract_addresses_from_once_parquet, extract_existing_results_from_parquet, merge_once_columns,
-    read_once_column_index_async, read_once_parquet_state_async, write_once_column_index_async,
     write_once_results_to_parquet_async, write_record_batch_to_parquet_async,
 };
 use super::types::{
@@ -24,22 +30,11 @@ use super::types::{
 use crate::decoding::{DecoderMessage, OnceCallResult as DecoderOnceCallResult};
 use crate::raw_data::historical::factories::FactoryAddressData;
 use crate::storage::contract_index::{
-    get_missing_contracts, range_key, read_contract_index, update_contract_index,
-    write_contract_index, ExpectedContracts,
+    range_key, read_contract_index, update_contract_index as update_ci, write_contract_index,
+    ExpectedContracts,
 };
 use crate::storage::upload_parquet_to_s3;
 use crate::types::config::contract::{AddressOrAddresses, Contracts};
-
-fn unique_factory_address_count(factory_data: &FactoryAddressData, collection_name: &str) -> u64 {
-    factory_data
-        .addresses_by_block
-        .values()
-        .flat_map(|addrs| addrs.iter())
-        .filter(|(_, _, coll)| coll == collection_name)
-        .map(|(_, addr, _)| addr.0 .0)
-        .collect::<HashSet<[u8; 20]>>()
-        .len() as u64
-}
 
 pub(crate) async fn process_once_calls_regular(
     range: &BlockRange,
@@ -63,72 +58,29 @@ pub(crate) async fn process_once_calls_regular(
         let sub_dir = ctx.output_dir.join(contract_name).join("once");
         let output_path = sub_dir.join(&file_name);
 
-        // Determine which function calls are missing from the existing file
-        let all_fn_names: Vec<String> = call_configs
-            .iter()
-            .map(|c| c.function_name.clone())
-            .collect();
+        let all_fn_names = extract_fn_names(call_configs);
 
-        // Read the parquet file once (if it exists) to get schema, null entries,
-        // and batches. This replaces 3 separate file opens with 1.
-        let (missing_fn_names, has_existing_file, null_entries, mut parquet_state) =
-            if ctx.existing_files.contains(&rel_path) {
-                let index = read_once_column_index_async(sub_dir.clone()).await;
-                let mut state = read_once_parquet_state_async(output_path.clone()).await?;
-                let existing_cols: HashSet<String> = if let Some(cols) = index.get(&file_name) {
-                    cols.iter().cloned().collect()
-                } else {
-                    tracing::debug!(
-                        "File {} exists but not in index, using schema from parquet state",
-                        output_path.display()
-                    );
-                    state.column_names.clone()
-                };
-                let missing: Vec<String> = all_fn_names
-                    .iter()
-                    .filter(|f| !existing_cols.contains(*f))
-                    .cloned()
-                    .collect();
-                // Filter null entries to only existing (non-missing) columns
-                let null_entries: HashMap<String, HashSet<[u8; 20]>> = state
-                    .null_entries
-                    .drain()
-                    .filter(|(k, _)| existing_cols.contains(k) && !missing.contains(k))
-                    .collect();
-                if missing.is_empty() && null_entries.is_empty() {
-                    tracing::debug!(
-                    "Skipping once eth_calls for {} blocks {}-{} (all columns present, no nulls)",
-                    contract_name,
-                    range.start,
-                    range.end - 1
-                );
-                    continue;
-                }
-                if !missing.is_empty() {
-                    tracing::info!(
-                        "Found {} missing once columns for {} blocks {}-{}: {:?}",
-                        missing.len(),
-                        contract_name,
-                        range.start,
-                        range.end - 1,
-                        missing
-                    );
-                }
-                if !null_entries.is_empty() {
-                    let null_count: usize = null_entries.values().map(|s| s.len()).sum();
-                    tracing::info!(
-                    "Found {} null entries across {} columns for {} blocks {}-{}, will re-fetch",
-                    null_count,
-                    null_entries.len(),
-                    contract_name,
-                    range.start,
-                    range.end - 1,
-                );
-                }
-                (missing, true, null_entries, Some(state))
-            } else {
-                (all_fn_names.clone(), false, HashMap::new(), None)
-            };
+        // Check parquet file state: returns None if file is already complete
+        let file_state = check_regular_once_file_state(
+            &rel_path,
+            &file_name,
+            &sub_dir,
+            &output_path,
+            &all_fn_names,
+            ctx.existing_files,
+            contract_name,
+            range.start,
+            range.end,
+        )
+        .await?;
+        let file_state = match file_state {
+            Some(s) => s,
+            None => continue,
+        };
+        let missing_fn_names = file_state.missing_fn_names;
+        let has_existing_file = file_state.has_existing_file;
+        let null_entries = file_state.null_entries;
+        let mut parquet_state = file_state.parquet_state;
 
         // Filter call configs to only missing functions
         let configs_to_call: Vec<&OnceCallConfig> = call_configs
@@ -366,16 +318,13 @@ pub(crate) async fn process_once_calls_regular(
 
         // Update the column index — use all_fn_names directly instead of
         // re-reading the file we just wrote.
-        let actual_cols: Vec<String> = all_fn_names.clone();
-        let mut index = read_once_column_index_async(sub_dir.clone()).await;
-        index.insert(file_name.clone(), actual_cols.clone());
-        write_once_column_index_async(sub_dir.to_path_buf(), index).await?;
+        update_column_index(&sub_dir, &file_name, &all_fn_names).await?;
         tracing::info!(
             "Updated column index for {}: {} now has {} columns: {:?}",
             contract_name,
             file_name,
-            actual_cols.len(),
-            actual_cols
+            all_fn_names.len(),
+            all_fn_names
         );
 
         if let Some(tx) = ctx.decoder_tx {
@@ -415,116 +364,32 @@ pub(crate) async fn process_factory_once_calls(
         let sub_dir = ctx.output_dir.join(collection_name).join("once");
         let output_path = sub_dir.join(&file_name);
 
-        let all_fn_names: Vec<String> = call_configs
-            .iter()
-            .map(|c| c.function_name.clone())
-            .collect();
+        let all_fn_names = extract_fn_names(call_configs);
 
-        // Read the parquet file once (if it exists) to get schema, null entries,
-        // row count, and batches. This replaces 3 separate file opens with 1.
-        let (missing_fn_names, has_existing_file, null_entries, mut parquet_state) = if ctx
-            .existing_files
-            .contains(&rel_path)
-        {
-            let index = column_indexes.get(collection_name);
-            let indexed_cols: HashSet<String> = index
-                .and_then(|idx| idx.get(&file_name))
-                .map(|cols| cols.iter().cloned().collect())
-                .unwrap_or_default();
-
-            // Single read: get schema, null entries, row count, and batches
-            let mut state = read_once_parquet_state_async(output_path.clone()).await?;
-            let parquet_cols = &state.column_names;
-
-            // Missing: in config but not in the parquet file
-            let missing: Vec<String> = all_fn_names
-                .iter()
-                .filter(|f| !parquet_cols.contains(*f))
-                .cloned()
-                .collect();
-
-            // Only try to fill null results if:
-            // 1) there is no column index file (indexed_cols is empty)
-            // 2) the block range file is not in the column index
-            // 3) the column with nulls is not in the column index for that file
-            // If a column IS in the index, nulls are considered permanent.
-            let null_entries: HashMap<String, HashSet<[u8; 20]>> = {
-                let has_unindexed = all_fn_names
-                    .iter()
-                    .any(|f| parquet_cols.contains(f) && !indexed_cols.contains(f));
-                if !has_unindexed {
-                    HashMap::new()
-                } else {
-                    state
-                        .null_entries
-                        .drain()
-                        .filter(|(k, _)| !indexed_cols.contains(k))
-                        .collect()
-                }
-            };
-
-            if missing.is_empty() && null_entries.is_empty() {
-                // Column check passes. Also verify contract-index completeness.
-                let index_complete = match expected_contracts.and_then(|m| m.get(collection_name)) {
-                    None => true,
-                    Some(expected) => {
-                        let index = read_contract_index(&sub_dir);
-                        let rk = range_key(range.start, range.end - 1);
-                        get_missing_contracts(&index, &rk, expected).is_empty()
-                    }
-                };
-                let factory_addr_count =
-                    unique_factory_address_count(factory_data, collection_name);
-                let rows_complete =
-                    factory_addr_count == 0 || state.row_count >= factory_addr_count;
-
-                if index_complete && rows_complete {
-                    continue;
-                }
-
-                if !rows_complete {
-                    tracing::info!(
-                        "Factory once {} blocks {}-{}: file has {} rows but factory has {} unique addresses, re-checking",
-                        collection_name, range.start, range.end - 1,
-                        state.row_count, factory_addr_count,
-                    );
-                } else if !ctx.repair {
-                    continue;
-                }
-                if !index_complete {
-                    tracing::info!(
-                        "Factory once {} blocks {}-{}: columns complete but contract index incomplete, re-checking",
-                        collection_name,
-                        range.start,
-                        range.end - 1
-                    );
-                }
-            }
-            if !missing.is_empty() {
-                tracing::info!(
-                    "Found {} missing factory once columns for {} blocks {}-{}: {:?}",
-                    missing.len(),
-                    collection_name,
-                    range.start,
-                    range.end - 1,
-                    missing
-                );
-            }
-            if !null_entries.is_empty() {
-                let null_count: usize = null_entries.values().map(|s| s.len()).sum();
-                tracing::info!(
-                    "Found {} null entries across {} unindexed factory columns for {} blocks {}-{}, will re-fetch",
-                    null_count,
-                    null_entries.len(),
-                    collection_name,
-                    range.start,
-                    range.end - 1,
-                );
-            }
-            (missing, true, null_entries, Some(state))
-        } else {
-            (all_fn_names.clone(), false, HashMap::new(), None)
+        // Check parquet file state: returns None if file is already complete
+        let file_state = check_factory_once_file_state(
+            &rel_path,
+            &file_name,
+            &sub_dir,
+            &output_path,
+            &all_fn_names,
+            ctx.existing_files,
+            column_indexes,
+            collection_name,
+            range,
+            factory_data,
+            expected_contracts,
+            ctx.repair,
+        )
+        .await?;
+        let file_state = match file_state {
+            Some(s) => s,
+            None => continue,
         };
+        let missing_fn_names = file_state.missing_fn_names;
+        let has_existing_file = file_state.has_existing_file;
+        let null_entries = file_state.null_entries;
+        let mut parquet_state = file_state.parquet_state;
 
         let configs_to_call: Vec<&OnceCallConfig> = call_configs
             .iter()
@@ -551,16 +416,11 @@ pub(crate) async fn process_factory_once_calls(
 
         // Write empty file when no factory addresses discovered (no data for this range)
         if address_discovery.is_empty() && !has_existing_file {
-            tokio::fs::create_dir_all(&sub_dir).await?;
-            write_once_results_to_parquet_async(vec![], output_path.clone(), all_fn_names.clone())
-                .await?;
-            let mut index = read_once_column_index_async(sub_dir.clone()).await;
-            index.insert(file_name.clone(), all_fn_names.clone());
-            write_once_column_index_async(sub_dir.to_path_buf(), index).await?;
+            write_empty_once_file(&sub_dir, &output_path, &file_name, &all_fn_names).await?;
             if let Some(expected) = expected_contracts.and_then(|m| m.get(collection_name)) {
                 let rk = range_key(range.start, range.end - 1);
                 let mut ci = read_contract_index(&sub_dir);
-                update_contract_index(&mut ci, &rk, expected);
+                update_ci(&mut ci, &rk, expected);
                 if let Err(e) = write_contract_index(&sub_dir, &ci) {
                     tracing::warn!(
                         "Failed to write once contract index (empty range) for {}: {}",
@@ -726,15 +586,7 @@ pub(crate) async fn process_factory_once_calls(
             }
             // Rewrite empty parquet with full schema when columns are missing
             if !missing_fn_names.is_empty() && existing_addr_set.is_empty() {
-                write_once_results_to_parquet_async(
-                    vec![],
-                    output_path.clone(),
-                    all_fn_names.clone(),
-                )
-                .await?;
-                let mut index = read_once_column_index_async(sub_dir.clone()).await;
-                index.insert(file_name.clone(), all_fn_names.clone());
-                write_once_column_index_async(sub_dir.to_path_buf(), index).await?;
+                write_empty_once_file(&sub_dir, &output_path, &file_name, &all_fn_names).await?;
                 tracing::info!(
                     "Factory once {} blocks {}-{}: rewrote empty parquet with {} columns",
                     collection_name,
@@ -746,7 +598,7 @@ pub(crate) async fn process_factory_once_calls(
             if let Some(expected) = expected_contracts.and_then(|m| m.get(collection_name)) {
                 let rk = range_key(range.start, range.end - 1);
                 let mut ci = read_contract_index(&sub_dir);
-                update_contract_index(&mut ci, &rk, expected);
+                update_ci(&mut ci, &rk, expected);
                 if let Err(e) = write_contract_index(&sub_dir, &ci) {
                     tracing::warn!(
                         "Failed to write once contract index for {}: {}",
@@ -1063,23 +915,20 @@ pub(crate) async fn process_factory_once_calls(
 
         // Update the column index — use all_fn_names directly instead of
         // re-reading the file we just wrote.
-        let actual_cols: Vec<String> = all_fn_names.clone();
-        let mut index = read_once_column_index_async(sub_dir.clone()).await;
-        index.insert(file_name.clone(), actual_cols.clone());
-        write_once_column_index_async(sub_dir.to_path_buf(), index).await?;
+        update_column_index(&sub_dir, &file_name, &all_fn_names).await?;
         tracing::info!(
             "Updated column index for factory {}: {} now has {} columns: {:?}",
             collection_name,
             file_name,
-            actual_cols.len(),
-            actual_cols
+            all_fn_names.len(),
+            all_fn_names
         );
 
         // F. Write contract index after parquet write
         if let Some(expected) = expected_contracts.and_then(|m| m.get(collection_name)) {
             let rk = range_key(range.start, range.end - 1);
             let mut ci = read_contract_index(&sub_dir);
-            update_contract_index(&mut ci, &rk, expected);
+            update_ci(&mut ci, &rk, expected);
             if let Err(e) = write_contract_index(&sub_dir, &ci) {
                 tracing::warn!(
                     "Failed to write once contract index for {}: {}",
@@ -1131,40 +980,29 @@ pub(crate) async fn process_once_calls_multicall(
         let sub_dir = ctx.output_dir.join(contract_name).join("once");
         let output_path = sub_dir.join(&file_name);
 
-        let all_fn_names: Vec<String> = call_configs
-            .iter()
-            .map(|c| c.function_name.clone())
-            .collect();
+        let all_fn_names = extract_fn_names(call_configs);
 
-        // Read the parquet file once (if it exists) to get schema, null entries,
-        // and batches. This replaces 3 separate file opens with 1.
-        let (missing_fn_names, has_existing_file, null_entries, parquet_state) =
-            if ctx.existing_files.contains(&rel_path) {
-                let index = read_once_column_index_async(sub_dir.clone()).await;
-                let mut state = read_once_parquet_state_async(output_path.clone()).await?;
-                let existing_cols: HashSet<String> = if let Some(cols) = index.get(&file_name) {
-                    cols.iter().cloned().collect()
-                } else {
-                    state.column_names.clone()
-                };
-                let missing: Vec<String> = all_fn_names
-                    .iter()
-                    .filter(|f| !existing_cols.contains(*f))
-                    .cloned()
-                    .collect();
-                // Filter null entries to only existing (non-missing) columns
-                let null_entries: HashMap<String, HashSet<[u8; 20]>> = state
-                    .null_entries
-                    .drain()
-                    .filter(|(k, _)| existing_cols.contains(k) && !missing.contains(k))
-                    .collect();
-                if missing.is_empty() && null_entries.is_empty() {
-                    continue;
-                }
-                (missing, true, null_entries, Some(state))
-            } else {
-                (all_fn_names.clone(), false, HashMap::new(), None)
-            };
+        // Check parquet file state: returns None if file is already complete
+        let file_state = check_regular_once_file_state(
+            &rel_path,
+            &file_name,
+            &sub_dir,
+            &output_path,
+            &all_fn_names,
+            ctx.existing_files,
+            contract_name,
+            range.start,
+            range.end,
+        )
+        .await?;
+        let file_state = match file_state {
+            Some(s) => s,
+            None => continue,
+        };
+        let missing_fn_names = file_state.missing_fn_names;
+        let has_existing_file = file_state.has_existing_file;
+        let null_entries = file_state.null_entries;
+        let parquet_state = file_state.parquet_state;
 
         let configs_to_call: Vec<&OnceCallConfig> = call_configs
             .iter()
@@ -1431,10 +1269,7 @@ pub(crate) async fn process_once_calls_multicall(
                 .unwrap()
                 .to_string_lossy()
                 .to_string();
-            let actual_cols: Vec<String> = all_fn_names.clone();
-            let mut index = read_once_column_index_async(sub_dir.to_path_buf()).await;
-            index.insert(file_name.clone(), actual_cols);
-            write_once_column_index_async(sub_dir.to_path_buf(), index).await?;
+            update_column_index(sub_dir, &file_name, &all_fn_names).await?;
 
             if let Some(tx) = ctx.decoder_tx {
                 if let Some(results) = decoder_once_results {
@@ -1480,90 +1315,32 @@ pub(crate) async fn process_factory_once_calls_multicall(
         let sub_dir = ctx.output_dir.join(collection_name).join("once");
         let output_path = sub_dir.join(&file_name);
 
-        let all_fn_names: Vec<String> = call_configs
-            .iter()
-            .map(|c| c.function_name.clone())
-            .collect();
+        let all_fn_names = extract_fn_names(call_configs);
 
-        // Read the parquet file once (if it exists) to get schema, null entries,
-        // row count, and batches. This replaces 3 separate file opens with 1.
-        let (missing_fn_names, has_existing_file, null_entries, parquet_state) = if ctx
-            .existing_files
-            .contains(&rel_path)
-        {
-            let index = column_indexes.get(collection_name);
-            let indexed_cols: HashSet<String> = index
-                .and_then(|idx| idx.get(&file_name))
-                .map(|cols| cols.iter().cloned().collect())
-                .unwrap_or_default();
-
-            // Single read: get schema, null entries, row count, and batches
-            let mut state = read_once_parquet_state_async(output_path.clone()).await?;
-            let parquet_cols = &state.column_names;
-
-            // Missing: in config but not in the parquet file
-            let missing: Vec<String> = all_fn_names
-                .iter()
-                .filter(|f| !parquet_cols.contains(*f))
-                .cloned()
-                .collect();
-
-            let null_entries: HashMap<String, HashSet<[u8; 20]>> = {
-                let has_unindexed = all_fn_names
-                    .iter()
-                    .any(|f| parquet_cols.contains(f) && !indexed_cols.contains(f));
-                if !has_unindexed {
-                    HashMap::new()
-                } else {
-                    state
-                        .null_entries
-                        .drain()
-                        .filter(|(k, _)| !indexed_cols.contains(k))
-                        .collect()
-                }
-            };
-
-            if missing.is_empty() && null_entries.is_empty() {
-                // Column check passes. Also verify contract-index completeness.
-                let index_complete = match expected_contracts.and_then(|m| m.get(collection_name)) {
-                    None => true,
-                    Some(expected) => {
-                        let index = read_contract_index(&sub_dir);
-                        let rk = range_key(range.start, range.end - 1);
-                        get_missing_contracts(&index, &rk, expected).is_empty()
-                    }
-                };
-                let factory_addr_count =
-                    unique_factory_address_count(factory_data, collection_name);
-                let rows_complete =
-                    factory_addr_count == 0 || state.row_count >= factory_addr_count;
-
-                if index_complete && rows_complete {
-                    continue;
-                }
-
-                if !rows_complete {
-                    tracing::info!(
-                        "Factory once multicall {} blocks {}-{}: file has {} rows but factory has {} unique addresses, re-checking",
-                        collection_name, range.start, range.end - 1,
-                        state.row_count, factory_addr_count,
-                    );
-                } else if !ctx.repair {
-                    continue;
-                }
-                if !index_complete {
-                    tracing::info!(
-                        "Factory once multicall {} blocks {}-{}: columns complete but contract index incomplete, re-checking",
-                        collection_name,
-                        range.start,
-                        range.end - 1
-                    );
-                }
-            }
-            (missing, true, null_entries, Some(state))
-        } else {
-            (all_fn_names.clone(), false, HashMap::new(), None)
+        // Check parquet file state: returns None if file is already complete
+        let file_state = check_factory_once_file_state(
+            &rel_path,
+            &file_name,
+            &sub_dir,
+            &output_path,
+            &all_fn_names,
+            ctx.existing_files,
+            column_indexes,
+            collection_name,
+            range,
+            factory_data,
+            expected_contracts,
+            ctx.repair,
+        )
+        .await?;
+        let file_state = match file_state {
+            Some(s) => s,
+            None => continue,
         };
+        let missing_fn_names = file_state.missing_fn_names;
+        let has_existing_file = file_state.has_existing_file;
+        let null_entries = file_state.null_entries;
+        let parquet_state = file_state.parquet_state;
 
         let configs_to_call: Vec<&OnceCallConfig> = call_configs
             .iter()
@@ -1589,17 +1366,12 @@ pub(crate) async fn process_factory_once_calls_multicall(
 
         // Write empty file when no factory addresses discovered (no data for this range)
         if address_discovery.is_empty() && !has_existing_file {
-            tokio::fs::create_dir_all(&sub_dir).await?;
-            write_once_results_to_parquet_async(vec![], output_path.clone(), all_fn_names.clone())
-                .await?;
-            let mut index = read_once_column_index_async(sub_dir.clone()).await;
-            index.insert(file_name.clone(), all_fn_names.clone());
-            write_once_column_index_async(sub_dir.to_path_buf(), index).await?;
+            write_empty_once_file(&sub_dir, &output_path, &file_name, &all_fn_names).await?;
             // G. Write contract index in empty-file branch
             if let Some(expected) = expected_contracts.and_then(|m| m.get(collection_name)) {
                 let rk = range_key(range.start, range.end - 1);
                 let mut ci = read_contract_index(&sub_dir);
-                update_contract_index(&mut ci, &rk, expected);
+                update_ci(&mut ci, &rk, expected);
                 if let Err(e) = write_contract_index(&sub_dir, &ci) {
                     tracing::warn!(
                         "Failed to write once contract index (empty range) for {}: {}",
@@ -1638,16 +1410,11 @@ pub(crate) async fn process_factory_once_calls_multicall(
             if !ctx.repair {
                 continue;
             }
-            tokio::fs::create_dir_all(&sub_dir).await?;
-            write_once_results_to_parquet_async(vec![], output_path.clone(), all_fn_names.clone())
-                .await?;
-            let mut index = read_once_column_index_async(sub_dir.clone()).await;
-            index.insert(file_name.clone(), all_fn_names.clone());
-            write_once_column_index_async(sub_dir.to_path_buf(), index).await?;
+            write_empty_once_file(&sub_dir, &output_path, &file_name, &all_fn_names).await?;
             if let Some(expected) = expected_contracts.and_then(|m| m.get(collection_name)) {
                 let rk = range_key(range.start, range.end - 1);
                 let mut ci = read_contract_index(&sub_dir);
-                update_contract_index(&mut ci, &rk, expected);
+                update_ci(&mut ci, &rk, expected);
                 if let Err(e) = write_contract_index(&sub_dir, &ci) {
                     tracing::warn!(
                         "Failed to write once contract index for {}: {}",
@@ -1896,7 +1663,7 @@ pub(crate) async fn process_factory_once_calls_multicall(
             if let Some(expected) = expected_contracts.and_then(|m| m.get(&collection_name)) {
                 let rk = range_key(range.start, range.end - 1);
                 let mut ci = read_contract_index(sub_dir);
-                update_contract_index(&mut ci, &rk, expected);
+                update_ci(&mut ci, &rk, expected);
                 if let Err(e) = write_contract_index(sub_dir, &ci) {
                     tracing::warn!(
                         "Failed to write once contract index for {}: {}",
@@ -2189,16 +1956,13 @@ pub(crate) async fn process_factory_once_calls_multicall(
                 .unwrap()
                 .to_string_lossy()
                 .to_string();
-            let actual_cols: Vec<String> = all_fn_names.clone();
-            let mut index = read_once_column_index_async(sub_dir.to_path_buf()).await;
-            index.insert(file_name.clone(), actual_cols);
-            write_once_column_index_async(sub_dir.to_path_buf(), index).await?;
+            update_column_index(sub_dir, &file_name, &all_fn_names).await?;
 
             // F. Write contract index after parquet write
             if let Some(expected) = expected_contracts.and_then(|m| m.get(&collection_name)) {
                 let rk = range_key(range.start, range.end - 1);
                 let mut ci = read_contract_index(sub_dir);
-                update_contract_index(&mut ci, &rk, expected);
+                update_ci(&mut ci, &rk, expected);
                 if let Err(e) = write_contract_index(sub_dir, &ci) {
                     tracing::warn!(
                         "Failed to write once contract index for {}: {}",

--- a/src/raw_data/historical/eth_calls/regular_calls.rs
+++ b/src/raw_data/historical/eth_calls/regular_calls.rs
@@ -11,6 +11,7 @@ use alloy::rpc::types::{BlockId, BlockNumberOrTag, TransactionRequest};
 
 use super::config::{compute_function_selector, generate_param_combinations};
 use super::frequency::filter_blocks_for_frequency;
+use super::helpers::{collect_factory_addresses_by_collection, parse_function_name};
 use super::multicall::{
     execute_multicalls_generic, BlockMulticall, FactoryCallMeta, FactoryGroupInfo,
     MulticallSlotGeneric, RegularCallMeta, RegularGroupInfo,
@@ -43,15 +44,7 @@ pub(crate) async fn process_factory_range(
     mut pending_writes: Option<&mut AbortOnDropHandles>,
     contracts: &Contracts,
 ) -> Result<(), EthCallCollectionError> {
-    let mut addresses_by_collection: HashMap<String, HashSet<Address>> = HashMap::new();
-    for addrs in factory_data.addresses_by_block.values() {
-        for (_, addr, collection_name) in addrs {
-            addresses_by_collection
-                .entry(collection_name.clone())
-                .or_default()
-                .insert(*addr);
-        }
-    }
+    let addresses_by_collection = collect_factory_addresses_by_collection(factory_data);
 
     for (collection_name, call_configs) in factory_call_configs {
         let addresses = match addresses_by_collection.get(collection_name) {
@@ -65,12 +58,7 @@ pub(crate) async fn process_factory_range(
             }
 
             let selector = compute_function_selector(&call_config.function);
-            let function_name = call_config
-                .function
-                .split('(')
-                .next()
-                .unwrap_or(&call_config.function)
-                .to_string();
+            let function_name = parse_function_name(&call_config.function);
 
             let file_name = range.file_name("");
             let rel_path = format!("{}/{}/{}", collection_name, function_name, file_name);
@@ -339,15 +327,7 @@ pub(crate) async fn process_factory_range_multicall(
     contracts: &Contracts,
 ) -> Result<(), EthCallCollectionError> {
     // Collect factory addresses by collection
-    let mut addresses_by_collection: HashMap<String, HashSet<Address>> = HashMap::new();
-    for addrs in factory_data.addresses_by_block.values() {
-        for (_, addr, collection_name) in addrs {
-            addresses_by_collection
-                .entry(collection_name.clone())
-                .or_default()
-                .insert(*addr);
-        }
-    }
+    let addresses_by_collection = collect_factory_addresses_by_collection(factory_data);
 
     // Build per-group info for active groups
     let mut active_groups: Vec<FactoryGroupInfo> = Vec::new();
@@ -364,12 +344,7 @@ pub(crate) async fn process_factory_range_multicall(
             }
 
             let selector = compute_function_selector(&call_config.function);
-            let function_name = call_config
-                .function
-                .split('(')
-                .next()
-                .unwrap_or(&call_config.function)
-                .to_string();
+            let function_name = parse_function_name(&call_config.function);
 
             let file_name = range.file_name("");
             let rel_path = format!("{}/{}/{}", collection_name, function_name, file_name);


### PR DESCRIPTION
## Summary

- Create `src/raw_data/historical/eth_calls/helpers.rs` with 8 shared helper functions extracted from duplicated patterns across `once_calls.rs` (2799 lines), `regular_calls.rs` (1069 lines), and `event_triggers.rs` (1535 lines)
- Replace ~25 instances of duplicated code patterns with calls to the shared helpers, resulting in a net reduction of 284 lines across the existing files
- All 47 existing eth_calls tests pass unchanged

### Helpers introduced

| Helper | Replaces | Occurrences |
|--------|----------|-------------|
| `extract_fn_names` | `call_configs.iter().map(\|c\| c.function_name.clone()).collect()` | 4 in once_calls.rs |
| `parse_function_name` | `.split('(').next().unwrap_or(&call.function).to_string()` | 7 across config.rs, regular_calls.rs, event_triggers.rs |
| `check_regular_once_file_state` | Parquet state reading + missing column detection for regular once calls | 2 in once_calls.rs |
| `check_factory_once_file_state` | Parquet state reading + column/contract index/row completeness checks for factory once calls | 2 in once_calls.rs |
| `update_column_index` | `read_once_column_index_async` -> `insert` -> `write_once_column_index_async` | 8 in once_calls.rs |
| `write_empty_once_file` | `create_dir_all` + `write_once_results_to_parquet_async(vec![])` + `update_column_index` | 4 in once_calls.rs |
| `collect_factory_addresses_by_collection` | Factory address grouping loop | 2 in regular_calls.rs |
| `unique_factory_address_count` | Moved from once_calls.rs to helpers.rs (used by factory state checks) | 2 in once_calls.rs |

No expected conflicts with sibling PRs.