### PR TITLE
refactor: transformation engine improvements

### DIFF
--- a/src/raw_data/historical/logs.rs
+++ b/src/raw_data/historical/logs.rs
@@ -143,7 +143,7 @@ pub(crate) async fn process_completed_range(
             .send(DecoderMessage::LogsReady {
                 range_start,
                 range_end,
-                logs: std::sync::Arc::clone(&logs),
+                logs: (*logs).clone(),
                 live_mode: false,            // Historical mode: write to parquet
                 has_factory_matchers: false, // Factory addresses handled separately in historical mode
             })

--- a/src/transformations/engine.rs
+++ b/src/transformations/engine.rs
@@ -30,7 +30,9 @@ use super::historical::HistoricalDataReader;
 use super::live_state::{LiveProcessingState, PendingEventData};
 use super::registry::{extract_event_name, TransformationRegistry};
 use super::retry::{filter_calls_by_start_block, filter_events_by_start_block, RetryProcessor};
-use super::scheduler::dag::{DagScheduler, OutcomeStatus, WorkItem, WorkItemRunResult};
+use super::scheduler::dag::{
+    DagScheduler, OutcomeStatus, WorkItem, WorkItemOutcome, WorkItemRunResult,
+};
 use super::scheduler::loader::{
     read_receipt_addresses, CallDepScanner, CatchupLoader, CatchupPayload,
     run_call_dep_scanner_loop,
@@ -558,7 +560,6 @@ impl TransformationEngine {
         };
 
         let mut available = self.scan_available_ranges(base_dir).await?;
-        let mut available_starts: Vec<u64> = available.iter().map(|(start, _)| *start).collect();
 
         if available.is_empty() {
             tracing::info!(
@@ -569,8 +570,155 @@ impl TransformationEngine {
             return Ok(());
         }
 
-        // Collect handler descriptors uniformly across both kinds.
-        let mut handlers: Vec<CatchupHandler> = match kind {
+        // 1. Collect and sort handler descriptors.
+        let mut handlers = self.collect_catchup_handlers(kind);
+        let trigger_range_sets = self
+            .prepare_catchup_handlers(kind, &mut handlers, base_dir, &mut available)
+            .await?;
+        let available_starts: Vec<u64> = available.iter().map(|(start, _)| *start).collect();
+
+        // 2. Seed tracker from DB progress.
+        let tracker = Arc::new(CompletionTracker::with_available_starts(
+            available_starts.clone(),
+        ));
+        let self_completed = self
+            .seed_tracker_from_progress(&handlers, &tracker)
+            .await?;
+
+        // 3. Early exit if nothing to do.
+        let total_todo: usize = handlers
+            .iter()
+            .map(|ch| {
+                let done = self_completed
+                    .get(ch.handler.name())
+                    .map(|s| s.len())
+                    .unwrap_or(0);
+                available.len().saturating_sub(done)
+            })
+            .sum();
+
+        if total_todo == 0 {
+            tracing::info!("{} handler catchup: all handlers up to date", kind_label);
+            return Ok(());
+        }
+
+        tracing::info!(
+            "{} handler catchup: {} work items to process across {} handlers",
+            kind_label,
+            total_todo,
+            handlers.len()
+        );
+
+        gauge!(
+            "transformation_catchup_ranges_remaining",
+            "kind" => kind_label,
+        )
+        .set(total_todo as f64);
+
+        // 4. Build work items.
+        let (items, per_handler_submitted) = self
+            .build_catchup_work_items(
+                &handlers,
+                &available,
+                &self_completed,
+                &trigger_range_sets,
+                &tracker,
+            )
+            .await;
+
+        // Per-handler submission summary.
+        for ch in &handlers {
+            let count = per_handler_submitted
+                .get(ch.handler.name())
+                .copied()
+                .unwrap_or(0);
+            if count > 0 {
+                tracing::info!(
+                    "Handler {} catchup: submitting {} range(s)",
+                    ch.handler.handler_key(),
+                    count
+                );
+            }
+        }
+
+        if items.is_empty() {
+            tracing::info!("{} handler catchup: no work items to submit", kind_label);
+            return Ok(());
+        }
+
+        tracing::info!(
+            "{} catchup: executing {} work items across {} handlers",
+            kind_label,
+            items.len(),
+            per_handler_submitted.len()
+        );
+
+        // 5. Spawn background call-dep scanner.
+        let (cancel_tx, scanner_handle) = self
+            .spawn_call_dep_scanner(&handlers, &tracker)
+            .await;
+
+        // 6. Spawn progress reporter.
+        let progress_handle = Self::spawn_progress_reporter(
+            tracker.clone(),
+            kind_label,
+            available.len(),
+            &handlers,
+        );
+
+        // 7. Execute all items.
+        let loader = Arc::new(CatchupLoader {
+            decoded_logs_dir: self.decoded_logs_dir.clone(),
+            decoded_calls_dir: self.decoded_calls_dir.clone(),
+            raw_receipts_dir: self.raw_receipts_dir.clone(),
+            historical_reader: self.historical_reader.clone(),
+            rpc_client: self.executor.rpc_client.clone(),
+            contracts: self.contracts.clone(),
+            chain_name: self.chain_name.clone(),
+            chain_id: self.chain_id,
+            db_pool: self.db_pool.clone(),
+            finalizer: self.finalizer.clone(),
+        });
+
+        let scheduler = DagScheduler::new(tracker.clone(), self.handler_concurrency);
+        let catchup_start = Instant::now();
+        let loader_ref = loader.clone();
+        let outcomes = scheduler
+            .execute(items, move |item| {
+                let loader = loader_ref.clone();
+                Box::pin(async move {
+                    match loader.run(item).await {
+                        Ok(()) => WorkItemRunResult::Succeeded,
+                        Err(TransformationError::TransientBlocked(msg)) => {
+                            WorkItemRunResult::Blocked(msg)
+                        }
+                        Err(e) => WorkItemRunResult::Failed(e.to_string()),
+                    }
+                })
+            })
+            .await;
+
+        histogram!(
+            "transformation_catchup_total_duration_seconds",
+            "kind" => kind_label,
+        )
+        .record(catchup_start.elapsed().as_secs_f64());
+
+        // 8. Cancel background tasks and process outcomes.
+        let _ = cancel_tx.send(true);
+        if let Some(handle) = scanner_handle {
+            handle.abort();
+        }
+        progress_handle.abort();
+
+        Self::process_catchup_outcomes(outcomes, &handlers, kind_label, catchup_start)
+    }
+
+    // ─── Catchup Sub-steps ──────────────────────────────────────────
+
+    /// Collect handler descriptors uniformly across event and call handlers.
+    fn collect_catchup_handlers(&self, kind: HandlerKind) -> Vec<CatchupHandler> {
+        match kind {
             HandlerKind::Event => self
                 .registry
                 .unique_event_handlers()
@@ -628,9 +776,19 @@ impl TransformationEngine {
                     }
                 })
                 .collect(),
-        };
+        }
+    }
 
-        // Sort event handlers by topological order so dependencies are processed first
+    /// Sort handlers by topological order, scan per-handler trigger ranges,
+    /// and narrow the available set for call handlers.
+    async fn prepare_catchup_handlers(
+        &self,
+        kind: HandlerKind,
+        handlers: &mut Vec<CatchupHandler>,
+        base_dir: &Path,
+        available: &mut Vec<(u64, u64)>,
+    ) -> Result<HashMap<String, HashSet<(u64, u64)>>, TransformationError> {
+        // Sort event handlers by topological order so dependencies are processed first.
         if kind == HandlerKind::Event {
             let topo_order = self.registry.handler_topological_order();
             let position: HashMap<&str, usize> = topo_order
@@ -646,11 +804,9 @@ impl TransformationEngine {
             });
         }
 
-        // Catchup walks the union of all decoded ranges so dependency handlers
-        // can no-op complete unrelated ranges. Call deps, however, should only
-        // gate ranges where this handler actually has trigger parquet data.
+        // Build per-handler trigger range sets.
         let mut trigger_range_sets: HashMap<String, HashSet<(u64, u64)>> = HashMap::new();
-        for ch in &handlers {
+        for ch in handlers.iter() {
             let mut ranges: HashSet<(u64, u64)> = HashSet::new();
             for (source, trigger_name) in ch.triggers.iter() {
                 let dir = base_dir.join(source).join(trigger_name);
@@ -659,10 +815,7 @@ impl TransformationEngine {
             trigger_range_sets.insert(ch.handler.name().to_string(), ranges);
         }
 
-        // For call handlers, the base_dir scan picks up on_events/ files that
-        // belong to event-triggered call collection, polluting the available set
-        // with non-standard range sizes. Narrow available to only ranges that
-        // appear in at least one call handler's trigger directories.
+        // For call handlers, narrow available to only trigger-present ranges.
         if kind == HandlerKind::Call {
             let trigger_union: HashSet<(u64, u64)> = trigger_range_sets
                 .values()
@@ -670,18 +823,21 @@ impl TransformationEngine {
                 .collect();
             let mut narrowed: Vec<(u64, u64)> = trigger_union.into_iter().collect();
             narrowed.sort_by_key(|(start, _)| *start);
-            available = narrowed;
-            available_starts = available.iter().map(|(start, _)| *start).collect();
+            *available = narrowed;
         }
 
-        // Seed CompletionTracker from _handler_progress so downstream handlers
-        // can gate on upstream completion per range via the DAG scheduler.
-        // Use `with_available_starts` so the tracker can maintain contiguous watermarks.
-        let tracker = Arc::new(CompletionTracker::with_available_starts(available_starts.clone()));
-        // self_completed: handler_name → set of range_starts already processed.
-        // Used to skip building WorkItems for ranges already done.
+        Ok(trigger_range_sets)
+    }
+
+    /// Seed CompletionTracker from `_handler_progress` and return the per-handler
+    /// completed range_starts.
+    async fn seed_tracker_from_progress(
+        &self,
+        handlers: &[CatchupHandler],
+        tracker: &Arc<CompletionTracker>,
+    ) -> Result<HashMap<String, HashSet<u64>>, TransformationError> {
         let mut self_completed: HashMap<String, HashSet<u64>> = HashMap::new();
-        for ch in &handlers {
+        for ch in handlers {
             let completed = self
                 .finalizer
                 .get_completed_ranges_for_handler(&ch.handler.handler_key())
@@ -691,66 +847,31 @@ impl TransformationEngine {
                 .await;
             self_completed.insert(ch.handler.name().to_string(), completed);
         }
+        Ok(self_completed)
+    }
 
-        let total_todo: usize = handlers
-            .iter()
-            .map(|ch| {
-                let done = self_completed
-                    .get(ch.handler.name())
-                    .map(|s| s.len())
-                    .unwrap_or(0);
-                available.len().saturating_sub(done)
-            })
-            .sum();
-
-        if total_todo == 0 {
-            tracing::info!("{} handler catchup: all handlers up to date", kind_label);
-            return Ok(());
-        }
-
-        tracing::info!(
-            "{} handler catchup: {} work items to process across {} handlers",
-            kind_label,
-            total_todo,
-            handlers.len()
-        );
-
-        gauge!(
-            "transformation_catchup_ranges_remaining",
-            "kind" => kind_label,
-        )
-        .set(total_todo as f64);
-
-        let loader = Arc::new(CatchupLoader {
-            decoded_logs_dir: self.decoded_logs_dir.clone(),
-            decoded_calls_dir: self.decoded_calls_dir.clone(),
-            raw_receipts_dir: self.raw_receipts_dir.clone(),
-            historical_reader: self.historical_reader.clone(),
-            rpc_client: self.executor.rpc_client.clone(),
-            contracts: self.contracts.clone(),
-            chain_name: self.chain_name.clone(),
-            chain_id: self.chain_id,
-            db_pool: self.db_pool.clone(),
-            finalizer: self.finalizer.clone(),
-        });
-
-        let scheduler = DagScheduler::new(tracker.clone(), self.handler_concurrency);
-
-        // ── Build ALL work items upfront ────────────────────────────────
+    /// Build all catchup work items upfront.
+    async fn build_catchup_work_items(
+        &self,
+        handlers: &[CatchupHandler],
+        available: &[(u64, u64)],
+        self_completed: &HashMap<String, HashSet<u64>>,
+        trigger_range_sets: &HashMap<String, HashSet<(u64, u64)>>,
+        tracker: &Arc<CompletionTracker>,
+    ) -> (Vec<WorkItem>, HashMap<String, usize>) {
         let mut items: Vec<WorkItem> = Vec::new();
         let mut per_handler_submitted: HashMap<String, usize> = HashMap::new();
 
-        for ch in &handlers {
+        for ch in handlers {
             let name = ch.handler.name().to_string();
             let completed = self_completed.get(&name).cloned().unwrap_or_default();
 
-            for &(range_start, range_end) in &available {
+            for &(range_start, range_end) in available {
                 if completed.contains(&range_start) {
                     continue;
                 }
 
-                // Skip if any handler dep already failed — the tracker retains
-                // failure state, so submitting would immediately cascade-fail.
+                // Skip if any handler dep already failed.
                 let mut dep_failed = false;
                 for dep in ch.handler_deps.iter() {
                     if tracker.is_failed(dep, range_start).await {
@@ -762,9 +883,6 @@ impl TransformationEngine {
                     continue;
                 }
 
-                // Determine if this handler has trigger parquet data in this
-                // range. If not, call-dep gating is skipped (the handler will
-                // no-op and unblock same-range dependents).
                 let trigger_range_present = trigger_range_sets
                     .get(&name)
                     .is_some_and(|ranges| ranges.contains(&(range_start, range_end)));
@@ -798,55 +916,39 @@ impl TransformationEngine {
             }
         }
 
-        // Per-handler submission summary.
-        for ch in &handlers {
-            let count = per_handler_submitted
-                .get(ch.handler.name())
-                .copied()
-                .unwrap_or(0);
-            if count > 0 {
-                tracing::info!(
-                    "Handler {} catchup: submitting {} range(s)",
-                    ch.handler.handler_key(),
-                    count
-                );
-            }
-        }
+        (items, per_handler_submitted)
+    }
 
-        if items.is_empty() {
-            tracing::info!("{} handler catchup: no work items to submit", kind_label);
-            return Ok(());
-        }
-
-        tracing::info!(
-            "{} catchup: executing {} work items across {} handlers",
-            kind_label,
-            items.len(),
-            per_handler_submitted.len()
-        );
-
-        // ── Spawn background call-dep scanner ──────────────────────────
-        // Collect unique (source, function) pairs across all handlers.
+    /// Spawn the background call-dep scanner if any handler has call dependencies.
+    ///
+    /// Returns the cancel channel sender and optional scanner task handle.
+    async fn spawn_call_dep_scanner(
+        &self,
+        handlers: &[CatchupHandler],
+        tracker: &Arc<CompletionTracker>,
+    ) -> (
+        tokio::sync::watch::Sender<bool>,
+        Option<tokio::task::JoinHandle<()>>,
+    ) {
         let mut unique_call_deps: HashSet<(String, String)> = HashSet::new();
-        for ch in &handlers {
+        for ch in handlers {
             for dep in ch.call_deps.iter() {
                 unique_call_deps.insert(dep.clone());
             }
         }
         let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
-        let scanner_handle = if !unique_call_deps.is_empty() {
+        let handle = if !unique_call_deps.is_empty() {
             let scanner = CallDepScanner::new(
                 self.decoded_calls_dir.clone(),
                 self.raw_eth_calls_dir.clone(),
                 self.contracts.clone(),
                 unique_call_deps.into_iter().collect(),
             );
-            // Run one initial scan synchronously before spawning the loop so
-            // that items whose call deps are already on disk don't have to
-            // wait for the first 2s tick.
             let initial = scanner.scan_all().await;
             for ((source, func), ranges) in initial {
-                tracker.register_call_dep_ranges(&source, &func, ranges).await;
+                tracker
+                    .register_call_dep_ranges(&source, &func, ranges)
+                    .await;
             }
             Some(tokio::spawn(run_call_dep_scanner_loop(
                 scanner,
@@ -856,33 +958,37 @@ impl TransformationEngine {
         } else {
             None
         };
+        (cancel_tx, handle)
+    }
 
-        // ── Spawn background progress reporter ─────────────────────────
-        let progress_tracker = tracker.clone();
-        let progress_kind: &'static str = kind_label;
-        let total_available = available.len();
+    /// Spawn a background task that periodically logs catchup progress.
+    fn spawn_progress_reporter(
+        tracker: Arc<CompletionTracker>,
+        kind_label: &'static str,
+        total_available: usize,
+        handlers: &[CatchupHandler],
+    ) -> tokio::task::JoinHandle<()> {
         let handler_keys: HashMap<String, String> = handlers
             .iter()
             .map(|ch| (ch.handler.name().to_string(), ch.handler.handler_key()))
             .collect();
-        let progress_handle = tokio::spawn(async move {
+        tokio::spawn(async move {
             let mut interval = tokio::time::interval(Duration::from_secs(30));
             interval.tick().await; // skip immediate first tick
             loop {
                 interval.tick().await;
-                let snap = progress_tracker.snapshot_progress().await;
+                let snap = tracker.snapshot_progress().await;
                 let total_completed: usize = snap.values().map(|(c, _, _)| c).sum();
                 let total_failed: usize = snap.values().map(|(_, f, _)| f).sum();
                 let total_blocked: usize = snap.values().map(|(_, _, b)| b).sum();
                 tracing::info!(
                     "{} catchup progress: {}/{} completed, {} failed, {} blocked",
-                    progress_kind,
+                    kind_label,
                     total_completed,
                     total_available * snap.len(),
                     total_failed,
                     total_blocked,
                 );
-                // Log per-handler detail for handlers that are behind.
                 for (name, (completed, failed, blocked)) in &snap {
                     let remaining = total_available.saturating_sub(*completed);
                     if remaining > 0 || *failed > 0 || *blocked > 0 {
@@ -899,7 +1005,7 @@ impl TransformationEngine {
                 }
                 gauge!(
                     "transformation_catchup_ranges_remaining",
-                    "kind" => progress_kind,
+                    "kind" => kind_label,
                 )
                 .set(
                     snap.values()
@@ -907,40 +1013,16 @@ impl TransformationEngine {
                         .sum::<usize>() as f64,
                 );
             }
-        });
+        })
+    }
 
-        // ── Execute all items ──────────────────────────────────────────
-        let catchup_start = Instant::now();
-        let loader_ref = loader.clone();
-        let outcomes = scheduler
-            .execute(items, move |item| {
-                let loader = loader_ref.clone();
-                Box::pin(async move {
-                    match loader.run(item).await {
-                        Ok(()) => WorkItemRunResult::Succeeded,
-                        Err(TransformationError::TransientBlocked(msg)) => {
-                            WorkItemRunResult::Blocked(msg)
-                        }
-                        Err(e) => WorkItemRunResult::Failed(e.to_string()),
-                    }
-                })
-            })
-            .await;
-
-        histogram!(
-            "transformation_catchup_total_duration_seconds",
-            "kind" => kind_label,
-        )
-        .record(catchup_start.elapsed().as_secs_f64());
-
-        // ── Cancel background tasks ────────────────────────────────────
-        let _ = cancel_tx.send(true);
-        if let Some(handle) = scanner_handle {
-            handle.abort();
-        }
-        progress_handle.abort();
-
-        // ── Process outcomes ───────────────────────────────────────────
+    /// Process DAG scheduler outcomes: log, collect metrics, and return errors.
+    fn process_catchup_outcomes(
+        outcomes: Vec<WorkItemOutcome>,
+        handlers: &[CatchupHandler],
+        kind_label: &'static str,
+        catchup_start: Instant,
+    ) -> Result<(), TransformationError> {
         let handler_name_to_key: HashMap<String, String> = handlers
             .iter()
             .map(|ch| (ch.handler.name().to_string(), ch.handler.handler_key()))
@@ -1059,7 +1141,7 @@ impl TransformationEngine {
         }
 
         // Per-handler outcome summary.
-        for ch in &handlers {
+        for ch in handlers {
             let name = ch.handler.name();
             let Some(&(ok, failed, blocked_count, cascade, cascade_blocked_count, panicked)) =
                 per_handler_outcomes.get(name)

--- a/src/transformations/engine.rs
+++ b/src/transformations/engine.rs
@@ -941,6 +941,11 @@ impl TransformationEngine {
         progress_handle.abort();
 
         // ── Process outcomes ───────────────────────────────────────────
+        let handler_name_to_key: HashMap<String, String> = handlers
+            .iter()
+            .map(|ch| (ch.handler.name().to_string(), ch.handler.handler_key()))
+            .collect();
+
         let mut failed_items: Vec<(String, u64, String)> = Vec::new();
         let mut succeeded = 0usize;
         let mut blocked = 0usize;
@@ -957,10 +962,9 @@ impl TransformationEngine {
                 OutcomeStatus::Succeeded => {
                     succeeded += 1;
                     counts.0 += 1;
-                    let key = handlers
-                        .iter()
-                        .find(|ch| ch.handler.name() == outcome.handler_name)
-                        .map(|ch| ch.handler.handler_key())
+                    let key = handler_name_to_key
+                        .get(&outcome.handler_name)
+                        .cloned()
                         .unwrap_or_else(|| outcome.handler_name.clone());
                     counter!(
                         "transformation_catchup_ranges_completed_total",
@@ -979,10 +983,9 @@ impl TransformationEngine {
                     );
                     blocked += 1;
                     counts.2 += 1;
-                    let key = handlers
-                        .iter()
-                        .find(|ch| ch.handler.name() == outcome.handler_name)
-                        .map(|ch| ch.handler.handler_key())
+                    let key = handler_name_to_key
+                        .get(&outcome.handler_name)
+                        .cloned()
                         .unwrap_or_else(|| outcome.handler_name.clone());
                     failed_items.push((key, outcome.range_start, format!("blocked: {}", reason)));
                 }
@@ -994,10 +997,9 @@ impl TransformationEngine {
                         outcome.range_end,
                         reason
                     );
-                    let key = handlers
-                        .iter()
-                        .find(|ch| ch.handler.name() == outcome.handler_name)
-                        .map(|ch| ch.handler.handler_key())
+                    let key = handler_name_to_key
+                        .get(&outcome.handler_name)
+                        .cloned()
                         .unwrap_or_else(|| outcome.handler_name.clone());
                     failed_items.push((key, outcome.range_start, reason.clone()));
                     counts.1 += 1;
@@ -1009,10 +1011,9 @@ impl TransformationEngine {
                         outcome.range_start,
                         dep_name
                     );
-                    let key = handlers
-                        .iter()
-                        .find(|ch| ch.handler.name() == outcome.handler_name)
-                        .map(|ch| ch.handler.handler_key())
+                    let key = handler_name_to_key
+                        .get(&outcome.handler_name)
+                        .cloned()
                         .unwrap_or_else(|| outcome.handler_name.clone());
                     failed_items.push((
                         key,
@@ -1029,10 +1030,9 @@ impl TransformationEngine {
                         outcome.range_start,
                         dep_name
                     );
-                    let key = handlers
-                        .iter()
-                        .find(|ch| ch.handler.name() == outcome.handler_name)
-                        .map(|ch| ch.handler.handler_key())
+                    let key = handler_name_to_key
+                        .get(&outcome.handler_name)
+                        .cloned()
                         .unwrap_or_else(|| outcome.handler_name.clone());
                     failed_items.push((
                         key,
@@ -1048,10 +1048,9 @@ impl TransformationEngine {
                         outcome.handler_name,
                         outcome.range_start
                     );
-                    let key = handlers
-                        .iter()
-                        .find(|ch| ch.handler.name() == outcome.handler_name)
-                        .map(|ch| ch.handler.handler_key())
+                    let key = handler_name_to_key
+                        .get(&outcome.handler_name)
+                        .cloned()
                         .unwrap_or_else(|| outcome.handler_name.clone());
                     failed_items.push((key, outcome.range_start, "task panicked".to_string()));
                     counts.5 += 1;

--- a/src/transformations/engine.rs
+++ b/src/transformations/engine.rs
@@ -139,14 +139,14 @@ pub(crate) enum HandlerKind {
 struct CatchupHandler {
     handler: Arc<dyn super::traits::TransformationHandler>,
     /// (source, name) pairs — event names for Event, function names for Call.
-    triggers: Vec<(String, String)>,
+    triggers: Arc<Vec<(String, String)>>,
     /// Call dependencies (Event handlers only; empty for Call handlers).
-    call_deps: Vec<(String, String)>,
+    call_deps: Arc<Vec<(String, String)>>,
     /// Same-range handler dependencies gated by the DAG scheduler.
-    handler_deps: Vec<String>,
+    handler_deps: Arc<Vec<String>>,
     /// Catchup-only dependencies that require the upstream handler to be
     /// completed contiguously through this range before submission.
-    contiguous_handler_deps: Vec<String>,
+    contiguous_handler_deps: Arc<Vec<String>>,
     kind: HandlerKind,
     /// When true, the scheduler processes ranges one at a time in ascending order.
     sequential: bool,
@@ -597,10 +597,10 @@ impl TransformationEngine {
                     let sequential = info.handler.requires_sequential();
                     CatchupHandler {
                         handler: info.handler as Arc<dyn super::traits::TransformationHandler>,
-                        triggers,
-                        call_deps,
-                        handler_deps,
-                        contiguous_handler_deps,
+                        triggers: Arc::new(triggers),
+                        call_deps: Arc::new(call_deps),
+                        handler_deps: Arc::new(handler_deps),
+                        contiguous_handler_deps: Arc::new(contiguous_handler_deps),
                         kind: HandlerKind::Event,
                         sequential,
                     }
@@ -619,10 +619,10 @@ impl TransformationEngine {
                     let sequential = info.handler.requires_sequential();
                     CatchupHandler {
                         handler: info.handler as Arc<dyn super::traits::TransformationHandler>,
-                        triggers,
-                        call_deps: Vec::new(),
-                        handler_deps: Vec::new(),
-                        contiguous_handler_deps: Vec::new(),
+                        triggers: Arc::new(triggers),
+                        call_deps: Arc::new(Vec::new()),
+                        handler_deps: Arc::new(Vec::new()),
+                        contiguous_handler_deps: Arc::new(Vec::new()),
                         kind: HandlerKind::Call,
                         sequential,
                     }
@@ -652,7 +652,7 @@ impl TransformationEngine {
         let mut trigger_range_sets: HashMap<String, HashSet<(u64, u64)>> = HashMap::new();
         for ch in &handlers {
             let mut ranges: HashSet<(u64, u64)> = HashSet::new();
-            for (source, trigger_name) in &ch.triggers {
+            for (source, trigger_name) in ch.triggers.iter() {
                 let dir = base_dir.join(source).join(trigger_name);
                 ranges.extend(self.scan_available_ranges(&dir).await?);
             }
@@ -752,7 +752,7 @@ impl TransformationEngine {
                 // Skip if any handler dep already failed — the tracker retains
                 // failure state, so submitting would immediately cascade-fail.
                 let mut dep_failed = false;
-                for dep in &ch.handler_deps {
+                for dep in ch.handler_deps.iter() {
                     if tracker.is_failed(dep, range_start).await {
                         dep_failed = true;
                         break;
@@ -769,11 +769,11 @@ impl TransformationEngine {
                     .get(&name)
                     .is_some_and(|ranges| ranges.contains(&(range_start, range_end)));
 
-                let call_dep_keys: Vec<(String, String)> =
+                let call_dep_keys: Arc<Vec<(String, String)>> =
                     if trigger_range_present && !ch.call_deps.is_empty() {
                         ch.call_deps.clone()
                     } else {
-                        Vec::new()
+                        Arc::new(Vec::new())
                     };
 
                 *per_handler_submitted.entry(name.clone()).or_default() += 1;
@@ -829,7 +829,7 @@ impl TransformationEngine {
         // Collect unique (source, function) pairs across all handlers.
         let mut unique_call_deps: HashSet<(String, String)> = HashSet::new();
         for ch in &handlers {
-            for dep in &ch.call_deps {
+            for dep in ch.call_deps.iter() {
                 unique_call_deps.insert(dep.clone());
             }
         }
@@ -2425,9 +2425,9 @@ impl TransformationEngine {
                     handler_name: name,
                     range_start,
                     range_end,
-                    dep_names,
-                    contiguous_dep_names: Vec::new(),
-                    call_dep_keys: Vec::new(),
+                    dep_names: Arc::new(dep_names),
+                    contiguous_dep_names: Arc::new(Vec::new()),
+                    call_dep_keys: Arc::new(Vec::new()),
                     sequential: false,
                     payload: Box::new(ProcessRangePayload {
                         handler,
@@ -2455,9 +2455,9 @@ impl TransformationEngine {
                     handler_name: name,
                     range_start,
                     range_end,
-                    dep_names: vec![],
-                    contiguous_dep_names: Vec::new(),
-                    call_dep_keys: Vec::new(),
+                    dep_names: Arc::new(vec![]),
+                    contiguous_dep_names: Arc::new(Vec::new()),
+                    call_dep_keys: Arc::new(Vec::new()),
                     sequential: false,
                     payload: Box::new(ProcessRangePayload {
                         handler,

--- a/src/transformations/registry.rs
+++ b/src/transformations/registry.rs
@@ -468,6 +468,17 @@ impl TransformationRegistry {
         self.handler_name_to_key.get(name).map(|s| s.as_str())
     }
 
+    /// Resolve a handler name to its handler_key, falling back to the name itself.
+    ///
+    /// Useful when displaying metrics or log messages where a missing mapping
+    /// should not panic.
+    pub fn resolve_handler_key(&self, name: &str) -> String {
+        self.handler_name_to_key
+            .get(name)
+            .cloned()
+            .unwrap_or_else(|| name.to_string())
+    }
+
     /// Whether a handler was registered with more than one trigger.
     pub fn is_multi_trigger(&self, handler_key: &str) -> bool {
         self.multi_trigger_handler_keys.contains(handler_key)

--- a/src/transformations/retry.rs
+++ b/src/transformations/retry.rs
@@ -513,7 +513,7 @@ impl RetryProcessor {
             // the correct state for every possible dep via seeding/failing
             // above, so wait_ready resolves immediately for non-missing deps
             // and fails fast for call-blocked deps.
-            let dep_names = rh.handler_deps.clone();
+            let dep_names = Arc::new(rh.handler_deps.clone());
 
             name_to_key.insert(handler_name.clone(), handler_key);
             work_items.push(WorkItem {
@@ -521,8 +521,8 @@ impl RetryProcessor {
                 range_start,
                 range_end,
                 dep_names,
-                contiguous_dep_names: Vec::new(),
-                call_dep_keys: Vec::new(),
+                contiguous_dep_names: Arc::new(Vec::new()),
+                call_dep_keys: Arc::new(Vec::new()),
                 sequential: false,
                 payload: Box::new(RetryPayload {
                     handler: rh.handler.clone(),

--- a/src/transformations/scheduler/dag.rs
+++ b/src/transformations/scheduler/dag.rs
@@ -30,14 +30,14 @@ pub(crate) struct WorkItem {
     pub handler_name: String,
     pub range_start: u64,
     pub range_end: u64,
-    pub dep_names: Vec<String>,
+    pub dep_names: Arc<Vec<String>>,
     /// Handler names whose contiguous watermark must be >= `range_start` before
     /// this item can execute. Used for `contiguous_handler_dependencies`.
-    pub contiguous_dep_names: Vec<String>,
+    pub contiguous_dep_names: Arc<Vec<String>>,
     /// `(source, function)` pairs whose decoded call parquet files must be
     /// available on disk for `(range_start, range_end)` before this item can
     /// execute. Empty if no call deps or no trigger data in this range.
-    pub call_dep_keys: Vec<(String, String)>,
+    pub call_dep_keys: Arc<Vec<(String, String)>>,
     /// When `true`, the scheduler enforces one-at-a-time FIFO execution for this
     /// handler via a per-handler capacity-1 semaphore. Items must be submitted in
     /// ascending `range_start` order for the FIFO guarantee to hold.
@@ -443,9 +443,9 @@ mod tests {
             handler_name: name.to_string(),
             range_start,
             range_end: range_start + 1,
-            dep_names: deps.iter().map(|s| s.to_string()).collect(),
-            contiguous_dep_names: Vec::new(),
-            call_dep_keys: Vec::new(),
+            dep_names: Arc::new(deps.iter().map(|s| s.to_string()).collect()),
+            contiguous_dep_names: Arc::new(Vec::new()),
+            call_dep_keys: Arc::new(Vec::new()),
             sequential: false,
             payload: Box::new(()),
         }

--- a/src/transformations/scheduler/dag.rs
+++ b/src/transformations/scheduler/dag.rs
@@ -78,6 +78,16 @@ pub(crate) enum WorkItemRunResult {
     Blocked(String),
 }
 
+/// Per-handler sequential execution state.
+///
+/// Groups the capacity-1 FIFO semaphore and the blocked-range marker that
+/// together enforce one-at-a-time ascending-order execution for handlers
+/// with `sequential: true`.
+struct HandlerSequentialState {
+    semaphore: Arc<Semaphore>,
+    blocked_range: Arc<Mutex<Option<u64>>>,
+}
+
 /// Pure DAG scheduler — owns the [`CompletionTracker`] and a concurrency semaphore.
 ///
 /// DB writes, handler invocation, and context construction all live in the
@@ -118,25 +128,18 @@ impl DagScheduler {
             return Vec::new();
         }
 
-        // Build per-handler capacity-1 semaphores for sequential handlers.
-        // Tokio semaphores are FIFO, so items submitted in ascending range_start
-        // order will acquire permits in that order, guaranteeing block ordering.
-        let seq_sems: Arc<HashMap<String, Arc<Semaphore>>> = {
+        // Build per-handler sequential state (capacity-1 semaphore + blocked
+        // range marker) in a single pass. Tokio semaphores are FIFO, so items
+        // submitted in ascending range_start order acquire permits in order.
+        let seq_state: Arc<HashMap<String, HandlerSequentialState>> = {
             let mut m = HashMap::new();
             for item in &items {
                 if item.sequential {
                     m.entry(item.handler_name.clone())
-                        .or_insert_with(|| Arc::new(Semaphore::new(1)));
-                }
-            }
-            Arc::new(m)
-        };
-        let seq_blocked: Arc<HashMap<String, Arc<Mutex<Option<u64>>>>> = {
-            let mut m = HashMap::new();
-            for item in &items {
-                if item.sequential {
-                    m.entry(item.handler_name.clone())
-                        .or_insert_with(|| Arc::new(Mutex::new(None)));
+                        .or_insert_with(|| HandlerSequentialState {
+                            semaphore: Arc::new(Semaphore::new(1)),
+                            blocked_range: Arc::new(Mutex::new(None)),
+                        });
                 }
             }
             Arc::new(m)
@@ -156,8 +159,7 @@ impl DagScheduler {
             let call_dep_keys = item.call_dep_keys.clone();
             let tracker = self.tracker.clone();
             let permits = self.global_permits.clone();
-            let seq_sems = seq_sems.clone();
-            let seq_blocked = seq_blocked.clone();
+            let seq_state = seq_state.clone();
             let runner = runner.clone();
 
             // Data captured by the spawned task:
@@ -200,9 +202,12 @@ impl DagScheduler {
                 //    Acquired after dep-wait so parked sequential tasks don't
                 //    consume global permits. Dropped at end of scope, releasing
                 //    the next range in FIFO order.
-                let _seq_permit = match seq_sems.get(&name_for_task) {
-                    Some(sem) => Some(
-                        sem.clone()
+                let handler_seq = seq_state.get(&name_for_task);
+                let _seq_permit = match handler_seq {
+                    Some(state) => Some(
+                        state
+                            .semaphore
+                            .clone()
                             .acquire_owned()
                             .await
                             .expect("sequential semaphore never closed"),
@@ -210,8 +215,8 @@ impl DagScheduler {
                     None => None,
                 };
 
-                if let Some(blocked) = seq_blocked.get(&name_for_task) {
-                    let blocking_range = *blocked.lock().await;
+                if let Some(state) = handler_seq {
+                    let blocking_range = *state.blocked_range.lock().await;
                     if let Some(blocking_range) = blocking_range.filter(|r| *r < range_start) {
                         let reason = format!(
                             "waiting on earlier blocked range {} before processing {}",
@@ -257,8 +262,8 @@ impl DagScheduler {
                         }
                     }
                     WorkItemRunResult::Blocked(reason) => {
-                        if let Some(blocked) = seq_blocked.get(&name_for_task) {
-                            let mut blocked_range = blocked.lock().await;
+                        if let Some(state) = seq_state.get(&name_for_task) {
+                            let mut blocked_range = state.blocked_range.lock().await;
                             if blocked_range.is_none_or(|existing| range_start < existing) {
                                 *blocked_range = Some(range_start);
                             }

--- a/src/transformations/scheduler/loader.rs
+++ b/src/transformations/scheduler/loader.rs
@@ -270,8 +270,8 @@ pub(crate) struct CatchupPayload {
     pub handler_key: String,
     pub handler_name: &'static str,
     pub handler_version: u32,
-    pub triggers: Vec<(String, String)>,
-    pub call_deps: Vec<(String, String)>,
+    pub triggers: Arc<Vec<(String, String)>>,
+    pub call_deps: Arc<Vec<(String, String)>>,
     pub kind: HandlerKind,
 }
 
@@ -694,9 +694,9 @@ mod tests {
             handler_name: name.to_string(),
             range_start,
             range_end: range_start + 1000,
-            dep_names: deps.iter().map(|s| s.to_string()).collect(),
-            contiguous_dep_names: Vec::new(),
-            call_dep_keys: Vec::new(),
+            dep_names: Arc::new(deps.iter().map(|s| s.to_string()).collect()),
+            contiguous_dep_names: Arc::new(Vec::new()),
+            call_dep_keys: Arc::new(Vec::new()),
             sequential: false,
             payload: Box::new(()),
         }

--- a/src/transformations/scheduler/tracker.rs
+++ b/src/transformations/scheduler/tracker.rs
@@ -19,11 +19,32 @@
 //! `watch<HashSet<u64>>` would be an isolated drop-in swap if profiling shows
 //! contention.
 //!
+//! # Lock ordering
+//!
+//! Three independent RwLocks: `state`, `contiguous`, `call_dep_ranges`.
+//!
+//! **Invariant**: never hold `state` write lock and `contiguous` write lock
+//! simultaneously. `advance_contiguous_watermark` reads `state` then writes
+//! `contiguous` — safe ordering. `call_dep_ranges` is independent.
+//!
 //! [`DagScheduler`]: super::dag::DagScheduler
 
 use std::collections::{HashMap, HashSet};
 
 use tokio::sync::{Notify, RwLock};
+
+/// Per-handler completed/failed/blocked range state, grouped under one lock.
+struct HandlerRangeState {
+    completed: HashMap<String, HashSet<u64>>,
+    failed: HashMap<String, HashSet<u64>>,
+    blocked: HashMap<String, HashSet<u64>>,
+}
+
+/// Per-handler contiguous watermark state, grouped under one lock.
+struct ContiguousState {
+    watermarks: HashMap<String, Option<u64>>,
+    positions: HashMap<String, usize>,
+}
 
 /// In-memory state of per-`(handler_name, range_start)` completion/failure.
 ///
@@ -44,21 +65,15 @@ use tokio::sync::{Notify, RwLock};
 /// [`WorkItem`]: super::dag::WorkItem
 /// [`wait_ready`]: CompletionTracker::wait_ready
 pub(crate) struct CompletionTracker {
-    completed: RwLock<HashMap<String, HashSet<u64>>>,
-    failed: RwLock<HashMap<String, HashSet<u64>>>,
-    blocked: RwLock<HashMap<String, HashSet<u64>>>,
-    notify: Notify,
-    /// Sorted list of all available range_starts (immutable after construction).
-    available_starts: Vec<u64>,
-    /// Per-handler contiguous watermark: highest `range_start` where all ranges
-    /// from the first available through this one are completed with no gaps.
-    contiguous_watermarks: RwLock<HashMap<String, Option<u64>>>,
-    /// Per-handler index into `available_starts` for O(1) amortized watermark advance.
-    contiguous_positions: RwLock<HashMap<String, usize>>,
+    state: RwLock<HandlerRangeState>,
+    contiguous: RwLock<ContiguousState>,
     /// Per-`(source, function)` set of available call-dep range_starts.
     /// Matched by range_start only (log and call-dep files may have different range sizes).
     /// Updated by the background `CallDepScanner`.
     call_dep_ranges: RwLock<HashMap<(String, String), HashSet<u64>>>,
+    notify: Notify,
+    /// Sorted list of all available range_starts (immutable after construction).
+    available_starts: Vec<u64>,
 }
 
 /// Snapshot view of whether a set of dependencies is satisfied for a range.
@@ -88,14 +103,18 @@ pub(crate) enum DepWaitError {
 impl CompletionTracker {
     pub(crate) fn new() -> Self {
         Self {
-            completed: RwLock::new(HashMap::new()),
-            failed: RwLock::new(HashMap::new()),
-            blocked: RwLock::new(HashMap::new()),
+            state: RwLock::new(HandlerRangeState {
+                completed: HashMap::new(),
+                failed: HashMap::new(),
+                blocked: HashMap::new(),
+            }),
+            contiguous: RwLock::new(ContiguousState {
+                watermarks: HashMap::new(),
+                positions: HashMap::new(),
+            }),
+            call_dep_ranges: RwLock::new(HashMap::new()),
             notify: Notify::new(),
             available_starts: Vec::new(),
-            contiguous_watermarks: RwLock::new(HashMap::new()),
-            contiguous_positions: RwLock::new(HashMap::new()),
-            call_dep_ranges: RwLock::new(HashMap::new()),
         }
     }
 
@@ -106,14 +125,18 @@ impl CompletionTracker {
     pub(crate) fn with_available_starts(starts: Vec<u64>) -> Self {
         debug_assert!(starts.windows(2).all(|w| w[0] < w[1]), "starts must be sorted");
         Self {
-            completed: RwLock::new(HashMap::new()),
-            failed: RwLock::new(HashMap::new()),
-            blocked: RwLock::new(HashMap::new()),
+            state: RwLock::new(HandlerRangeState {
+                completed: HashMap::new(),
+                failed: HashMap::new(),
+                blocked: HashMap::new(),
+            }),
+            contiguous: RwLock::new(ContiguousState {
+                watermarks: HashMap::new(),
+                positions: HashMap::new(),
+            }),
+            call_dep_ranges: RwLock::new(HashMap::new()),
             notify: Notify::new(),
             available_starts: starts,
-            contiguous_watermarks: RwLock::new(HashMap::new()),
-            contiguous_positions: RwLock::new(HashMap::new()),
-            call_dep_ranges: RwLock::new(HashMap::new()),
         }
     }
 
@@ -129,8 +152,9 @@ impl CompletionTracker {
         ranges: impl IntoIterator<Item = u64>,
     ) {
         {
-            let mut completed = self.completed.write().await;
-            let entry = completed
+            let mut state = self.state.write().await;
+            let entry = state
+                .completed
                 .entry(handler_name.to_string())
                 .or_insert_with(HashSet::new);
             for range in ranges {
@@ -145,42 +169,38 @@ impl CompletionTracker {
     }
 
     /// Snapshot check: are all `deps` completed for `range_start`?
+    ///
+    /// Takes ONE read lock on `state` for all failed/blocked/completed checks.
     pub(crate) async fn probe(&self, deps: &[String], range_start: u64) -> DepState {
+        let state = self.state.read().await;
         // Check failed first so a failed dep is reported even if others are completed.
-        {
-            let failed = self.failed.read().await;
-            for dep in deps {
-                if failed
-                    .get(dep)
-                    .map(|ranges| ranges.contains(&range_start))
-                    .unwrap_or(false)
-                {
-                    return DepState::DepFailed {
-                        dep_name: dep.clone(),
-                    };
-                }
-            }
-        }
-        {
-            let blocked = self.blocked.read().await;
-            for dep in deps {
-                if blocked
-                    .get(dep)
-                    .map(|ranges| ranges.contains(&range_start))
-                    .unwrap_or(false)
-                {
-                    return DepState::DepBlocked {
-                        dep_name: dep.clone(),
-                    };
-                }
-            }
-        }
-        let completed = self.completed.read().await;
         for dep in deps {
-            let has = completed
+            if state
+                .failed
                 .get(dep)
-                .map(|ranges| ranges.contains(&range_start))
-                .unwrap_or(false);
+                .is_some_and(|ranges| ranges.contains(&range_start))
+            {
+                return DepState::DepFailed {
+                    dep_name: dep.clone(),
+                };
+            }
+        }
+        for dep in deps {
+            if state
+                .blocked
+                .get(dep)
+                .is_some_and(|ranges| ranges.contains(&range_start))
+            {
+                return DepState::DepBlocked {
+                    dep_name: dep.clone(),
+                };
+            }
+        }
+        for dep in deps {
+            let has = state
+                .completed
+                .get(dep)
+                .is_some_and(|ranges| ranges.contains(&range_start));
             if !has {
                 return DepState::Waiting;
             }
@@ -229,21 +249,22 @@ impl CompletionTracker {
 
     /// Mark `(handler_name, range_start)` as completed and wake all waiters.
     ///
+    /// Takes ONE write lock on `state` for both the completed insert and the
+    /// blocked cleanup (was 2 separate locks).
+    ///
     /// Also advances the contiguous watermark for this handler if applicable.
     pub(crate) async fn mark_completed(&self, handler_name: &str, range_start: u64) {
         {
-            let mut completed = self.completed.write().await;
-            completed
+            let mut state = self.state.write().await;
+            state
+                .completed
                 .entry(handler_name.to_string())
                 .or_insert_with(HashSet::new)
                 .insert(range_start);
-        }
-        {
-            let mut blocked = self.blocked.write().await;
-            if let Some(ranges) = blocked.get_mut(handler_name) {
+            if let Some(ranges) = state.blocked.get_mut(handler_name) {
                 ranges.remove(&range_start);
                 if ranges.is_empty() {
-                    blocked.remove(handler_name);
+                    state.blocked.remove(handler_name);
                 }
             }
         }
@@ -259,28 +280,29 @@ impl CompletionTracker {
     /// deps failed in a previous scheduler pass, avoiding wasted submissions
     /// that would immediately cascade-fail.
     pub(crate) async fn is_failed(&self, handler_name: &str, range_start: u64) -> bool {
-        let failed = self.failed.read().await;
-        failed
+        let state = self.state.read().await;
+        state
+            .failed
             .get(handler_name)
-            .map(|ranges| ranges.contains(&range_start))
-            .unwrap_or(false)
+            .is_some_and(|ranges| ranges.contains(&range_start))
     }
 
     /// Mark `(handler_name, range_start)` as failed and wake all waiters.
+    ///
+    /// Takes ONE write lock on `state` for both the failed insert and the
+    /// blocked cleanup (was 2 separate locks).
     pub(crate) async fn mark_failed(&self, handler_name: &str, range_start: u64) {
         {
-            let mut failed = self.failed.write().await;
-            failed
+            let mut state = self.state.write().await;
+            state
+                .failed
                 .entry(handler_name.to_string())
                 .or_insert_with(HashSet::new)
                 .insert(range_start);
-        }
-        {
-            let mut blocked = self.blocked.write().await;
-            if let Some(ranges) = blocked.get_mut(handler_name) {
+            if let Some(ranges) = state.blocked.get_mut(handler_name) {
                 ranges.remove(&range_start);
                 if ranges.is_empty() {
-                    blocked.remove(handler_name);
+                    state.blocked.remove(handler_name);
                 }
             }
         }
@@ -290,8 +312,9 @@ impl CompletionTracker {
     /// Mark `(handler_name, range_start)` as transiently blocked for this pass.
     pub(crate) async fn mark_blocked(&self, handler_name: &str, range_start: u64) {
         {
-            let mut blocked = self.blocked.write().await;
-            blocked
+            let mut state = self.state.write().await;
+            state
+                .blocked
                 .entry(handler_name.to_string())
                 .or_insert_with(HashSet::new)
                 .insert(range_start);
@@ -301,11 +324,11 @@ impl CompletionTracker {
 
     /// Clear a transient blocked mark before the next scheduler pass.
     pub(crate) async fn clear_blocked(&self, handler_name: &str, range_start: u64) {
-        let mut blocked = self.blocked.write().await;
-        if let Some(ranges) = blocked.get_mut(handler_name) {
+        let mut state = self.state.write().await;
+        if let Some(ranges) = state.blocked.get_mut(handler_name) {
             ranges.remove(&range_start);
             if ranges.is_empty() {
-                blocked.remove(handler_name);
+                state.blocked.remove(handler_name);
             }
         }
     }
@@ -313,20 +336,22 @@ impl CompletionTracker {
     /// Check whether `(handler_name, range_start)` is transiently blocked.
     #[cfg(test)]
     pub(crate) async fn is_blocked(&self, handler_name: &str, range_start: u64) -> bool {
-        let blocked = self.blocked.read().await;
-        blocked
+        let state = self.state.read().await;
+        state
+            .blocked
             .get(handler_name)
-            .map(|ranges| ranges.contains(&range_start))
-            .unwrap_or(false)
+            .is_some_and(|ranges| ranges.contains(&range_start))
     }
 
     // ─── Contiguous watermark tracking ──────────────────────────────────
 
     /// Full recomputation of contiguous watermark from position 0.
     /// Used during `seed_completed`.
+    ///
+    /// Reads `state` (read lock) then writes `contiguous` (write lock).
     async fn recompute_contiguous_watermark(&self, handler_name: &str) {
-        let completed = self.completed.read().await;
-        let handler_completed = completed.get(handler_name);
+        let state = self.state.read().await;
+        let handler_completed = state.completed.get(handler_name);
         let mut pos = 0usize;
         let mut watermark: Option<u64> = None;
         for (i, &start) in self.available_starts.iter().enumerate() {
@@ -337,11 +362,10 @@ impl CompletionTracker {
                 break;
             }
         }
-        drop(completed);
-        let mut watermarks = self.contiguous_watermarks.write().await;
-        watermarks.insert(handler_name.to_string(), watermark);
-        let mut positions = self.contiguous_positions.write().await;
-        positions.insert(handler_name.to_string(), pos);
+        drop(state);
+        let mut contiguous = self.contiguous.write().await;
+        contiguous.watermarks.insert(handler_name.to_string(), watermark);
+        contiguous.positions.insert(handler_name.to_string(), pos);
     }
 
     /// Incrementally advance the contiguous watermark after a new completion.
@@ -350,25 +374,28 @@ impl CompletionTracker {
     /// `available_starts` while each successive range_start is in
     /// `completed[handler_name]`. O(k) amortized where k = newly-contiguous
     /// ranges (typically 0 or 1).
+    ///
+    /// Reads `state` (read lock), then reads/writes `contiguous` as needed.
+    /// Never holds both write locks simultaneously.
     async fn advance_contiguous_watermark(&self, handler_name: &str) {
-        let completed = self.completed.read().await;
-        let handler_completed = match completed.get(handler_name) {
+        let state = self.state.read().await;
+        let handler_completed = match state.completed.get(handler_name) {
             Some(c) => c,
             None => return,
         };
 
-        let watermarks_read = self.contiguous_watermarks.read().await;
-        let current_watermark = watermarks_read
+        let contiguous_read = self.contiguous.read().await;
+        let current_watermark = contiguous_read
+            .watermarks
             .get(handler_name)
             .copied()
             .flatten();
-        let positions_read = self.contiguous_positions.read().await;
-        let current_pos = positions_read
+        let current_pos = contiguous_read
+            .positions
             .get(handler_name)
             .copied()
             .unwrap_or(0);
-        drop(positions_read);
-        drop(watermarks_read);
+        drop(contiguous_read);
 
         // Determine the starting index for the walk. If there is no watermark
         // yet, start from 0 (the handler might now have completed the first
@@ -390,20 +417,19 @@ impl CompletionTracker {
             }
         }
 
-        // Only take write locks if something changed.
+        // Only take write lock if something changed.
         if new_watermark != current_watermark {
-            drop(completed);
-            let mut watermarks = self.contiguous_watermarks.write().await;
-            watermarks.insert(handler_name.to_string(), new_watermark);
-            let mut positions = self.contiguous_positions.write().await;
-            positions.insert(handler_name.to_string(), new_pos);
+            drop(state);
+            let mut contiguous = self.contiguous.write().await;
+            contiguous.watermarks.insert(handler_name.to_string(), new_watermark);
+            contiguous.positions.insert(handler_name.to_string(), new_pos);
         }
     }
 
     /// Read the current contiguous watermark for a handler.
     pub(crate) async fn contiguous_watermark(&self, handler_name: &str) -> Option<u64> {
-        let watermarks = self.contiguous_watermarks.read().await;
-        watermarks.get(handler_name).copied().flatten()
+        let contiguous = self.contiguous.read().await;
+        contiguous.watermarks.get(handler_name).copied().flatten()
     }
 
     // ─── Call-dep range tracking ────────────────────────────────────────
@@ -437,6 +463,9 @@ impl CompletionTracker {
     // ─── Extended wait (handler deps + contiguous deps + call deps) ─────
 
     /// Snapshot check for the extended readiness condition.
+    ///
+    /// Takes ONE read lock on `state` for all failed/blocked/completed checks
+    /// (was 3 separate locks).
     pub(crate) async fn probe_extended(
         &self,
         handler_deps: &[String],
@@ -444,27 +473,21 @@ impl CompletionTracker {
         call_dep_keys: &[(String, String)],
         range_start: u64,
     ) -> DepState {
-        // 1. Check handler deps failed/blocked/waiting (existing logic).
+        // 1. Check handler deps failed/blocked/waiting under one read lock.
         {
-            let failed = self.failed.read().await;
+            let state = self.state.read().await;
             for dep in handler_deps {
-                if failed.get(dep).is_some_and(|r| r.contains(&range_start)) {
+                if state.failed.get(dep).is_some_and(|r| r.contains(&range_start)) {
                     return DepState::DepFailed { dep_name: dep.clone() };
                 }
             }
-        }
-        {
-            let blocked = self.blocked.read().await;
             for dep in handler_deps {
-                if blocked.get(dep).is_some_and(|r| r.contains(&range_start)) {
+                if state.blocked.get(dep).is_some_and(|r| r.contains(&range_start)) {
                     return DepState::DepBlocked { dep_name: dep.clone() };
                 }
             }
-        }
-        {
-            let completed = self.completed.read().await;
             for dep in handler_deps {
-                if !completed.get(dep).is_some_and(|r| r.contains(&range_start)) {
+                if !state.completed.get(dep).is_some_and(|r| r.contains(&range_start)) {
                     return DepState::Waiting;
                 }
             }
@@ -472,9 +495,9 @@ impl CompletionTracker {
 
         // 2. Check contiguous handler deps.
         if !contiguous_deps.is_empty() {
-            let watermarks = self.contiguous_watermarks.read().await;
+            let contiguous = self.contiguous.read().await;
             for dep in contiguous_deps {
-                let watermark = watermarks.get(dep).copied().flatten();
+                let watermark = contiguous.watermarks.get(dep).copied().flatten();
                 if !watermark.is_some_and(|w| w >= range_start) {
                     return DepState::Waiting;
                 }
@@ -533,21 +556,20 @@ impl CompletionTracker {
     /// Snapshot of per-handler progress for periodic logging.
     ///
     /// Returns `(completed_count, failed_count, blocked_count)` per handler.
+    /// Takes ONE read lock on `state` (was 3 separate locks).
     pub(crate) async fn snapshot_progress(
         &self,
     ) -> HashMap<String, (usize, usize, usize)> {
-        let completed = self.completed.read().await;
-        let failed = self.failed.read().await;
-        let blocked = self.blocked.read().await;
+        let state = self.state.read().await;
 
         let mut result: HashMap<String, (usize, usize, usize)> = HashMap::new();
-        for (name, ranges) in completed.iter() {
+        for (name, ranges) in state.completed.iter() {
             result.entry(name.clone()).or_default().0 = ranges.len();
         }
-        for (name, ranges) in failed.iter() {
+        for (name, ranges) in state.failed.iter() {
             result.entry(name.clone()).or_default().1 = ranges.len();
         }
-        for (name, ranges) in blocked.iter() {
+        for (name, ranges) in state.blocked.iter() {
             result.entry(name.clone()).or_default().2 = ranges.len();
         }
         result


### PR DESCRIPTION
## Summary

- **Add `resolve_handler_key` to registry** -- convenience method for name-to-key resolution with fallback, plus fix pre-existing Arc/Vec type mismatch in historical logs
- **Replace O(n*m) handler lookup with HashMap** -- build `handler_name_to_key` HashMap before the outcome loop instead of doing a linear scan per outcome
- **Arc-wrap shared collections** -- `CatchupHandler`, `WorkItem`, and `CatchupPayload` fields (`triggers`, `call_deps`, `handler_deps`, `contiguous_handler_deps`, `dep_names`, `contiguous_dep_names`, `call_dep_keys`) changed from `Vec` to `Arc<Vec>` to avoid deep-cloning per work item
- **Consolidate sequential state** -- replace two identical iteration loops building `seq_sems`/`seq_blocked` with a single `HandlerSequentialState` struct grouping the semaphore and blocked-range marker
- **Break up `run_handler_catchup`** -- extract 7 focused sub-methods (`collect_catchup_handlers`, `prepare_catchup_handlers`, `seed_tracker_from_progress`, `build_catchup_work_items`, `spawn_call_dep_scanner`, `spawn_progress_reporter`, `process_catchup_outcomes`) so the residual orchestrator is ~60 lines
- **Consolidate CompletionTracker locks** -- replace 6 independent `RwLock`s with 3 logically grouped locks (`HandlerRangeState`, `ContiguousState`, `call_dep_ranges`), reducing lock acquisitions per operation (e.g. `mark_completed` 2->1 write lock, `probe_extended` 3->1 read lock)

No expected conflicts with sibling PRs.