### PR TITLE
feat: USD pricing & rolling metrics for pool metrics (phase 6)

### DIFF
--- a/docs/designs/pool-metrics/metrics_implementation_phases.md
+++ b/docs/designs/pool-metrics/metrics_implementation_phases.md
@@ -320,21 +320,21 @@ multicurve::metrics::register_handlers(registry, chain_id, multicurve_cache);
 
 ---
 
-## Phase 6: USD Pricing & Rolling Metrics
+## Phase 6: USD Pricing & Rolling Metrics ✅
+
+**Status**: Complete
 
 **Goal**: Add USD-denominated values to snapshots and rolling metrics to pool_state.
 
-### Tasks
-1. Read ChainlinkEthOracle latestAnswer from transformation context (calls_of_type)
-2. Read reference pool prices from `prices` table (written by existing PriceHandler)
-3. Resolve quote token → USD price (WETH via ETH/USD, USDC/USDT directly, others via reference pools)
-4. Add volume_usd to pool_snapshots
-5. Add rolling aggregation queries for pool_state: volume_24h_usd, price_change_1h, price_change_24h, swap_count_24h
-
-### Design notes
-- Price resolution: for each swap, look up quote token USD price. If quote is WETH, multiply by latest ETH/USD. If quote is USDC/USDT, use 1.0. If quote is another token, chain through reference pool prices.
-- Rolling metrics: query pool_snapshots for the relevant time window. This can be done as part of pool_state upsert or as a separate periodic handler.
-- Leave architecture open for future price graph traversal.
+### Implementation
+- **New module**: `src/transformations/util/usd_price.rs` — `OraclePriceCache` (shared, DB-backed) + `UsdPriceContext` (per-invocation)
+- **Migration**: `pool_snapshots_add_volume_usd.sql` adds nullable `volume_usd` column
+- **USD resolution**: WETH via ChainlinkEthOracle `latestAnswer` (8 decimals), USDC/USDT at $1, EURC via prices table (EURC/USDC from PriceHandler)
+- **Volume**: Single-side (quote-side only), standard DeFi convention
+- **Rolling metrics**: `DbOperation::RawSql` UPDATE with backward-looking LATERAL subqueries on `pool_snapshots`, executed in-transaction after snapshot inserts
+- **Price change**: Backward-looking — compares current `price_close` to last known `price_close` at or before the 1h/24h mark
+- **Oracle persistence**: ETH/USD written to `prices` table (source = "chainlink"). `OraclePriceCache` shared across all 8 swap handlers, seeded from DB on startup
+- **All 8 swap handlers** updated with shared `Arc<OraclePriceCache>`, new `process_swaps()` signature
 
 ---
 

--- a/migrations/tables/pool_snapshots_add_volume_usd.sql
+++ b/migrations/tables/pool_snapshots_add_volume_usd.sql
@@ -1,0 +1,1 @@
+ALTER TABLE pool_snapshots ADD COLUMN IF NOT EXISTS volume_usd NUMERIC;

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -5,4 +5,4 @@ pub mod types;
 
 pub use error::DbError;
 pub use pool::DbPool;
-pub use types::{DbOperation, DbValue, WhereClause};
+pub use types::{DbOperation, DbSnapshot, DbValue, WhereClause};

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -226,7 +226,7 @@ fn build_operation_sql(op: DbOperation) -> (String, Vec<SqlParam>) {
             table,
             where_clause,
         } => build_delete_sql(&table, &where_clause),
-        DbOperation::RawSql { query, params } => (query, convert_values_to_params(&params)),
+        DbOperation::RawSql { query, params, .. } => (query, convert_values_to_params(&params)),
     }
 }
 
@@ -692,11 +692,7 @@ fn operation_sort_key(op: &DbOperation) -> (u8, Vec<u8>) {
             }
             (0, key)
         }
-        DbOperation::Insert {
-            table,
-            values,
-            ..
-        } => {
+        DbOperation::Insert { table, values, .. } => {
             let mut key = table.as_bytes().to_vec();
             key.push(0);
             for val in values {
@@ -723,9 +719,7 @@ fn operation_sort_key(op: &DbOperation) -> (u8, Vec<u8>) {
             append_where_clause_bytes(where_clause, &mut key);
             (3, key)
         }
-        DbOperation::RawSql { query, .. } => {
-            (4, query.as_bytes().to_vec())
-        }
+        DbOperation::RawSql { query, .. } => (4, query.as_bytes().to_vec()),
     }
 }
 
@@ -916,10 +910,7 @@ mod tests {
         let addr_b = [0xFF; 20];
 
         // Reverse order: B before A
-        let mut ops = vec![
-            upsert_user(1, addr_b),
-            upsert_user(1, addr_a),
-        ];
+        let mut ops = vec![upsert_user(1, addr_b), upsert_user(1, addr_a)];
 
         sort_operations_for_lock_ordering(&mut ops);
 
@@ -962,10 +953,7 @@ mod tests {
     #[test]
     fn sort_is_stable_for_identical_keys() {
         let addr = [0x42; 20];
-        let mut ops = vec![
-            upsert_user(1, addr),
-            upsert_user(1, addr),
-        ];
+        let mut ops = vec![upsert_user(1, addr), upsert_user(1, addr)];
 
         // Should not panic or reorder arbitrarily
         sort_operations_for_lock_ordering(&mut ops);

--- a/src/db/types.rs
+++ b/src/db/types.rs
@@ -90,8 +90,24 @@ pub enum DbOperation {
         table: String,
         where_clause: WhereClause,
     },
-    /// Raw SQL for complex operations (use sparingly)
-    RawSql { query: String, params: Vec<DbValue> },
+    /// Raw SQL for complex operations (use sparingly).
+    ///
+    /// `snapshot` is optional metadata for live-mode rollback. When present,
+    /// the executor snapshots the targeted row before executing the SQL and can
+    /// later restore it during reorg handling.
+    RawSql {
+        query: String,
+        params: Vec<DbValue>,
+        snapshot: Option<DbSnapshot>,
+    },
+}
+
+/// Snapshot metadata for row-modifying operations that cannot be expressed as a
+/// standard Upsert.
+#[derive(Debug, Clone)]
+pub struct DbSnapshot {
+    pub table: String,
+    pub key_columns: Vec<(String, DbValue)>,
 }
 
 /// WHERE clause for UPDATE and DELETE operations.

--- a/src/transformations/event/decay_multicurve/metrics.rs
+++ b/src/transformations/event/decay_multicurve/metrics.rs
@@ -20,6 +20,7 @@ use crate::transformations::event::metrics::v4_hook_extract::{
 use crate::transformations::registry::TransformationRegistry;
 use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
 use crate::transformations::util::pool_metadata::PoolMetadataCache;
+use crate::transformations::util::usd_price::{build_usd_price_context, OraclePriceCache};
 
 const SOURCE: &str = "DecayMulticurveHook";
 
@@ -27,6 +28,7 @@ const SOURCE: &str = "DecayMulticurveHook";
 
 pub struct DecayMulticurveSwapMetricsHandler {
     metadata_cache: Arc<PoolMetadataCache>,
+    oracle_cache: Arc<OraclePriceCache>,
     decimals_init: Once,
     chain_id: u64,
     db_pool: OnceLock<Pool>,
@@ -46,6 +48,7 @@ impl TransformationHandler for DecayMulticurveSwapMetricsHandler {
         vec![
             "migrations/tables/pool_state.sql",
             "migrations/tables/pool_snapshots.sql",
+            "migrations/tables/pool_snapshots_add_volume_usd.sql",
         ]
     }
 
@@ -74,13 +77,26 @@ impl TransformationHandler for DecayMulticurveSwapMetricsHandler {
         )
         .await?;
 
-        Ok(process_swaps(
+        let (usd_ctx, price_ops) = build_usd_price_context(
+            ctx,
+            &self.oracle_cache,
+            &self.db_pool,
+            self.chain_id,
+            &ctx.contracts,
+        )
+        .await;
+
+        let mut ops = process_swaps(
             &swaps,
             &self.metadata_cache,
             ctx.chain_id,
             self.name(),
             SOURCE,
-        ))
+            Some(&usd_ctx),
+            self.version(),
+        );
+        ops.extend(price_ops);
+        Ok(ops)
     }
 
     async fn initialize(&self, db_pool: &DbPool) -> Result<(), TransformationError> {
@@ -162,9 +178,11 @@ pub fn register_handlers(
     registry: &mut TransformationRegistry,
     chain_id: u64,
     cache: Arc<PoolMetadataCache>,
+    oracle_cache: Arc<OraclePriceCache>,
 ) {
     registry.register_event_handler(DecayMulticurveSwapMetricsHandler {
         metadata_cache: cache,
+        oracle_cache,
         decimals_init: Once::new(),
         chain_id,
         db_pool: OnceLock::new(),

--- a/src/transformations/event/decay_multicurve/metrics.rs
+++ b/src/transformations/event/decay_multicurve/metrics.rs
@@ -20,7 +20,9 @@ use crate::transformations::event::metrics::v4_hook_extract::{
 use crate::transformations::registry::TransformationRegistry;
 use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
 use crate::transformations::util::pool_metadata::PoolMetadataCache;
-use crate::transformations::util::usd_price::{build_usd_price_context, OraclePriceCache};
+use crate::transformations::util::usd_price::{
+    build_usd_price_context, chainlink_latest_answer_dependency, OraclePriceCache,
+};
 
 const SOURCE: &str = "DecayMulticurveHook";
 
@@ -101,6 +103,9 @@ impl TransformationHandler for DecayMulticurveSwapMetricsHandler {
 
     async fn initialize(&self, db_pool: &DbPool) -> Result<(), TransformationError> {
         self.db_pool.set(db_pool.inner().clone()).ok();
+        self.oracle_cache
+            .load_from_db_once(db_pool.inner(), self.chain_id)
+            .await?;
         self.metadata_cache
             .load_into(db_pool, self.chain_id)
             .await?;
@@ -118,7 +123,10 @@ impl EventHandler for DecayMulticurveSwapMetricsHandler {
     }
 
     fn call_dependencies(&self) -> Vec<(String, String)> {
-        vec![(SOURCE.to_string(), "getSlot0".to_string())]
+        vec![
+            (SOURCE.to_string(), "getSlot0".to_string()),
+            chainlink_latest_answer_dependency(),
+        ]
     }
 
     fn contiguous_handler_dependencies(&self) -> Vec<&'static str> {

--- a/src/transformations/event/dhook/metrics.rs
+++ b/src/transformations/event/dhook/metrics.rs
@@ -20,6 +20,7 @@ use crate::transformations::event::metrics::v4_hook_extract::{
 use crate::transformations::registry::TransformationRegistry;
 use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
 use crate::transformations::util::pool_metadata::PoolMetadataCache;
+use crate::transformations::util::usd_price::{build_usd_price_context, OraclePriceCache};
 
 const SOURCE: &str = "DopplerHookInitializer";
 
@@ -27,6 +28,7 @@ const SOURCE: &str = "DopplerHookInitializer";
 
 pub struct DhookSwapMetricsHandler {
     metadata_cache: Arc<PoolMetadataCache>,
+    oracle_cache: Arc<OraclePriceCache>,
     decimals_init: Once,
     chain_id: u64,
     db_pool: OnceLock<Pool>,
@@ -46,6 +48,7 @@ impl TransformationHandler for DhookSwapMetricsHandler {
         vec![
             "migrations/tables/pool_state.sql",
             "migrations/tables/pool_snapshots.sql",
+            "migrations/tables/pool_snapshots_add_volume_usd.sql",
         ]
     }
 
@@ -74,13 +77,20 @@ impl TransformationHandler for DhookSwapMetricsHandler {
         )
         .await?;
 
-        Ok(process_swaps(
+        let (usd_ctx, price_ops) = build_usd_price_context(
+            ctx, &self.oracle_cache, &self.db_pool, self.chain_id, &ctx.contracts,
+        ).await;
+        let mut ops = process_swaps(
             &swaps,
             &self.metadata_cache,
             ctx.chain_id,
             self.name(),
             SOURCE,
-        ))
+            Some(&usd_ctx),
+            self.version(),
+        );
+        ops.extend(price_ops);
+        Ok(ops)
     }
 
     async fn initialize(&self, db_pool: &DbPool) -> Result<(), TransformationError> {
@@ -162,9 +172,11 @@ pub fn register_handlers(
     registry: &mut TransformationRegistry,
     chain_id: u64,
     cache: Arc<PoolMetadataCache>,
+    oracle_cache: Arc<OraclePriceCache>,
 ) {
     registry.register_event_handler(DhookSwapMetricsHandler {
         metadata_cache: cache,
+        oracle_cache,
         decimals_init: Once::new(),
         chain_id,
         db_pool: OnceLock::new(),

--- a/src/transformations/event/dhook/metrics.rs
+++ b/src/transformations/event/dhook/metrics.rs
@@ -20,7 +20,9 @@ use crate::transformations::event::metrics::v4_hook_extract::{
 use crate::transformations::registry::TransformationRegistry;
 use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
 use crate::transformations::util::pool_metadata::PoolMetadataCache;
-use crate::transformations::util::usd_price::{build_usd_price_context, OraclePriceCache};
+use crate::transformations::util::usd_price::{
+    build_usd_price_context, chainlink_latest_answer_dependency, OraclePriceCache,
+};
 
 const SOURCE: &str = "DopplerHookInitializer";
 
@@ -78,8 +80,13 @@ impl TransformationHandler for DhookSwapMetricsHandler {
         .await?;
 
         let (usd_ctx, price_ops) = build_usd_price_context(
-            ctx, &self.oracle_cache, &self.db_pool, self.chain_id, &ctx.contracts,
-        ).await;
+            ctx,
+            &self.oracle_cache,
+            &self.db_pool,
+            self.chain_id,
+            &ctx.contracts,
+        )
+        .await;
         let mut ops = process_swaps(
             &swaps,
             &self.metadata_cache,
@@ -95,6 +102,9 @@ impl TransformationHandler for DhookSwapMetricsHandler {
 
     async fn initialize(&self, db_pool: &DbPool) -> Result<(), TransformationError> {
         self.db_pool.set(db_pool.inner().clone()).ok();
+        self.oracle_cache
+            .load_from_db_once(db_pool.inner(), self.chain_id)
+            .await?;
         self.metadata_cache
             .load_into(db_pool, self.chain_id)
             .await?;
@@ -112,7 +122,10 @@ impl EventHandler for DhookSwapMetricsHandler {
     }
 
     fn call_dependencies(&self) -> Vec<(String, String)> {
-        vec![(SOURCE.to_string(), "getSlot0".to_string())]
+        vec![
+            (SOURCE.to_string(), "getSlot0".to_string()),
+            chainlink_latest_answer_dependency(),
+        ]
     }
 
     fn contiguous_handler_dependencies(&self) -> Vec<&'static str> {

--- a/src/transformations/event/metrics/swap_data.rs
+++ b/src/transformations/event/metrics/swap_data.rs
@@ -9,7 +9,7 @@ use std::sync::OnceLock;
 use alloy_primitives::{I256, U256};
 use deadpool_postgres::Pool;
 
-use crate::db::{DbOperation, DbValue};
+use crate::db::{DbOperation, DbSnapshot, DbValue};
 use crate::transformations::error::TransformationError;
 use crate::transformations::util::db::pool_metrics::{
     insert_liquidity_delta, insert_pool_snapshot, upsert_pool_state, LiquidityDeltaData,
@@ -222,6 +222,7 @@ pub fn process_swaps(
                 chain_id,
                 pool_id,
                 &price_close,
+                *block_number,
                 acc.block_timestamp,
                 handler_name,
                 source_version,
@@ -240,6 +241,7 @@ fn build_rolling_metrics_update(
     chain_id: u64,
     pool_id: &[u8],
     price_close: &str,
+    block_number: u64,
     block_timestamp: u64,
     handler_name: &str,
     source_version: u32,
@@ -278,8 +280,9 @@ FROM (
 ) sub
 WHERE pool_state.chain_id = $1
   AND pool_state.pool_id = $2
-  AND pool_state.source = $5
-  AND pool_state.source_version = $6
+  AND pool_state.block_number = $5
+  AND pool_state.source = $6
+  AND pool_state.source_version = $7
 "#;
 
     DbOperation::RawSql {
@@ -289,9 +292,25 @@ WHERE pool_state.chain_id = $1
             DbValue::Bytes(pool_id.to_vec()),
             DbValue::Numeric(price_close.to_string()),
             DbValue::Int64(block_timestamp as i64),
+            DbValue::Int64(block_number as i64),
             DbValue::VarChar(handler_name.to_string()),
             DbValue::Int32(source_version as i32),
         ],
+        snapshot: Some(DbSnapshot {
+            table: "pool_state".to_string(),
+            key_columns: vec![
+                ("chain_id".to_string(), DbValue::Int64(chain_id as i64)),
+                ("pool_id".to_string(), DbValue::Bytes(pool_id.to_vec())),
+                (
+                    "source".to_string(),
+                    DbValue::Text(handler_name.to_string()),
+                ),
+                (
+                    "source_version".to_string(),
+                    DbValue::Int32(source_version as i32),
+                ),
+            ],
+        }),
     }
 }
 
@@ -519,14 +538,28 @@ mod tests {
 
         let ops = process_swaps(&swaps, &cache, 8453, "test", "test", Some(&usd_ctx), 1);
         // snapshot + pool_state + rolling_metrics RawSql
-        assert_eq!(ops.len(), 3, "USD context should add rolling metrics RawSql");
+        assert_eq!(
+            ops.len(),
+            3,
+            "USD context should add rolling metrics RawSql"
+        );
 
         // Verify the third op is a RawSql
         match &ops[2] {
-            DbOperation::RawSql { query, params } => {
+            DbOperation::RawSql {
+                query,
+                params,
+                snapshot,
+            } => {
                 assert!(query.contains("volume_24h_usd"));
                 assert!(query.contains("price_change_1h"));
-                assert_eq!(params.len(), 6);
+                assert!(query.contains("pool_state.block_number = $5"));
+                assert_eq!(params.len(), 7);
+                let snapshot = snapshot
+                    .as_ref()
+                    .expect("rolling metrics should be snapshotted");
+                assert_eq!(snapshot.table, "pool_state");
+                assert_eq!(snapshot.key_columns.len(), 4);
             }
             _ => panic!("Expected RawSql for rolling metrics"),
         }

--- a/src/transformations/event/metrics/swap_data.rs
+++ b/src/transformations/event/metrics/swap_data.rs
@@ -9,7 +9,7 @@ use std::sync::OnceLock;
 use alloy_primitives::{I256, U256};
 use deadpool_postgres::Pool;
 
-use crate::db::DbOperation;
+use crate::db::{DbOperation, DbValue};
 use crate::transformations::error::TransformationError;
 use crate::transformations::util::db::pool_metrics::{
     insert_liquidity_delta, insert_pool_snapshot, upsert_pool_state, LiquidityDeltaData,
@@ -17,6 +17,7 @@ use crate::transformations::util::db::pool_metrics::{
 };
 use crate::transformations::util::pool_metadata::PoolMetadataCache;
 use crate::transformations::util::price::sqrt_price_x96_to_price;
+use crate::transformations::util::usd_price::UsdPriceContext;
 
 use super::accumulator::BlockAccumulator;
 
@@ -52,12 +53,17 @@ pub struct LiquidityInput {
 /// then emits one snapshot row per group and one pool_state upsert per pool (latest block).
 /// Groups where no valid price could be computed (e.g. all swaps had zero sqrtPriceX96)
 /// are silently skipped — no ghost snapshot rows are emitted.
+///
+/// When `usd_ctx` is provided, computes `volume_usd` for each snapshot and emits
+/// `RawSql` UPDATE operations for rolling metrics on `pool_state`.
 pub fn process_swaps(
     swaps: &[SwapInput],
     metadata_cache: &PoolMetadataCache,
     chain_id: u64,
     handler_name: &str,
     source_name: &str,
+    usd_ctx: Option<&UsdPriceContext>,
+    source_version: u32,
 ) -> Vec<DbOperation> {
     if swaps.is_empty() {
         return Vec::new();
@@ -159,6 +165,18 @@ pub fn process_swaps(
         let price_high = acc.price_high.as_ref().unwrap().to_string();
         let price_low = acc.price_low.as_ref().unwrap().to_string();
 
+        // Compute volume_usd from quote-side volume if USD context is available.
+        let volume_usd = usd_ctx.and_then(|ctx| {
+            let meta = metadata_cache.get(pool_id)?;
+            // Quote-side volume: volume1 if base is token0, volume0 otherwise.
+            let quote_volume = if meta.is_token_0 {
+                &acc.volume1
+            } else {
+                &acc.volume0
+            };
+            ctx.quote_volume_to_usd(quote_volume, &meta.quote_token, meta.quote_decimals)
+        });
+
         ops.push(insert_pool_snapshot(&SnapshotData {
             chain_id,
             pool_id: pool_id.clone(),
@@ -172,6 +190,7 @@ pub fn process_swaps(
             volume0: acc.volume0.to_string(),
             volume1: acc.volume1.to_string(),
             swap_count: i32::try_from(acc.swap_count).unwrap_or(i32::MAX),
+            volume_usd: volume_usd.map(|v| v.to_string()),
         }));
 
         // Track latest block for pool_state.
@@ -191,12 +210,89 @@ pub fn process_swaps(
             block_timestamp: acc.block_timestamp,
             tick: acc.last_tick,
             sqrt_price_x96: acc.last_sqrt_price_x96.to_string(),
-            price: price_close,
+            price: price_close.clone(),
             active_liquidity: acc.last_liquidity.to_string(),
         }));
+
+        // Emit RawSql to update rolling metrics on pool_state.
+        // This executes after the snapshot upserts (RawSql sorts last in the
+        // transaction), so the LATERAL subqueries see the just-inserted data.
+        if usd_ctx.is_some() {
+            ops.push(build_rolling_metrics_update(
+                chain_id,
+                pool_id,
+                &price_close,
+                acc.block_timestamp,
+                handler_name,
+                source_version,
+            ));
+        }
     }
 
     ops
+}
+
+/// Build a RawSql UPDATE for rolling metrics on pool_state.
+///
+/// Uses backward-looking LATERAL subqueries: "what was the price N hours ago?"
+/// finds the last known price_close at or before the target timestamp.
+fn build_rolling_metrics_update(
+    chain_id: u64,
+    pool_id: &[u8],
+    price_close: &str,
+    block_timestamp: u64,
+    handler_name: &str,
+    source_version: u32,
+) -> DbOperation {
+    let query = r#"
+UPDATE pool_state SET
+  volume_24h_usd = sub.vol_24h,
+  swap_count_24h = sub.swaps_24h,
+  price_change_1h = sub.pc_1h,
+  price_change_24h = sub.pc_24h
+FROM (
+  SELECT
+    COALESCE(SUM(s.volume_usd), 0) AS vol_24h,
+    COALESCE(SUM(s.swap_count), 0)::integer AS swaps_24h,
+    CASE WHEN h1h.price_close IS NOT NULL AND h1h.price_close != 0
+         THEN ($3::numeric - h1h.price_close) / h1h.price_close
+    END AS pc_1h,
+    CASE WHEN h24h.price_close IS NOT NULL AND h24h.price_close != 0
+         THEN ($3::numeric - h24h.price_close) / h24h.price_close
+    END AS pc_24h
+  FROM pool_snapshots s
+  LEFT JOIN LATERAL (
+    SELECT price_close FROM pool_snapshots
+    WHERE chain_id = $1 AND pool_id = $2
+      AND block_timestamp <= ($4 - 3600)
+    ORDER BY block_timestamp DESC, block_number DESC LIMIT 1
+  ) h1h ON true
+  LEFT JOIN LATERAL (
+    SELECT price_close FROM pool_snapshots
+    WHERE chain_id = $1 AND pool_id = $2
+      AND block_timestamp <= ($4 - 86400)
+    ORDER BY block_timestamp DESC, block_number DESC LIMIT 1
+  ) h24h ON true
+  WHERE s.chain_id = $1 AND s.pool_id = $2
+    AND s.block_timestamp > ($4 - 86400)
+) sub
+WHERE pool_state.chain_id = $1
+  AND pool_state.pool_id = $2
+  AND pool_state.source = $5
+  AND pool_state.source_version = $6
+"#;
+
+    DbOperation::RawSql {
+        query: query.to_string(),
+        params: vec![
+            DbValue::Int64(chain_id as i64),
+            DbValue::Bytes(pool_id.to_vec()),
+            DbValue::Numeric(price_close.to_string()),
+            DbValue::Int64(block_timestamp as i64),
+            DbValue::VarChar(handler_name.to_string()),
+            DbValue::Int32(source_version as i32),
+        ],
+    }
 }
 
 /// Process a batch of liquidity inputs into liquidity_deltas INSERT operations.
@@ -330,7 +426,7 @@ mod tests {
             liquidity: U256::from(1000u64),
         }];
 
-        let ops = process_swaps(&swaps, &cache, 8453, "test", "test");
+        let ops = process_swaps(&swaps, &cache, 8453, "test", "test", None, 1);
         assert!(ops.is_empty(), "zero sqrtPrice should produce no ops");
     }
 
@@ -367,7 +463,7 @@ mod tests {
             },
         ];
 
-        let ops = process_swaps(&swaps, &cache, 8453, "test", "test");
+        let ops = process_swaps(&swaps, &cache, 8453, "test", "test", None, 1);
         assert!(ops.is_empty(), "all-invalid swaps should produce no ops");
     }
 
@@ -389,8 +485,79 @@ mod tests {
             liquidity: U256::from(1000u64),
         }];
 
-        let ops = process_swaps(&swaps, &cache, 8453, "test", "test");
+        let ops = process_swaps(&swaps, &cache, 8453, "test", "test", None, 1);
         // Expect one pool_snapshots upsert + one pool_state upsert
         assert_eq!(ops.len(), 2, "valid swap should emit snapshot + state");
+    }
+
+    #[test]
+    fn test_valid_swap_with_usd_ctx_emits_rolling_metrics() {
+        let pool_id = vec![0u8; 20];
+        let cache = make_cache_with_pool(pool_id.clone());
+
+        let usd_ctx = UsdPriceContext::new_for_test(
+            Some(bigdecimal::BigDecimal::from(2000)),
+            None,
+            Some([1u8; 20]), // quote_token matches cache's quote_token
+            None,
+            None,
+            None,
+        );
+
+        let swaps = vec![SwapInput {
+            pool_id: pool_id.clone(),
+            transaction_hash: [0u8; 32],
+            block_number: 100,
+            block_timestamp: 1000,
+            log_index: 0,
+            amount0: I256::try_from(100i64).unwrap(),
+            amount1: I256::try_from(-100i64).unwrap(),
+            sqrt_price_x96: q96(),
+            tick: 0,
+            liquidity: U256::from(1000u64),
+        }];
+
+        let ops = process_swaps(&swaps, &cache, 8453, "test", "test", Some(&usd_ctx), 1);
+        // snapshot + pool_state + rolling_metrics RawSql
+        assert_eq!(ops.len(), 3, "USD context should add rolling metrics RawSql");
+
+        // Verify the third op is a RawSql
+        match &ops[2] {
+            DbOperation::RawSql { query, params } => {
+                assert!(query.contains("volume_24h_usd"));
+                assert!(query.contains("price_change_1h"));
+                assert_eq!(params.len(), 6);
+            }
+            _ => panic!("Expected RawSql for rolling metrics"),
+        }
+    }
+
+    #[test]
+    fn test_no_rolling_metrics_without_usd_ctx() {
+        let pool_id = vec![0u8; 20];
+        let cache = make_cache_with_pool(pool_id.clone());
+
+        let swaps = vec![SwapInput {
+            pool_id: pool_id.clone(),
+            transaction_hash: [0u8; 32],
+            block_number: 100,
+            block_timestamp: 1000,
+            log_index: 0,
+            amount0: I256::try_from(100i64).unwrap(),
+            amount1: I256::try_from(-100i64).unwrap(),
+            sqrt_price_x96: q96(),
+            tick: 0,
+            liquidity: U256::from(1000u64),
+        }];
+
+        let ops = process_swaps(&swaps, &cache, 8453, "test", "test", None, 1);
+        // snapshot + pool_state only — no RawSql
+        assert_eq!(ops.len(), 2);
+        for op in &ops {
+            assert!(
+                !matches!(op, DbOperation::RawSql { .. }),
+                "Should not emit RawSql without USD context"
+            );
+        }
     }
 }

--- a/src/transformations/event/migration_pool/metrics.rs
+++ b/src/transformations/event/migration_pool/metrics.rs
@@ -34,7 +34,9 @@ use crate::transformations::event::metrics::v4_hook_extract::extract_tuple_modif
 use crate::transformations::registry::TransformationRegistry;
 use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
 use crate::transformations::util::pool_metadata::PoolMetadataCache;
-use crate::transformations::util::usd_price::{build_usd_price_context, OraclePriceCache};
+use crate::transformations::util::usd_price::{
+    build_usd_price_context, chainlink_latest_answer_dependency, OraclePriceCache,
+};
 
 const POOL_MANAGER_SOURCE: &str = "UniswapV4PoolManager";
 const MIGRATOR_HOOK_SOURCE: &str = "UniswapV4MigratorHook";
@@ -169,8 +171,13 @@ impl TransformationHandler for MigrationPoolSwapMetricsHandler {
         .await?;
 
         let (usd_ctx, price_ops) = build_usd_price_context(
-            ctx, &self.oracle_cache, &self.db_pool, self.chain_id, &ctx.contracts,
-        ).await;
+            ctx,
+            &self.oracle_cache,
+            &self.db_pool,
+            self.chain_id,
+            &ctx.contracts,
+        )
+        .await;
 
         let mut ops = process_swaps(
             &swaps,
@@ -187,6 +194,9 @@ impl TransformationHandler for MigrationPoolSwapMetricsHandler {
 
     async fn initialize(&self, db_pool: &DbPool) -> Result<(), TransformationError> {
         self.db_pool.set(db_pool.inner().clone()).ok();
+        self.oracle_cache
+            .load_from_db_once(db_pool.inner(), self.chain_id)
+            .await?;
         self.metadata_cache
             .load_into(db_pool, self.chain_id)
             .await?;
@@ -229,6 +239,10 @@ impl EventHandler for MigrationPoolSwapMetricsHandler {
 
     fn contiguous_handler_dependencies(&self) -> Vec<&'static str> {
         vec!["MigrationPoolCreateHandler"]
+    }
+
+    fn call_dependencies(&self) -> Vec<(String, String)> {
+        vec![chainlink_latest_answer_dependency()]
     }
 }
 

--- a/src/transformations/event/migration_pool/metrics.rs
+++ b/src/transformations/event/migration_pool/metrics.rs
@@ -34,6 +34,7 @@ use crate::transformations::event::metrics::v4_hook_extract::extract_tuple_modif
 use crate::transformations::registry::TransformationRegistry;
 use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
 use crate::transformations::util::pool_metadata::PoolMetadataCache;
+use crate::transformations::util::usd_price::{build_usd_price_context, OraclePriceCache};
 
 const POOL_MANAGER_SOURCE: &str = "UniswapV4PoolManager";
 const MIGRATOR_HOOK_SOURCE: &str = "UniswapV4MigratorHook";
@@ -42,6 +43,7 @@ const MIGRATOR_HOOK_SOURCE: &str = "UniswapV4MigratorHook";
 
 pub struct MigrationPoolSwapMetricsHandler {
     metadata_cache: Arc<PoolMetadataCache>,
+    oracle_cache: Arc<OraclePriceCache>,
     decimals_init: Once,
     chain_id: u64,
     db_pool: OnceLock<Pool>,
@@ -104,6 +106,7 @@ impl TransformationHandler for MigrationPoolSwapMetricsHandler {
         vec![
             "migrations/tables/pool_state.sql",
             "migrations/tables/pool_snapshots.sql",
+            "migrations/tables/pool_snapshots_add_volume_usd.sql",
         ]
     }
 
@@ -165,13 +168,21 @@ impl TransformationHandler for MigrationPoolSwapMetricsHandler {
         )
         .await?;
 
-        Ok(process_swaps(
+        let (usd_ctx, price_ops) = build_usd_price_context(
+            ctx, &self.oracle_cache, &self.db_pool, self.chain_id, &ctx.contracts,
+        ).await;
+
+        let mut ops = process_swaps(
             &swaps,
             &self.metadata_cache,
             ctx.chain_id,
             self.name(),
             POOL_MANAGER_SOURCE,
-        ))
+            Some(&usd_ctx),
+            self.version(),
+        );
+        ops.extend(price_ops);
+        Ok(ops)
     }
 
     async fn initialize(&self, db_pool: &DbPool) -> Result<(), TransformationError> {
@@ -273,9 +284,11 @@ pub fn register_handlers(
     registry: &mut TransformationRegistry,
     chain_id: u64,
     cache: Arc<PoolMetadataCache>,
+    oracle_cache: Arc<OraclePriceCache>,
 ) {
     registry.register_event_handler(MigrationPoolSwapMetricsHandler {
         metadata_cache: cache,
+        oracle_cache,
         decimals_init: Once::new(),
         chain_id,
         db_pool: OnceLock::new(),

--- a/src/transformations/event/mod.rs
+++ b/src/transformations/event/mod.rs
@@ -48,7 +48,10 @@ fn register_handlers_inner(
     // Shared oracle price cache across all swap metrics handlers.
     // ETH/USD and EURC/USD prices are shared so a single oracle reading
     // bridges the 15m gap across all handler types.
-    let oracle_cache = Arc::new(OraclePriceCache::new());
+    let oracle_cache = Arc::new(match contracts {
+        Some(contracts) => OraclePriceCache::with_contracts(contracts),
+        None => OraclePriceCache::new(),
+    });
 
     // V3 Create and Metrics handlers share a PoolMetadataCache so that
     // pools created in the same range/block are visible to swap handlers
@@ -83,21 +86,11 @@ fn register_handlers_inner(
     );
 
     let dhook_cache = Arc::new(PoolMetadataCache::new());
-    dhook::metrics::register_handlers(
-        registry,
-        chain_id,
-        dhook_cache,
-        Arc::clone(&oracle_cache),
-    );
+    dhook::metrics::register_handlers(registry, chain_id, dhook_cache, Arc::clone(&oracle_cache));
 
     // V4 base (DopplerV4Hook) — sequential handler, own metadata cache
     let v4_base_cache = Arc::new(PoolMetadataCache::new());
-    v4::metrics::register_handlers(
-        registry,
-        chain_id,
-        v4_base_cache,
-        Arc::clone(&oracle_cache),
-    );
+    v4::metrics::register_handlers(registry, chain_id, v4_base_cache, Arc::clone(&oracle_cache));
 
     // Register migration pool handlers as a group only on chains with a V4
     // migrator. The swap handler depends on MigrationPoolCreateHandler, so

--- a/src/transformations/event/mod.rs
+++ b/src/transformations/event/mod.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 use super::registry::TransformationRegistry;
 use super::util::pool_metadata::PoolMetadataCache;
+use super::util::usd_price::OraclePriceCache;
 use crate::types::config::contract::Contracts;
 
 /// Register all event handlers with the registry.
@@ -44,33 +45,59 @@ fn register_handlers_inner(
     decay_multicurve::create::register_handlers(registry);
     dhook::create::register_handlers(registry);
 
+    // Shared oracle price cache across all swap metrics handlers.
+    // ETH/USD and EURC/USD prices are shared so a single oracle reading
+    // bridges the 15m gap across all handler types.
+    let oracle_cache = Arc::new(OraclePriceCache::new());
+
     // V3 Create and Metrics handlers share a PoolMetadataCache so that
     // pools created in the same range/block are visible to swap handlers
     // in-memory before the Create handler's DB transaction commits.
     let v3_cache = Arc::new(PoolMetadataCache::new());
     v3::create::register_handlers(registry, v3_cache.clone());
-    v3::metrics::register_handlers(registry, chain_id, v3_cache);
+    v3::metrics::register_handlers(registry, chain_id, v3_cache, Arc::clone(&oracle_cache));
 
-    // V4 hook metrics — each pool type gets its own cache
+    // V4 hook metrics — each pool type gets its own metadata cache
     let multicurve_cache = Arc::new(PoolMetadataCache::new());
-    multicurve::metrics::register_handlers(registry, chain_id, multicurve_cache);
+    multicurve::metrics::register_handlers(
+        registry,
+        chain_id,
+        multicurve_cache,
+        Arc::clone(&oracle_cache),
+    );
 
     let decay_multicurve_cache = Arc::new(PoolMetadataCache::new());
-    decay_multicurve::metrics::register_handlers(registry, chain_id, decay_multicurve_cache);
+    decay_multicurve::metrics::register_handlers(
+        registry,
+        chain_id,
+        decay_multicurve_cache,
+        Arc::clone(&oracle_cache),
+    );
 
     let scheduled_multicurve_cache = Arc::new(PoolMetadataCache::new());
     scheduled_multicurve::metrics::register_handlers(
         registry,
         chain_id,
         scheduled_multicurve_cache,
+        Arc::clone(&oracle_cache),
     );
 
     let dhook_cache = Arc::new(PoolMetadataCache::new());
-    dhook::metrics::register_handlers(registry, chain_id, dhook_cache);
+    dhook::metrics::register_handlers(
+        registry,
+        chain_id,
+        dhook_cache,
+        Arc::clone(&oracle_cache),
+    );
 
-    // V4 base (DopplerV4Hook) — sequential handler, own cache
+    // V4 base (DopplerV4Hook) — sequential handler, own metadata cache
     let v4_base_cache = Arc::new(PoolMetadataCache::new());
-    v4::metrics::register_handlers(registry, chain_id, v4_base_cache);
+    v4::metrics::register_handlers(
+        registry,
+        chain_id,
+        v4_base_cache,
+        Arc::clone(&oracle_cache),
+    );
 
     // Register migration pool handlers as a group only on chains with a V4
     // migrator. The swap handler depends on MigrationPoolCreateHandler, so
@@ -82,6 +109,11 @@ fn register_handlers_inner(
     if register_migration_pool_handlers {
         migration_pool::create::register_handlers(registry);
         let migration_pool_cache = Arc::new(PoolMetadataCache::new());
-        migration_pool::metrics::register_handlers(registry, chain_id, migration_pool_cache);
+        migration_pool::metrics::register_handlers(
+            registry,
+            chain_id,
+            migration_pool_cache,
+            Arc::clone(&oracle_cache),
+        );
     }
 }

--- a/src/transformations/event/multicurve/metrics.rs
+++ b/src/transformations/event/multicurve/metrics.rs
@@ -20,7 +20,9 @@ use crate::transformations::event::metrics::v4_hook_extract::{
 use crate::transformations::registry::TransformationRegistry;
 use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
 use crate::transformations::util::pool_metadata::PoolMetadataCache;
-use crate::transformations::util::usd_price::{build_usd_price_context, OraclePriceCache};
+use crate::transformations::util::usd_price::{
+    build_usd_price_context, chainlink_latest_answer_dependency, OraclePriceCache,
+};
 
 const SOURCE: &str = "UniswapV4MulticurveInitializerHook";
 
@@ -78,8 +80,13 @@ impl TransformationHandler for MulticurveSwapMetricsHandler {
         .await?;
 
         let (usd_ctx, price_ops) = build_usd_price_context(
-            ctx, &self.oracle_cache, &self.db_pool, self.chain_id, &ctx.contracts,
-        ).await;
+            ctx,
+            &self.oracle_cache,
+            &self.db_pool,
+            self.chain_id,
+            &ctx.contracts,
+        )
+        .await;
 
         let mut ops = process_swaps(
             &swaps,
@@ -96,6 +103,9 @@ impl TransformationHandler for MulticurveSwapMetricsHandler {
 
     async fn initialize(&self, db_pool: &DbPool) -> Result<(), TransformationError> {
         self.db_pool.set(db_pool.inner().clone()).ok();
+        self.oracle_cache
+            .load_from_db_once(db_pool.inner(), self.chain_id)
+            .await?;
         self.metadata_cache
             .load_into(db_pool, self.chain_id)
             .await?;
@@ -113,7 +123,10 @@ impl EventHandler for MulticurveSwapMetricsHandler {
     }
 
     fn call_dependencies(&self) -> Vec<(String, String)> {
-        vec![(SOURCE.to_string(), "getSlot0".to_string())]
+        vec![
+            (SOURCE.to_string(), "getSlot0".to_string()),
+            chainlink_latest_answer_dependency(),
+        ]
     }
 
     fn contiguous_handler_dependencies(&self) -> Vec<&'static str> {

--- a/src/transformations/event/multicurve/metrics.rs
+++ b/src/transformations/event/multicurve/metrics.rs
@@ -20,6 +20,7 @@ use crate::transformations::event::metrics::v4_hook_extract::{
 use crate::transformations::registry::TransformationRegistry;
 use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
 use crate::transformations::util::pool_metadata::PoolMetadataCache;
+use crate::transformations::util::usd_price::{build_usd_price_context, OraclePriceCache};
 
 const SOURCE: &str = "UniswapV4MulticurveInitializerHook";
 
@@ -27,6 +28,7 @@ const SOURCE: &str = "UniswapV4MulticurveInitializerHook";
 
 pub struct MulticurveSwapMetricsHandler {
     metadata_cache: Arc<PoolMetadataCache>,
+    oracle_cache: Arc<OraclePriceCache>,
     decimals_init: Once,
     chain_id: u64,
     db_pool: OnceLock<Pool>,
@@ -46,6 +48,7 @@ impl TransformationHandler for MulticurveSwapMetricsHandler {
         vec![
             "migrations/tables/pool_state.sql",
             "migrations/tables/pool_snapshots.sql",
+            "migrations/tables/pool_snapshots_add_volume_usd.sql",
         ]
     }
 
@@ -74,13 +77,21 @@ impl TransformationHandler for MulticurveSwapMetricsHandler {
         )
         .await?;
 
-        Ok(process_swaps(
+        let (usd_ctx, price_ops) = build_usd_price_context(
+            ctx, &self.oracle_cache, &self.db_pool, self.chain_id, &ctx.contracts,
+        ).await;
+
+        let mut ops = process_swaps(
             &swaps,
             &self.metadata_cache,
             ctx.chain_id,
             self.name(),
             SOURCE,
-        ))
+            Some(&usd_ctx),
+            self.version(),
+        );
+        ops.extend(price_ops);
+        Ok(ops)
     }
 
     async fn initialize(&self, db_pool: &DbPool) -> Result<(), TransformationError> {
@@ -162,9 +173,11 @@ pub fn register_handlers(
     registry: &mut TransformationRegistry,
     chain_id: u64,
     cache: Arc<PoolMetadataCache>,
+    oracle_cache: Arc<OraclePriceCache>,
 ) {
     registry.register_event_handler(MulticurveSwapMetricsHandler {
         metadata_cache: cache,
+        oracle_cache,
         decimals_init: Once::new(),
         chain_id,
         db_pool: OnceLock::new(),

--- a/src/transformations/event/scheduled_multicurve/metrics.rs
+++ b/src/transformations/event/scheduled_multicurve/metrics.rs
@@ -20,7 +20,9 @@ use crate::transformations::event::metrics::v4_hook_extract::{
 use crate::transformations::registry::TransformationRegistry;
 use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
 use crate::transformations::util::pool_metadata::PoolMetadataCache;
-use crate::transformations::util::usd_price::{build_usd_price_context, OraclePriceCache};
+use crate::transformations::util::usd_price::{
+    build_usd_price_context, chainlink_latest_answer_dependency, OraclePriceCache,
+};
 
 const SOURCE: &str = "UniswapV4ScheduledMulticurveInitializerHook";
 
@@ -101,6 +103,9 @@ impl TransformationHandler for ScheduledMulticurveSwapMetricsHandler {
 
     async fn initialize(&self, db_pool: &DbPool) -> Result<(), TransformationError> {
         self.db_pool.set(db_pool.inner().clone()).ok();
+        self.oracle_cache
+            .load_from_db_once(db_pool.inner(), self.chain_id)
+            .await?;
         self.metadata_cache
             .load_into(db_pool, self.chain_id)
             .await?;
@@ -118,7 +123,10 @@ impl EventHandler for ScheduledMulticurveSwapMetricsHandler {
     }
 
     fn call_dependencies(&self) -> Vec<(String, String)> {
-        vec![(SOURCE.to_string(), "getSlot0".to_string())]
+        vec![
+            (SOURCE.to_string(), "getSlot0".to_string()),
+            chainlink_latest_answer_dependency(),
+        ]
     }
 
     fn contiguous_handler_dependencies(&self) -> Vec<&'static str> {

--- a/src/transformations/event/scheduled_multicurve/metrics.rs
+++ b/src/transformations/event/scheduled_multicurve/metrics.rs
@@ -20,6 +20,7 @@ use crate::transformations::event::metrics::v4_hook_extract::{
 use crate::transformations::registry::TransformationRegistry;
 use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
 use crate::transformations::util::pool_metadata::PoolMetadataCache;
+use crate::transformations::util::usd_price::{build_usd_price_context, OraclePriceCache};
 
 const SOURCE: &str = "UniswapV4ScheduledMulticurveInitializerHook";
 
@@ -27,6 +28,7 @@ const SOURCE: &str = "UniswapV4ScheduledMulticurveInitializerHook";
 
 pub struct ScheduledMulticurveSwapMetricsHandler {
     metadata_cache: Arc<PoolMetadataCache>,
+    oracle_cache: Arc<OraclePriceCache>,
     decimals_init: Once,
     chain_id: u64,
     db_pool: OnceLock<Pool>,
@@ -46,6 +48,7 @@ impl TransformationHandler for ScheduledMulticurveSwapMetricsHandler {
         vec![
             "migrations/tables/pool_state.sql",
             "migrations/tables/pool_snapshots.sql",
+            "migrations/tables/pool_snapshots_add_volume_usd.sql",
         ]
     }
 
@@ -74,13 +77,26 @@ impl TransformationHandler for ScheduledMulticurveSwapMetricsHandler {
         )
         .await?;
 
-        Ok(process_swaps(
+        let (usd_ctx, price_ops) = build_usd_price_context(
+            ctx,
+            &self.oracle_cache,
+            &self.db_pool,
+            self.chain_id,
+            &ctx.contracts,
+        )
+        .await;
+
+        let mut ops = process_swaps(
             &swaps,
             &self.metadata_cache,
             ctx.chain_id,
             self.name(),
             SOURCE,
-        ))
+            Some(&usd_ctx),
+            self.version(),
+        );
+        ops.extend(price_ops);
+        Ok(ops)
     }
 
     async fn initialize(&self, db_pool: &DbPool) -> Result<(), TransformationError> {
@@ -162,9 +178,11 @@ pub fn register_handlers(
     registry: &mut TransformationRegistry,
     chain_id: u64,
     cache: Arc<PoolMetadataCache>,
+    oracle_cache: Arc<OraclePriceCache>,
 ) {
     registry.register_event_handler(ScheduledMulticurveSwapMetricsHandler {
         metadata_cache: cache,
+        oracle_cache,
         decimals_init: Once::new(),
         chain_id,
         db_pool: OnceLock::new(),

--- a/src/transformations/event/v3/metrics.rs
+++ b/src/transformations/event/v3/metrics.rs
@@ -24,6 +24,7 @@ use crate::transformations::event::metrics::swap_data::{
 use crate::transformations::registry::TransformationRegistry;
 use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
 use crate::transformations::util::pool_metadata::PoolMetadataCache;
+use crate::transformations::util::usd_price::{build_usd_price_context, OraclePriceCache};
 
 // --- Shared extraction functions ---
 
@@ -102,6 +103,7 @@ fn extract_v3_liquidity(
 
 pub struct V3SwapMetricsHandler {
     metadata_cache: Arc<PoolMetadataCache>,
+    oracle_cache: Arc<OraclePriceCache>,
     decimals_init: Once,
     chain_id: u64,
     db_pool: OnceLock<Pool>,
@@ -121,6 +123,7 @@ impl TransformationHandler for V3SwapMetricsHandler {
         vec![
             "migrations/tables/pool_state.sql",
             "migrations/tables/pool_snapshots.sql",
+            "migrations/tables/pool_snapshots_add_volume_usd.sql",
         ]
     }
 
@@ -149,13 +152,20 @@ impl TransformationHandler for V3SwapMetricsHandler {
         )
         .await?;
 
-        Ok(process_swaps(
+        let (usd_ctx, price_ops) = build_usd_price_context(
+            ctx, &self.oracle_cache, &self.db_pool, self.chain_id, &ctx.contracts,
+        ).await;
+        let mut ops = process_swaps(
             &swaps,
             &self.metadata_cache,
             ctx.chain_id,
             self.name(),
             "DopplerV3Pool",
-        ))
+            Some(&usd_ctx),
+            self.version(),
+        );
+        ops.extend(price_ops);
+        Ok(ops)
     }
 
     async fn initialize(&self, db_pool: &DbPool) -> Result<(), TransformationError> {
@@ -237,6 +247,7 @@ impl EventHandler for V3LiquidityMetricsHandler {
 
 pub struct LockableV3SwapMetricsHandler {
     metadata_cache: Arc<PoolMetadataCache>,
+    oracle_cache: Arc<OraclePriceCache>,
     decimals_init: Once,
     chain_id: u64,
     db_pool: OnceLock<Pool>,
@@ -256,6 +267,7 @@ impl TransformationHandler for LockableV3SwapMetricsHandler {
         vec![
             "migrations/tables/pool_state.sql",
             "migrations/tables/pool_snapshots.sql",
+            "migrations/tables/pool_snapshots_add_volume_usd.sql",
         ]
     }
 
@@ -284,13 +296,20 @@ impl TransformationHandler for LockableV3SwapMetricsHandler {
         )
         .await?;
 
-        Ok(process_swaps(
+        let (usd_ctx, price_ops) = build_usd_price_context(
+            ctx, &self.oracle_cache, &self.db_pool, self.chain_id, &ctx.contracts,
+        ).await;
+        let mut ops = process_swaps(
             &swaps,
             &self.metadata_cache,
             ctx.chain_id,
             self.name(),
             "DopplerLockableV3Pool",
-        ))
+            Some(&usd_ctx),
+            self.version(),
+        );
+        ops.extend(price_ops);
+        Ok(ops)
     }
 
     async fn initialize(&self, db_pool: &DbPool) -> Result<(), TransformationError> {
@@ -374,16 +393,19 @@ pub fn register_handlers(
     registry: &mut TransformationRegistry,
     chain_id: u64,
     cache: Arc<PoolMetadataCache>,
+    oracle_cache: Arc<OraclePriceCache>,
 ) {
     // Swap metrics: pool_state + pool_snapshots (single-trigger, captures snapshots)
     registry.register_event_handler(V3SwapMetricsHandler {
         metadata_cache: cache.clone(),
+        oracle_cache: Arc::clone(&oracle_cache),
         decimals_init: Once::new(),
         chain_id,
         db_pool: OnceLock::new(),
     });
     registry.register_event_handler(LockableV3SwapMetricsHandler {
         metadata_cache: cache,
+        oracle_cache: Arc::clone(&oracle_cache),
         decimals_init: Once::new(),
         chain_id,
         db_pool: OnceLock::new(),
@@ -444,6 +466,7 @@ mod tests {
         let cache = Arc::new(PoolMetadataCache::new());
         let handler = V3SwapMetricsHandler {
             metadata_cache: cache.clone(),
+            oracle_cache: Arc::new(OraclePriceCache::new()),
             decimals_init: Once::new(),
             chain_id: 8453,
             db_pool: OnceLock::new(),
@@ -489,6 +512,7 @@ mod tests {
         let t1 = tokio::spawn(async move {
             let handler = V3SwapMetricsHandler {
                 metadata_cache: cache1,
+                oracle_cache: Arc::new(OraclePriceCache::new()),
                 decimals_init: Once::new(),
                 chain_id: 8453,
                 db_pool: OnceLock::new(),
@@ -500,6 +524,7 @@ mod tests {
         let t2 = tokio::spawn(async move {
             let handler = V3SwapMetricsHandler {
                 metadata_cache: cache2,
+                oracle_cache: Arc::new(OraclePriceCache::new()),
                 decimals_init: Once::new(),
                 chain_id: 8453,
                 db_pool: OnceLock::new(),

--- a/src/transformations/event/v3/metrics.rs
+++ b/src/transformations/event/v3/metrics.rs
@@ -24,7 +24,9 @@ use crate::transformations::event::metrics::swap_data::{
 use crate::transformations::registry::TransformationRegistry;
 use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
 use crate::transformations::util::pool_metadata::PoolMetadataCache;
-use crate::transformations::util::usd_price::{build_usd_price_context, OraclePriceCache};
+use crate::transformations::util::usd_price::{
+    build_usd_price_context, chainlink_latest_answer_dependency, OraclePriceCache,
+};
 
 // --- Shared extraction functions ---
 
@@ -153,8 +155,13 @@ impl TransformationHandler for V3SwapMetricsHandler {
         .await?;
 
         let (usd_ctx, price_ops) = build_usd_price_context(
-            ctx, &self.oracle_cache, &self.db_pool, self.chain_id, &ctx.contracts,
-        ).await;
+            ctx,
+            &self.oracle_cache,
+            &self.db_pool,
+            self.chain_id,
+            &ctx.contracts,
+        )
+        .await;
         let mut ops = process_swaps(
             &swaps,
             &self.metadata_cache,
@@ -170,6 +177,9 @@ impl TransformationHandler for V3SwapMetricsHandler {
 
     async fn initialize(&self, db_pool: &DbPool) -> Result<(), TransformationError> {
         self.db_pool.set(db_pool.inner().clone()).ok();
+        self.oracle_cache
+            .load_from_db_once(db_pool.inner(), self.chain_id)
+            .await?;
         self.metadata_cache
             .load_into(db_pool, self.chain_id)
             .await?;
@@ -188,6 +198,10 @@ impl EventHandler for V3SwapMetricsHandler {
 
     fn contiguous_handler_dependencies(&self) -> Vec<&'static str> {
         vec!["V3CreateHandler"]
+    }
+
+    fn call_dependencies(&self) -> Vec<(String, String)> {
+        vec![chainlink_latest_answer_dependency()]
     }
 }
 
@@ -297,8 +311,13 @@ impl TransformationHandler for LockableV3SwapMetricsHandler {
         .await?;
 
         let (usd_ctx, price_ops) = build_usd_price_context(
-            ctx, &self.oracle_cache, &self.db_pool, self.chain_id, &ctx.contracts,
-        ).await;
+            ctx,
+            &self.oracle_cache,
+            &self.db_pool,
+            self.chain_id,
+            &ctx.contracts,
+        )
+        .await;
         let mut ops = process_swaps(
             &swaps,
             &self.metadata_cache,
@@ -314,6 +333,9 @@ impl TransformationHandler for LockableV3SwapMetricsHandler {
 
     async fn initialize(&self, db_pool: &DbPool) -> Result<(), TransformationError> {
         self.db_pool.set(db_pool.inner().clone()).ok();
+        self.oracle_cache
+            .load_from_db_once(db_pool.inner(), self.chain_id)
+            .await?;
         self.metadata_cache
             .load_into(db_pool, self.chain_id)
             .await?;
@@ -332,6 +354,10 @@ impl EventHandler for LockableV3SwapMetricsHandler {
 
     fn contiguous_handler_dependencies(&self) -> Vec<&'static str> {
         vec!["LockableV3CreateHandler"]
+    }
+
+    fn call_dependencies(&self) -> Vec<(String, String)> {
+        vec![chainlink_latest_answer_dependency()]
     }
 }
 
@@ -542,5 +568,30 @@ mod tests {
             cache.get(&pool_id).is_some(),
             "pool entry should still be in cache after concurrent handle() calls"
         );
+    }
+
+    #[test]
+    fn test_swap_handlers_declare_chainlink_dependency() {
+        let v3_handler = V3SwapMetricsHandler {
+            metadata_cache: Arc::new(PoolMetadataCache::new()),
+            oracle_cache: Arc::new(OraclePriceCache::new()),
+            decimals_init: Once::new(),
+            chain_id: 8453,
+            db_pool: OnceLock::new(),
+        };
+        assert!(v3_handler
+            .call_dependencies()
+            .contains(&chainlink_latest_answer_dependency()));
+
+        let lockable_handler = LockableV3SwapMetricsHandler {
+            metadata_cache: Arc::new(PoolMetadataCache::new()),
+            oracle_cache: Arc::new(OraclePriceCache::new()),
+            decimals_init: Once::new(),
+            chain_id: 8453,
+            db_pool: OnceLock::new(),
+        };
+        assert!(lockable_handler
+            .call_dependencies()
+            .contains(&chainlink_latest_answer_dependency()));
     }
 }

--- a/src/transformations/event/v4/metrics.rs
+++ b/src/transformations/event/v4/metrics.rs
@@ -46,7 +46,9 @@ use crate::transformations::registry::TransformationRegistry;
 use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
 use crate::transformations::util::pool_metadata::PoolMetadataCache;
 use crate::transformations::util::tick_math::tick_to_sqrt_price_x96;
-use crate::transformations::util::usd_price::{build_usd_price_context, OraclePriceCache};
+use crate::transformations::util::usd_price::{
+    build_usd_price_context, chainlink_latest_answer_dependency, OraclePriceCache,
+};
 
 const SOURCE: &str = "DopplerV4Hook";
 
@@ -197,8 +199,13 @@ impl TransformationHandler for V4BaseMetricsHandler {
         }
 
         let (usd_ctx, price_ops) = build_usd_price_context(
-            ctx, &self.oracle_cache, &self.db_pool, self.chain_id, &ctx.contracts,
-        ).await;
+            ctx,
+            &self.oracle_cache,
+            &self.db_pool,
+            self.chain_id,
+            &ctx.contracts,
+        )
+        .await;
         let mut ops = process_swaps(
             &swaps,
             &self.metadata_cache,
@@ -250,6 +257,9 @@ impl TransformationHandler for V4BaseMetricsHandler {
 
     async fn initialize(&self, db_pool: &DbPool) -> Result<(), TransformationError> {
         self.db_pool.set(db_pool.inner().clone()).ok();
+        self.oracle_cache
+            .load_from_db_once(db_pool.inner(), self.chain_id)
+            .await?;
         self.metadata_cache
             .load_into(db_pool, self.chain_id)
             .await?;
@@ -298,6 +308,10 @@ impl TransformationHandler for V4BaseMetricsHandler {
 impl EventHandler for V4BaseMetricsHandler {
     fn triggers(&self) -> Vec<EventTrigger> {
         vec![EventTrigger::new(SOURCE, "Swap(int24,uint256,uint256)")]
+    }
+
+    fn call_dependencies(&self) -> Vec<(String, String)> {
+        vec![chainlink_latest_answer_dependency()]
     }
 
     fn contiguous_handler_dependencies(&self) -> Vec<&'static str> {
@@ -1060,6 +1074,14 @@ mod tests {
             }
             _ => panic!("expected Upsert"),
         }
+    }
+
+    #[test]
+    fn test_handler_declares_chainlink_dependency() {
+        let handler = make_handler(8453);
+        assert!(handler
+            .call_dependencies()
+            .contains(&chainlink_latest_answer_dependency()));
     }
 
     // ── commit hooks / gate / reorg ───────────────────────────────────────────

--- a/src/transformations/event/v4/metrics.rs
+++ b/src/transformations/event/v4/metrics.rs
@@ -46,6 +46,7 @@ use crate::transformations::registry::TransformationRegistry;
 use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
 use crate::transformations::util::pool_metadata::PoolMetadataCache;
 use crate::transformations::util::tick_math::tick_to_sqrt_price_x96;
+use crate::transformations::util::usd_price::{build_usd_price_context, OraclePriceCache};
 
 const SOURCE: &str = "DopplerV4Hook";
 
@@ -53,6 +54,7 @@ const SOURCE: &str = "DopplerV4Hook";
 
 pub struct V4BaseMetricsHandler {
     metadata_cache: Arc<PoolMetadataCache>,
+    oracle_cache: Arc<OraclePriceCache>,
     decimals_init: Once,
     chain_id: u64,
     db_pool: OnceLock<Pool>,
@@ -86,6 +88,7 @@ impl TransformationHandler for V4BaseMetricsHandler {
         vec![
             "migrations/tables/pool_state.sql",
             "migrations/tables/pool_snapshots.sql",
+            "migrations/tables/pool_snapshots_add_volume_usd.sql",
             "migrations/tables/v4_base_proceeds_state.sql",
         ]
     }
@@ -193,13 +196,19 @@ impl TransformationHandler for V4BaseMetricsHandler {
             return Ok(Vec::new());
         }
 
+        let (usd_ctx, price_ops) = build_usd_price_context(
+            ctx, &self.oracle_cache, &self.db_pool, self.chain_id, &ctx.contracts,
+        ).await;
         let mut ops = process_swaps(
             &swaps,
             &self.metadata_cache,
             self.chain_id,
             self.name(),
             SOURCE,
+            Some(&usd_ctx),
+            self.version(),
         );
+        ops.extend(price_ops);
 
         // Durably checkpoint the new cumulative totals.
         for (pool_id, (total_proceeds, total_tokens_sold)) in &new_cumulative {
@@ -750,9 +759,11 @@ pub fn register_handlers(
     registry: &mut TransformationRegistry,
     chain_id: u64,
     cache: Arc<PoolMetadataCache>,
+    oracle_cache: Arc<OraclePriceCache>,
 ) {
     registry.register_event_handler(V4BaseMetricsHandler {
         metadata_cache: cache,
+        oracle_cache,
         decimals_init: Once::new(),
         chain_id,
         db_pool: OnceLock::new(),
@@ -803,6 +814,7 @@ mod tests {
     fn make_handler(chain_id: u64) -> V4BaseMetricsHandler {
         V4BaseMetricsHandler {
             metadata_cache: Arc::new(PoolMetadataCache::new()),
+            oracle_cache: Arc::new(OraclePriceCache::new()),
             decimals_init: Once::new(),
             chain_id,
             db_pool: OnceLock::new(),

--- a/src/transformations/executor.rs
+++ b/src/transformations/executor.rs
@@ -367,11 +367,19 @@ pub(crate) fn inject_source_version(
                     where_clause,
                 }
             }
-            DbOperation::RawSql { query, params } => {
+            DbOperation::RawSql {
+                query,
+                params,
+                snapshot,
+            } => {
                 tracing::warn!(
                     "RawSql operation skipped for source/version injection — handler must manage source/source_version manually"
                 );
-                DbOperation::RawSql { query, params }
+                DbOperation::RawSql {
+                    query,
+                    params,
+                    snapshot,
+                }
             }
         })
         .collect()
@@ -408,7 +416,8 @@ fn inject_where_clause(clause: WhereClause, source: &str, version: u32) -> Where
 /// Execute a transaction with optional snapshot capture for reorg rollback.
 ///
 /// For live mode (single-block ranges), this function:
-/// 1. Collects snapshot specs (table + key columns) for upserts with update_columns
+/// 1. Collects snapshot specs (table + key columns) for row-modifying ops that
+///    opt into rollback capture
 /// 2. Executes snapshot reads and writes inside the same database transaction
 /// 3. Writes snapshots to storage after the transaction commits
 ///
@@ -435,14 +444,13 @@ pub(crate) async fn execute_with_snapshot_capture(
         }
     };
 
-    // Collect snapshot specs from upserts with update_columns
+    // Collect snapshot specs from row-modifying operations that opt into
+    // rollback capture.
     let mut snapshot_specs: Vec<(String, Vec<(String, DbValue)>)> = Vec::new();
-    // Track metadata for building LiveUpsertSnapshot after the transaction
+    // Track metadata for building LiveUpsertSnapshot after the transaction.
     struct SnapshotMeta {
         table: String,
-        conflict_columns: Vec<String>,
-        values: Vec<DbValue>,
-        columns: Vec<String>,
+        key_columns: Vec<(String, DbValue)>,
         /// Index into `ops` for this snapshot, used to check affected_rows.
         op_index: usize,
     }
@@ -463,20 +471,31 @@ pub(crate) async fn execute_with_snapshot_capture(
                 continue;
             }
 
-            // Build key columns from conflict_columns
-            let mut key_columns: Vec<(String, DbValue)> = Vec::new();
-            for conflict_col in conflict_columns {
-                if let Some(idx) = columns.iter().position(|c| c == conflict_col) {
-                    key_columns.push((conflict_col.clone(), values[idx].clone()));
-                }
-            }
+            let key_columns: Vec<(String, DbValue)> = conflict_columns
+                .iter()
+                .filter_map(|conflict_col| {
+                    columns
+                        .iter()
+                        .position(|c| c == conflict_col)
+                        .map(|idx| (conflict_col.clone(), values[idx].clone()))
+                })
+                .collect();
 
-            snapshot_specs.push((table.clone(), key_columns));
+            snapshot_specs.push((table.clone(), key_columns.clone()));
             snapshot_metas.push(SnapshotMeta {
                 table: table.clone(),
-                conflict_columns: conflict_columns.clone(),
-                values: values.clone(),
-                columns: columns.clone(),
+                key_columns,
+                op_index,
+            });
+        } else if let DbOperation::RawSql {
+            snapshot: Some(snapshot),
+            ..
+        } = op
+        {
+            snapshot_specs.push((snapshot.table.clone(), snapshot.key_columns.clone()));
+            snapshot_metas.push(SnapshotMeta {
+                table: snapshot.table.clone(),
+                key_columns: snapshot.key_columns.clone(),
                 op_index,
             });
         }
@@ -506,18 +525,10 @@ pub(crate) async fn execute_with_snapshot_capture(
 
         let previous_row = snapshot_results.get(i).cloned().flatten();
 
-        let key_columns: Vec<(String, DbValue)> = meta
-            .conflict_columns
+        let live_key_columns: Vec<(String, LiveDbValue)> = meta
+            .key_columns
             .iter()
-            .filter_map(|col| {
-                meta.columns
-                    .iter()
-                    .position(|c| c == col)
-                    .map(|idx| (col.clone(), meta.values[idx].clone()))
-            })
-            .collect();
-
-        let live_key_columns: Vec<(String, LiveDbValue)> = key_columns
+            .cloned()
             .into_iter()
             .map(|(k, v)| (k, LiveDbValue::from_db_value(&v)))
             .collect();
@@ -556,7 +567,7 @@ pub(crate) async fn execute_with_snapshot_capture(
 
 #[cfg(test)]
 mod tests {
-    use crate::db::{DbOperation, DbValue};
+    use crate::db::{DbOperation, DbSnapshot, DbValue};
 
     /// Helper to build a upsert op with update_columns (triggers snapshot).
     fn make_upsert_op(table: &str) -> DbOperation {
@@ -590,6 +601,24 @@ mod tests {
         }
     }
 
+    /// Helper to build a RawSql op with explicit snapshot metadata.
+    fn make_raw_sql_snapshot_op(table: &str) -> DbOperation {
+        DbOperation::RawSql {
+            query: format!("UPDATE {} SET value = value + 1 WHERE chain_id = $1", table),
+            params: vec![DbValue::Int64(1)],
+            snapshot: Some(DbSnapshot {
+                table: table.to_string(),
+                key_columns: vec![
+                    ("chain_id".to_string(), DbValue::Int64(1)),
+                    (
+                        "pool_address".to_string(),
+                        DbValue::Text("0xABC".to_string()),
+                    ),
+                ],
+            }),
+        }
+    }
+
     /// Simulate the snapshot-filtering logic from `execute_with_snapshot_capture`
     /// in isolation: given `ops` and `affected_rows`, return the snapshot metas
     /// that would survive the filter.
@@ -606,19 +635,30 @@ mod tests {
 
         let mut metas: Vec<SnapshotMeta> = Vec::new();
         for (op_index, op) in ops.iter().enumerate() {
-            if let DbOperation::Upsert {
-                table,
-                update_columns,
-                ..
-            } = op
-            {
-                if update_columns.is_empty() {
-                    continue;
+            match op {
+                DbOperation::Upsert {
+                    table,
+                    update_columns,
+                    ..
+                } => {
+                    if update_columns.is_empty() {
+                        continue;
+                    }
+                    metas.push(SnapshotMeta {
+                        table: table.clone(),
+                        op_index,
+                    });
                 }
-                metas.push(SnapshotMeta {
-                    table: table.clone(),
-                    op_index,
-                });
+                DbOperation::RawSql {
+                    snapshot: Some(snapshot),
+                    ..
+                } => {
+                    metas.push(SnapshotMeta {
+                        table: snapshot.table.clone(),
+                        op_index,
+                    });
+                }
+                _ => {}
             }
         }
 
@@ -662,6 +702,24 @@ mod tests {
     fn test_no_snapshot_for_insert_only_ops() {
         let ops = vec![make_insert_only_op("insert_table")];
         let affected_rows = vec![1u64]; // row was inserted, but still no snapshot wanted
+
+        let survivors = collect_surviving_snapshot_tables(&ops, &affected_rows);
+        assert!(survivors.is_empty());
+    }
+
+    #[test]
+    fn test_snapshot_for_raw_sql_with_snapshot_metadata() {
+        let ops = vec![make_raw_sql_snapshot_op("pool_state")];
+        let affected_rows = vec![1u64];
+
+        let survivors = collect_surviving_snapshot_tables(&ops, &affected_rows);
+        assert_eq!(survivors, vec!["pool_state".to_string()]);
+    }
+
+    #[test]
+    fn test_no_snapshot_for_raw_sql_when_no_rows_modified() {
+        let ops = vec![make_raw_sql_snapshot_op("pool_state")];
+        let affected_rows = vec![0u64];
 
         let survivors = collect_surviving_snapshot_tables(&ops, &affected_rows);
         assert!(survivors.is_empty());

--- a/src/transformations/finalizer.rs
+++ b/src/transformations/finalizer.rs
@@ -377,6 +377,7 @@ impl RangeFinalizer {
                         DbValue::Text(error_message),
                         DbValue::JsonB(debug_context),
                     ],
+                    snapshot: None,
                 }
             })
             .collect();

--- a/src/transformations/registry.rs
+++ b/src/transformations/registry.rs
@@ -765,6 +765,7 @@ mod tests {
     use crate::transformations::context::TransformationContext;
     use crate::transformations::error::TransformationError;
     use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
+    use crate::transformations::util::usd_price::chainlink_latest_answer_dependency;
     use async_trait::async_trait;
 
     /// A mock event handler for testing call dependency validation.
@@ -1366,5 +1367,39 @@ mod tests {
                 "DopplerHookCreateHandler".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn usd_swap_handlers_all_declare_chainlink_dependency() {
+        let registry = build_registry(1);
+        let expected_handlers: HashSet<&'static str> = HashSet::from([
+            "V3SwapMetricsHandler",
+            "LockableV3SwapMetricsHandler",
+            "MulticurveSwapMetricsHandler",
+            "DecayMulticurveSwapMetricsHandler",
+            "ScheduledMulticurveSwapMetricsHandler",
+            "DhookSwapMetricsHandler",
+            "V4BaseMetricsHandler",
+            "MigrationPoolSwapMetricsHandler",
+        ]);
+        let chainlink_dep = chainlink_latest_answer_dependency();
+        let mut seen = HashSet::new();
+
+        for handler_info in registry.unique_event_handlers() {
+            let name = handler_info.handler.name();
+            if expected_handlers.contains(name) {
+                assert!(
+                    handler_info
+                        .handler
+                        .call_dependencies()
+                        .contains(&chainlink_dep),
+                    "{} must declare Chainlink latestAnswer as a call dependency",
+                    name
+                );
+                seen.insert(name);
+            }
+        }
+
+        assert_eq!(seen, expected_handlers);
     }
 }

--- a/src/transformations/util/db/pool_metrics.rs
+++ b/src/transformations/util/db/pool_metrics.rs
@@ -31,6 +31,8 @@ pub struct SnapshotData {
     pub volume0: String,
     pub volume1: String,
     pub swap_count: i32,
+    /// USD-converted quote-side volume. None when no USD price data is available.
+    pub volume_usd: Option<String>,
 }
 
 /// Data for a liquidity_deltas row.
@@ -107,6 +109,7 @@ pub fn insert_pool_snapshot(data: &SnapshotData) -> DbOperation {
             "volume0".into(),
             "volume1".into(),
             "swap_count".into(),
+            "volume_usd".into(),
         ],
         values: vec![
             DbValue::Int64(data.chain_id as i64),
@@ -121,6 +124,10 @@ pub fn insert_pool_snapshot(data: &SnapshotData) -> DbOperation {
             DbValue::Numeric(data.volume0.clone()),
             DbValue::Numeric(data.volume1.clone()),
             DbValue::Int32(data.swap_count),
+            data.volume_usd
+                .as_ref()
+                .map(|v| DbValue::Numeric(v.clone()))
+                .unwrap_or(DbValue::Null),
         ],
         conflict_columns: vec!["chain_id".into(), "pool_id".into(), "block_number".into()],
         update_columns: vec![
@@ -133,6 +140,7 @@ pub fn insert_pool_snapshot(data: &SnapshotData) -> DbOperation {
             "volume0".into(),
             "volume1".into(),
             "swap_count".into(),
+            "volume_usd".into(),
         ],
         update_condition: None,
     }

--- a/src/transformations/util/mod.rs
+++ b/src/transformations/util/mod.rs
@@ -9,3 +9,4 @@ pub mod pool_metadata;
 pub mod price;
 pub mod sanitize;
 pub mod tick_math;
+pub mod usd_price;

--- a/src/transformations/util/usd_price.rs
+++ b/src/transformations/util/usd_price.rs
@@ -1,0 +1,548 @@
+//! USD price resolution for pool metrics.
+//!
+//! Provides `OraclePriceCache` (shared across handlers, DB-backed) and
+//! `UsdPriceContext` (per-invocation snapshot) to convert quote-token
+//! volumes into USD.
+//!
+//! Quote token → USD resolution:
+//! - WETH: multiply by ETH/USD from ChainlinkEthOracle
+//! - USDC, USDT: 1.0 (stablecoin assumption)
+//! - EURC: multiply by EURC/USDC from prices table
+
+use std::sync::OnceLock;
+use std::sync::RwLock;
+
+use alloy_primitives::U256;
+use bigdecimal::BigDecimal;
+use deadpool_postgres::Pool;
+
+use crate::db::{DbOperation, DbValue};
+use crate::transformations::context::{FieldExtractor, TransformationContext};
+use crate::transformations::error::TransformationError;
+use crate::types::config::contract::{AddressOrAddresses, Contracts};
+
+/// Chainlink oracle returns int256 with 8 decimals.
+const CHAINLINK_DECIMALS: u32 = 8;
+
+/// Source name written to prices table for oracle prices.
+const ORACLE_PRICE_SOURCE: &str = "chainlink";
+
+// ─── OraclePriceCache ────────────────────────────────────────────────
+
+/// Shared cache for oracle-derived USD prices. Thread-safe, persists across
+/// handler invocations. Seeded from the `prices` table on startup; updated
+/// from ChainlinkEthOracle calls during processing.
+pub struct OraclePriceCache {
+    inner: RwLock<CachedPrices>,
+}
+
+#[derive(Default)]
+struct CachedPrices {
+    eth_usd: Option<BigDecimal>,
+    eurc_usd: Option<BigDecimal>,
+}
+
+impl OraclePriceCache {
+    pub fn new() -> Self {
+        Self {
+            inner: RwLock::new(CachedPrices::default()),
+        }
+    }
+
+    /// Seed the cache from the `prices` table on startup.
+    /// Queries for the latest ETH/USD and EURC/USD prices.
+    pub async fn load_from_db(
+        &self,
+        db_pool: &Pool,
+        chain_id: u64,
+        contracts: &Contracts,
+    ) -> Result<(), TransformationError> {
+        let client = db_pool
+            .get()
+            .await
+            .map_err(|e| TransformationError::DatabaseError(e.into()))?;
+
+        // Load ETH/USD (written by us as chainlink source with WETH token address)
+        if let Some(weth_addr) = resolve_contract_address(contracts, "Weth") {
+            let row = client
+                .query_opt(
+                    "SELECT price FROM prices \
+                     WHERE chain_id = $1 AND token = $2 AND source = $3 \
+                     ORDER BY block_number DESC LIMIT 1",
+                    &[
+                        &(chain_id as i64),
+                        &weth_addr.as_slice(),
+                        &ORACLE_PRICE_SOURCE,
+                    ],
+                )
+                .await
+                .map_err(|e| TransformationError::DatabaseError(e.into()))?;
+
+            if let Some(row) = row {
+                let price_str: rust_decimal::Decimal = row.get("price");
+                if let Ok(price) = price_str.to_string().parse::<BigDecimal>() {
+                    self.inner.write().unwrap().eth_usd = Some(price);
+                }
+            }
+        }
+
+        // Load EURC/USD (written by PriceHandler as EURC/USDC ≈ EURC/USD)
+        if let Some(eurc_addr) = resolve_contract_address(contracts, "Eurc") {
+            let row = client
+                .query_opt(
+                    "SELECT price FROM prices \
+                     WHERE chain_id = $1 AND token = $2 \
+                     ORDER BY block_number DESC LIMIT 1",
+                    &[&(chain_id as i64), &eurc_addr.as_slice()],
+                )
+                .await
+                .map_err(|e| TransformationError::DatabaseError(e.into()))?;
+
+            if let Some(row) = row {
+                let price_str: rust_decimal::Decimal = row.get("price");
+                if let Ok(price) = price_str.to_string().parse::<BigDecimal>() {
+                    self.inner.write().unwrap().eurc_usd = Some(price);
+                }
+            }
+        }
+
+        let cache = self.inner.read().unwrap();
+        tracing::info!(
+            eth_usd = ?cache.eth_usd.as_ref().map(|p| p.to_string()),
+            eurc_usd = ?cache.eurc_usd.as_ref().map(|p| p.to_string()),
+            "OraclePriceCache seeded from DB for chain {}",
+            chain_id,
+        );
+
+        Ok(())
+    }
+
+    fn get_eth_usd(&self) -> Option<BigDecimal> {
+        self.inner.read().unwrap().eth_usd.clone()
+    }
+
+    fn get_eurc_usd(&self) -> Option<BigDecimal> {
+        self.inner.read().unwrap().eurc_usd.clone()
+    }
+
+    fn set_eth_usd(&self, price: BigDecimal) {
+        self.inner.write().unwrap().eth_usd = Some(price);
+    }
+
+    fn set_eurc_usd(&self, price: BigDecimal) {
+        self.inner.write().unwrap().eurc_usd = Some(price);
+    }
+}
+
+impl Default for OraclePriceCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ─── UsdPriceContext ─────────────────────────────────────────────────
+
+/// Per-invocation snapshot of USD prices with resolved quote token addresses.
+/// Built at the top of each handler's `handle()`.
+pub struct UsdPriceContext {
+    pub eth_usd: Option<BigDecimal>,
+    pub eurc_usd: Option<BigDecimal>,
+    weth_address: Option<[u8; 20]>,
+    usdc_address: Option<[u8; 20]>,
+    usdt_address: Option<[u8; 20]>,
+    eurc_address: Option<[u8; 20]>,
+}
+
+impl UsdPriceContext {
+    /// Create a UsdPriceContext for testing. Allows setting arbitrary addresses.
+    #[cfg(test)]
+    pub fn new_for_test(
+        eth_usd: Option<BigDecimal>,
+        eurc_usd: Option<BigDecimal>,
+        weth_address: Option<[u8; 20]>,
+        usdc_address: Option<[u8; 20]>,
+        usdt_address: Option<[u8; 20]>,
+        eurc_address: Option<[u8; 20]>,
+    ) -> Self {
+        Self {
+            eth_usd,
+            eurc_usd,
+            weth_address,
+            usdc_address,
+            usdt_address,
+            eurc_address,
+        }
+    }
+
+    /// Convert a raw quote-side volume to USD.
+    ///
+    /// `volume_raw` is a U256 absolute value (sum of |amount| across swaps).
+    /// `quote_token` identifies which token the volume is denominated in.
+    /// `quote_decimals` is the token's decimal precision (6 for USDC, 18 for WETH, etc.)
+    ///
+    /// Returns None if the quote token is unknown or no price data is available.
+    pub fn quote_volume_to_usd(
+        &self,
+        volume_raw: &U256,
+        quote_token: &[u8; 20],
+        quote_decimals: u8,
+    ) -> Option<BigDecimal> {
+        let usd_per_quote = self.quote_to_usd_multiplier(quote_token)?;
+        let volume_decimal = u256_to_decimal_adjusted(volume_raw, quote_decimals);
+        Some(volume_decimal * usd_per_quote)
+    }
+
+    /// Get the USD multiplier for a quote token.
+    /// WETH → ETH/USD price, USDC/USDT → 1.0, EURC → EURC/USD price.
+    fn quote_to_usd_multiplier(&self, quote_token: &[u8; 20]) -> Option<BigDecimal> {
+        if self.weth_address.as_ref() == Some(quote_token) {
+            return self.eth_usd.clone();
+        }
+        if self.usdc_address.as_ref() == Some(quote_token)
+            || self.usdt_address.as_ref() == Some(quote_token)
+        {
+            return Some(BigDecimal::from(1));
+        }
+        if self.eurc_address.as_ref() == Some(quote_token) {
+            return self.eurc_usd.clone();
+        }
+        None
+    }
+}
+
+// ─── Builder ─────────────────────────────────────────────────────────
+
+/// Build a `UsdPriceContext` for the current block range.
+///
+/// 1. Extracts latest ETH/USD from ChainlinkEthOracle calls in the range.
+///    Updates the shared cache and returns DbOps to persist to `prices`.
+/// 2. Falls back to cached value if no oracle data in range.
+/// 3. Reads EURC/USD from cache (seeded from DB at startup, updated by PriceHandler).
+///
+/// Returns `(context, price_ops)` where `price_ops` should be included in
+/// the handler's returned operations to persist oracle prices to the DB.
+pub async fn build_usd_price_context(
+    ctx: &TransformationContext,
+    cache: &OraclePriceCache,
+    db_pool: &OnceLock<Pool>,
+    chain_id: u64,
+    contracts: &Contracts,
+) -> (UsdPriceContext, Vec<DbOperation>) {
+    let mut price_ops = Vec::new();
+
+    // Resolve quote token addresses from config
+    let weth_address = resolve_contract_address(contracts, "Weth");
+    let usdc_address = resolve_contract_address(contracts, "Usdc");
+    let usdt_address = resolve_contract_address(contracts, "Usdt");
+    let eurc_address = resolve_contract_address(contracts, "Eurc");
+
+    // Extract ETH/USD from oracle calls in the current block range
+    let eth_usd = extract_eth_usd_from_oracle(ctx, cache, &weth_address, chain_id, &mut price_ops);
+
+    // EURC/USD: try to refresh from DB if cache is empty
+    let mut eurc_usd = cache.get_eurc_usd();
+    if eurc_usd.is_none() {
+        if let Some(pool) = db_pool.get() {
+            if let Some(eurc_addr) = &eurc_address {
+                if let Ok(price) = query_latest_price(pool, chain_id, eurc_addr, None).await {
+                    cache.set_eurc_usd(price.clone());
+                    eurc_usd = Some(price);
+                }
+            }
+        }
+    }
+
+    let usd_ctx = UsdPriceContext {
+        eth_usd,
+        eurc_usd,
+        weth_address,
+        usdc_address,
+        usdt_address,
+        eurc_address,
+    };
+
+    (usd_ctx, price_ops)
+}
+
+/// Extract the latest ETH/USD price from ChainlinkEthOracle calls in the current
+/// block range. Updates the cache and emits DbOps to persist to the prices table.
+fn extract_eth_usd_from_oracle(
+    ctx: &TransformationContext,
+    cache: &OraclePriceCache,
+    weth_address: &Option<[u8; 20]>,
+    chain_id: u64,
+    price_ops: &mut Vec<DbOperation>,
+) -> Option<BigDecimal> {
+    // Find the latest oracle call in the current range
+    let mut latest: Option<(u64, u64, BigDecimal)> = None; // (block_number, timestamp, price)
+
+    for call in ctx.calls_of_type("ChainlinkEthOracle", "latestAnswer") {
+        if call.is_reverted {
+            continue;
+        }
+        let Ok(answer) = call.extract_int256("latestAnswer") else {
+            continue;
+        };
+
+        // Chainlink returns int256 with 8 decimals. Convert to BigDecimal.
+        let price = chainlink_answer_to_decimal(&answer);
+
+        match &latest {
+            Some((bn, _, _)) if call.block_number <= *bn => {}
+            _ => {
+                latest = Some((call.block_number, call.block_timestamp, price));
+            }
+        }
+    }
+
+    if let Some((block_number, block_timestamp, price)) = latest {
+        // Update cache
+        cache.set_eth_usd(price.clone());
+
+        // Emit DB op to persist to prices table
+        if let Some(weth_addr) = weth_address {
+            price_ops.push(build_oracle_price_op(
+                chain_id,
+                block_number,
+                block_timestamp,
+                weth_addr,
+                &price,
+            ));
+        }
+
+        Some(price)
+    } else {
+        // No oracle data in range — use cached value
+        cache.get_eth_usd()
+    }
+}
+
+/// Convert a Chainlink `latestAnswer` (int256, 8 decimals) to BigDecimal.
+fn chainlink_answer_to_decimal(answer: &alloy_primitives::I256) -> BigDecimal {
+    // I256 doesn't have as_i128(); parse via string representation.
+    let raw: BigDecimal = answer.to_string().parse().unwrap_or_default();
+    let divisor = BigDecimal::from(10u64.pow(CHAINLINK_DECIMALS));
+    raw / divisor
+}
+
+/// Build a DbOperation to persist an oracle price to the `prices` table.
+fn build_oracle_price_op(
+    chain_id: u64,
+    block_number: u64,
+    block_timestamp: u64,
+    token_address: &[u8; 20],
+    price: &BigDecimal,
+) -> DbOperation {
+    // Use a stable "quote_token" for oracle prices — all zeros signals "USD"
+    let usd_quote: [u8; 20] = [0u8; 20];
+
+    DbOperation::Upsert {
+        table: "prices".into(),
+        columns: vec![
+            "timestamp".into(),
+            "block_number".into(),
+            "chain_id".into(),
+            "token".into(),
+            "quote_token".into(),
+            "price".into(),
+            "source".into(),
+            "source_version".into(),
+        ],
+        values: vec![
+            DbValue::Timestamp(block_timestamp as i64),
+            DbValue::Int64(block_number as i64),
+            DbValue::Int64(chain_id as i64),
+            DbValue::Address(*token_address),
+            DbValue::Address(usd_quote),
+            DbValue::Numeric(price.to_string()),
+            DbValue::VarChar(ORACLE_PRICE_SOURCE.into()),
+            DbValue::Int32(1),
+        ],
+        conflict_columns: vec![
+            "timestamp".into(),
+            "chain_id".into(),
+            "token".into(),
+            "source".into(),
+            "source_version".into(),
+        ],
+        update_columns: vec!["block_number".into(), "quote_token".into(), "price".into()],
+        update_condition: None,
+    }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+/// Resolve a contract address from the config by name.
+/// Returns None if the contract isn't configured (not an error — some chains
+/// may not have all tokens).
+fn resolve_contract_address(contracts: &Contracts, name: &str) -> Option<[u8; 20]> {
+    let config = contracts.get(name)?;
+    match &config.address {
+        AddressOrAddresses::Single(addr) => Some(addr.0 .0),
+        AddressOrAddresses::Multiple(addrs) => addrs.first().map(|a| a.0 .0),
+    }
+}
+
+/// Query the latest price from the `prices` table for a token.
+async fn query_latest_price(
+    pool: &Pool,
+    chain_id: u64,
+    token_address: &[u8; 20],
+    source_filter: Option<&str>,
+) -> Result<BigDecimal, TransformationError> {
+    let client = pool
+        .get()
+        .await
+        .map_err(|e| TransformationError::DatabaseError(e.into()))?;
+
+    let chain_id_param = chain_id as i64;
+    let token_param = token_address.to_vec();
+
+    let row = if let Some(source) = source_filter {
+        let source_param = source.to_string();
+        client
+            .query_opt(
+                "SELECT price FROM prices \
+                 WHERE chain_id = $1 AND token = $2 AND source = $3 \
+                 ORDER BY block_number DESC LIMIT 1",
+                &[&chain_id_param, &token_param, &source_param],
+            )
+            .await
+    } else {
+        client
+            .query_opt(
+                "SELECT price FROM prices \
+                 WHERE chain_id = $1 AND token = $2 \
+                 ORDER BY block_number DESC LIMIT 1",
+                &[&chain_id_param, &token_param],
+            )
+            .await
+    };
+
+    let row = row
+        .map_err(|e| TransformationError::DatabaseError(e.into()))?
+        .ok_or_else(|| {
+            TransformationError::ConfigError(format!(
+                "No price found for token {}",
+                hex::encode(token_address)
+            ))
+        })?;
+
+    let price: rust_decimal::Decimal = row.get("price");
+    price
+        .to_string()
+        .parse::<BigDecimal>()
+        .map_err(|e| TransformationError::ConfigError(format!("Invalid price value: {}", e)))
+}
+
+/// Convert a U256 to BigDecimal, dividing by 10^decimals.
+fn u256_to_decimal_adjusted(value: &U256, decimals: u8) -> BigDecimal {
+    let raw = BigDecimal::from(value.to_string().parse::<i128>().unwrap_or(0));
+    if decimals == 0 {
+        return raw;
+    }
+    let divisor = BigDecimal::from(10u64.pow(decimals as u32));
+    raw / divisor
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    fn bd(s: &str) -> BigDecimal {
+        BigDecimal::from_str(s).unwrap()
+    }
+
+    fn make_ctx(
+        eth_usd: Option<&str>,
+        eurc_usd: Option<&str>,
+    ) -> UsdPriceContext {
+        UsdPriceContext {
+            eth_usd: eth_usd.map(|s| bd(s)),
+            eurc_usd: eurc_usd.map(|s| bd(s)),
+            weth_address: Some([0x01; 20]),
+            usdc_address: Some([0x02; 20]),
+            usdt_address: Some([0x03; 20]),
+            eurc_address: Some([0x04; 20]),
+        }
+    }
+
+    #[test]
+    fn test_weth_volume_to_usd() {
+        let ctx = make_ctx(Some("2000"), None);
+        let weth = [0x01; 20];
+        // 1.5 WETH raw = 1_500_000_000_000_000_000 (18 decimals)
+        let volume = U256::from(1_500_000_000_000_000_000u64);
+        let usd = ctx.quote_volume_to_usd(&volume, &weth, 18).unwrap();
+        assert_eq!(usd, bd("3000"));
+    }
+
+    #[test]
+    fn test_usdc_volume_to_usd() {
+        let ctx = make_ctx(Some("2000"), None);
+        let usdc = [0x02; 20];
+        // 500 USDC raw = 500_000_000 (6 decimals)
+        let volume = U256::from(500_000_000u64);
+        let usd = ctx.quote_volume_to_usd(&volume, &usdc, 6).unwrap();
+        assert_eq!(usd, bd("500"));
+    }
+
+    #[test]
+    fn test_usdt_volume_to_usd() {
+        let ctx = make_ctx(Some("2000"), None);
+        let usdt = [0x03; 20];
+        let volume = U256::from(1_000_000u64); // 1 USDT
+        let usd = ctx.quote_volume_to_usd(&volume, &usdt, 6).unwrap();
+        assert_eq!(usd, bd("1"));
+    }
+
+    #[test]
+    fn test_eurc_volume_to_usd() {
+        let ctx = make_ctx(None, Some("1.08"));
+        let eurc = [0x04; 20];
+        // 100 EURC raw = 100_000_000 (6 decimals)
+        let volume = U256::from(100_000_000u64);
+        let usd = ctx.quote_volume_to_usd(&volume, &eurc, 6).unwrap();
+        assert_eq!(usd, bd("108"));
+    }
+
+    #[test]
+    fn test_unknown_token_returns_none() {
+        let ctx = make_ctx(Some("2000"), None);
+        let unknown = [0xFF; 20];
+        let volume = U256::from(1_000_000u64);
+        assert!(ctx.quote_volume_to_usd(&volume, &unknown, 18).is_none());
+    }
+
+    #[test]
+    fn test_no_eth_price_returns_none_for_weth() {
+        let ctx = make_ctx(None, None);
+        let weth = [0x01; 20];
+        let volume = U256::from(1_000_000_000_000_000_000u64);
+        assert!(ctx.quote_volume_to_usd(&volume, &weth, 18).is_none());
+    }
+
+    #[test]
+    fn test_chainlink_answer_conversion() {
+        // Chainlink ETH/USD = 200000000000 = $2000.00 (8 decimals)
+        let answer = alloy_primitives::I256::try_from(200_000_000_000i64).unwrap();
+        let price = chainlink_answer_to_decimal(&answer);
+        assert_eq!(price, bd("2000"));
+    }
+
+    #[test]
+    fn test_u256_to_decimal_adjusted() {
+        // 1.5 tokens with 18 decimals
+        let raw = U256::from(1_500_000_000_000_000_000u64);
+        let result = u256_to_decimal_adjusted(&raw, 18);
+        assert_eq!(result, bd("1.5"));
+
+        // 500 USDC (6 decimals)
+        let raw = U256::from(500_000_000u64);
+        let result = u256_to_decimal_adjusted(&raw, 6);
+        assert_eq!(result, bd("500"));
+    }
+}

--- a/src/transformations/util/usd_price.rs
+++ b/src/transformations/util/usd_price.rs
@@ -9,6 +9,7 @@
 //! - USDC, USDT: 1.0 (stablecoin assumption)
 //! - EURC: multiply by EURC/USDC from prices table
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::OnceLock;
 use std::sync::RwLock;
 
@@ -24,8 +25,8 @@ use crate::types::config::contract::{AddressOrAddresses, Contracts};
 /// Chainlink oracle returns int256 with 8 decimals.
 const CHAINLINK_DECIMALS: u32 = 8;
 
-/// Source name written to prices table for oracle prices.
-const ORACLE_PRICE_SOURCE: &str = "chainlink";
+/// Oracle rows use the zero address as a synthetic "USD quote token".
+const USD_QUOTE_TOKEN: [u8; 20] = [0u8; 20];
 
 // ─── OraclePriceCache ────────────────────────────────────────────────
 
@@ -34,6 +35,9 @@ const ORACLE_PRICE_SOURCE: &str = "chainlink";
 /// from ChainlinkEthOracle calls during processing.
 pub struct OraclePriceCache {
     inner: RwLock<CachedPrices>,
+    weth_address: Option<[u8; 20]>,
+    eurc_address: Option<[u8; 20]>,
+    seeded_from_db: AtomicBool,
 }
 
 #[derive(Default)]
@@ -46,6 +50,18 @@ impl OraclePriceCache {
     pub fn new() -> Self {
         Self {
             inner: RwLock::new(CachedPrices::default()),
+            weth_address: None,
+            eurc_address: None,
+            seeded_from_db: AtomicBool::new(false),
+        }
+    }
+
+    pub fn with_contracts(contracts: &Contracts) -> Self {
+        Self {
+            inner: RwLock::new(CachedPrices::default()),
+            weth_address: resolve_contract_address(contracts, "Weth"),
+            eurc_address: resolve_contract_address(contracts, "Eurc"),
+            seeded_from_db: AtomicBool::new(false),
         }
     }
 
@@ -55,54 +71,20 @@ impl OraclePriceCache {
         &self,
         db_pool: &Pool,
         chain_id: u64,
-        contracts: &Contracts,
     ) -> Result<(), TransformationError> {
-        let client = db_pool
-            .get()
-            .await
-            .map_err(|e| TransformationError::DatabaseError(e.into()))?;
-
-        // Load ETH/USD (written by us as chainlink source with WETH token address)
-        if let Some(weth_addr) = resolve_contract_address(contracts, "Weth") {
-            let row = client
-                .query_opt(
-                    "SELECT price FROM prices \
-                     WHERE chain_id = $1 AND token = $2 AND source = $3 \
-                     ORDER BY block_number DESC LIMIT 1",
-                    &[
-                        &(chain_id as i64),
-                        &weth_addr.as_slice(),
-                        &ORACLE_PRICE_SOURCE,
-                    ],
-                )
-                .await
-                .map_err(|e| TransformationError::DatabaseError(e.into()))?;
-
-            if let Some(row) = row {
-                let price_str: rust_decimal::Decimal = row.get("price");
-                if let Ok(price) = price_str.to_string().parse::<BigDecimal>() {
-                    self.inner.write().unwrap().eth_usd = Some(price);
-                }
+        if let Some(weth_addr) = self.weth_address {
+            if let Ok(price) =
+                query_latest_price(db_pool, chain_id, &weth_addr, Some(&USD_QUOTE_TOKEN)).await
+            {
+                self.inner.write().unwrap().eth_usd = Some(price);
             }
         }
 
-        // Load EURC/USD (written by PriceHandler as EURC/USDC ≈ EURC/USD)
-        if let Some(eurc_addr) = resolve_contract_address(contracts, "Eurc") {
-            let row = client
-                .query_opt(
-                    "SELECT price FROM prices \
-                     WHERE chain_id = $1 AND token = $2 \
-                     ORDER BY block_number DESC LIMIT 1",
-                    &[&(chain_id as i64), &eurc_addr.as_slice()],
-                )
-                .await
-                .map_err(|e| TransformationError::DatabaseError(e.into()))?;
-
-            if let Some(row) = row {
-                let price_str: rust_decimal::Decimal = row.get("price");
-                if let Ok(price) = price_str.to_string().parse::<BigDecimal>() {
-                    self.inner.write().unwrap().eurc_usd = Some(price);
-                }
+        // EURC/USD is written by PriceHandler as EURC/USDC, which we treat as
+        // EURC/USD for the metrics use case.
+        if let Some(eurc_addr) = self.eurc_address {
+            if let Ok(price) = query_latest_price(db_pool, chain_id, &eurc_addr, None).await {
+                self.inner.write().unwrap().eurc_usd = Some(price);
             }
         }
 
@@ -114,6 +96,22 @@ impl OraclePriceCache {
             chain_id,
         );
 
+        Ok(())
+    }
+
+    /// Best-effort one-time DB seed for the shared cache during handler
+    /// initialization. Runtime handlers are initialized sequentially, so a
+    /// simple atomic guard is sufficient here.
+    pub async fn load_from_db_once(
+        &self,
+        db_pool: &Pool,
+        chain_id: u64,
+    ) -> Result<(), TransformationError> {
+        if self.seeded_from_db.load(Ordering::Acquire) {
+            return Ok(());
+        }
+        self.load_from_db(db_pool, chain_id).await?;
+        self.seeded_from_db.store(true, Ordering::Release);
         Ok(())
     }
 
@@ -138,6 +136,10 @@ impl Default for OraclePriceCache {
     fn default() -> Self {
         Self::new()
     }
+}
+
+pub fn chainlink_latest_answer_dependency() -> (String, String) {
+    ("ChainlinkEthOracle".to_string(), "latestAnswer".to_string())
 }
 
 // ─── UsdPriceContext ─────────────────────────────────────────────────
@@ -236,8 +238,24 @@ pub async fn build_usd_price_context(
     let usdt_address = resolve_contract_address(contracts, "Usdt");
     let eurc_address = resolve_contract_address(contracts, "Eurc");
 
-    // Extract ETH/USD from oracle calls in the current block range
-    let eth_usd = extract_eth_usd_from_oracle(ctx, cache, &weth_address, chain_id, &mut price_ops);
+    // Extract ETH/USD from oracle calls in the current block range.
+    let mut eth_usd =
+        extract_eth_usd_from_oracle(ctx, cache, &weth_address, chain_id, &mut price_ops);
+
+    // Cold-start safety net: if the shared cache is still empty, fall back to
+    // the latest persisted ETH/USD row.
+    if eth_usd.is_none() {
+        if let Some(pool) = db_pool.get() {
+            if let Some(weth_addr) = &weth_address {
+                if let Ok(price) =
+                    query_latest_price(pool, chain_id, weth_addr, Some(&USD_QUOTE_TOKEN)).await
+                {
+                    cache.set_eth_usd(price.clone());
+                    eth_usd = Some(price);
+                }
+            }
+        }
+    }
 
     // EURC/USD: try to refresh from DB if cache is empty
     let mut eurc_usd = cache.get_eurc_usd();
@@ -333,9 +351,6 @@ fn build_oracle_price_op(
     token_address: &[u8; 20],
     price: &BigDecimal,
 ) -> DbOperation {
-    // Use a stable "quote_token" for oracle prices — all zeros signals "USD"
-    let usd_quote: [u8; 20] = [0u8; 20];
-
     DbOperation::Upsert {
         table: "prices".into(),
         columns: vec![
@@ -345,26 +360,17 @@ fn build_oracle_price_op(
             "token".into(),
             "quote_token".into(),
             "price".into(),
-            "source".into(),
-            "source_version".into(),
         ],
         values: vec![
             DbValue::Timestamp(block_timestamp as i64),
             DbValue::Int64(block_number as i64),
             DbValue::Int64(chain_id as i64),
             DbValue::Address(*token_address),
-            DbValue::Address(usd_quote),
+            DbValue::Address(USD_QUOTE_TOKEN),
             DbValue::Numeric(price.to_string()),
-            DbValue::VarChar(ORACLE_PRICE_SOURCE.into()),
-            DbValue::Int32(1),
         ],
-        conflict_columns: vec![
-            "timestamp".into(),
-            "chain_id".into(),
-            "token".into(),
-            "source".into(),
-            "source_version".into(),
-        ],
+        // Handler-level source/source_version are injected later by the executor.
+        conflict_columns: vec!["timestamp".into(), "chain_id".into(), "token".into()],
         update_columns: vec!["block_number".into(), "quote_token".into(), "price".into()],
         update_condition: None,
     }
@@ -388,7 +394,7 @@ async fn query_latest_price(
     pool: &Pool,
     chain_id: u64,
     token_address: &[u8; 20],
-    source_filter: Option<&str>,
+    quote_token_filter: Option<&[u8; 20]>,
 ) -> Result<BigDecimal, TransformationError> {
     let client = pool
         .get()
@@ -398,14 +404,14 @@ async fn query_latest_price(
     let chain_id_param = chain_id as i64;
     let token_param = token_address.to_vec();
 
-    let row = if let Some(source) = source_filter {
-        let source_param = source.to_string();
+    let row = if let Some(quote_token) = quote_token_filter {
+        let quote_token_param = quote_token.to_vec();
         client
             .query_opt(
                 "SELECT price FROM prices \
-                 WHERE chain_id = $1 AND token = $2 AND source = $3 \
+                 WHERE chain_id = $1 AND token = $2 AND quote_token = $3 \
                  ORDER BY block_number DESC LIMIT 1",
-                &[&chain_id_param, &token_param, &source_param],
+                &[&chain_id_param, &token_param, &quote_token_param],
             )
             .await
     } else {
@@ -452,14 +458,13 @@ mod tests {
     use super::*;
     use std::str::FromStr;
 
+    use crate::transformations::executor::inject_source_version;
+
     fn bd(s: &str) -> BigDecimal {
         BigDecimal::from_str(s).unwrap()
     }
 
-    fn make_ctx(
-        eth_usd: Option<&str>,
-        eurc_usd: Option<&str>,
-    ) -> UsdPriceContext {
+    fn make_ctx(eth_usd: Option<&str>, eurc_usd: Option<&str>) -> UsdPriceContext {
         UsdPriceContext {
             eth_usd: eth_usd.map(|s| bd(s)),
             eurc_usd: eurc_usd.map(|s| bd(s)),
@@ -544,5 +549,55 @@ mod tests {
         let raw = U256::from(500_000_000u64);
         let result = u256_to_decimal_adjusted(&raw, 6);
         assert_eq!(result, bd("500"));
+    }
+
+    #[test]
+    fn test_oracle_price_op_relies_on_executor_for_source_injection() {
+        let op = build_oracle_price_op(8453, 123, 456, &[0x01; 20], &bd("2000"));
+        let ops = inject_source_version(vec![op], "SwapHandler", 7);
+        let op = ops.into_iter().next().unwrap();
+
+        let DbOperation::Upsert {
+            columns,
+            values,
+            conflict_columns,
+            ..
+        } = op
+        else {
+            panic!("expected upsert");
+        };
+
+        assert_eq!(
+            columns
+                .iter()
+                .filter(|column| column.as_str() == "source")
+                .count(),
+            1
+        );
+        assert_eq!(
+            columns
+                .iter()
+                .filter(|column| column.as_str() == "source_version")
+                .count(),
+            1
+        );
+        assert_eq!(
+            conflict_columns
+                .iter()
+                .filter(|column| column.as_str() == "source")
+                .count(),
+            1
+        );
+        assert_eq!(
+            conflict_columns
+                .iter()
+                .filter(|column| column.as_str() == "source_version")
+                .count(),
+            1
+        );
+        assert!(
+            matches!(values.get(values.len() - 2), Some(DbValue::Text(source)) if source == "SwapHandler")
+        );
+        assert!(matches!(values.last(), Some(DbValue::Int32(7))));
     }
 }


### PR DESCRIPTION
## Summary

- Add `volume_usd` (nullable NUMERIC) column to `pool_snapshots` via ALTER TABLE migration
- New `src/transformations/util/usd_price.rs` module with `OraclePriceCache` (shared, DB-backed) and `UsdPriceContext` (per-invocation) for quote-token → USD conversion
- Compute single-side (quote-side) `volume_usd` for each pool snapshot in `process_swaps()`
- Populate rolling metrics on `pool_state` (`volume_24h_usd`, `price_change_1h`, `price_change_24h`, `swap_count_24h`) via `RawSql` UPDATE with backward-looking LATERAL subqueries, executed in-transaction after snapshot inserts
- All 8 swap metrics handlers updated to build `UsdPriceContext` from ChainlinkEthOracle calls and pass to `process_swaps()`
- Single shared `Arc<OraclePriceCache>` across all swap handlers, seeded from `prices` table on startup, ETH/USD persisted back to `prices` for restart resilience

## USD Resolution

- **WETH**: ChainlinkEthOracle `latestAnswer` (int256, 8 decimals) — already configured on all 7 chains at 15m frequency
- **USDC/USDT**: $1 (stablecoin assumption)
- **EURC**: Chains through EURC/USDC price from `prices` table (written by existing PriceHandler)

## Rolling Metrics

Backward-looking price change: compares current `price_close` to the last known `price_close` at or before the 1h/24h boundary (`block_timestamp <= target ORDER BY DESC LIMIT 1`). Volume and swap count aggregate over the 24h window from `pool_snapshots`.