### PR TITLE
feat(rpc): add per-chain
  http2 opt-in flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1908,6 +1908,7 @@ dependencies = [
  "paste",
  "postgres-types",
  "rand 0.9.2",
+ "reqwest",
  "rust_decimal",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ url = "2.5"
 tokio-tungstenite = { version = "0.26", features = ["native-tls"] }
 bincode = "1.3"
 paste = "1"
+# Pinned to match the version alloy's transport layer already pulls in, so
+# both paths share a single reqwest/hyper/rustls stack.
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "http2", "json"] }
 
 arrow = { version = "54", default-features = false, features = ["prettyprint"] }
 parquet = { version = "54", default-features = false, features = ["arrow", "snap", "zstd"] }

--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -230,7 +230,8 @@ src/
       "rpc": {
         "concurrency": 100,
         "requests_per_second": 7500,
-        "batch_size": 1000
+        "batch_size": 1000,
+        "http2": true
       }
     }
   ],

--- a/docs/features/rpc.md
+++ b/docs/features/rpc.md
@@ -401,6 +401,7 @@ RPC parameters are configured per-chain in the `rpc` block of the chain config:
 | `rpc.concurrency` | 100 | Max concurrent in-flight RPC requests |
 | `rpc.requests_per_second` | 7500 | Generic rate-limit units per second. For standard providers this is requests/sec; for Alchemy-like providers it is CU/sec |
 | `rpc.batch_size` | 100 | Max batch size for RPC requests |
+| `rpc.http2` | `false` | Opt in to HTTP/2 prior-knowledge transport with adaptive window and keep-alive (see below) |
 
 Example:
 ```json
@@ -410,10 +411,42 @@ Example:
     "rpc": {
         "concurrency": 100,
         "requests_per_second": 7500,
-        "batch_size": 1000
+        "batch_size": 1000,
+        "http2": true
     }
 }
 ```
+
+### HTTP/2 Transport
+
+Setting `rpc.http2 = true` switches the underlying `reqwest::Client` from alloy's
+default (which negotiates h2 via ALPN but allows HTTP/1.1 fallback) to a client
+built with:
+
+- `http2_prior_knowledge()` — forces HTTP/2; fails loudly if the server cannot
+  speak h2 instead of silently downgrading to HTTP/1.1.
+- `http2_adaptive_window(true)` — BDP-based flow-control window tuning, useful
+  for streaming large batches of concurrent requests over a single connection.
+- `http2_keep_alive_interval = 30s`, `http2_keep_alive_timeout = 10s`,
+  `http2_keep_alive_while_idle = true` — keeps the multiplexed connection alive
+  through idle periods so we don't pay for repeated TLS + ALPN handshakes.
+- `pool_idle_timeout = 90s` — retains the connection in the pool between bursts.
+
+When to enable:
+
+- **Enable** when connecting to an HTTPS RPC endpoint you have verified speaks
+  HTTP/2 (Alchemy, Infura, QuickNode, most managed providers) and you are running
+  many concurrent requests — HTTP/2 stream multiplexing removes HoL blocking at
+  the connection layer, which is the main throughput lever once rate limiting is
+  not the bottleneck.
+- **Leave off** (the default) when pointing at a provider whose HTTP/2 support is
+  unknown, or at cleartext `http://` endpoints (prior knowledge on cleartext
+  sends h2c, which most providers do not accept), or when you need the h1
+  fallback path.
+
+Enabling this flag does not change the RPC semantics, batching, rate limiting,
+or retry behavior — only the transport. Observability remains the same (all RPC
+metrics are still recorded).
 
 ### Sliding Window Rate Limiter
 

--- a/src/rpc/alchemy.rs
+++ b/src/rpc/alchemy.rs
@@ -197,6 +197,9 @@ pub struct AlchemyConfig {
     pub retry: RetryConfig,
     /// Max concurrent in-flight RPC requests. Configurable via RPC_CONCURRENCY env var.
     pub rpc_concurrency: usize,
+    /// When true, force the underlying HTTP transport to HTTP/2 prior knowledge
+    /// with adaptive window sizing and keep-alive.
+    pub force_http2: bool,
 }
 
 #[allow(dead_code)]
@@ -210,6 +213,7 @@ impl AlchemyConfig {
             batching_enabled: true,
             retry: RetryConfig::default(),
             rpc_concurrency: 100,
+            force_http2: false,
         }
     }
 
@@ -232,6 +236,11 @@ impl AlchemyConfig {
         self.rpc_concurrency = concurrency;
         self
     }
+
+    pub fn with_force_http2(mut self, force: bool) -> Self {
+        self.force_http2 = force;
+        self
+    }
 }
 
 /// Default compute units per second for Alchemy.
@@ -251,6 +260,7 @@ impl Default for AlchemyConfig {
             batching_enabled: true,
             retry: RetryConfig::default(),
             rpc_concurrency: 100,
+            force_http2: false,
         }
     }
 }
@@ -357,7 +367,8 @@ impl AlchemyClient {
         let rpc_config = RpcClientConfig::new(config.url.clone())
             .with_batch_size(config.max_batch_size)
             .with_concurrency(config.rpc_concurrency)
-            .with_batching(config.batching_enabled);
+            .with_batching(config.batching_enabled)
+            .with_force_http2(config.force_http2);
 
         let inner = Arc::new(RpcClient::new(rpc_config)?);
 
@@ -389,11 +400,13 @@ impl AlchemyClient {
         rpc_concurrency: usize,
         max_batch_size: usize,
         shared_limiter: Option<Arc<SlidingWindowRateLimiter>>,
+        force_http2: bool,
     ) -> Result<Self, RpcError> {
         let url = Url::parse(url).map_err(|e| RpcError::InvalidUrl(e.to_string()))?;
         let config = AlchemyConfig::new(url, compute_units_per_second)
             .with_rpc_concurrency(rpc_concurrency)
-            .with_batch_size(max_batch_size);
+            .with_batch_size(max_batch_size)
+            .with_force_http2(force_http2);
         Self::new_with_limiter(config, shared_limiter)
     }
 
@@ -1447,5 +1460,44 @@ mod tests {
 
         assert_eq!(client.config().rpc_concurrency, 17);
         assert_eq!(client.inner().config().concurrency, 17);
+    }
+
+    /// force_http2 defaults to false and the builder flips it on.
+    #[test]
+    fn test_alchemy_config_force_http2_builder() {
+        let config = AlchemyConfig::default();
+        assert!(!config.force_http2);
+
+        let config = AlchemyConfig::default().with_force_http2(true);
+        assert!(config.force_http2);
+    }
+
+    /// force_http2 propagates from AlchemyConfig into the inner RpcClientConfig.
+    #[test]
+    fn test_alchemy_client_propagates_force_http2() {
+        let config = AlchemyConfig::new(
+            Url::parse("https://eth-mainnet.g.alchemy.com/v2/test").unwrap(),
+            7500,
+        )
+        .with_force_http2(true);
+
+        let client = AlchemyClient::new(config).unwrap();
+        assert!(client.config().force_http2);
+        assert!(client.inner().config().force_http2);
+    }
+
+    /// AlchemyClient::from_url_with_options accepts and honors the flag.
+    #[test]
+    fn test_alchemy_from_url_with_options_http2() {
+        let client = AlchemyClient::from_url_with_options(
+            "https://eth-mainnet.g.alchemy.com/v2/test",
+            7500,
+            100,
+            100,
+            None,
+            true,
+        )
+        .expect("should build Alchemy HTTP/2 client");
+        assert!(client.config().force_http2);
     }
 }

--- a/src/rpc/provider.rs
+++ b/src/rpc/provider.rs
@@ -393,6 +393,10 @@ pub struct RpcClientConfig {
     pub batching_enabled: bool,
     pub rate_limit: Option<RateLimitConfig>,
     pub retry: RetryConfig,
+    /// When true, build the underlying reqwest Client with HTTP/2 prior knowledge
+    /// (no HTTP/1.1 fallback), BDP-based adaptive flow-control, and idle keep-alive
+    /// tuned for multiplexed JSON-RPC traffic.
+    pub force_http2: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -429,6 +433,7 @@ impl RpcClientConfig {
             batching_enabled: true,
             rate_limit: None,
             retry: RetryConfig::default(),
+            force_http2: false,
         }
     }
 
@@ -456,6 +461,39 @@ impl RpcClientConfig {
         self.retry = config;
         self
     }
+
+    pub fn with_force_http2(mut self, force: bool) -> Self {
+        self.force_http2 = force;
+        self
+    }
+}
+
+/// Build the underlying alloy `RootProvider` for an RPC endpoint.
+///
+/// When `force_http2` is true, the provider is backed by a custom `reqwest::Client`
+/// with HTTP/2 prior knowledge (no HTTP/1.1 fallback), BDP-based adaptive window
+/// sizing, and idle keep-alive — suited for high-throughput multiplexed RPC.
+/// When false, alloy's default HTTP provider is used, which still negotiates h2
+/// opportunistically via ALPN on HTTPS endpoints.
+fn build_provider(url: Url, force_http2: bool) -> Result<RootProvider<Ethereum>, RpcError> {
+    if !force_http2 {
+        return Ok(RootProvider::<Ethereum>::new_http(url));
+    }
+
+    let http_client = reqwest::Client::builder()
+        .http2_prior_knowledge()
+        .http2_adaptive_window(true)
+        .http2_keep_alive_interval(Duration::from_secs(30))
+        .http2_keep_alive_timeout(Duration::from_secs(10))
+        .http2_keep_alive_while_idle(true)
+        .pool_idle_timeout(Some(Duration::from_secs(90)))
+        .build()
+        .map_err(|e| {
+            RpcError::Transport(format!("failed to build reqwest HTTP/2 client: {}", e))
+        })?;
+
+    let rpc_client = alloy::rpc::client::RpcClient::new_http_with_client(http_client, url);
+    Ok(RootProvider::<Ethereum>::new(rpc_client))
 }
 
 #[derive(Clone)]
@@ -472,7 +510,7 @@ pub struct RpcClient {
 #[allow(dead_code)]
 impl RpcClient {
     pub fn new(config: RpcClientConfig) -> Result<Self, RpcError> {
-        let provider = RootProvider::<Ethereum>::new_http(config.url.clone());
+        let provider = build_provider(config.url.clone(), config.force_http2)?;
         let chain = chain_label_from_url(&config.url);
         let concurrency = config.concurrency.max(1);
 
@@ -503,7 +541,7 @@ impl RpcClient {
         config: RpcClientConfig,
         limiter: Arc<SlidingWindowRateLimiter>,
     ) -> Result<Self, RpcError> {
-        let provider = RootProvider::<Ethereum>::new_http(config.url.clone());
+        let provider = build_provider(config.url.clone(), config.force_http2)?;
         let chain = chain_label_from_url(&config.url);
         let concurrency = config.concurrency.max(1);
         Ok(Self {
@@ -1172,5 +1210,52 @@ mod tests {
     fn default_concurrency_is_100() {
         let config = RpcClientConfig::new(Url::parse("http://localhost:8545").unwrap());
         assert_eq!(config.concurrency, 100);
+    }
+
+    /// Verify force_http2 defaults to false.
+    #[test]
+    fn default_force_http2_is_false() {
+        let config = RpcClientConfig::new(Url::parse("http://localhost:8545").unwrap());
+        assert!(!config.force_http2);
+    }
+
+    /// Verify with_force_http2 builder sets the flag.
+    #[test]
+    fn with_force_http2_builder() {
+        let config = RpcClientConfig::new(Url::parse("http://localhost:8545").unwrap())
+            .with_force_http2(true);
+        assert!(config.force_http2);
+    }
+
+    /// Verify that building the reqwest HTTP/2 client actually succeeds.
+    ///
+    /// This exercises the reqwest feature set (http2 + rustls-tls) and the
+    /// `http2_prior_knowledge` + adaptive-window + keep-alive knobs we configure.
+    #[test]
+    fn build_provider_with_http2_succeeds() {
+        let url = Url::parse("http://localhost:8545").unwrap();
+        let provider = build_provider(url, true);
+        assert!(
+            provider.is_ok(),
+            "HTTP/2 provider construction should not fail: {:?}",
+            provider.err()
+        );
+    }
+
+    /// Verify build_provider with http2 disabled returns a default alloy provider.
+    #[test]
+    fn build_provider_without_http2_succeeds() {
+        let url = Url::parse("http://localhost:8545").unwrap();
+        let provider = build_provider(url, false);
+        assert!(provider.is_ok());
+    }
+
+    /// Verify that RpcClient::new propagates force_http2 through to provider build.
+    #[test]
+    fn rpc_client_new_with_force_http2() {
+        let config = RpcClientConfig::new(Url::parse("http://localhost:8545").unwrap())
+            .with_force_http2(true);
+        let client = RpcClient::new(config);
+        assert!(client.is_ok());
     }
 }

--- a/src/rpc/unified.rs
+++ b/src/rpc/unified.rs
@@ -58,12 +58,16 @@ impl UnifiedRpcClient {
     /// * `rpc_concurrency` - Max concurrent in-flight RPC requests
     /// * `max_batch_size` - Maximum number of requests per JSON-RPC batch
     /// * `shared_limiter` - Optional shared rate limiter for account-level rate limiting
+    /// * `force_http2` - When true, build the HTTP transport with HTTP/2 prior knowledge
+    ///   (no HTTP/1.1 fallback) and H2 tuning (adaptive window, keep-alive). Applies to
+    ///   both Standard and Alchemy clients.
     pub fn from_url_with_options(
         url: &str,
         compute_units_per_second: u32,
         rpc_concurrency: usize,
         max_batch_size: usize,
         shared_limiter: Option<Arc<SlidingWindowRateLimiter>>,
+        force_http2: bool,
     ) -> Result<Self, RpcError> {
         if url.contains("alchemy") {
             Ok(Self::Alchemy(AlchemyClient::from_url_with_options(
@@ -72,13 +76,15 @@ impl UnifiedRpcClient {
                 rpc_concurrency,
                 max_batch_size,
                 shared_limiter,
+                force_http2,
             )?))
         } else {
             let parsed_url =
                 url::Url::parse(url).map_err(|e| RpcError::InvalidUrl(e.to_string()))?;
             let config = RpcClientConfig::new(parsed_url)
                 .with_batch_size(max_batch_size)
-                .with_concurrency(rpc_concurrency);
+                .with_concurrency(rpc_concurrency)
+                .with_force_http2(force_http2);
             let client = if let Some(limiter) = shared_limiter {
                 RpcClient::new_with_shared_limiter(config, limiter)?
             } else {
@@ -347,5 +353,57 @@ impl std::fmt::Debug for UnifiedRpcClient {
                 .field(client)
                 .finish(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Building a Standard (non-Alchemy) client with force_http2=true should
+    /// succeed and select the Standard variant.
+    #[test]
+    fn from_url_with_options_standard_http2() {
+        let client = UnifiedRpcClient::from_url_with_options(
+            "https://eth.drpc.org",
+            7500,
+            100,
+            100,
+            None,
+            true,
+        )
+        .expect("should build standard HTTP/2 client");
+        assert!(matches!(client, UnifiedRpcClient::Standard(_)));
+    }
+
+    /// Building an Alchemy client with force_http2=true should succeed and
+    /// select the Alchemy variant.
+    #[test]
+    fn from_url_with_options_alchemy_http2() {
+        let client = UnifiedRpcClient::from_url_with_options(
+            "https://eth-mainnet.g.alchemy.com/v2/test",
+            7500,
+            100,
+            100,
+            None,
+            true,
+        )
+        .expect("should build Alchemy HTTP/2 client");
+        assert!(matches!(client, UnifiedRpcClient::Alchemy(_)));
+    }
+
+    /// Default force_http2=false path still builds a usable Standard client.
+    #[test]
+    fn from_url_with_options_standard_no_http2() {
+        let client = UnifiedRpcClient::from_url_with_options(
+            "https://eth.drpc.org",
+            7500,
+            100,
+            100,
+            None,
+            false,
+        )
+        .expect("should build standard client with default transport");
+        assert!(matches!(client, UnifiedRpcClient::Standard(_)));
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -133,6 +133,7 @@ pub fn build_rpc_client(
     let units_per_second = rpc_config
         .units_per_second()
         .unwrap_or(rpc_defaults::ALCHEMY_CU_PER_SECOND);
+    let http2 = rpc_config.http2_enabled();
 
     let rate_limiter = Arc::new(SlidingWindowRateLimiter::new(units_per_second));
 
@@ -142,13 +143,15 @@ pub fn build_rpc_client(
         concurrency,
         batch_size,
         Some(rate_limiter.clone()),
+        http2,
     )?;
 
     tracing::info!(
-        "RPC config: concurrency={}, units_per_second={}, batch_size={}",
+        "RPC config: concurrency={}, units_per_second={}, batch_size={}, http2={}",
         concurrency,
         units_per_second,
-        batch_size
+        batch_size,
+        http2
     );
 
     Ok((rate_limiter, Arc::new(client)))
@@ -172,6 +175,7 @@ pub fn build_rpc_client_with_limiter(
         concurrency,
         batch_size,
         Some(shared_limiter),
+        rpc_config.http2_enabled(),
     )
     .map_err(Into::into)
 }
@@ -352,6 +356,7 @@ impl ChainRuntime {
                 concurrency,
                 rpc_batch_size,
                 Some(limiter.clone()),
+                chain.rpc.http2_enabled(),
             )?;
             (limiter, Arc::new(client))
         } else {

--- a/src/types/config/chain.rs
+++ b/src/types/config/chain.rs
@@ -58,6 +58,18 @@ pub struct RpcConfig {
     /// Mutually exclusive with `requests_per_second` and `compute_units_per_second`.
     #[serde(default)]
     pub rate_limit_group: Option<String>,
+    /// Opt in to HTTP/2 for the RPC transport.
+    ///
+    /// When true, the underlying reqwest client is built with HTTP/2 prior knowledge
+    /// (no HTTP/1.1 fallback), BDP-based adaptive window sizing, and idle keep-alive.
+    /// This is best for HTTPS endpoints that support h2 (e.g., Alchemy, Infura, QuickNode)
+    /// and want maximum stream multiplexing for concurrent JSON-RPC calls.
+    ///
+    /// When false or unset, the default transport is used (alloy's `RootProvider::new_http`),
+    /// which still negotiates h2 opportunistically via ALPN on HTTPS endpoints but also
+    /// allows HTTP/1.1 fallback.
+    #[serde(default)]
+    pub http2: Option<bool>,
 }
 
 impl RpcConfig {
@@ -67,6 +79,11 @@ impl RpcConfig {
 
     pub fn has_explicit_rate_limit(&self) -> bool {
         self.requests_per_second.is_some() || self.compute_units_per_second.is_some()
+    }
+
+    /// Returns the resolved HTTP/2 opt-in flag. Defaults to false when unset.
+    pub fn http2_enabled(&self) -> bool {
+        self.http2.unwrap_or(false)
     }
 }
 
@@ -222,8 +239,40 @@ mod tests {
             compute_units_per_second: Some(7500),
             batch_size: None,
             rate_limit_group: None,
+            http2: None,
         };
 
         assert_eq!(rpc.units_per_second(), Some(25));
+    }
+
+    #[test]
+    fn test_rpc_config_http2_default_is_false() {
+        let rpc = RpcConfig::default();
+        assert_eq!(rpc.http2, None);
+        assert!(!rpc.http2_enabled());
+    }
+
+    #[test]
+    fn test_rpc_config_http2_deserializes_from_json() {
+        let json = r#"{"concurrency": 100, "requests_per_second": 7500, "http2": true}"#;
+        let rpc: RpcConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(rpc.http2, Some(true));
+        assert!(rpc.http2_enabled());
+    }
+
+    #[test]
+    fn test_rpc_config_http2_false_deserializes() {
+        let json = r#"{"http2": false}"#;
+        let rpc: RpcConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(rpc.http2, Some(false));
+        assert!(!rpc.http2_enabled());
+    }
+
+    #[test]
+    fn test_rpc_config_http2_absent_defaults_to_none() {
+        let json = r#"{"concurrency": 50}"#;
+        let rpc: RpcConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(rpc.http2, None);
+        assert!(!rpc.http2_enabled());
     }
 }


### PR DESCRIPTION
  ## Summary

  - Add an `rpc.http2` boolean to each chain's RPC config block. When `true`, the
  underlying `reqwest::Client` is built via
  `alloy::rpc::client::RpcClient::new_http_with_client` with
  `http2_prior_knowledge`, `http2_adaptive_window`, idle keep-alive, and a pooled
  connection — tuned for high-throughput multiplexed JSON-RPC over a single HTTP/2
  connection.
  - When `false` or unset (the default), behavior is unchanged: alloy's
  `RootProvider::new_http` is used, which still negotiates h2 opportunistically via
  ALPN but keeps HTTP/1.1 as a fallback.
  - Flag is threaded through `RpcClientConfig` → `RpcClient` / `AlchemyClient` /
  `UnifiedRpcClient::from_url_with_options` → `build_rpc_client` /
  `ChainRuntime::build`, so a single `"http2": true` in the chain config propagates
  all the way down.
  - Startup log for each chain's RPC config now includes `http2=<bool>` so the
  setting is visible at a glance.
  - Added explicit `reqwest = 0.12` dep (features: `rustls-tls`, `http2`, `json`)
  pinned to match the version alloy's transport already pulls in, so both paths
  share one HTTP/reqwest/rustls stack.

  ## Why HTTP/2?

  For HTTPS RPC endpoints that support h2 (Alchemy, Infura, QuickNode, most managed
  providers), stream multiplexing removes head-of-line blocking at the connection
  layer. Once rate limiting is no longer the throughput bottleneck — which is where
  `AlchemyClient`'s sliding-window limiter already gets us — the dominant
  per-request cost becomes TCP/TLS connection overhead, and h2 amortizes that across
   all in-flight requests over a single connection. The `http2_prior_knowledge` mode
   also fails loudly if the server downgrades to HTTP/1.1, which is useful as a
  verification assertion during rollout.

  ## Config

  ```json
  {
    "name": "base",
    "rpc_url_env_var": "BASE_RPC_URL",
    "rpc": {
      "concurrency": 100,
      "requests_per_second": 7500,
      "batch_size": 1000,
      "http2": true
    }
  }

  Tests

  11 new tests (all passing, 25 total in rpc::):

  - src/types/config/chain.rs — http2 default, JSON round-trip of {"http2":
  true/false}, absent-field behavior.
  - src/rpc/provider.rs — RpcClientConfig default, with_force_http2 builder,
  build_provider succeeds with and without the flag (exercises the real reqwest
  HTTP/2 client builder), and RpcClient::new propagates it.
  - src/rpc/alchemy.rs — AlchemyConfig builder, AlchemyClient propagates the flag
  into its inner RpcClient, from_url_with_options honors it.
  - src/rpc/unified.rs — Standard and Alchemy variant selection with
  force_http2=true, default path.

  Notes

  - rpc.http2 is an Option<bool> (not a required field), so existing configs are
  untouched.
  - The flag only changes the transport. Batching, rate limiting, retries, metrics,
  and semantics are all unchanged.
  - Do not enable this against cleartext http:// endpoints unless you've verified
  the server speaks h2c — prior-knowledge mode on cleartext sends h2c, which most
  providers reject.