### PR TITLE
add github actions workflow for tests and clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: cargo test
+        run: cargo test --workspace
+
+      - name: cargo clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings


### PR DESCRIPTION
This adds a CI workflow so every push to `main` and every PR runs `cargo test` and `cargo clippy` (with `-D warnings`) on Ubuntu.

There was no automated check in the repo before, so regressions were easy to miss. This follows the usual pattern (checkout, stable toolchain with clippy, rust-cache, then test + clippy).

Concurrency is limited to one run per branch so new pushes cancel outdated jobs.

Fixes: n/a (infrastructure only).

Related: [issue #77](https://github.com/whetstoneresearch/doppler-indexer-rs/issues/77) (receipt dispatch cap) already appears addressed in `current/receipts.rs` via `receipt_join_set.len() < receipt_fetch_concurrency` for block-receipt mode.