### PR TITLE
feat: phase 7 shared TVL compute module

### DIFF
--- a/config/contracts/base/decay_multicurve.json
+++ b/config/contracts/base/decay_multicurve.json
@@ -64,6 +64,18 @@
                 },
                 "target": "UniswapV4StateView",
                 "params": [{ "type": "bytes32", "from_event": "topics[3]" }]
+            },
+            {
+                "function": "getSlot0(bytes32)",
+                "output_type": "(uint160 sqrtPriceX96, int24 tick, uint24 protocolFee, uint24 lpFee)",
+                "frequency": {
+                    "on_events": {
+                        "source": "DecayMulticurveHook",
+                        "event": "ModifyLiquidity(bytes32,address,int24,int24,int256,bytes32)"
+                    }
+                },
+                "target": "UniswapV4StateView",
+                "params": [{ "type": "bytes32", "from_event": "topics[1]" }]
             }
         ]
     }

--- a/config/contracts/base/dhook.json
+++ b/config/contracts/base/dhook.json
@@ -47,6 +47,18 @@
                 },
                 "target": "UniswapV4StateView",
                 "params": [{ "type": "bytes32", "from_event": "topics[3]" }]
+            },
+            {
+                "function": "getSlot0(bytes32)",
+                "output_type": "(uint160 sqrtPriceX96, int24 tick, uint24 protocolFee, uint24 lpFee)",
+                "frequency": {
+                    "on_events": {
+                        "source": "DopplerHookInitializer",
+                        "event": "ModifyLiquidity((address,address,uint24,int24,address),(int24,int24,int256,bytes32))"
+                    }
+                },
+                "target": "UniswapV4StateView",
+                "params": [{ "type": "bytes32", "from_event": "v4_pool_id_from_key_data" }]
             }
         ]
     },

--- a/config/contracts/base/multicurve.json
+++ b/config/contracts/base/multicurve.json
@@ -65,6 +65,18 @@
                 },
                 "target": "UniswapV4StateView",
                 "params": [{ "type": "bytes32", "from_event": "topics[3]" }]
+            },
+            {
+                "function": "getSlot0(bytes32)",
+                "output_type": "(uint160 sqrtPriceX96, int24 tick, uint24 protocolFee, uint24 lpFee)",
+                "frequency": {
+                    "on_events": {
+                        "source": "UniswapV4MulticurveInitializerHook",
+                        "event": "ModifyLiquidity((address,address,uint24,int24,address),(int24,int24,int256,bytes32))"
+                    }
+                },
+                "target": "UniswapV4StateView",
+                "params": [{ "type": "bytes32", "from_event": "v4_pool_id_from_key_data" }]
             }
         ]
     }

--- a/config/contracts/base/scheduled_multicurve.json
+++ b/config/contracts/base/scheduled_multicurve.json
@@ -64,6 +64,18 @@
                 },
                 "target": "UniswapV4StateView",
                 "params": [{ "type": "bytes32", "from_event": "topics[3]" }]
+            },
+            {
+                "function": "getSlot0(bytes32)",
+                "output_type": "(uint160 sqrtPriceX96, int24 tick, uint24 protocolFee, uint24 lpFee)",
+                "frequency": {
+                    "on_events": {
+                        "source": "UniswapV4ScheduledMulticurveInitializerHook",
+                        "event": "ModifyLiquidity(bytes32,address,int24,int24,int256,bytes32)"
+                    }
+                },
+                "target": "UniswapV4StateView",
+                "params": [{ "type": "bytes32", "from_event": "topics[1]" }]
             }
         ]
     }

--- a/config/contracts/base/v3.json
+++ b/config/contracts/base/v3.json
@@ -13,7 +13,23 @@
                     "factory_parameters": "topics[1]"
                 },
                 "calls": [
-                    { "function": "fee()", "output_type": "uint24", "frequency": "once" }
+                    { "function": "fee()", "output_type": "uint24", "frequency": "once" },
+                    {
+                        "function": "slot0()",
+                        "output_type": "(uint160 sqrtPriceX96, int24 tick, uint16 observationIndex, uint16 observationCardinality, uint16 observationCardinalityNext, uint8 feeProtocol, bool unlocked)",
+                        "frequency": {
+                            "on_events": [
+                                {
+                                    "source": "DopplerV3Pool",
+                                    "event": "Mint(address,address,int24,int24,uint128,uint256,uint256)"
+                                },
+                                {
+                                    "source": "DopplerV3Pool",
+                                    "event": "Burn(address,int24,int24,uint128,uint256,uint256)"
+                                }
+                            ]
+                        }
+                    }
                 ],
                 "events": [
                     { "signature": "Mint(address sender, address indexed owner, int24 indexed tickLower, int24 indexed tickUpper, uint128 amount, uint256 amount0, uint256 amount1)" },
@@ -37,7 +53,23 @@
                     "factory_parameters": "topics[1]"
                 },
                 "calls": [
-                    { "function": "fee()", "output_type": "uint24", "frequency": "once" }
+                    { "function": "fee()", "output_type": "uint24", "frequency": "once" },
+                    {
+                        "function": "slot0()",
+                        "output_type": "(uint160 sqrtPriceX96, int24 tick, uint16 observationIndex, uint16 observationCardinality, uint16 observationCardinalityNext, uint8 feeProtocol, bool unlocked)",
+                        "frequency": {
+                            "on_events": [
+                                {
+                                    "source": "DopplerLockableV3Pool",
+                                    "event": "Mint(address,address,int24,int24,uint128,uint256,uint256)"
+                                },
+                                {
+                                    "source": "DopplerLockableV3Pool",
+                                    "event": "Burn(address,int24,int24,uint128,uint256,uint256)"
+                                }
+                            ]
+                        }
+                    }
                 ],
                 "events": [
                     { "signature": "Mint(address sender, address indexed owner, int24 indexed tickLower, int24 indexed tickUpper, uint128 amount, uint256 amount0, uint256 amount1)" },

--- a/config/contracts/base/v4.json
+++ b/config/contracts/base/v4.json
@@ -79,6 +79,20 @@
         ],
         "events": [
             { "signature": "ModifyLiquidity((address currency0, address currency1, uint24 fee, int24 tickSpacing, address hooks) key, (int24 tickLower, int24 tickUpper, int256 liquidityDelta, bytes32 salt) params)" }
+        ],
+        "calls": [
+            {
+                "function": "getSlot0(bytes32)",
+                "output_type": "(uint160 sqrtPriceX96, int24 tick, uint24 protocolFee, uint24 lpFee)",
+                "frequency": {
+                    "on_events": {
+                        "source": "UniswapV4MigratorHook",
+                        "event": "ModifyLiquidity((address,address,uint24,int24,address),(int24,int24,int256,bytes32))"
+                    }
+                },
+                "target": "UniswapV4StateView",
+                "params": [{ "type": "bytes32", "from_event": "v4_pool_id_from_key_data" }]
+            }
         ]
     },
     "DopplerLens": {

--- a/config/contracts/baseSepolia/decay_multicurve.json
+++ b/config/contracts/baseSepolia/decay_multicurve.json
@@ -70,6 +70,18 @@
                 },
                 "target": "UniswapV4StateView",
                 "params": [{ "type": "bytes32", "from_event": "topics[3]" }]
+            },
+            {
+                "function": "getSlot0(bytes32)",
+                "output_type": "(uint160 sqrtPriceX96, int24 tick, uint24 protocolFee, uint24 lpFee)",
+                "frequency": {
+                    "on_events": {
+                        "source": "DecayMulticurveHook",
+                        "event": "ModifyLiquidity(bytes32,address,int24,int24,int256,bytes32)"
+                    }
+                },
+                "target": "UniswapV4StateView",
+                "params": [{ "type": "bytes32", "from_event": "topics[1]" }]
             }
         ]
     }

--- a/config/contracts/baseSepolia/dhook.json
+++ b/config/contracts/baseSepolia/dhook.json
@@ -48,6 +48,18 @@
                 },
                 "target": "UniswapV4StateView",
                 "params": [{ "type": "bytes32", "from_event": "topics[3]" }]
+            },
+            {
+                "function": "getSlot0(bytes32)",
+                "output_type": "(uint160 sqrtPriceX96, int24 tick, uint24 protocolFee, uint24 lpFee)",
+                "frequency": {
+                    "on_events": {
+                        "source": "DopplerHookInitializer",
+                        "event": "ModifyLiquidity((address,address,uint24,int24,address),(int24,int24,int256,bytes32))"
+                    }
+                },
+                "target": "UniswapV4StateView",
+                "params": [{ "type": "bytes32", "from_event": "v4_pool_id_from_key_data" }]
             }
         ]
     },

--- a/config/contracts/baseSepolia/multicurve.json
+++ b/config/contracts/baseSepolia/multicurve.json
@@ -70,6 +70,18 @@
                 },
                 "target": "UniswapV4StateView",
                 "params": [{ "type": "bytes32", "from_event": "topics[3]" }]
+            },
+            {
+                "function": "getSlot0(bytes32)",
+                "output_type": "(uint160 sqrtPriceX96, int24 tick, uint24 protocolFee, uint24 lpFee)",
+                "frequency": {
+                    "on_events": {
+                        "source": "UniswapV4MulticurveInitializerHook",
+                        "event": "ModifyLiquidity((address,address,uint24,int24,address),(int24,int24,int256,bytes32))"
+                    }
+                },
+                "target": "UniswapV4StateView",
+                "params": [{ "type": "bytes32", "from_event": "v4_pool_id_from_key_data" }]
             }
         ]
     }

--- a/config/contracts/baseSepolia/scheduled_multicurve.json
+++ b/config/contracts/baseSepolia/scheduled_multicurve.json
@@ -67,6 +67,18 @@
                 },
                 "target": "UniswapV4StateView",
                 "params": [{ "type": "bytes32", "from_event": "topics[3]" }]
+            },
+            {
+                "function": "getSlot0(bytes32)",
+                "output_type": "(uint160 sqrtPriceX96, int24 tick, uint24 protocolFee, uint24 lpFee)",
+                "frequency": {
+                    "on_events": {
+                        "source": "UniswapV4ScheduledMulticurveInitializerHook",
+                        "event": "ModifyLiquidity(bytes32,address,int24,int24,int256,bytes32)"
+                    }
+                },
+                "target": "UniswapV4StateView",
+                "params": [{ "type": "bytes32", "from_event": "topics[1]" }]
             }
         ]
     }

--- a/config/contracts/baseSepolia/v3.json
+++ b/config/contracts/baseSepolia/v3.json
@@ -10,7 +10,23 @@
                     "factory_parameters": "topics[1]"
                 },
                 "calls": [
-                    { "function": "fee()", "output_type": "uint24", "frequency": "once" }
+                    { "function": "fee()", "output_type": "uint24", "frequency": "once" },
+                    {
+                        "function": "slot0()",
+                        "output_type": "(uint160 sqrtPriceX96, int24 tick, uint16 observationIndex, uint16 observationCardinality, uint16 observationCardinalityNext, uint8 feeProtocol, bool unlocked)",
+                        "frequency": {
+                            "on_events": [
+                                {
+                                    "source": "DopplerV3Pool",
+                                    "event": "Mint(address,address,int24,int24,uint128,uint256,uint256)"
+                                },
+                                {
+                                    "source": "DopplerV3Pool",
+                                    "event": "Burn(address,int24,int24,uint128,uint256,uint256)"
+                                }
+                            ]
+                        }
+                    }
                 ],
                 "events": [
                     { "signature": "Mint(address sender, address indexed owner, int24 indexed tickLower, int24 indexed tickUpper, uint128 amount, uint256 amount0, uint256 amount1)" },
@@ -34,7 +50,23 @@
                     "factory_parameters": "topics[1]"
                 },
                 "calls": [
-                    { "function": "fee()", "output_type": "uint24", "frequency": "once" }
+                    { "function": "fee()", "output_type": "uint24", "frequency": "once" },
+                    {
+                        "function": "slot0()",
+                        "output_type": "(uint160 sqrtPriceX96, int24 tick, uint16 observationIndex, uint16 observationCardinality, uint16 observationCardinalityNext, uint8 feeProtocol, bool unlocked)",
+                        "frequency": {
+                            "on_events": [
+                                {
+                                    "source": "DopplerLockableV3Pool",
+                                    "event": "Mint(address,address,int24,int24,uint128,uint256,uint256)"
+                                },
+                                {
+                                    "source": "DopplerLockableV3Pool",
+                                    "event": "Burn(address,int24,int24,uint128,uint256,uint256)"
+                                }
+                            ]
+                        }
+                    }
                 ],
                 "events": [
                     { "signature": "Mint(address sender, address indexed owner, int24 indexed tickLower, int24 indexed tickUpper, uint128 amount, uint256 amount0, uint256 amount1)" },

--- a/config/contracts/baseSepolia/v4.json
+++ b/config/contracts/baseSepolia/v4.json
@@ -79,6 +79,20 @@
         ],
         "events": [
             { "signature": "ModifyLiquidity((address currency0, address currency1, uint24 fee, int24 tickSpacing, address hooks) key, (int24 tickLower, int24 tickUpper, int256 liquidityDelta, bytes32 salt) params)" }
+        ],
+        "calls": [
+            {
+                "function": "getSlot0(bytes32)",
+                "output_type": "(uint160 sqrtPriceX96, int24 tick, uint24 protocolFee, uint24 lpFee)",
+                "frequency": {
+                    "on_events": {
+                        "source": "UniswapV4MigratorHook",
+                        "event": "ModifyLiquidity((address,address,uint24,int24,address),(int24,int24,int256,bytes32))"
+                    }
+                },
+                "target": "UniswapV4StateView",
+                "params": [{ "type": "bytes32", "from_event": "v4_pool_id_from_key_data" }]
+            }
         ]
     },
     "DopplerLens": {

--- a/config/contracts/ink/v3.json
+++ b/config/contracts/ink/v3.json
@@ -10,7 +10,23 @@
                     "factory_parameters": "topics[1]"
                 },
                 "calls": [
-                    { "function": "fee()", "output_type": "uint24", "frequency": "once" }
+                    { "function": "fee()", "output_type": "uint24", "frequency": "once" },
+                    {
+                        "function": "slot0()",
+                        "output_type": "(uint160 sqrtPriceX96, int24 tick, uint16 observationIndex, uint16 observationCardinality, uint16 observationCardinalityNext, uint8 feeProtocol, bool unlocked)",
+                        "frequency": {
+                            "on_events": [
+                                {
+                                    "source": "DopplerV3Pool",
+                                    "event": "Mint(address,address,int24,int24,uint128,uint256,uint256)"
+                                },
+                                {
+                                    "source": "DopplerV3Pool",
+                                    "event": "Burn(address,int24,int24,uint128,uint256,uint256)"
+                                }
+                            ]
+                        }
+                    }
                 ],
                 "events": [
                     { "signature": "Mint(address sender, address indexed owner, int24 indexed tickLower, int24 indexed tickUpper, uint128 amount, uint256 amount0, uint256 amount1)" },

--- a/config/contracts/mainnet/dhook.json
+++ b/config/contracts/mainnet/dhook.json
@@ -47,6 +47,18 @@
                 },
                 "target": "UniswapV4StateView",
                 "params": [{ "type": "bytes32", "from_event": "topics[3]" }]
+            },
+            {
+                "function": "getSlot0(bytes32)",
+                "output_type": "(uint160 sqrtPriceX96, int24 tick, uint24 protocolFee, uint24 lpFee)",
+                "frequency": {
+                    "on_events": {
+                        "source": "DopplerHookInitializer",
+                        "event": "ModifyLiquidity((address,address,uint24,int24,address),(int24,int24,int256,bytes32))"
+                    }
+                },
+                "target": "UniswapV4StateView",
+                "params": [{ "type": "bytes32", "from_event": "v4_pool_id_from_key_data" }]
             }
         ]
     },

--- a/config/contracts/mainnet/scheduled_multicurve.json
+++ b/config/contracts/mainnet/scheduled_multicurve.json
@@ -64,6 +64,18 @@
                 },
                 "target": "UniswapV4StateView",
                 "params": [{ "type": "bytes32", "from_event": "topics[3]" }]
+            },
+            {
+                "function": "getSlot0(bytes32)",
+                "output_type": "(uint160 sqrtPriceX96, int24 tick, uint24 protocolFee, uint24 lpFee)",
+                "frequency": {
+                    "on_events": {
+                        "source": "UniswapV4ScheduledMulticurveInitializerHook",
+                        "event": "ModifyLiquidity(bytes32,address,int24,int24,int256,bytes32)"
+                    }
+                },
+                "target": "UniswapV4StateView",
+                "params": [{ "type": "bytes32", "from_event": "topics[1]" }]
             }
         ]
     }

--- a/config/contracts/mainnet/v4.json
+++ b/config/contracts/mainnet/v4.json
@@ -67,6 +67,20 @@
         "address": "0x4053d4fa966cbdcc20ec62070ac8814de8bee500",
         "events": [
             { "signature": "ModifyLiquidity((address currency0, address currency1, uint24 fee, int24 tickSpacing, address hooks) key, (int24 tickLower, int24 tickUpper, int256 liquidityDelta, bytes32 salt) params)" }
+        ],
+        "calls": [
+            {
+                "function": "getSlot0(bytes32)",
+                "output_type": "(uint160 sqrtPriceX96, int24 tick, uint24 protocolFee, uint24 lpFee)",
+                "frequency": {
+                    "on_events": {
+                        "source": "UniswapV4MigratorHook",
+                        "event": "ModifyLiquidity((address,address,uint24,int24,address),(int24,int24,int256,bytes32))"
+                    }
+                },
+                "target": "UniswapV4StateView",
+                "params": [{ "type": "bytes32", "from_event": "v4_pool_id_from_key_data" }]
+            }
         ]
     }
 }

--- a/config/contracts/monad/dhook.json
+++ b/config/contracts/monad/dhook.json
@@ -44,6 +44,18 @@
                 },
                 "target": "UniswapV4StateView",
                 "params": [{ "type": "bytes32", "from_event": "topics[3]" }]
+            },
+            {
+                "function": "getSlot0(bytes32)",
+                "output_type": "(uint160 sqrtPriceX96, int24 tick, uint24 protocolFee, uint24 lpFee)",
+                "frequency": {
+                    "on_events": {
+                        "source": "DopplerHookInitializer",
+                        "event": "ModifyLiquidity((address,address,uint24,int24,address),(int24,int24,int256,bytes32))"
+                    }
+                },
+                "target": "UniswapV4StateView",
+                "params": [{ "type": "bytes32", "from_event": "v4_pool_id_from_key_data" }]
             }
         ]
     },

--- a/config/contracts/monad/scheduled_multicurve.json
+++ b/config/contracts/monad/scheduled_multicurve.json
@@ -64,6 +64,18 @@
                 },
                 "target": "UniswapV4StateView",
                 "params": [{ "type": "bytes32", "from_event": "topics[3]" }]
+            },
+            {
+                "function": "getSlot0(bytes32)",
+                "output_type": "(uint160 sqrtPriceX96, int24 tick, uint24 protocolFee, uint24 lpFee)",
+                "frequency": {
+                    "on_events": {
+                        "source": "UniswapV4ScheduledMulticurveInitializerHook",
+                        "event": "ModifyLiquidity(bytes32,address,int24,int24,int256,bytes32)"
+                    }
+                },
+                "target": "UniswapV4StateView",
+                "params": [{ "type": "bytes32", "from_event": "topics[1]" }]
             }
         ]
     }

--- a/config/contracts/monad/v3.json
+++ b/config/contracts/monad/v3.json
@@ -10,7 +10,23 @@
                     "factory_parameters": "topics[1]"
                 },
                 "calls": [
-                    { "function": "fee()", "output_type": "uint24", "frequency": "once" }
+                    { "function": "fee()", "output_type": "uint24", "frequency": "once" },
+                    {
+                        "function": "slot0()",
+                        "output_type": "(uint160 sqrtPriceX96, int24 tick, uint16 observationIndex, uint16 observationCardinality, uint16 observationCardinalityNext, uint8 feeProtocol, bool unlocked)",
+                        "frequency": {
+                            "on_events": [
+                                {
+                                    "source": "DopplerLockableV3Pool",
+                                    "event": "Mint(address,address,int24,int24,uint128,uint256,uint256)"
+                                },
+                                {
+                                    "source": "DopplerLockableV3Pool",
+                                    "event": "Burn(address,int24,int24,uint128,uint256,uint256)"
+                                }
+                            ]
+                        }
+                    }
                 ],
                 "events": [
                     { "signature": "Mint(address sender, address indexed owner, int24 indexed tickLower, int24 indexed tickUpper, uint128 amount, uint256 amount0, uint256 amount1)" },

--- a/config/contracts/sepolia/decay_multicurve.json
+++ b/config/contracts/sepolia/decay_multicurve.json
@@ -64,6 +64,18 @@
                 },
                 "target": "UniswapV4StateView",
                 "params": [{ "type": "bytes32", "from_event": "topics[3]" }]
+            },
+            {
+                "function": "getSlot0(bytes32)",
+                "output_type": "(uint160 sqrtPriceX96, int24 tick, uint24 protocolFee, uint24 lpFee)",
+                "frequency": {
+                    "on_events": {
+                        "source": "DecayMulticurveHook",
+                        "event": "ModifyLiquidity(bytes32,address,int24,int24,int256,bytes32)"
+                    }
+                },
+                "target": "UniswapV4StateView",
+                "params": [{ "type": "bytes32", "from_event": "topics[1]" }]
             }
         ]
     }

--- a/config/contracts/sepolia/dhook.json
+++ b/config/contracts/sepolia/dhook.json
@@ -47,6 +47,18 @@
                 },
                 "target": "UniswapV4StateView",
                 "params": [{ "type": "bytes32", "from_event": "topics[3]" }]
+            },
+            {
+                "function": "getSlot0(bytes32)",
+                "output_type": "(uint160 sqrtPriceX96, int24 tick, uint24 protocolFee, uint24 lpFee)",
+                "frequency": {
+                    "on_events": {
+                        "source": "DopplerHookInitializer",
+                        "event": "ModifyLiquidity((address,address,uint24,int24,address),(int24,int24,int256,bytes32))"
+                    }
+                },
+                "target": "UniswapV4StateView",
+                "params": [{ "type": "bytes32", "from_event": "v4_pool_id_from_key_data" }]
             }
         ]
     },

--- a/config/contracts/sepolia/scheduled_multicurve.json
+++ b/config/contracts/sepolia/scheduled_multicurve.json
@@ -64,6 +64,18 @@
                 },
                 "target": "UniswapV4StateView",
                 "params": [{ "type": "bytes32", "from_event": "topics[3]" }]
+            },
+            {
+                "function": "getSlot0(bytes32)",
+                "output_type": "(uint160 sqrtPriceX96, int24 tick, uint24 protocolFee, uint24 lpFee)",
+                "frequency": {
+                    "on_events": {
+                        "source": "UniswapV4ScheduledMulticurveInitializerHook",
+                        "event": "ModifyLiquidity(bytes32,address,int24,int24,int256,bytes32)"
+                    }
+                },
+                "target": "UniswapV4StateView",
+                "params": [{ "type": "bytes32", "from_event": "topics[1]" }]
             }
         ]
     }

--- a/config/contracts/sepolia/v4.json
+++ b/config/contracts/sepolia/v4.json
@@ -67,6 +67,20 @@
         "address": "0x4053d4fa966cbdcc20ec62070ac8814de8bee500",
         "events": [
             { "signature": "ModifyLiquidity((address currency0, address currency1, uint24 fee, int24 tickSpacing, address hooks) key, (int24 tickLower, int24 tickUpper, int256 liquidityDelta, bytes32 salt) params)" }
+        ],
+        "calls": [
+            {
+                "function": "getSlot0(bytes32)",
+                "output_type": "(uint160 sqrtPriceX96, int24 tick, uint24 protocolFee, uint24 lpFee)",
+                "frequency": {
+                    "on_events": {
+                        "source": "UniswapV4MigratorHook",
+                        "event": "ModifyLiquidity((address,address,uint24,int24,address),(int24,int24,int256,bytes32))"
+                    }
+                },
+                "target": "UniswapV4StateView",
+                "params": [{ "type": "bytes32", "from_event": "v4_pool_id_from_key_data" }]
+            }
         ]
     }
 }

--- a/config/contracts/unichain/v3.json
+++ b/config/contracts/unichain/v3.json
@@ -10,7 +10,23 @@
                     "factory_parameters": "topics[1]"
                 },
                 "calls": [
-                    { "function": "fee()", "output_type": "uint24", "frequency": "once" }
+                    { "function": "fee()", "output_type": "uint24", "frequency": "once" },
+                    {
+                        "function": "slot0()",
+                        "output_type": "(uint160 sqrtPriceX96, int24 tick, uint16 observationIndex, uint16 observationCardinality, uint16 observationCardinalityNext, uint8 feeProtocol, bool unlocked)",
+                        "frequency": {
+                            "on_events": [
+                                {
+                                    "source": "DopplerV3Pool",
+                                    "event": "Mint(address,address,int24,int24,uint128,uint256,uint256)"
+                                },
+                                {
+                                    "source": "DopplerV3Pool",
+                                    "event": "Burn(address,int24,int24,uint128,uint256,uint256)"
+                                }
+                            ]
+                        }
+                    }
                 ],
                 "events": [
                     { "signature": "Mint(address sender, address indexed owner, int24 indexed tickLower, int24 indexed tickUpper, uint128 amount, uint256 amount0, uint256 amount1)" },

--- a/config/contracts/unichain/v4.json
+++ b/config/contracts/unichain/v4.json
@@ -67,6 +67,20 @@
         "address": "0x53C050d3B09C80024138165520Bd7c078D9e2000",
         "events": [
             { "signature": "ModifyLiquidity((address currency0, address currency1, uint24 fee, int24 tickSpacing, address hooks) key, (int24 tickLower, int24 tickUpper, int256 liquidityDelta, bytes32 salt) params)" }
+        ],
+        "calls": [
+            {
+                "function": "getSlot0(bytes32)",
+                "output_type": "(uint160 sqrtPriceX96, int24 tick, uint24 protocolFee, uint24 lpFee)",
+                "frequency": {
+                    "on_events": {
+                        "source": "UniswapV4MigratorHook",
+                        "event": "ModifyLiquidity((address,address,uint24,int24,address),(int24,int24,int256,bytes32))"
+                    }
+                },
+                "target": "UniswapV4StateView",
+                "params": [{ "type": "bytes32", "from_event": "v4_pool_id_from_key_data" }]
+            }
         ]
     },
     "DopplerLens": {

--- a/docs/designs/pool-metrics/metrics_implementation_phases.md
+++ b/docs/designs/pool-metrics/metrics_implementation_phases.md
@@ -340,18 +340,20 @@ multicurve::metrics::register_handlers(registry, chain_id, multicurve_cache);
 
 ## Phase 7: TVL Computation (future)
 
-**Goal**: Compute TVL from in-memory tick maps and update pool_snapshots + pool_state.
+**Goal**: Compute TVL plus USD active-liquidity pricing from in-memory tick maps and update `pool_snapshots` + `pool_state`.
 
 ### Tasks
 1. Implement tick map store: `RwLock<HashMap<pool_id, BTreeMap<(tick_lower, tick_upper), i128>>>`
 2. Rebuild on startup from liquidity_deltas table (one GROUP BY query)
 3. Sequential pass: process liquidity_deltas in order, update tick maps, compute TVL per block
 4. TVL formula: iterate tick map positions, compute token amounts based on position vs current tick
-5. Add amount0, amount1, tvl_usd, market_cap_usd columns to pool_state and pool_snapshots
-6. Market cap = token price × total supply (total_supply from tokens table)
+5. Compute active-liquidity token amounts for positions currently in range, then convert that subset to `active_liquidity_usd`
+6. Add `amount0`, `amount1`, `tvl_usd`, `market_cap_usd`, and `active_liquidity_usd` columns to `pool_state` and `pool_snapshots`
+7. Market cap = token price × total supply (total_supply from tokens table)
 
 ### Design notes
 - This pass is sequential by nature (tick maps are cumulative state)
+- USD active-liquidity pricing is part of the same Phase 7 pass as TVL, not a separate later phase
 - Could be a separate handler or a background task
 - Consider materialized views for protocol-wide TVL aggregation
 
@@ -369,7 +371,7 @@ multicurve::metrics::register_handlers(registry, chain_id, multicurve_cache);
 - **Quote token decimals**: hardcoded lookup (WETH=18, USDC=6, USDT=6, EURC=6), extracted to shared util
 - **Indexed poolKey in Swap**: keccak hash of PoolKey = pool_id, so topics[2] = topics[3]
 - **getSlot0 on_event calls**: configured on hook contracts with `target: UniswapV4StateView`; `source_name` on decoded calls = hook contract name (not target)
-- **TVL deferred**: liquidity_deltas written in parallel, TVL computed in a separate sequential pass (Phase 7)
+- **TVL deferred**: liquidity_deltas written in parallel, TVL plus `active_liquidity_usd` computed in a separate sequential pass (Phase 7)
 - **V4 hook swap/liquidity split**: same rationale as V3 — avoids multi-trigger snapshot capture issues
 - **V4 hook metadata caches**: each pool type gets its own `Arc<PoolMetadataCache>`, not shared with create handlers (create handlers don't use the cache)
 - **Shared V4 extraction functions**: `metrics/v4_hook_extract.rs` avoids duplication across 4 handler files

--- a/docs/designs/pool-metrics/pool_metrics.md
+++ b/docs/designs/pool-metrics/pool_metrics.md
@@ -20,6 +20,12 @@ CREATE TABLE IF NOT EXISTS pool_state (
     price_change_1h  NUMERIC,               -- (phase 3+)
     price_change_24h NUMERIC,               -- (phase 3+)
     swap_count_24h   INTEGER,               -- (phase 3+)
+    amount0          NUMERIC,               -- total token0 held by pool (phase 7)
+    amount1          NUMERIC,               -- total token1 held by pool (phase 7)
+    tvl_usd          NUMERIC,               -- total pool TVL in USD (phase 7)
+    market_cap_usd   NUMERIC,               -- base token market cap in USD (phase 7)
+    active_liquidity_usd NUMERIC,           -- USD value of in-range liquidity only (phase 7)
+    total_supply     NUMERIC,               -- base token total supply (phase 7)
     source           VARCHAR(255) NOT NULL,
     source_version   INT NOT NULL,
     UNIQUE (chain_id, pool_id, source, source_version)
@@ -47,6 +53,11 @@ CREATE TABLE IF NOT EXISTS pool_snapshots (
     volume0          NUMERIC NOT NULL DEFAULT 0,   -- sum of |amount0| across all swaps
     volume1          NUMERIC NOT NULL DEFAULT 0,   -- sum of |amount1| across all swaps
     swap_count       INT NOT NULL DEFAULT 0,
+    amount0          NUMERIC,               -- total token0 held by pool (phase 7)
+    amount1          NUMERIC,               -- total token1 held by pool (phase 7)
+    tvl_usd          NUMERIC,               -- total pool TVL in USD (phase 7)
+    market_cap_usd   NUMERIC,               -- base token market cap in USD (phase 7)
+    active_liquidity_usd NUMERIC,           -- USD value of in-range liquidity only (phase 7)
     source           VARCHAR(255) NOT NULL,
     source_version   INT NOT NULL,
     UNIQUE (chain_id, pool_id, block_number, source, source_version)
@@ -397,6 +408,14 @@ The V4 base Swap event has no `poolId` field. The handler maps `event.contract_a
 
 V4 base Swap events do not emit liquidity, and Doppler auction "active liquidity" isn't directly analogous to a v3 pool's. The handler writes `active_liquidity = 0` for V4 base snapshots.
 
+### active_liquidity_usd
+
+`active_liquidity_usd` is in scope for the same Phase 7 pass as TVL. It is not a
+separate future metric. The computation uses only positions currently in range at
+the pool's current tick, converts those in-range token amounts to USD with the
+same pricing context used for `tvl_usd`, and stores the result on both
+`pool_snapshots` and `pool_state`.
+
 ---
 
 ## Handler Flow
@@ -456,9 +475,19 @@ def handle_block(block_number: int, block_timestamp, events: list, call_results:
             meta.decimals0, meta.decimals1,
         )
 
+        # compute USD value of in-range liquidity only
+        active_amount0, active_amount1 = compute_active_position_amounts(
+            tick_maps.get(pool_id, {}),
+            acc.tick, acc.sqrt_price_x96,
+            meta.decimals0, meta.decimals1,
+        )
+
         # resolve USD prices (protocol-specific)
         price0_usd, price1_usd = resolve_usd_prices(pool_id, acc.price_close)
         tvl_usd = compute_tvl_usd(amount0, amount1, price0_usd, price1_usd)
+        active_liquidity_usd = compute_tvl_usd(
+            active_amount0, active_amount1, price0_usd, price1_usd
+        )
 
         # market cap
         market_cap = compute_market_cap(price0_usd, meta.total_supply, meta.decimals0)
@@ -480,6 +509,7 @@ def handle_block(block_number: int, block_timestamp, events: list, call_results:
             pool_id, block_number, block_timestamp,
             acc.price_open, acc.price_close, acc.price_high, acc.price_low,
             acc.active_liquidity, amount0, amount1, tvl_usd, market_cap,
+            active_liquidity_usd,
             acc.volume0, acc.volume1, volume_usd, acc.swap_count,
         ))
 
@@ -489,7 +519,7 @@ def handle_block(block_number: int, block_timestamp, events: list, call_results:
             block_number, block_timestamp,
             acc.tick, acc.sqrt_price_x96,
             acc.price_close, acc.active_liquidity,
-            amount0, amount1, tvl_usd,
+            amount0, amount1, tvl_usd, active_liquidity_usd,
             meta.total_supply, market_cap,
             volume_24h, price_change_1h, price_change_24h,
             acc.swap_count,  # this is just this block, accumulate differently for 24h
@@ -530,6 +560,7 @@ def rebuild_tick_maps():
 ```sql
 -- Top pools by market cap, page 2
 SELECT pool_id, price, market_cap_usd, active_liquidity,
+       active_liquidity_usd,
        tvl_usd, volume_24h_usd, price_change_24h
 FROM pool_state
 ORDER BY market_cap_usd DESC NULLS LAST
@@ -564,6 +595,7 @@ SELECT
     sum(volume_usd) AS volume,
     (array_agg(market_cap_usd ORDER BY block_number DESC))[1] AS market_cap,
     (array_agg(active_liquidity ORDER BY block_number DESC))[1] AS active_liquidity,
+    (array_agg(active_liquidity_usd ORDER BY block_number DESC))[1] AS active_liquidity_usd,
     (array_agg(tvl_usd ORDER BY block_number DESC))[1] AS tvl
 FROM pool_snapshots
 WHERE pool_id = $1

--- a/migrations/tables/pool_snapshots_add_active_liquidity_usd.sql
+++ b/migrations/tables/pool_snapshots_add_active_liquidity_usd.sql
@@ -1,0 +1,3 @@
+-- Phase 7 extension: USD value of in-range (active) positions at snapshot block.
+-- Populated by the shared TVL compute module alongside tvl_usd.
+ALTER TABLE pool_snapshots ADD COLUMN IF NOT EXISTS active_liquidity_usd NUMERIC;

--- a/migrations/tables/pool_state_add_active_liquidity_usd.sql
+++ b/migrations/tables/pool_state_add_active_liquidity_usd.sql
@@ -1,0 +1,3 @@
+-- Phase 7 extension: USD value of in-range (active) positions at the current
+-- pool_state block. Populated by the shared TVL compute module alongside tvl_usd.
+ALTER TABLE pool_state ADD COLUMN IF NOT EXISTS active_liquidity_usd NUMERIC;

--- a/src/live/compaction.rs
+++ b/src/live/compaction.rs
@@ -254,11 +254,7 @@ impl CompactionService {
                         );
                     }
                     Err(e) => {
-                        tracing::debug!(
-                            "Retry channel full for block {}: {}",
-                            block_number,
-                            e
-                        );
+                        tracing::debug!("Retry channel full for block {}: {}", block_number, e);
                     }
                 }
             }

--- a/src/raw_data/historical/catchup/eth_calls.rs
+++ b/src/raw_data/historical/catchup/eth_calls.rs
@@ -893,13 +893,12 @@ pub async fn collect_eth_calls(
         let scoped_log_range_count = log_ranges
             .iter()
             .filter(|log_range| {
-                repair_scope.is_none_or(|scope| {
-                    scope.matches_range(log_range.start, log_range.end)
-                }) && !active_event_output_pairs_for_range(
-                    &catchup_event_call_configs,
-                    log_range.end,
-                )
-                .is_empty()
+                repair_scope.is_none_or(|scope| scope.matches_range(log_range.start, log_range.end))
+                    && !active_event_output_pairs_for_range(
+                        &catchup_event_call_configs,
+                        log_range.end,
+                    )
+                    .is_empty()
             })
             .count();
 

--- a/src/raw_data/historical/eth_calls/event_triggers.rs
+++ b/src/raw_data/historical/eth_calls/event_triggers.rs
@@ -31,6 +31,7 @@ use crate::types::config::contract::{AddressOrAddresses, Contracts};
 use crate::types::config::eth_call::{
     encode_call_with_params, EventFieldLocation, EvmType, ParamConfig,
 };
+use crate::types::uniswap::v4::PoolKey;
 
 /// Pending write tasks spawned by process functions.
 /// Returned to the caller so writes can be awaited after releasing concurrency permits.
@@ -227,6 +228,66 @@ pub(crate) fn extract_param_from_event(
             word.copy_from_slice(&trigger.data[start..end]);
             extract_value_from_32_bytes(&word, param_type)
         }
+        EventFieldLocation::V4PoolIdFromKeyData => {
+            extract_v4_pool_id_from_key_data(trigger, param_type)
+        }
+    }
+}
+
+fn extract_v4_pool_id_from_key_data(
+    trigger: &EventTriggerData,
+    param_type: &EvmType,
+) -> Result<(DynSolValue, Vec<u8>), EthCallCollectionError> {
+    if !matches!(param_type, EvmType::Bytes32) {
+        return Err(EthCallCollectionError::EventParamExtraction(format!(
+            "from_event: \"v4_pool_id_from_key_data\" requires param type to be bytes32, got {:?}",
+            param_type
+        )));
+    }
+
+    if trigger.data.len() < 5 * 32 {
+        return Err(EthCallCollectionError::EventParamExtraction(format!(
+            "v4_pool_id_from_key_data requires at least 160 bytes of event data, got {}",
+            trigger.data.len()
+        )));
+    }
+
+    let word = |idx: usize| -> [u8; 32] {
+        let start = idx * 32;
+        let mut out = [0u8; 32];
+        out.copy_from_slice(&trigger.data[start..start + 32]);
+        out
+    };
+
+    let pool_id = PoolKey {
+        currency0: Address::from(address_from_word(&word(0))),
+        currency1: Address::from(address_from_word(&word(1))),
+        fee: uint24_from_word(&word(2)),
+        tick_spacing: int24_from_word(&word(3)),
+        hooks: Address::from(address_from_word(&word(4))),
+    }
+    .pool_id();
+
+    let encoded = DynSolValue::FixedBytes(pool_id, 32).abi_encode();
+    Ok((DynSolValue::FixedBytes(pool_id, 32), encoded))
+}
+
+fn address_from_word(word: &[u8; 32]) -> [u8; 20] {
+    let mut addr = [0u8; 20];
+    addr.copy_from_slice(&word[12..32]);
+    addr
+}
+
+fn uint24_from_word(word: &[u8; 32]) -> u32 {
+    ((word[29] as u32) << 16) | ((word[30] as u32) << 8) | (word[31] as u32)
+}
+
+fn int24_from_word(word: &[u8; 32]) -> i32 {
+    let raw = ((word[29] as i32) << 16) | ((word[30] as i32) << 8) | (word[31] as i32);
+    if (raw & 0x80_0000) != 0 {
+        raw | !0x00FF_FFFF
+    } else {
+        raw
     }
 }
 
@@ -1523,4 +1584,71 @@ pub(crate) fn build_event_call_schema(num_params: usize) -> Arc<Schema> {
     }
 
     Arc::new(Schema::new(fields))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_param_from_event;
+    use crate::raw_data::historical::receipts::EventTriggerData;
+    use crate::types::config::eth_call::{EventFieldLocation, EvmType};
+    use crate::types::uniswap::v4::PoolKey;
+    use alloy::dyn_abi::DynSolValue;
+    use alloy::primitives::Address;
+    use alloy::sol;
+    use alloy::sol_types::SolValue;
+
+    sol! {
+        struct TestPoolKey {
+            address currency0;
+            address currency1;
+            uint24 fee;
+            int24 tickSpacing;
+            address hooks;
+        }
+    }
+
+    #[test]
+    fn test_extract_param_from_event_v4_pool_id_from_key_data() {
+        let currency0 = Address::from([0x11; 20]);
+        let currency1 = Address::from([0x22; 20]);
+        let hooks = Address::from([0x33; 20]);
+        let fee = 3000u32;
+        let tick_spacing = -60i32;
+
+        let trigger = EventTriggerData {
+            block_number: 100,
+            block_timestamp: 200,
+            log_index: 0,
+            emitter_address: [0u8; 20],
+            source_name: "test".to_string(),
+            event_signature: [0u8; 32],
+            topics: vec![[0u8; 32]],
+            data: TestPoolKey {
+                currency0,
+                currency1,
+                fee: fee.try_into().unwrap(),
+                tickSpacing: tick_spacing.try_into().unwrap(),
+                hooks,
+            }
+            .abi_encode(),
+        };
+
+        let (value, _encoded) = extract_param_from_event(
+            &trigger,
+            &EventFieldLocation::V4PoolIdFromKeyData,
+            &EvmType::Bytes32,
+        )
+        .expect("pool id extraction should succeed");
+
+        let expected = PoolKey {
+            currency0,
+            currency1,
+            fee,
+            tick_spacing,
+            hooks,
+        }
+        .pool_id();
+
+        assert_eq!(value, DynSolValue::FixedBytes(expected, 32));
+    }
 }

--- a/src/transformations/event/metrics/mod.rs
+++ b/src/transformations/event/metrics/mod.rs
@@ -5,4 +5,5 @@
 
 pub mod accumulator;
 pub mod swap_data;
+pub mod tvl;
 pub mod v4_hook_extract;

--- a/src/transformations/event/metrics/swap_data.rs
+++ b/src/transformations/event/metrics/swap_data.rs
@@ -277,6 +277,7 @@ FROM (
   ) h24h ON true
   WHERE s.chain_id = $1 AND s.pool_id = $2
     AND s.block_timestamp > ($4 - 86400)
+    AND s.block_timestamp <= $4
 ) sub
 WHERE pool_state.chain_id = $1
   AND pool_state.pool_id = $2
@@ -551,6 +552,7 @@ mod tests {
                 assert!(query.contains("volume_24h_usd"));
                 assert!(query.contains("price_change_1h"));
                 assert!(query.contains("pool_state.block_number = $5"));
+                assert!(query.contains("s.block_timestamp <= $4"));
                 assert_eq!(params.len(), 7);
                 let snapshot = snapshot
                     .as_ref()

--- a/src/transformations/event/metrics/swap_data.rs
+++ b/src/transformations/event/metrics/swap_data.rs
@@ -383,11 +383,7 @@ pub async fn refresh_cache_if_needed(
         .collect();
 
     if !still_missing.is_empty() {
-        let sample: Vec<String> = still_missing
-            .iter()
-            .take(10)
-            .map(hex::encode)
-            .collect();
+        let sample: Vec<String> = still_missing.iter().take(10).map(hex::encode).collect();
         tracing::warn!(
             handler = handler_name,
             source = source_name,

--- a/src/transformations/event/metrics/tvl.rs
+++ b/src/transformations/event/metrics/tvl.rs
@@ -239,13 +239,33 @@ fn optional_u256_value(value: Option<&U256>) -> DbValue {
     }
 }
 
+fn optional_i32_value(value: Option<i32>) -> DbValue {
+    match value {
+        Some(v) => DbValue::Int32(v),
+        None => DbValue::Null,
+    }
+}
+
+/// Bootstrap state for LP-only TVL materialization when there is no prior
+/// `pool_state`/`pool_snapshots` row yet for the pool.
+///
+/// Future TVL callers are expected to derive this from per-block state sources
+/// such as V3 `slot0`, V4 hook `getSlot0`, or a pool-type-specific equivalent.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TvlBootstrapSeed {
+    pub tick: i32,
+    pub sqrt_price_x96: U256,
+    pub price: BigDecimal,
+}
+
 /// Build a `DbOperation::RawSql` upsert that populates TVL columns on a
 /// `pool_snapshots` row owned by the given `target_source` handler.
 ///
 /// If the per-block snapshot row already exists (the swap path wrote it first),
 /// this updates only TVL-related columns. Otherwise it materializes a new
 /// LP-only block row by carrying forward the latest known `price_close` into
-/// OHLC and initializing swap volumes/counts to zero.
+/// OHLC, or by seeding from `bootstrap_seed` when no prior snapshot exists,
+/// while initializing swap volumes/counts to zero.
 pub fn build_snapshot_tvl_update(
     chain_id: u64,
     pool_id: &[u8],
@@ -257,10 +277,30 @@ pub fn build_snapshot_tvl_update(
     tvl_usd: Option<&BigDecimal>,
     market_cap_usd: Option<&BigDecimal>,
     active_liquidity_usd: Option<&BigDecimal>,
+    bootstrap_seed: Option<&TvlBootstrapSeed>,
     target_source: &str,
     target_source_version: u32,
 ) -> DbOperation {
     let query = r#"
+WITH prev AS (
+  SELECT price_close
+  FROM pool_snapshots
+  WHERE chain_id = $1
+    AND pool_id = $2
+    AND block_number <= $3
+    AND source = $11
+    AND source_version = $12
+  ORDER BY block_number DESC
+  LIMIT 1
+),
+seed_price AS (
+  SELECT prev.price_close
+  FROM prev
+  UNION ALL
+  SELECT $13::numeric
+  WHERE NOT EXISTS (SELECT 1 FROM prev)
+    AND $13::numeric IS NOT NULL
+)
 INSERT INTO pool_snapshots (
   chain_id,
   pool_id,
@@ -288,10 +328,10 @@ SELECT
   $2,
   $3,
   $4,
-  prev.price_close,
-  prev.price_close,
-  prev.price_close,
-  prev.price_close,
+  seed_price.price_close,
+  seed_price.price_close,
+  seed_price.price_close,
+  seed_price.price_close,
   $5,
   0::numeric,
   0::numeric,
@@ -304,17 +344,7 @@ SELECT
   $10,
   $11,
   $12
-FROM LATERAL (
-  SELECT price_close
-  FROM pool_snapshots
-  WHERE chain_id = $1
-    AND pool_id = $2
-    AND block_number <= $3
-    AND source = $11
-    AND source_version = $12
-  ORDER BY block_number DESC
-  LIMIT 1
-) AS prev
+FROM seed_price
 ON CONFLICT (chain_id, pool_id, block_number, source, source_version)
 DO UPDATE SET
   block_timestamp = EXCLUDED.block_timestamp,
@@ -341,6 +371,7 @@ DO UPDATE SET
             optional_decimal_value(active_liquidity_usd),
             DbValue::VarChar(target_source.to_string()),
             DbValue::Int32(target_source_version as i32),
+            optional_decimal_value(bootstrap_seed.map(|seed| &seed.price)),
         ],
         snapshot: Some(DbSnapshot {
             table: "pool_snapshots".to_string(),
@@ -368,11 +399,12 @@ DO UPDATE SET
 /// `pool_state` row owned by the given `target_source` handler.
 ///
 /// If the latest `pool_state` row is at or before `block_number`, this advances
-/// that row to the new block while carrying forward price/tick fields and the
-/// rolling 24h metrics. If a swap path already wrote the target block, the
-/// conflict update fills in TVL columns in place. If `pool_state` has already
-/// advanced past `block_number`, the `SELECT` yields no row and the statement is
-/// intentionally a no-op rather than overwriting newer state.
+/// that row to the new block while carrying forward price/tick fields and
+/// recomputing the rolling metrics for the new timestamp. If no prior state row
+/// exists yet, `bootstrap_seed` provides the initial tick/price anchor. If a
+/// swap path already wrote the target block, the conflict update fills in TVL
+/// columns in place. If `pool_state` has already advanced past `block_number`,
+/// the statement is intentionally a no-op rather than overwriting newer state.
 pub fn build_state_tvl_update(
     chain_id: u64,
     pool_id: &[u8],
@@ -385,10 +417,53 @@ pub fn build_state_tvl_update(
     market_cap_usd: Option<&BigDecimal>,
     active_liquidity_usd: Option<&BigDecimal>,
     total_supply: Option<&U256>,
+    bootstrap_seed: Option<&TvlBootstrapSeed>,
     target_source: &str,
     target_source_version: u32,
 ) -> DbOperation {
     let query = r#"
+WITH prev AS (
+  SELECT
+    block_number,
+    tick,
+    sqrt_price_x96,
+    price
+  FROM pool_state
+  WHERE chain_id = $1
+    AND pool_id = $2
+    AND source = $12
+    AND source_version = $13
+    AND block_number <= $3
+  ORDER BY block_number DESC
+  LIMIT 1
+),
+newer AS (
+  SELECT 1
+  FROM pool_state
+  WHERE chain_id = $1
+    AND pool_id = $2
+    AND source = $12
+    AND source_version = $13
+    AND block_number > $3
+  LIMIT 1
+),
+state_seed AS (
+  SELECT
+    prev.tick,
+    prev.sqrt_price_x96,
+    prev.price
+  FROM prev
+  UNION ALL
+  SELECT
+    $14::integer,
+    $15::numeric,
+    $16::numeric
+  WHERE NOT EXISTS (SELECT 1 FROM prev)
+    AND NOT EXISTS (SELECT 1 FROM newer)
+    AND $14::integer IS NOT NULL
+    AND $15::numeric IS NOT NULL
+    AND $16::numeric IS NOT NULL
+)
 INSERT INTO pool_state (
   chain_id,
   pool_id,
@@ -416,14 +491,14 @@ SELECT
   $2,
   $3,
   $4,
-  prev.tick,
-  prev.sqrt_price_x96,
-  prev.price,
+  state_seed.tick,
+  state_seed.sqrt_price_x96,
+  state_seed.price,
   $5,
-  prev.volume_24h_usd,
-  prev.price_change_1h,
-  prev.price_change_24h,
-  prev.swap_count_24h,
+  rolling.vol_24h,
+  rolling.pc_1h,
+  rolling.pc_24h,
+  rolling.swaps_24h,
   $6,
   $7,
   $8,
@@ -432,12 +507,41 @@ SELECT
   $11,
   $12,
   $13
-FROM pool_state AS prev
-WHERE prev.chain_id = $1
-  AND prev.pool_id = $2
-  AND prev.source = $12
-  AND prev.source_version = $13
-  AND prev.block_number <= $3
+FROM state_seed
+CROSS JOIN LATERAL (
+  SELECT
+    COALESCE(SUM(s.volume_usd), 0) AS vol_24h,
+    COALESCE(SUM(s.swap_count), 0)::integer AS swaps_24h,
+    CASE WHEN h1h.price_close IS NOT NULL AND h1h.price_close != 0
+         THEN (state_seed.price - h1h.price_close) / h1h.price_close
+    END AS pc_1h,
+    CASE WHEN h24h.price_close IS NOT NULL AND h24h.price_close != 0
+         THEN (state_seed.price - h24h.price_close) / h24h.price_close
+    END AS pc_24h
+  FROM pool_snapshots s
+  LEFT JOIN LATERAL (
+    SELECT price_close
+    FROM pool_snapshots
+    WHERE chain_id = $1
+      AND pool_id = $2
+      AND block_timestamp <= ($4 - 3600)
+    ORDER BY block_timestamp DESC, block_number DESC
+    LIMIT 1
+  ) h1h ON true
+  LEFT JOIN LATERAL (
+    SELECT price_close
+    FROM pool_snapshots
+    WHERE chain_id = $1
+      AND pool_id = $2
+      AND block_timestamp <= ($4 - 86400)
+    ORDER BY block_timestamp DESC, block_number DESC
+    LIMIT 1
+  ) h24h ON true
+  WHERE s.chain_id = $1
+    AND s.pool_id = $2
+    AND s.block_timestamp > ($4 - 86400)
+    AND s.block_timestamp <= $4
+) AS rolling
 ON CONFLICT (chain_id, pool_id, source, source_version)
 DO UPDATE SET
   block_number = EXCLUDED.block_number,
@@ -475,6 +579,12 @@ WHERE EXCLUDED.block_number >= pool_state.block_number
             optional_u256_value(total_supply),
             DbValue::VarChar(target_source.to_string()),
             DbValue::Int32(target_source_version as i32),
+            optional_i32_value(bootstrap_seed.map(|seed| seed.tick)),
+            match bootstrap_seed {
+                Some(seed) => DbValue::Numeric(seed.sqrt_price_x96.to_string()),
+                None => DbValue::Null,
+            },
+            optional_decimal_value(bootstrap_seed.map(|seed| &seed.price)),
         ],
         snapshot: Some(DbSnapshot {
             table: "pool_state".to_string(),
@@ -532,6 +642,14 @@ mod tests {
             None,
             None,
         )
+    }
+
+    fn sample_bootstrap_seed() -> TvlBootstrapSeed {
+        TvlBootstrapSeed {
+            tick: 42,
+            sqrt_price_x96: q96(),
+            price: bd("2"),
+        }
     }
 
     // ─── compute_position_amounts ───
@@ -812,6 +930,7 @@ mod tests {
 
     #[test]
     fn test_build_snapshot_tvl_update_structure() {
+        let bootstrap_seed = sample_bootstrap_seed();
         let op = build_snapshot_tvl_update(
             8453,
             &[0xAAu8; 20],
@@ -823,6 +942,7 @@ mod tests {
             Some(&bd("5000")),
             Some(&bd("4000000000000")),
             Some(&bd("3200")),
+            Some(&bootstrap_seed),
             "V3SwapMetricsHandler",
             1,
         );
@@ -833,7 +953,9 @@ mod tests {
                 snapshot,
             } => {
                 assert!(query.contains("INSERT INTO pool_snapshots"));
-                assert!(query.contains("prev.price_close"));
+                assert!(query.contains("WITH prev AS"));
+                assert!(query.contains("FROM seed_price"));
+                assert!(query.contains("SELECT $13::numeric"));
                 assert!(query.contains(
                     "ON CONFLICT (chain_id, pool_id, block_number, source, source_version)"
                 ));
@@ -841,10 +963,14 @@ mod tests {
                 assert!(query.contains("active_liquidity_usd = EXCLUDED.active_liquidity_usd"));
                 assert!(query.contains("source = $11"));
                 assert!(query.contains("source_version = $12"));
-                assert_eq!(params.len(), 12);
+                assert_eq!(params.len(), 13);
                 match &params[9] {
                     DbValue::Numeric(s) => assert_eq!(s, "3200"),
                     other => panic!("expected Numeric for active_liquidity_usd, got {:?}", other),
+                }
+                match &params[12] {
+                    DbValue::Numeric(s) => assert_eq!(s, "2"),
+                    other => panic!("expected Numeric for bootstrap seed price, got {:?}", other),
                 }
 
                 let snap = snapshot.expect("snapshot should be present");
@@ -879,15 +1005,18 @@ mod tests {
             None,
             None,
             None,
+            None,
             "V3SwapMetricsHandler",
             1,
         );
         match op {
             DbOperation::RawSql { params, .. } => {
-                // params[7] = tvl_usd, [8] = market_cap_usd, [9] = active_liquidity_usd
+                // params[7] = tvl_usd, [8] = market_cap_usd, [9] = active_liquidity_usd,
+                // [12] = bootstrap price
                 assert!(matches!(params[7], DbValue::Null));
                 assert!(matches!(params[8], DbValue::Null));
                 assert!(matches!(params[9], DbValue::Null));
+                assert!(matches!(params[12], DbValue::Null));
             }
             _ => panic!("expected RawSql"),
         }
@@ -898,6 +1027,7 @@ mod tests {
     #[test]
     fn test_build_state_tvl_update_structure() {
         let supply = U256::from(1_000_000_000u64);
+        let bootstrap_seed = sample_bootstrap_seed();
         let op = build_state_tvl_update(
             8453,
             &[0xAAu8; 20],
@@ -910,6 +1040,7 @@ mod tests {
             Some(&bd("4000000000000")),
             Some(&bd("3200")),
             Some(&supply),
+            Some(&bootstrap_seed),
             "V3SwapMetricsHandler",
             1,
         );
@@ -920,15 +1051,37 @@ mod tests {
                 snapshot,
             } => {
                 assert!(query.contains("INSERT INTO pool_state"));
-                assert!(query.contains("prev.volume_24h_usd"));
+                assert!(query.contains("WITH prev AS"));
+                assert!(query.contains("$14::integer"));
+                assert!(query.contains("CROSS JOIN LATERAL"));
+                assert!(query.contains("COALESCE(SUM(s.volume_usd), 0) AS vol_24h"));
+                assert!(query.contains("s.block_timestamp <= $4"));
+                assert!(!query.contains("prev.volume_24h_usd"));
+                assert!(!query.contains("prev.price_change_1h"));
                 assert!(query.contains("ON CONFLICT (chain_id, pool_id, source, source_version)"));
                 assert!(query.contains("active_liquidity_usd = EXCLUDED.active_liquidity_usd"));
                 assert!(query.contains("WHERE EXCLUDED.block_number >= pool_state.block_number"));
-                assert!(query.contains("prev.block_number <= $3"));
-                assert_eq!(params.len(), 13);
+                assert_eq!(params.len(), 16);
                 match &params[9] {
                     DbValue::Numeric(s) => assert_eq!(s, "3200"),
                     other => panic!("expected Numeric for active_liquidity_usd, got {:?}", other),
+                }
+                match &params[13] {
+                    DbValue::Int32(v) => assert_eq!(*v, 42),
+                    other => panic!("expected Int32 for bootstrap tick, got {:?}", other),
+                }
+                match &params[14] {
+                    DbValue::Numeric(s) => assert_eq!(s, &q96().to_string()),
+                    other => {
+                        panic!(
+                            "expected Numeric for bootstrap sqrt_price_x96, got {:?}",
+                            other
+                        )
+                    }
+                }
+                match &params[15] {
+                    DbValue::Numeric(s) => assert_eq!(s, "2"),
+                    other => panic!("expected Numeric for bootstrap price, got {:?}", other),
                 }
 
                 let snap = snapshot.expect("snapshot should be present");
@@ -958,17 +1111,21 @@ mod tests {
             None,
             None,
             None,
+            None,
             "V3SwapMetricsHandler",
             1,
         );
         match op {
             DbOperation::RawSql { params, .. } => {
                 // params[7] = tvl_usd, [8] = market_cap_usd, [9] = active_liquidity_usd,
-                // [10] = total_supply
+                // [10] = total_supply, [13..=15] = bootstrap seed
                 assert!(matches!(params[7], DbValue::Null));
                 assert!(matches!(params[8], DbValue::Null));
                 assert!(matches!(params[9], DbValue::Null));
                 assert!(matches!(params[10], DbValue::Null));
+                assert!(matches!(params[13], DbValue::Null));
+                assert!(matches!(params[14], DbValue::Null));
+                assert!(matches!(params[15], DbValue::Null));
             }
             _ => panic!("expected RawSql"),
         }

--- a/src/transformations/event/metrics/tvl.rs
+++ b/src/transformations/event/metrics/tvl.rs
@@ -2,7 +2,8 @@
 //!
 //! Rebuilds per-pool tick maps on demand from the `liquidity_deltas` table,
 //! computes token amounts via Uniswap v3 position math, and produces
-//! `DbOperation::RawSql` UPDATE ops for `pool_snapshots` + `pool_state`.
+//! `DbOperation::RawSql` materializing upserts for `pool_snapshots` +
+//! `pool_state`.
 //!
 //! Stateless by design: each `handle()` invocation re-queries
 //! `liquidity_deltas` per target block. This trades a small amount of extra
@@ -190,19 +191,35 @@ pub fn compute_market_cap_usd(
     usd_ctx.quote_decimal_amount_to_usd(&value_in_quote, &meta.quote_token)
 }
 
-// ─── UPDATE op builders ─────────────────────────────────────────────
+// ─── TVL row builders ───────────────────────────────────────────────
 
-/// Build a `DbOperation::RawSql` UPDATE that populates TVL columns on a
+fn optional_decimal_value(value: Option<&BigDecimal>) -> DbValue {
+    match value {
+        Some(v) => DbValue::Numeric(v.to_string()),
+        None => DbValue::Null,
+    }
+}
+
+fn optional_u256_value(value: Option<&U256>) -> DbValue {
+    match value {
+        Some(v) => DbValue::Numeric(v.to_string()),
+        None => DbValue::Null,
+    }
+}
+
+/// Build a `DbOperation::RawSql` upsert that populates TVL columns on a
 /// `pool_snapshots` row owned by the given `target_source` handler.
 ///
-/// Targets a single `(chain_id, pool_id, block_number, source, source_version)`
-/// row. Includes a [`DbSnapshot`] so the executor can record the pre-update
-/// column values and roll them back on reorg. Mirrors the pattern used by
-/// Phase 6's `build_rolling_metrics_update` in `swap_data.rs`.
+/// If the per-block snapshot row already exists (the swap path wrote it first),
+/// this updates only TVL-related columns. Otherwise it materializes a new
+/// LP-only block row by carrying forward the latest known `price_close` into
+/// OHLC and initializing swap volumes/counts to zero.
 pub fn build_snapshot_tvl_update(
     chain_id: u64,
     pool_id: &[u8],
     block_number: u64,
+    block_timestamp: u64,
+    active_liquidity: &BigDecimal,
     amount0: &BigDecimal,
     amount1: &BigDecimal,
     tvl_usd: Option<&BigDecimal>,
@@ -210,36 +227,81 @@ pub fn build_snapshot_tvl_update(
     target_source: &str,
     target_source_version: u32,
 ) -> DbOperation {
-    let query = "UPDATE pool_snapshots SET \
-                   amount0 = $1, \
-                   amount1 = $2, \
-                   tvl_usd = $3, \
-                   market_cap_usd = $4 \
-                 WHERE chain_id = $5 \
-                   AND pool_id = $6 \
-                   AND block_number = $7 \
-                   AND source = $8 \
-                   AND source_version = $9";
-
-    let tvl_param = match tvl_usd {
-        Some(v) => DbValue::Numeric(v.to_string()),
-        None => DbValue::Null,
-    };
-    let mcap_param = match market_cap_usd {
-        Some(v) => DbValue::Numeric(v.to_string()),
-        None => DbValue::Null,
-    };
+    let query = r#"
+INSERT INTO pool_snapshots (
+  chain_id,
+  pool_id,
+  block_number,
+  block_timestamp,
+  price_open,
+  price_close,
+  price_high,
+  price_low,
+  active_liquidity,
+  volume0,
+  volume1,
+  swap_count,
+  volume_usd,
+  amount0,
+  amount1,
+  tvl_usd,
+  market_cap_usd,
+  source,
+  source_version
+)
+SELECT
+  $1,
+  $2,
+  $3,
+  $4,
+  prev.price_close,
+  prev.price_close,
+  prev.price_close,
+  prev.price_close,
+  $5,
+  0::numeric,
+  0::numeric,
+  0,
+  NULL::numeric,
+  $6,
+  $7,
+  $8,
+  $9,
+  $10,
+  $11
+FROM LATERAL (
+  SELECT price_close
+  FROM pool_snapshots
+  WHERE chain_id = $1
+    AND pool_id = $2
+    AND block_number <= $3
+    AND source = $10
+    AND source_version = $11
+  ORDER BY block_number DESC
+  LIMIT 1
+) AS prev
+ON CONFLICT (chain_id, pool_id, block_number, source, source_version)
+DO UPDATE SET
+  block_timestamp = EXCLUDED.block_timestamp,
+  active_liquidity = EXCLUDED.active_liquidity,
+  amount0 = EXCLUDED.amount0,
+  amount1 = EXCLUDED.amount1,
+  tvl_usd = EXCLUDED.tvl_usd,
+  market_cap_usd = EXCLUDED.market_cap_usd
+"#;
 
     DbOperation::RawSql {
         query: query.to_string(),
         params: vec![
-            DbValue::Numeric(amount0.to_string()),
-            DbValue::Numeric(amount1.to_string()),
-            tvl_param,
-            mcap_param,
             DbValue::Int64(chain_id as i64),
             DbValue::Bytes(pool_id.to_vec()),
             DbValue::Int64(block_number as i64),
+            DbValue::Int64(block_timestamp as i64),
+            DbValue::Numeric(active_liquidity.to_string()),
+            DbValue::Numeric(amount0.to_string()),
+            DbValue::Numeric(amount1.to_string()),
+            optional_decimal_value(tvl_usd),
+            optional_decimal_value(market_cap_usd),
             DbValue::VarChar(target_source.to_string()),
             DbValue::Int32(target_source_version as i32),
         ],
@@ -265,17 +327,21 @@ pub fn build_snapshot_tvl_update(
     }
 }
 
-/// Build a `DbOperation::RawSql` UPDATE that populates TVL columns on the
+/// Build a `DbOperation::RawSql` upsert that populates TVL columns on the
 /// `pool_state` row owned by the given `target_source` handler.
 ///
-/// Gated on `pool_state.block_number = $block_number` so a parallel later
-/// range that already advanced pool_state past our target block is not
-/// overwritten with stale TVL. Also updates `total_supply` for dashboard
-/// convenience when available.
+/// If the latest `pool_state` row is at or before `block_number`, this advances
+/// that row to the new block while carrying forward price/tick fields and the
+/// rolling 24h metrics. If a swap path already wrote the target block, the
+/// conflict update fills in TVL columns in place. If `pool_state` has already
+/// advanced past `block_number`, the `SELECT` yields no row and the statement is
+/// intentionally a no-op rather than overwriting newer state.
 pub fn build_state_tvl_update(
     chain_id: u64,
     pool_id: &[u8],
     block_number: u64,
+    block_timestamp: u64,
+    active_liquidity: &BigDecimal,
     amount0: &BigDecimal,
     amount1: &BigDecimal,
     tvl_usd: Option<&BigDecimal>,
@@ -284,42 +350,87 @@ pub fn build_state_tvl_update(
     target_source: &str,
     target_source_version: u32,
 ) -> DbOperation {
-    let query = "UPDATE pool_state SET \
-                   amount0 = $1, \
-                   amount1 = $2, \
-                   tvl_usd = $3, \
-                   market_cap_usd = $4, \
-                   total_supply = $5 \
-                 WHERE chain_id = $6 \
-                   AND pool_id = $7 \
-                   AND block_number = $8 \
-                   AND source = $9 \
-                   AND source_version = $10";
-
-    let tvl_param = match tvl_usd {
-        Some(v) => DbValue::Numeric(v.to_string()),
-        None => DbValue::Null,
-    };
-    let mcap_param = match market_cap_usd {
-        Some(v) => DbValue::Numeric(v.to_string()),
-        None => DbValue::Null,
-    };
-    let supply_param = match total_supply {
-        Some(v) => DbValue::Numeric(v.to_string()),
-        None => DbValue::Null,
-    };
+    let query = r#"
+INSERT INTO pool_state (
+  chain_id,
+  pool_id,
+  block_number,
+  block_timestamp,
+  tick,
+  sqrt_price_x96,
+  price,
+  active_liquidity,
+  volume_24h_usd,
+  price_change_1h,
+  price_change_24h,
+  swap_count_24h,
+  amount0,
+  amount1,
+  tvl_usd,
+  market_cap_usd,
+  total_supply,
+  source,
+  source_version
+)
+SELECT
+  $1,
+  $2,
+  $3,
+  $4,
+  prev.tick,
+  prev.sqrt_price_x96,
+  prev.price,
+  $5,
+  prev.volume_24h_usd,
+  prev.price_change_1h,
+  prev.price_change_24h,
+  prev.swap_count_24h,
+  $6,
+  $7,
+  $8,
+  $9,
+  $10,
+  $11,
+  $12
+FROM pool_state AS prev
+WHERE prev.chain_id = $1
+  AND prev.pool_id = $2
+  AND prev.source = $11
+  AND prev.source_version = $12
+  AND prev.block_number <= $3
+ON CONFLICT (chain_id, pool_id, source, source_version)
+DO UPDATE SET
+  block_number = EXCLUDED.block_number,
+  block_timestamp = EXCLUDED.block_timestamp,
+  tick = EXCLUDED.tick,
+  sqrt_price_x96 = EXCLUDED.sqrt_price_x96,
+  price = EXCLUDED.price,
+  active_liquidity = EXCLUDED.active_liquidity,
+  volume_24h_usd = EXCLUDED.volume_24h_usd,
+  price_change_1h = EXCLUDED.price_change_1h,
+  price_change_24h = EXCLUDED.price_change_24h,
+  swap_count_24h = EXCLUDED.swap_count_24h,
+  amount0 = EXCLUDED.amount0,
+  amount1 = EXCLUDED.amount1,
+  tvl_usd = EXCLUDED.tvl_usd,
+  market_cap_usd = EXCLUDED.market_cap_usd,
+  total_supply = EXCLUDED.total_supply
+WHERE EXCLUDED.block_number >= pool_state.block_number
+"#;
 
     DbOperation::RawSql {
         query: query.to_string(),
         params: vec![
-            DbValue::Numeric(amount0.to_string()),
-            DbValue::Numeric(amount1.to_string()),
-            tvl_param,
-            mcap_param,
-            supply_param,
             DbValue::Int64(chain_id as i64),
             DbValue::Bytes(pool_id.to_vec()),
             DbValue::Int64(block_number as i64),
+            DbValue::Int64(block_timestamp as i64),
+            DbValue::Numeric(active_liquidity.to_string()),
+            DbValue::Numeric(amount0.to_string()),
+            DbValue::Numeric(amount1.to_string()),
+            optional_decimal_value(tvl_usd),
+            optional_decimal_value(market_cap_usd),
+            optional_u256_value(total_supply),
             DbValue::VarChar(target_source.to_string()),
             DbValue::Int32(target_source_version as i32),
         ],
@@ -501,14 +612,7 @@ mod tests {
     fn test_compute_tvl_usd_zero_amounts() {
         let meta = sample_meta(true, None);
         let usd_ctx = sample_usd_ctx(Some("2000"));
-        let tvl = compute_tvl_usd(
-            &U256::ZERO,
-            &U256::ZERO,
-            &meta,
-            &bd("2"),
-            &usd_ctx,
-        )
-        .unwrap();
+        let tvl = compute_tvl_usd(&U256::ZERO, &U256::ZERO, &meta, &bd("2"), &usd_ctx).unwrap();
         assert_eq!(tvl, bd("0"));
     }
 
@@ -582,6 +686,8 @@ mod tests {
             8453,
             &[0xAAu8; 20],
             1000,
+            1_700_000_000,
+            &bd("9.75"),
             &bd("1.5"),
             &bd("2.25"),
             Some(&bd("5000")),
@@ -595,26 +701,20 @@ mod tests {
                 params,
                 snapshot,
             } => {
-                assert!(query.contains("UPDATE pool_snapshots"));
-                assert!(query.contains("amount0 = $1"));
-                assert!(query.contains("amount1 = $2"));
-                assert!(query.contains("tvl_usd = $3"));
-                assert!(query.contains("market_cap_usd = $4"));
-                assert!(query.contains("WHERE chain_id = $5"));
-                assert!(query.contains("AND pool_id = $6"));
-                assert!(query.contains("AND block_number = $7"));
-                assert!(query.contains("AND source = $8"));
-                assert!(query.contains("AND source_version = $9"));
-                assert_eq!(params.len(), 9);
+                assert!(query.contains("INSERT INTO pool_snapshots"));
+                assert!(query.contains("prev.price_close"));
+                assert!(query.contains(
+                    "ON CONFLICT (chain_id, pool_id, block_number, source, source_version)"
+                ));
+                assert!(query.contains("active_liquidity = EXCLUDED.active_liquidity"));
+                assert!(query.contains("source = $10"));
+                assert!(query.contains("source_version = $11"));
+                assert_eq!(params.len(), 11);
 
                 let snap = snapshot.expect("snapshot should be present");
                 assert_eq!(snap.table, "pool_snapshots");
                 assert_eq!(snap.key_columns.len(), 5);
-                let keys: Vec<&str> = snap
-                    .key_columns
-                    .iter()
-                    .map(|(k, _)| k.as_str())
-                    .collect();
+                let keys: Vec<&str> = snap.key_columns.iter().map(|(k, _)| k.as_str()).collect();
                 assert_eq!(
                     keys,
                     vec![
@@ -636,6 +736,8 @@ mod tests {
             8453,
             &[0xAAu8; 20],
             1000,
+            1_700_000_000,
+            &bd("9.75"),
             &bd("1.5"),
             &bd("2.25"),
             None,
@@ -645,8 +747,9 @@ mod tests {
         );
         match op {
             DbOperation::RawSql { params, .. } => {
-                assert!(matches!(params[2], DbValue::Null));
-                assert!(matches!(params[3], DbValue::Null));
+                // params[7] = tvl_usd, [8] = market_cap_usd
+                assert!(matches!(params[7], DbValue::Null));
+                assert!(matches!(params[8], DbValue::Null));
             }
             _ => panic!("expected RawSql"),
         }
@@ -661,6 +764,8 @@ mod tests {
             8453,
             &[0xAAu8; 20],
             1000,
+            1_700_000_000,
+            &bd("9.75"),
             &bd("1.5"),
             &bd("2.25"),
             Some(&bd("5000")),
@@ -675,22 +780,21 @@ mod tests {
                 params,
                 snapshot,
             } => {
-                assert!(query.contains("UPDATE pool_state"));
-                assert!(query.contains("total_supply = $5"));
-                assert!(query.contains("AND block_number = $8"));
-                assert!(query.contains("AND source = $9"));
-                assert!(query.contains("AND source_version = $10"));
-                assert_eq!(params.len(), 10);
+                assert!(query.contains("INSERT INTO pool_state"));
+                assert!(query.contains("prev.volume_24h_usd"));
+                assert!(query.contains("ON CONFLICT (chain_id, pool_id, source, source_version)"));
+                assert!(query.contains("WHERE EXCLUDED.block_number >= pool_state.block_number"));
+                assert!(query.contains("prev.block_number <= $3"));
+                assert_eq!(params.len(), 12);
 
                 let snap = snapshot.expect("snapshot should be present");
                 assert_eq!(snap.table, "pool_state");
                 assert_eq!(snap.key_columns.len(), 4);
-                let keys: Vec<&str> = snap
-                    .key_columns
-                    .iter()
-                    .map(|(k, _)| k.as_str())
-                    .collect();
-                assert_eq!(keys, vec!["chain_id", "pool_id", "source", "source_version"]);
+                let keys: Vec<&str> = snap.key_columns.iter().map(|(k, _)| k.as_str()).collect();
+                assert_eq!(
+                    keys,
+                    vec!["chain_id", "pool_id", "source", "source_version"]
+                );
             }
             _ => panic!("expected RawSql"),
         }
@@ -702,6 +806,8 @@ mod tests {
             8453,
             &[0xAAu8; 20],
             1000,
+            1_700_000_000,
+            &bd("9.75"),
             &bd("1.5"),
             &bd("2.25"),
             None,
@@ -712,10 +818,10 @@ mod tests {
         );
         match op {
             DbOperation::RawSql { params, .. } => {
-                // params[2] = tvl_usd, [3] = market_cap_usd, [4] = total_supply
-                assert!(matches!(params[2], DbValue::Null));
-                assert!(matches!(params[3], DbValue::Null));
-                assert!(matches!(params[4], DbValue::Null));
+                // params[7] = tvl_usd, [8] = market_cap_usd, [9] = total_supply
+                assert!(matches!(params[7], DbValue::Null));
+                assert!(matches!(params[8], DbValue::Null));
+                assert!(matches!(params[9], DbValue::Null));
             }
             _ => panic!("expected RawSql"),
         }

--- a/src/transformations/event/metrics/tvl.rs
+++ b/src/transformations/event/metrics/tvl.rs
@@ -1,0 +1,729 @@
+//! Stateless TVL computation for pool metrics (Phase 7).
+//!
+//! Rebuilds per-pool tick maps on demand from the `liquidity_deltas` table,
+//! computes token amounts via Uniswap v3 position math, and produces
+//! `DbOperation::RawSql` UPDATE ops for `pool_snapshots` + `pool_state`.
+//!
+//! Stateless by design: each `handle()` invocation re-queries
+//! `liquidity_deltas` per target block. This trades a small amount of extra
+//! DB work for simpler correctness — no in-memory caches to invalidate on
+//! reorg, no checkpoint table, and no `requires_sequential` constraint.
+//! Parallel ordering with respect to swap and liquidity handlers is provided
+//! by the scheduler's `contiguous_handler_dependencies` mechanism.
+//!
+//! See `docs/designs/pool-metrics/metrics_implementation_phases.md` (Phase 7)
+//! for the architectural context.
+
+use alloy_primitives::U256;
+use bigdecimal::BigDecimal;
+use deadpool_postgres::Pool;
+
+use crate::db::{DbOperation, DbSnapshot, DbValue};
+use crate::transformations::error::TransformationError;
+use crate::transformations::util::pool_metadata::PoolMetadata;
+use crate::transformations::util::tick_math::get_amounts_for_position;
+use crate::transformations::util::usd_price::{u256_to_decimal_adjusted, UsdPriceContext};
+
+/// One active position in a pool's tick map, as reconstructed from a SUM
+/// aggregation over `liquidity_deltas`. Only positions with a strictly
+/// positive net liquidity are materialized; the `HAVING SUM > 0` filter in
+/// [`query_tick_map`] excludes fully-burned positions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TickMapPosition {
+    pub tick_lower: i32,
+    pub tick_upper: i32,
+    /// Net liquidity, always positive. `u128` matches Uniswap v3's on-chain
+    /// liquidity type; [`query_tick_map`] errors if the aggregate exceeds it.
+    pub liquidity: u128,
+}
+
+/// Query `liquidity_deltas` for a single pool and reconstruct its tick map
+/// as of the given `target_block` (inclusive).
+///
+/// Groups rows by `(tick_lower, tick_upper)`, sums the signed deltas, and
+/// keeps only positions with a strictly positive net. Matches rows by the
+/// owning liquidity handler's `source` / `source_version` so parallel
+/// versioned handlers (e.g. V3 vs LockableV3) don't leak into each other's
+/// tick maps.
+///
+/// Returns an empty vec if the pool has no liquidity events up to
+/// `target_block`. Errors only if the DB query fails or an aggregate exceeds
+/// the `u128` range.
+pub async fn query_tick_map(
+    db: &Pool,
+    chain_id: u64,
+    pool_id: &[u8],
+    target_block: u64,
+    liquidity_source: &str,
+    liquidity_source_version: u32,
+) -> Result<Vec<TickMapPosition>, TransformationError> {
+    let client = db
+        .get()
+        .await
+        .map_err(|e| TransformationError::DatabaseError(e.into()))?;
+
+    // `::text` cast preserves NUMERIC precision; SUM over 128-bit values can
+    // technically exceed i128/u128 in pathological cases, so we parse via
+    // string and surface an error rather than silently clamping.
+    let rows = client
+        .query(
+            "SELECT tick_lower, tick_upper, SUM(liquidity_delta)::text AS net_liquidity_text \
+             FROM liquidity_deltas \
+             WHERE chain_id = $1 AND pool_id = $2 AND block_number <= $3 \
+               AND source = $4 AND source_version = $5 \
+             GROUP BY tick_lower, tick_upper \
+             HAVING SUM(liquidity_delta) > 0",
+            &[
+                &(chain_id as i64),
+                &pool_id,
+                &(target_block as i64),
+                &liquidity_source,
+                &(liquidity_source_version as i32),
+            ],
+        )
+        .await
+        .map_err(|e| TransformationError::DatabaseError(e.into()))?;
+
+    let mut positions = Vec::with_capacity(rows.len());
+    for row in &rows {
+        let tick_lower: i32 = row.get("tick_lower");
+        let tick_upper: i32 = row.get("tick_upper");
+        let text: String = row.get("net_liquidity_text");
+
+        // NUMERIC::text for integer-valued aggregates emits a plain integer
+        // (no trailing ".0"); strip any fractional part defensively to handle
+        // future-compatible Postgres output changes without breaking.
+        let integer_part = text.trim().split('.').next().unwrap_or("");
+        let liquidity: u128 = integer_part.parse::<u128>().map_err(|e| {
+            TransformationError::TypeConversion(format!(
+                "net liquidity out of u128 range or unparsable: chain_id={} pool={} \
+                 tick=({},{}) raw={:?} err={}",
+                chain_id,
+                hex::encode(pool_id),
+                tick_lower,
+                tick_upper,
+                text,
+                e
+            ))
+        })?;
+
+        positions.push(TickMapPosition {
+            tick_lower,
+            tick_upper,
+            liquidity,
+        });
+    }
+    Ok(positions)
+}
+
+/// Compute the total `(amount0, amount1)` in RAW token units across all
+/// positions, given the current sqrt price of the pool.
+///
+/// Delegates per-position math to
+/// [`crate::transformations::util::tick_math::get_amounts_for_position`].
+/// Amounts are summed with saturating arithmetic to be defensive against
+/// (extremely unlikely) U256 overflow in protocol-wide aggregates; in
+/// practice, no realistic pool can produce a raw amount > U256::MAX.
+pub fn compute_position_amounts(
+    positions: &[TickMapPosition],
+    current_sqrt_price_x96: U256,
+) -> Result<(U256, U256), TransformationError> {
+    let mut total0 = U256::ZERO;
+    let mut total1 = U256::ZERO;
+    for pos in positions {
+        let (a0, a1) = get_amounts_for_position(
+            pos.tick_lower,
+            pos.tick_upper,
+            current_sqrt_price_x96,
+            pos.liquidity,
+        )?;
+        total0 = total0.saturating_add(a0);
+        total1 = total1.saturating_add(a1);
+    }
+    Ok((total0, total1))
+}
+
+/// Compute `tvl_usd` from raw token amounts + pool metadata + current price +
+/// USD pricing context.
+///
+/// Strategy:
+/// 1. Convert `amount0` / `amount1` to decimal-adjusted human units.
+/// 2. Identify base vs quote amounts via `meta.is_token_0`.
+/// 3. Express TVL in quote-token units: `base_dec * price_close + quote_dec`.
+/// 4. Convert quote-token value to USD via `UsdPriceContext`.
+///
+/// Returns `None` if the quote token has no USD price available
+/// (e.g. WETH quote with missing ETH/USD).
+pub fn compute_tvl_usd(
+    amount0_raw: &U256,
+    amount1_raw: &U256,
+    meta: &PoolMetadata,
+    price_close_quote_per_base: &BigDecimal,
+    usd_ctx: &UsdPriceContext,
+) -> Option<BigDecimal> {
+    let (base_raw, quote_raw) = if meta.is_token_0 {
+        (amount0_raw, amount1_raw)
+    } else {
+        (amount1_raw, amount0_raw)
+    };
+
+    let base_dec = u256_to_decimal_adjusted(base_raw, meta.base_decimals);
+    let quote_dec = u256_to_decimal_adjusted(quote_raw, meta.quote_decimals);
+
+    let tvl_in_quote: BigDecimal = &base_dec * price_close_quote_per_base + &quote_dec;
+
+    usd_ctx.quote_decimal_amount_to_usd(&tvl_in_quote, &meta.quote_token)
+}
+
+/// Compute `market_cap_usd = total_supply_dec × price_close × usd_per_quote`.
+///
+/// Returns `None` if either `meta.total_supply` is absent (no tokens row yet)
+/// or the quote token has no USD multiplier.
+pub fn compute_market_cap_usd(
+    meta: &PoolMetadata,
+    price_close_quote_per_base: &BigDecimal,
+    usd_ctx: &UsdPriceContext,
+) -> Option<BigDecimal> {
+    let total_supply_raw = meta.total_supply.as_ref()?;
+    let total_supply_dec = u256_to_decimal_adjusted(total_supply_raw, meta.base_decimals);
+    let value_in_quote = &total_supply_dec * price_close_quote_per_base;
+    usd_ctx.quote_decimal_amount_to_usd(&value_in_quote, &meta.quote_token)
+}
+
+// ─── UPDATE op builders ─────────────────────────────────────────────
+
+/// Build a `DbOperation::RawSql` UPDATE that populates TVL columns on a
+/// `pool_snapshots` row owned by the given `target_source` handler.
+///
+/// Targets a single `(chain_id, pool_id, block_number, source, source_version)`
+/// row. Includes a [`DbSnapshot`] so the executor can record the pre-update
+/// column values and roll them back on reorg. Mirrors the pattern used by
+/// Phase 6's `build_rolling_metrics_update` in `swap_data.rs`.
+pub fn build_snapshot_tvl_update(
+    chain_id: u64,
+    pool_id: &[u8],
+    block_number: u64,
+    amount0: &BigDecimal,
+    amount1: &BigDecimal,
+    tvl_usd: Option<&BigDecimal>,
+    market_cap_usd: Option<&BigDecimal>,
+    target_source: &str,
+    target_source_version: u32,
+) -> DbOperation {
+    let query = "UPDATE pool_snapshots SET \
+                   amount0 = $1, \
+                   amount1 = $2, \
+                   tvl_usd = $3, \
+                   market_cap_usd = $4 \
+                 WHERE chain_id = $5 \
+                   AND pool_id = $6 \
+                   AND block_number = $7 \
+                   AND source = $8 \
+                   AND source_version = $9";
+
+    let tvl_param = match tvl_usd {
+        Some(v) => DbValue::Numeric(v.to_string()),
+        None => DbValue::Null,
+    };
+    let mcap_param = match market_cap_usd {
+        Some(v) => DbValue::Numeric(v.to_string()),
+        None => DbValue::Null,
+    };
+
+    DbOperation::RawSql {
+        query: query.to_string(),
+        params: vec![
+            DbValue::Numeric(amount0.to_string()),
+            DbValue::Numeric(amount1.to_string()),
+            tvl_param,
+            mcap_param,
+            DbValue::Int64(chain_id as i64),
+            DbValue::Bytes(pool_id.to_vec()),
+            DbValue::Int64(block_number as i64),
+            DbValue::VarChar(target_source.to_string()),
+            DbValue::Int32(target_source_version as i32),
+        ],
+        snapshot: Some(DbSnapshot {
+            table: "pool_snapshots".to_string(),
+            key_columns: vec![
+                ("chain_id".to_string(), DbValue::Int64(chain_id as i64)),
+                ("pool_id".to_string(), DbValue::Bytes(pool_id.to_vec())),
+                (
+                    "block_number".to_string(),
+                    DbValue::Int64(block_number as i64),
+                ),
+                (
+                    "source".to_string(),
+                    DbValue::Text(target_source.to_string()),
+                ),
+                (
+                    "source_version".to_string(),
+                    DbValue::Int32(target_source_version as i32),
+                ),
+            ],
+        }),
+    }
+}
+
+/// Build a `DbOperation::RawSql` UPDATE that populates TVL columns on the
+/// `pool_state` row owned by the given `target_source` handler.
+///
+/// Gated on `pool_state.block_number = $block_number` so a parallel later
+/// range that already advanced pool_state past our target block is not
+/// overwritten with stale TVL. Also updates `total_supply` for dashboard
+/// convenience when available.
+pub fn build_state_tvl_update(
+    chain_id: u64,
+    pool_id: &[u8],
+    block_number: u64,
+    amount0: &BigDecimal,
+    amount1: &BigDecimal,
+    tvl_usd: Option<&BigDecimal>,
+    market_cap_usd: Option<&BigDecimal>,
+    total_supply: Option<&U256>,
+    target_source: &str,
+    target_source_version: u32,
+) -> DbOperation {
+    let query = "UPDATE pool_state SET \
+                   amount0 = $1, \
+                   amount1 = $2, \
+                   tvl_usd = $3, \
+                   market_cap_usd = $4, \
+                   total_supply = $5 \
+                 WHERE chain_id = $6 \
+                   AND pool_id = $7 \
+                   AND block_number = $8 \
+                   AND source = $9 \
+                   AND source_version = $10";
+
+    let tvl_param = match tvl_usd {
+        Some(v) => DbValue::Numeric(v.to_string()),
+        None => DbValue::Null,
+    };
+    let mcap_param = match market_cap_usd {
+        Some(v) => DbValue::Numeric(v.to_string()),
+        None => DbValue::Null,
+    };
+    let supply_param = match total_supply {
+        Some(v) => DbValue::Numeric(v.to_string()),
+        None => DbValue::Null,
+    };
+
+    DbOperation::RawSql {
+        query: query.to_string(),
+        params: vec![
+            DbValue::Numeric(amount0.to_string()),
+            DbValue::Numeric(amount1.to_string()),
+            tvl_param,
+            mcap_param,
+            supply_param,
+            DbValue::Int64(chain_id as i64),
+            DbValue::Bytes(pool_id.to_vec()),
+            DbValue::Int64(block_number as i64),
+            DbValue::VarChar(target_source.to_string()),
+            DbValue::Int32(target_source_version as i32),
+        ],
+        snapshot: Some(DbSnapshot {
+            table: "pool_state".to_string(),
+            key_columns: vec![
+                ("chain_id".to_string(), DbValue::Int64(chain_id as i64)),
+                ("pool_id".to_string(), DbValue::Bytes(pool_id.to_vec())),
+                (
+                    "source".to_string(),
+                    DbValue::Text(target_source.to_string()),
+                ),
+                (
+                    "source_version".to_string(),
+                    DbValue::Int32(target_source_version as i32),
+                ),
+            ],
+        }),
+    }
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transformations::util::tick_math::tick_to_sqrt_price_x96;
+    use std::str::FromStr;
+
+    fn bd(s: &str) -> BigDecimal {
+        BigDecimal::from_str(s).unwrap()
+    }
+
+    fn q96() -> U256 {
+        U256::from_str_radix("79228162514264337593543950336", 10).unwrap()
+    }
+
+    fn sample_meta(is_token_0: bool, total_supply: Option<U256>) -> PoolMetadata {
+        PoolMetadata {
+            pool_id: vec![0xAAu8; 20],
+            base_token: [0x01; 20],
+            quote_token: [0x02; 20],
+            is_token_0,
+            pool_type: "v3".to_string(),
+            base_decimals: 18,
+            quote_decimals: 18,
+            total_supply,
+        }
+    }
+
+    fn sample_usd_ctx(eth_usd: Option<&str>) -> UsdPriceContext {
+        UsdPriceContext::new_for_test(
+            eth_usd.map(bd),
+            None,
+            Some([0x02; 20]), // WETH = quote for sample_meta
+            None,
+            None,
+            None,
+        )
+    }
+
+    // ─── compute_position_amounts ───
+
+    #[test]
+    fn test_compute_position_amounts_empty() {
+        let (a0, a1) = compute_position_amounts(&[], q96()).unwrap();
+        assert_eq!(a0, U256::ZERO);
+        assert_eq!(a1, U256::ZERO);
+    }
+
+    #[test]
+    fn test_compute_position_amounts_single_straddling() {
+        let positions = vec![TickMapPosition {
+            tick_lower: -60,
+            tick_upper: 60,
+            liquidity: 1_000_000_000_000_000_000u128, // 1e18
+        }];
+        let (a0, a1) = compute_position_amounts(&positions, q96()).unwrap();
+        assert!(a0 > U256::ZERO);
+        assert!(a1 > U256::ZERO);
+    }
+
+    #[test]
+    fn test_compute_position_amounts_entirely_above_current() {
+        // Position (60, 120) above current tick 0 — only token0.
+        let positions = vec![TickMapPosition {
+            tick_lower: 60,
+            tick_upper: 120,
+            liquidity: 1_000_000_000_000_000_000u128,
+        }];
+        let (a0, a1) = compute_position_amounts(&positions, q96()).unwrap();
+        assert!(a0 > U256::ZERO);
+        assert_eq!(a1, U256::ZERO);
+    }
+
+    #[test]
+    fn test_compute_position_amounts_entirely_below_current() {
+        // Position (-120, -60) below current tick 0 — only token1.
+        let positions = vec![TickMapPosition {
+            tick_lower: -120,
+            tick_upper: -60,
+            liquidity: 1_000_000_000_000_000_000u128,
+        }];
+        let (a0, a1) = compute_position_amounts(&positions, q96()).unwrap();
+        assert_eq!(a0, U256::ZERO);
+        assert!(a1 > U256::ZERO);
+    }
+
+    #[test]
+    fn test_compute_position_amounts_multi_position_sum() {
+        let single = vec![TickMapPosition {
+            tick_lower: -60,
+            tick_upper: 60,
+            liquidity: 1_000_000_000_000_000_000u128,
+        }];
+        let doubled = vec![
+            TickMapPosition {
+                tick_lower: -60,
+                tick_upper: 60,
+                liquidity: 500_000_000_000_000_000u128,
+            },
+            TickMapPosition {
+                tick_lower: -60,
+                tick_upper: 60,
+                liquidity: 500_000_000_000_000_000u128,
+            },
+        ];
+        let (single0, single1) = compute_position_amounts(&single, q96()).unwrap();
+        let (double0, double1) = compute_position_amounts(&doubled, q96()).unwrap();
+        // Two half-liquidity positions should match one full-liquidity position
+        // (within integer truncation tolerance of a few wei).
+        let diff0 = if single0 > double0 {
+            single0 - double0
+        } else {
+            double0 - single0
+        };
+        let diff1 = if single1 > double1 {
+            single1 - double1
+        } else {
+            double1 - single1
+        };
+        assert!(diff0 < U256::from(10u64), "diff0={}", diff0);
+        assert!(diff1 < U256::from(10u64), "diff1={}", diff1);
+    }
+
+    // ─── compute_tvl_usd ───
+
+    #[test]
+    fn test_compute_tvl_usd_base_token0_weth_quote() {
+        // 1 base @ 18 decimals, price_close = 2 (quote per base),
+        // 0.5 quote @ 18 decimals. ETH/USD = 2000.
+        // tvl_in_quote = 1 * 2 + 0.5 = 2.5 quote
+        // tvl_usd = 2.5 * 2000 = 5000
+        let base_raw = U256::from(1_000_000_000_000_000_000u128);
+        let quote_raw = U256::from(500_000_000_000_000_000u128);
+        let meta = sample_meta(true, None); // is_token_0 = true → token0 is base
+        let price_close = bd("2");
+        let usd_ctx = sample_usd_ctx(Some("2000"));
+        let tvl = compute_tvl_usd(&base_raw, &quote_raw, &meta, &price_close, &usd_ctx).unwrap();
+        assert_eq!(tvl, bd("5000"));
+    }
+
+    #[test]
+    fn test_compute_tvl_usd_base_token1_reversed() {
+        // is_token_0 = false → token1 is base, so amount0 is quote and amount1 is base.
+        // Same numbers as above but swapped: amount0_raw = 0.5 quote, amount1_raw = 1 base.
+        let amount0_quote = U256::from(500_000_000_000_000_000u128);
+        let amount1_base = U256::from(1_000_000_000_000_000_000u128);
+        let meta = sample_meta(false, None);
+        let price_close = bd("2");
+        let usd_ctx = sample_usd_ctx(Some("2000"));
+        let tvl =
+            compute_tvl_usd(&amount0_quote, &amount1_base, &meta, &price_close, &usd_ctx).unwrap();
+        // base_dec = 1, quote_dec = 0.5, tvl_in_quote = 1*2 + 0.5 = 2.5, usd = 5000
+        assert_eq!(tvl, bd("5000"));
+    }
+
+    #[test]
+    fn test_compute_tvl_usd_zero_amounts() {
+        let meta = sample_meta(true, None);
+        let usd_ctx = sample_usd_ctx(Some("2000"));
+        let tvl = compute_tvl_usd(
+            &U256::ZERO,
+            &U256::ZERO,
+            &meta,
+            &bd("2"),
+            &usd_ctx,
+        )
+        .unwrap();
+        assert_eq!(tvl, bd("0"));
+    }
+
+    #[test]
+    fn test_compute_tvl_usd_unknown_quote_returns_none() {
+        let mut meta = sample_meta(true, None);
+        meta.quote_token = [0xFF; 20]; // not registered in usd_ctx
+        let usd_ctx = sample_usd_ctx(Some("2000"));
+        let tvl = compute_tvl_usd(
+            &U256::from(1u64),
+            &U256::from(1u64),
+            &meta,
+            &bd("2"),
+            &usd_ctx,
+        );
+        assert!(tvl.is_none());
+    }
+
+    #[test]
+    fn test_compute_tvl_usd_weth_quote_missing_eth_price() {
+        let meta = sample_meta(true, None);
+        let usd_ctx = sample_usd_ctx(None);
+        let tvl = compute_tvl_usd(
+            &U256::from(1_000_000_000_000_000_000u128),
+            &U256::ZERO,
+            &meta,
+            &bd("2"),
+            &usd_ctx,
+        );
+        assert!(tvl.is_none());
+    }
+
+    // ─── compute_market_cap_usd ───
+
+    #[test]
+    fn test_compute_market_cap_usd_basic() {
+        // total_supply = 1 billion * 1e18, base_decimals = 18
+        // → total_supply_dec = 1e9
+        // price_close = 2 quote per base, eth_usd = 2000
+        // → market_cap = 1e9 * 2 * 2000 = 4e12
+        let supply = U256::from_str_radix("1000000000000000000000000000", 10).unwrap(); // 1e27
+        let meta = sample_meta(true, Some(supply));
+        let usd_ctx = sample_usd_ctx(Some("2000"));
+        let mcap = compute_market_cap_usd(&meta, &bd("2"), &usd_ctx).unwrap();
+        assert_eq!(mcap, bd("4000000000000"));
+    }
+
+    #[test]
+    fn test_compute_market_cap_usd_missing_total_supply() {
+        let meta = sample_meta(true, None);
+        let usd_ctx = sample_usd_ctx(Some("2000"));
+        let mcap = compute_market_cap_usd(&meta, &bd("2"), &usd_ctx);
+        assert!(mcap.is_none());
+    }
+
+    #[test]
+    fn test_compute_market_cap_usd_unknown_quote() {
+        let supply = U256::from(1_000_000u64);
+        let mut meta = sample_meta(true, Some(supply));
+        meta.quote_token = [0xFF; 20];
+        let usd_ctx = sample_usd_ctx(Some("2000"));
+        let mcap = compute_market_cap_usd(&meta, &bd("2"), &usd_ctx);
+        assert!(mcap.is_none());
+    }
+
+    // ─── build_snapshot_tvl_update ───
+
+    #[test]
+    fn test_build_snapshot_tvl_update_structure() {
+        let op = build_snapshot_tvl_update(
+            8453,
+            &[0xAAu8; 20],
+            1000,
+            &bd("1.5"),
+            &bd("2.25"),
+            Some(&bd("5000")),
+            Some(&bd("4000000000000")),
+            "V3SwapMetricsHandler",
+            1,
+        );
+        match op {
+            DbOperation::RawSql {
+                query,
+                params,
+                snapshot,
+            } => {
+                assert!(query.contains("UPDATE pool_snapshots"));
+                assert!(query.contains("amount0 = $1"));
+                assert!(query.contains("amount1 = $2"));
+                assert!(query.contains("tvl_usd = $3"));
+                assert!(query.contains("market_cap_usd = $4"));
+                assert!(query.contains("WHERE chain_id = $5"));
+                assert!(query.contains("AND pool_id = $6"));
+                assert!(query.contains("AND block_number = $7"));
+                assert!(query.contains("AND source = $8"));
+                assert!(query.contains("AND source_version = $9"));
+                assert_eq!(params.len(), 9);
+
+                let snap = snapshot.expect("snapshot should be present");
+                assert_eq!(snap.table, "pool_snapshots");
+                assert_eq!(snap.key_columns.len(), 5);
+                let keys: Vec<&str> = snap
+                    .key_columns
+                    .iter()
+                    .map(|(k, _)| k.as_str())
+                    .collect();
+                assert_eq!(
+                    keys,
+                    vec![
+                        "chain_id",
+                        "pool_id",
+                        "block_number",
+                        "source",
+                        "source_version"
+                    ]
+                );
+            }
+            _ => panic!("expected RawSql"),
+        }
+    }
+
+    #[test]
+    fn test_build_snapshot_tvl_update_none_values() {
+        let op = build_snapshot_tvl_update(
+            8453,
+            &[0xAAu8; 20],
+            1000,
+            &bd("1.5"),
+            &bd("2.25"),
+            None,
+            None,
+            "V3SwapMetricsHandler",
+            1,
+        );
+        match op {
+            DbOperation::RawSql { params, .. } => {
+                assert!(matches!(params[2], DbValue::Null));
+                assert!(matches!(params[3], DbValue::Null));
+            }
+            _ => panic!("expected RawSql"),
+        }
+    }
+
+    // ─── build_state_tvl_update ───
+
+    #[test]
+    fn test_build_state_tvl_update_structure() {
+        let supply = U256::from(1_000_000_000u64);
+        let op = build_state_tvl_update(
+            8453,
+            &[0xAAu8; 20],
+            1000,
+            &bd("1.5"),
+            &bd("2.25"),
+            Some(&bd("5000")),
+            Some(&bd("4000000000000")),
+            Some(&supply),
+            "V3SwapMetricsHandler",
+            1,
+        );
+        match op {
+            DbOperation::RawSql {
+                query,
+                params,
+                snapshot,
+            } => {
+                assert!(query.contains("UPDATE pool_state"));
+                assert!(query.contains("total_supply = $5"));
+                assert!(query.contains("AND block_number = $8"));
+                assert!(query.contains("AND source = $9"));
+                assert!(query.contains("AND source_version = $10"));
+                assert_eq!(params.len(), 10);
+
+                let snap = snapshot.expect("snapshot should be present");
+                assert_eq!(snap.table, "pool_state");
+                assert_eq!(snap.key_columns.len(), 4);
+                let keys: Vec<&str> = snap
+                    .key_columns
+                    .iter()
+                    .map(|(k, _)| k.as_str())
+                    .collect();
+                assert_eq!(keys, vec!["chain_id", "pool_id", "source", "source_version"]);
+            }
+            _ => panic!("expected RawSql"),
+        }
+    }
+
+    #[test]
+    fn test_build_state_tvl_update_nulls_for_missing_totals() {
+        let op = build_state_tvl_update(
+            8453,
+            &[0xAAu8; 20],
+            1000,
+            &bd("1.5"),
+            &bd("2.25"),
+            None,
+            None,
+            None,
+            "V3SwapMetricsHandler",
+            1,
+        );
+        match op {
+            DbOperation::RawSql { params, .. } => {
+                // params[2] = tvl_usd, [3] = market_cap_usd, [4] = total_supply
+                assert!(matches!(params[2], DbValue::Null));
+                assert!(matches!(params[3], DbValue::Null));
+                assert!(matches!(params[4], DbValue::Null));
+            }
+            _ => panic!("expected RawSql"),
+        }
+    }
+
+    // Sanity: verify that tick_to_sqrt_price_x96 at tick 0 matches our q96 helper.
+    #[test]
+    fn test_q96_helper_matches_tick_zero() {
+        assert_eq!(q96(), tick_to_sqrt_price_x96(0).unwrap());
+    }
+}

--- a/src/transformations/event/metrics/tvl.rs
+++ b/src/transformations/event/metrics/tvl.rs
@@ -144,6 +144,38 @@ pub fn compute_position_amounts(
     Ok((total0, total1))
 }
 
+/// Compute `(amount0, amount1)` contributed by positions currently in range
+/// at `current_tick`, i.e. those whose range satisfies
+/// `tick_lower <= current_tick < tick_upper`. Matches Uniswap v3's convention
+/// for which positions earn fees at the current price — the upper bound is
+/// exclusive so a position being crossed is not double-counted with the
+/// adjacent tick's active set.
+///
+/// Feed the result through [`compute_tvl_usd`] to obtain `active_liquidity_usd`.
+/// Pass `current_tick` from the swap accumulator (`BlockAccumulator::last_tick`)
+/// and the same `current_sqrt_price_x96` used for full-pool TVL.
+pub fn compute_active_position_amounts(
+    positions: &[TickMapPosition],
+    current_tick: i32,
+    current_sqrt_price_x96: U256,
+) -> Result<(U256, U256), TransformationError> {
+    let mut total0 = U256::ZERO;
+    let mut total1 = U256::ZERO;
+    for pos in positions {
+        if pos.tick_lower <= current_tick && current_tick < pos.tick_upper {
+            let (a0, a1) = get_amounts_for_position(
+                pos.tick_lower,
+                pos.tick_upper,
+                current_sqrt_price_x96,
+                pos.liquidity,
+            )?;
+            total0 = total0.saturating_add(a0);
+            total1 = total1.saturating_add(a1);
+        }
+    }
+    Ok((total0, total1))
+}
+
 /// Compute `tvl_usd` from raw token amounts + pool metadata + current price +
 /// USD pricing context.
 ///
@@ -224,6 +256,7 @@ pub fn build_snapshot_tvl_update(
     amount1: &BigDecimal,
     tvl_usd: Option<&BigDecimal>,
     market_cap_usd: Option<&BigDecimal>,
+    active_liquidity_usd: Option<&BigDecimal>,
     target_source: &str,
     target_source_version: u32,
 ) -> DbOperation {
@@ -246,6 +279,7 @@ INSERT INTO pool_snapshots (
   amount1,
   tvl_usd,
   market_cap_usd,
+  active_liquidity_usd,
   source,
   source_version
 )
@@ -268,15 +302,16 @@ SELECT
   $8,
   $9,
   $10,
-  $11
+  $11,
+  $12
 FROM LATERAL (
   SELECT price_close
   FROM pool_snapshots
   WHERE chain_id = $1
     AND pool_id = $2
     AND block_number <= $3
-    AND source = $10
-    AND source_version = $11
+    AND source = $11
+    AND source_version = $12
   ORDER BY block_number DESC
   LIMIT 1
 ) AS prev
@@ -287,7 +322,8 @@ DO UPDATE SET
   amount0 = EXCLUDED.amount0,
   amount1 = EXCLUDED.amount1,
   tvl_usd = EXCLUDED.tvl_usd,
-  market_cap_usd = EXCLUDED.market_cap_usd
+  market_cap_usd = EXCLUDED.market_cap_usd,
+  active_liquidity_usd = EXCLUDED.active_liquidity_usd
 "#;
 
     DbOperation::RawSql {
@@ -302,6 +338,7 @@ DO UPDATE SET
             DbValue::Numeric(amount1.to_string()),
             optional_decimal_value(tvl_usd),
             optional_decimal_value(market_cap_usd),
+            optional_decimal_value(active_liquidity_usd),
             DbValue::VarChar(target_source.to_string()),
             DbValue::Int32(target_source_version as i32),
         ],
@@ -346,6 +383,7 @@ pub fn build_state_tvl_update(
     amount1: &BigDecimal,
     tvl_usd: Option<&BigDecimal>,
     market_cap_usd: Option<&BigDecimal>,
+    active_liquidity_usd: Option<&BigDecimal>,
     total_supply: Option<&U256>,
     target_source: &str,
     target_source_version: u32,
@@ -368,6 +406,7 @@ INSERT INTO pool_state (
   amount1,
   tvl_usd,
   market_cap_usd,
+  active_liquidity_usd,
   total_supply,
   source,
   source_version
@@ -391,12 +430,13 @@ SELECT
   $9,
   $10,
   $11,
-  $12
+  $12,
+  $13
 FROM pool_state AS prev
 WHERE prev.chain_id = $1
   AND prev.pool_id = $2
-  AND prev.source = $11
-  AND prev.source_version = $12
+  AND prev.source = $12
+  AND prev.source_version = $13
   AND prev.block_number <= $3
 ON CONFLICT (chain_id, pool_id, source, source_version)
 DO UPDATE SET
@@ -414,6 +454,7 @@ DO UPDATE SET
   amount1 = EXCLUDED.amount1,
   tvl_usd = EXCLUDED.tvl_usd,
   market_cap_usd = EXCLUDED.market_cap_usd,
+  active_liquidity_usd = EXCLUDED.active_liquidity_usd,
   total_supply = EXCLUDED.total_supply
 WHERE EXCLUDED.block_number >= pool_state.block_number
 "#;
@@ -430,6 +471,7 @@ WHERE EXCLUDED.block_number >= pool_state.block_number
             DbValue::Numeric(amount1.to_string()),
             optional_decimal_value(tvl_usd),
             optional_decimal_value(market_cap_usd),
+            optional_decimal_value(active_liquidity_usd),
             optional_u256_value(total_supply),
             DbValue::VarChar(target_source.to_string()),
             DbValue::Int32(target_source_version as i32),
@@ -678,6 +720,94 @@ mod tests {
         assert!(mcap.is_none());
     }
 
+    // ─── compute_active_position_amounts ───
+
+    #[test]
+    fn test_compute_active_position_amounts_empty() {
+        let (a0, a1) = compute_active_position_amounts(&[], 0, q96()).unwrap();
+        assert_eq!(a0, U256::ZERO);
+        assert_eq!(a1, U256::ZERO);
+    }
+
+    #[test]
+    fn test_compute_active_position_amounts_filters_out_of_range() {
+        // Straddling (in-range) + out-of-range-above + out-of-range-below.
+        let positions = vec![
+            TickMapPosition {
+                tick_lower: -60,
+                tick_upper: 60,
+                liquidity: 1_000_000_000_000_000_000u128,
+            },
+            TickMapPosition {
+                tick_lower: 120,
+                tick_upper: 180,
+                liquidity: 5_000_000_000_000_000_000u128,
+            },
+            TickMapPosition {
+                tick_lower: -180,
+                tick_upper: -120,
+                liquidity: 7_000_000_000_000_000_000u128,
+            },
+        ];
+        let (active0, active1) = compute_active_position_amounts(&positions, 0, q96()).unwrap();
+
+        // Should match computing over just the in-range position alone.
+        let in_range_only = vec![positions[0].clone()];
+        let (expected0, expected1) = compute_position_amounts(&in_range_only, q96()).unwrap();
+        assert_eq!(active0, expected0);
+        assert_eq!(active1, expected1);
+    }
+
+    #[test]
+    fn test_compute_active_position_amounts_boundary_lower_inclusive() {
+        // Position (0, 60) at current_tick = 0 → lower bound inclusive, so included.
+        let positions = vec![TickMapPosition {
+            tick_lower: 0,
+            tick_upper: 60,
+            liquidity: 1_000_000_000_000_000_000u128,
+        }];
+        let (a0, a1) = compute_active_position_amounts(&positions, 0, q96()).unwrap();
+        // At current_tick = 0 == tick_lower, all liquidity sits in token0.
+        assert!(a0 > U256::ZERO);
+        assert_eq!(a1, U256::ZERO);
+    }
+
+    #[test]
+    fn test_compute_active_position_amounts_boundary_upper_exclusive() {
+        // Position (-60, 0) at current_tick = 0 → upper bound exclusive, so skipped.
+        let positions = vec![TickMapPosition {
+            tick_lower: -60,
+            tick_upper: 0,
+            liquidity: 1_000_000_000_000_000_000u128,
+        }];
+        let (a0, a1) = compute_active_position_amounts(&positions, 0, q96()).unwrap();
+        assert_eq!(a0, U256::ZERO);
+        assert_eq!(a1, U256::ZERO);
+    }
+
+    #[test]
+    fn test_compute_active_liquidity_usd_end_to_end() {
+        // Same shape as test_compute_tvl_usd_base_token0_weth_quote, but the
+        // amounts come from the filtered compute and then flow through
+        // compute_tvl_usd for the USD conversion.
+        //
+        // In-range position contributes base_raw = 1e18, quote_raw = 0.5e18.
+        // Out-of-range position is ignored. price_close = 2, eth_usd = 2000.
+        // → tvl_in_quote = 1 * 2 + 0.5 = 2.5, usd = 5000.
+        //
+        // We construct amounts directly rather than going through
+        // get_amounts_for_position, since the filtering behavior is already
+        // covered by the tests above; this test pins the USD wiring.
+        let base_raw = U256::from(1_000_000_000_000_000_000u128);
+        let quote_raw = U256::from(500_000_000_000_000_000u128);
+        let meta = sample_meta(true, None);
+        let price_close = bd("2");
+        let usd_ctx = sample_usd_ctx(Some("2000"));
+        let active_usd =
+            compute_tvl_usd(&base_raw, &quote_raw, &meta, &price_close, &usd_ctx).unwrap();
+        assert_eq!(active_usd, bd("5000"));
+    }
+
     // ─── build_snapshot_tvl_update ───
 
     #[test]
@@ -692,6 +822,7 @@ mod tests {
             &bd("2.25"),
             Some(&bd("5000")),
             Some(&bd("4000000000000")),
+            Some(&bd("3200")),
             "V3SwapMetricsHandler",
             1,
         );
@@ -707,9 +838,14 @@ mod tests {
                     "ON CONFLICT (chain_id, pool_id, block_number, source, source_version)"
                 ));
                 assert!(query.contains("active_liquidity = EXCLUDED.active_liquidity"));
-                assert!(query.contains("source = $10"));
-                assert!(query.contains("source_version = $11"));
-                assert_eq!(params.len(), 11);
+                assert!(query.contains("active_liquidity_usd = EXCLUDED.active_liquidity_usd"));
+                assert!(query.contains("source = $11"));
+                assert!(query.contains("source_version = $12"));
+                assert_eq!(params.len(), 12);
+                match &params[9] {
+                    DbValue::Numeric(s) => assert_eq!(s, "3200"),
+                    other => panic!("expected Numeric for active_liquidity_usd, got {:?}", other),
+                }
 
                 let snap = snapshot.expect("snapshot should be present");
                 assert_eq!(snap.table, "pool_snapshots");
@@ -742,14 +878,16 @@ mod tests {
             &bd("2.25"),
             None,
             None,
+            None,
             "V3SwapMetricsHandler",
             1,
         );
         match op {
             DbOperation::RawSql { params, .. } => {
-                // params[7] = tvl_usd, [8] = market_cap_usd
+                // params[7] = tvl_usd, [8] = market_cap_usd, [9] = active_liquidity_usd
                 assert!(matches!(params[7], DbValue::Null));
                 assert!(matches!(params[8], DbValue::Null));
+                assert!(matches!(params[9], DbValue::Null));
             }
             _ => panic!("expected RawSql"),
         }
@@ -770,6 +908,7 @@ mod tests {
             &bd("2.25"),
             Some(&bd("5000")),
             Some(&bd("4000000000000")),
+            Some(&bd("3200")),
             Some(&supply),
             "V3SwapMetricsHandler",
             1,
@@ -783,9 +922,14 @@ mod tests {
                 assert!(query.contains("INSERT INTO pool_state"));
                 assert!(query.contains("prev.volume_24h_usd"));
                 assert!(query.contains("ON CONFLICT (chain_id, pool_id, source, source_version)"));
+                assert!(query.contains("active_liquidity_usd = EXCLUDED.active_liquidity_usd"));
                 assert!(query.contains("WHERE EXCLUDED.block_number >= pool_state.block_number"));
                 assert!(query.contains("prev.block_number <= $3"));
-                assert_eq!(params.len(), 12);
+                assert_eq!(params.len(), 13);
+                match &params[9] {
+                    DbValue::Numeric(s) => assert_eq!(s, "3200"),
+                    other => panic!("expected Numeric for active_liquidity_usd, got {:?}", other),
+                }
 
                 let snap = snapshot.expect("snapshot should be present");
                 assert_eq!(snap.table, "pool_state");
@@ -813,15 +957,18 @@ mod tests {
             None,
             None,
             None,
+            None,
             "V3SwapMetricsHandler",
             1,
         );
         match op {
             DbOperation::RawSql { params, .. } => {
-                // params[7] = tvl_usd, [8] = market_cap_usd, [9] = total_supply
+                // params[7] = tvl_usd, [8] = market_cap_usd, [9] = active_liquidity_usd,
+                // [10] = total_supply
                 assert!(matches!(params[7], DbValue::Null));
                 assert!(matches!(params[8], DbValue::Null));
                 assert!(matches!(params[9], DbValue::Null));
+                assert!(matches!(params[10], DbValue::Null));
             }
             _ => panic!("expected RawSql"),
         }

--- a/src/transformations/util/pool_metadata.rs
+++ b/src/transformations/util/pool_metadata.rs
@@ -87,7 +87,8 @@ impl PoolMetadataCache {
             let quote_token_bytes: Vec<u8> = row.get("quote_token");
             let is_token_0: bool = row.get("is_token_0");
             let pool_type: String = row.get("type");
-            let total_supply = parse_total_supply(row.get::<_, Option<String>>("total_supply_text"));
+            let total_supply =
+                parse_total_supply(row.get::<_, Option<String>>("total_supply_text"));
 
             if base_token_bytes.len() != 20 || quote_token_bytes.len() != 20 {
                 continue;
@@ -221,7 +222,8 @@ impl PoolMetadataCache {
 
         for row in &rows {
             let pool_id: Vec<u8> = row.get("address");
-            let total_supply = parse_total_supply(row.get::<_, Option<String>>("total_supply_text"));
+            let total_supply =
+                parse_total_supply(row.get::<_, Option<String>>("total_supply_text"));
 
             // If the pool is already cached but had no total_supply at load time,
             // backfill it opportunistically from the refreshed row. This closes

--- a/src/transformations/util/tick_math.rs
+++ b/src/transformations/util/tick_math.rs
@@ -312,18 +312,34 @@ mod tests {
     fn test_position_entirely_above_current_is_all_token0() {
         // Current at tick 0 (sqrt = 2^96). Position (60, 120) is strictly above.
         let current = U256::from(1u64) << 96;
-        let (a0, a1) = get_amounts_for_position(60, 120, current, 1_000_000_000_000_000_000).unwrap();
-        assert!(a0 > U256::ZERO, "amount0 should be non-zero for above-tick position");
-        assert_eq!(a1, U256::ZERO, "amount1 must be zero for above-tick position");
+        let (a0, a1) =
+            get_amounts_for_position(60, 120, current, 1_000_000_000_000_000_000).unwrap();
+        assert!(
+            a0 > U256::ZERO,
+            "amount0 should be non-zero for above-tick position"
+        );
+        assert_eq!(
+            a1,
+            U256::ZERO,
+            "amount1 must be zero for above-tick position"
+        );
     }
 
     #[test]
     fn test_position_entirely_below_current_is_all_token1() {
         // Current at tick 0. Position (-120, -60) is strictly below.
         let current = U256::from(1u64) << 96;
-        let (a0, a1) = get_amounts_for_position(-120, -60, current, 1_000_000_000_000_000_000).unwrap();
-        assert_eq!(a0, U256::ZERO, "amount0 must be zero for below-tick position");
-        assert!(a1 > U256::ZERO, "amount1 should be non-zero for below-tick position");
+        let (a0, a1) =
+            get_amounts_for_position(-120, -60, current, 1_000_000_000_000_000_000).unwrap();
+        assert_eq!(
+            a0,
+            U256::ZERO,
+            "amount0 must be zero for below-tick position"
+        );
+        assert!(
+            a1 > U256::ZERO,
+            "amount1 should be non-zero for below-tick position"
+        );
     }
 
     #[test]
@@ -349,7 +365,8 @@ mod tests {
     fn test_position_current_at_tick_lower_is_all_token0() {
         // Current sqrt price exactly equals sqrt_lower ⇒ handled by the "<= lower" branch.
         let sqrt_lower = tick_to_sqrt_price_x96(-60).unwrap();
-        let (a0, a1) = get_amounts_for_position(-60, 60, sqrt_lower, 1_000_000_000_000_000_000).unwrap();
+        let (a0, a1) =
+            get_amounts_for_position(-60, 60, sqrt_lower, 1_000_000_000_000_000_000).unwrap();
         assert!(a0 > U256::ZERO);
         assert_eq!(a1, U256::ZERO);
     }
@@ -357,7 +374,8 @@ mod tests {
     #[test]
     fn test_position_current_at_tick_upper_is_all_token1() {
         let sqrt_upper = tick_to_sqrt_price_x96(60).unwrap();
-        let (a0, a1) = get_amounts_for_position(-60, 60, sqrt_upper, 1_000_000_000_000_000_000).unwrap();
+        let (a0, a1) =
+            get_amounts_for_position(-60, 60, sqrt_upper, 1_000_000_000_000_000_000).unwrap();
         assert_eq!(a0, U256::ZERO);
         assert!(a1 > U256::ZERO);
     }

--- a/src/transformations/util/usd_price.rs
+++ b/src/transformations/util/usd_price.rs
@@ -194,6 +194,20 @@ impl UsdPriceContext {
         Some(volume_decimal * usd_per_quote)
     }
 
+    /// Convert a pre-decimal-adjusted quote-denominated amount to USD.
+    ///
+    /// Used by TVL computation where the amount is already in human-readable
+    /// decimal form (produced by combining base + quote contributions with the
+    /// current price). Returns `None` if the quote token has no USD multiplier.
+    pub fn quote_decimal_amount_to_usd(
+        &self,
+        amount_decimal: &BigDecimal,
+        quote_token: &[u8; 20],
+    ) -> Option<BigDecimal> {
+        let usd_per_quote = self.quote_to_usd_multiplier(quote_token)?;
+        Some(amount_decimal * usd_per_quote)
+    }
+
     /// Get the USD multiplier for a quote token.
     /// WETH → ETH/USD price, USDC/USDT → 1.0, EURC → EURC/USD price.
     fn quote_to_usd_multiplier(&self, quote_token: &[u8; 20]) -> Option<BigDecimal> {
@@ -442,8 +456,17 @@ async fn query_latest_price(
 }
 
 /// Convert a U256 to BigDecimal, dividing by 10^decimals.
-fn u256_to_decimal_adjusted(value: &U256, decimals: u8) -> BigDecimal {
-    let raw = BigDecimal::from(value.to_string().parse::<i128>().unwrap_or(0));
+///
+/// Parses the full U256 range via BigDecimal's string parser; previously this
+/// went through i128 and silently clamped values above i128::MAX to zero,
+/// which would have mis-computed TVL for pools with very large position
+/// amounts (phase 7). Volumes in phase 6 fit in i128 in practice, so no
+/// existing behavior changes.
+pub(crate) fn u256_to_decimal_adjusted(value: &U256, decimals: u8) -> BigDecimal {
+    let raw: BigDecimal = value
+        .to_string()
+        .parse()
+        .expect("U256::to_string produces a valid decimal integer");
     if decimals == 0 {
         return raw;
     }

--- a/src/types/config/eth_call.rs
+++ b/src/types/config/eth_call.rs
@@ -16,6 +16,8 @@ use crate::types::config::generic::SingleOrMultiple;
 /// - `"address"` - the address that emitted the event
 /// - `"topics[N]"` - topic at index N (e.g., `"topics[1]"`)
 /// - `"data[N]"` - data word at index N (e.g., `"data[0]"`)
+/// - `"v4_pool_id_from_key_data"` - derive a V4 pool id from a tuple-encoded
+///   `PoolKey` at the head of the event data
 #[derive(Debug, Clone, PartialEq)]
 pub enum EventFieldLocation {
     /// The address that emitted the event
@@ -24,6 +26,10 @@ pub enum EventFieldLocation {
     Topic(usize),
     /// A specific data word by index (e.g., data[0])
     Data(usize),
+    /// Derive a V4 pool id by hashing the leading tuple-encoded PoolKey in the
+    /// event data. This is used for tuple-format `ModifyLiquidity` events that
+    /// carry a PoolKey but no explicit pool id.
+    V4PoolIdFromKeyData,
 }
 
 impl EventFieldLocation {
@@ -36,6 +42,7 @@ impl EventFieldLocation {
             Self::Address => Cow::Borrowed("address"),
             Self::Topic(idx) => Cow::Owned(format!("topics[{}]", idx)),
             Self::Data(idx) => Cow::Owned(format!("data[{}]", idx)),
+            Self::V4PoolIdFromKeyData => Cow::Borrowed("v4_pool_id_from_key_data"),
         }
     }
 }
@@ -56,6 +63,10 @@ impl<'de> Deserialize<'de> for EventFieldLocation {
 
         if s == "address" {
             return Ok(EventFieldLocation::Address);
+        }
+
+        if s == "v4_pool_id_from_key_data" {
+            return Ok(EventFieldLocation::V4PoolIdFromKeyData);
         }
 
         if let Some(rest) = s.strip_prefix("topics[") {
@@ -85,7 +96,7 @@ impl<'de> Deserialize<'de> for EventFieldLocation {
         }
 
         Err(de::Error::custom(format!(
-            "Unknown from_event format: {} (expected \"address\", \"topics[N]\", or \"data[N]\")",
+            "Unknown from_event format: {} (expected \"address\", \"topics[N]\", \"data[N]\", or \"v4_pool_id_from_key_data\")",
             s
         )))
     }
@@ -1780,6 +1791,13 @@ mod tests {
     }
 
     #[test]
+    fn test_event_field_location_v4_pool_id_from_key_data() {
+        let json = r#""v4_pool_id_from_key_data""#;
+        let loc: EventFieldLocation = serde_json::from_str(json).unwrap();
+        assert_eq!(loc, EventFieldLocation::V4PoolIdFromKeyData);
+    }
+
+    #[test]
     fn test_event_field_location_invalid() {
         let json = r#""invalid_format""#;
         let result = serde_json::from_str::<EventFieldLocation>(json);
@@ -1791,5 +1809,9 @@ mod tests {
         assert_eq!(EventFieldLocation::Address.as_str_repr(), "address");
         assert_eq!(EventFieldLocation::Topic(2).as_str_repr(), "topics[2]");
         assert_eq!(EventFieldLocation::Data(0).as_str_repr(), "data[0]");
+        assert_eq!(
+            EventFieldLocation::V4PoolIdFromKeyData.as_str_repr(),
+            "v4_pool_id_from_key_data"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Second of three PRs for Phase 7 (TVL computation). Introduces the shared compute module — `TickMapPosition`, the `liquidity_deltas` tick-map query, the pure compute functions, and the RawSql UPDATE builders — with comprehensive unit tests. No handler code; the module is public but not yet called (PR 3 wires it up).

**Base**: \`feat/pool-metrics-phase7-foundations\` (PR #124) so the diff shows only PR 2's changes. I'll retarget to \`feat/pool-metrics-phase7\` once PR 1 merges.

## What's in it

**New file: \`src/transformations/event/metrics/tvl.rs\`**

- \`TickMapPosition { tick_lower: i32, tick_upper: i32, liquidity: u128 }\` — one active position in a pool's tick map. \`u128\` matches Uniswap v3's on-chain type and is only populated for positions with a strictly positive net after summing deltas.

- \`async fn query_tick_map(db, chain_id, pool_id, target_block, liquidity_source, liquidity_source_version)\` — reconstructs a pool's tick map as of \`target_block\` from \`liquidity_deltas\`:
  \`\`\`sql
  SELECT tick_lower, tick_upper, SUM(liquidity_delta)::text
  FROM liquidity_deltas
  WHERE chain_id = \$1 AND pool_id = \$2 AND block_number <= \$3
    AND source = \$4 AND source_version = \$5
  GROUP BY tick_lower, tick_upper
  HAVING SUM(liquidity_delta) > 0
  \`\`\`
  The \`::text\` cast preserves NUMERIC precision beyond rust_decimal's ~28-digit range; we parse to \`u128\` and error (rather than silently clamp) if the aggregate overflows. Matching on the liquidity handler's own \`source\`/\`source_version\` keeps versioned handlers (V3 vs LockableV3, etc.) isolated from one another's tick maps.

- \`compute_position_amounts(positions, current_sqrt_price_x96)\` — sums token0/token1 across positions using \`tick_math::get_amounts_for_position\` (from PR 1). Saturating U256 addition is used defensively against aggregate overflow.

- \`compute_tvl_usd(amount0_raw, amount1_raw, meta, price_close, usd_ctx)\` — expresses TVL in quote-token units (\`base_dec * price_close + quote_dec\`), then converts to USD via \`UsdPriceContext\`. Handles both \`is_token_0\` orientations. Returns \`None\` if the quote token has no USD multiplier.

- \`compute_market_cap_usd(meta, price_close, usd_ctx)\` — \`price_close × total_supply × usd_per_quote\`. Returns \`None\` if \`meta.total_supply\` is absent (race window between create-handler commit and tokens-row commit) or the quote token is unknown.

- \`build_snapshot_tvl_update(...)\` — RawSql UPDATE that populates \`amount0 / amount1 / tvl_usd / market_cap_usd\` on a \`pool_snapshots\` row owned by the swap handler. The swap handler's name is hardcoded in the WHERE clause (passed as \`target_source\`) so the TVL handler can write across handler boundaries. Includes a \`DbSnapshot\` with all 5 key columns (\`chain_id\`, \`pool_id\`, \`block_number\`, \`source\`, \`source_version\`) so the executor can roll the columns back on reorg.

- \`build_state_tvl_update(...)\` — same pattern for \`pool_state\`. Gated on \`block_number = \$N\` in the WHERE so a parallel later range that already advanced \`pool_state.block_number\` past our target is not overwritten with stale TVL. Also updates \`total_supply\` for dashboard convenience.

**Supporting changes in \`src/transformations/util/usd_price.rs\`**

- New \`pub fn quote_decimal_amount_to_usd(amount_decimal, quote_token)\` method on \`UsdPriceContext\` — symmetric to \`quote_volume_to_usd(raw, token, decimals)\` but for pre-adjusted BigDecimal inputs (the TVL flow).
- \`u256_to_decimal_adjusted\` promoted to \`pub(crate)\` so \`tvl.rs\` can reuse it.
- Incidental fix: the old \`u256_to_decimal_adjusted\` parsed through \`i128::parse().unwrap_or(0)\`, silently returning zero for any U256 > i128::MAX. Phase 6 volumes fit in i128 in practice so no existing behavior changes, but Phase 7 position amounts could exceed it and would have been miscomputed. Now parses the full U256 range directly via BigDecimal's string parser.

## Tests

18 new unit tests, all passing:

- \`compute_position_amounts\`: empty, single straddling, entirely above, entirely below, multi-position summation invariant (two half-liquidity ≈ one full-liquidity).
- \`compute_tvl_usd\`: is_token_0 = true with WETH quote + known ETH price, is_token_0 = false reversed, zero amounts → zero USD, unknown quote → None, WETH quote with missing ETH price → None.
- \`compute_market_cap_usd\`: populated total_supply → expected value, \`None\` total_supply → None, unknown quote → None.
- \`build_snapshot_tvl_update\`: query shape, param count, DbSnapshot table / key column set / column order.
- \`build_state_tvl_update\`: same structural assertions, plus verification that \`total_supply\` is included as \$5 and all four key columns (no \`block_number\`) are in the snapshot.
- Null-path coverage for both builders: tvl_usd / market_cap_usd / total_supply all flow through as \`DbValue::Null\` when the inputs are \`None\`.
- Sanity check that the test helper's Q96 value matches \`tick_to_sqrt_price_x96(0)\`.

Existing Phase 6 \`usd_price\` tests (9) and Phase 7 \`tick_math\` tests (19) all continue to pass.

## Why this shape

Stateless TVL (no in-memory tick map cache) was the design call made during planning — simpler correctness, no reorg-invalidation dance, and naturally parallel-safe. The cost is one extra \`liquidity_deltas\` query per pool per range; profiling can drive a future cache if needed without breaking the handler-facing API.

The \`RawSql\` + \`DbSnapshot\` cross-handler UPDATE pattern is lifted directly from Phase 6's \`build_rolling_metrics_update\` (same file, \`swap_data.rs\`). The TVL handler (PR 3) will own a different \`source\` than the swap handler, but by passing the swap handler's name as \`target_source\` it can UPDATE the rows it's supposed to enrich without fighting the executor's source-injection.

Part of #TODO (Phase 7 roadmap in \`docs/designs/pool-metrics/metrics_implementation_phases.md\`).