### PR TITLE
feat: solana config layer (phase 3)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [features]
 default = []
 bench = []
+solana = []
 
 [dependencies]
 alloy-primitives = { version = "1.5.2", features = ["serde"] }

--- a/src/live/collector.rs
+++ b/src/live/collector.rs
@@ -1645,6 +1645,10 @@ mod tests {
             block_receipts_method: None,
             factory_collections: HashMap::new(),
             rpc: Default::default(),
+            #[cfg(feature = "solana")]
+            solana_programs: Default::default(),
+            #[cfg(feature = "solana")]
+            commitment: Default::default(),
         }
     }
 

--- a/src/live/eth_calls.rs
+++ b/src/live/eth_calls.rs
@@ -830,6 +830,10 @@ mod tests {
             block_receipts_method: None,
             factory_collections: HashMap::new(),
             rpc: Default::default(),
+            #[cfg(feature = "solana")]
+            solana_programs: Default::default(),
+            #[cfg(feature = "solana")]
+            commitment: Default::default(),
         }
     }
 

--- a/src/raw_data/historical/current/eth_calls/range_processor.rs
+++ b/src/raw_data/historical/current/eth_calls/range_processor.rs
@@ -357,6 +357,10 @@ mod tests {
             block_receipts_method: None,
             factory_collections: HashMap::new(),
             rpc: Default::default(),
+            #[cfg(feature = "solana")]
+            solana_programs: Default::default(),
+            #[cfg(feature = "solana")]
+            commitment: Default::default(),
         }
     }
 

--- a/src/types/config/chain.rs
+++ b/src/types/config/chain.rs
@@ -8,6 +8,10 @@ use crate::types::config::contract::{
     load_contracts_from_path, load_factory_collections_from_path, Contracts, FactoryCollections,
 };
 use crate::types::config::generic::InlineOrPath;
+#[cfg(feature = "solana")]
+use crate::types::config::solana::{
+    load_solana_programs_from_path, SolanaCommitment, SolanaPrograms,
+};
 
 /// RPC method to use for fetching block receipts.
 ///
@@ -88,6 +92,15 @@ pub struct ChainConfigRaw {
     /// RPC client configuration (rate limiting, concurrency).
     #[serde(default)]
     pub rpc: RpcConfig,
+    /// Solana program configuration. Inline or file/directory path.
+    /// Resolved into `ChainConfig.solana_programs`.
+    #[cfg(feature = "solana")]
+    #[serde(default)]
+    pub programs: Option<InlineOrPath<SolanaPrograms>>,
+    /// Solana commitment level. Defaults to `confirmed` when absent.
+    #[cfg(feature = "solana")]
+    #[serde(default)]
+    pub commitment: Option<SolanaCommitment>,
 }
 
 #[derive(Debug, Clone)]
@@ -104,6 +117,12 @@ pub struct ChainConfig {
     pub factory_collections: FactoryCollections,
     /// RPC client configuration (rate limiting, concurrency).
     pub rpc: RpcConfig,
+    /// Resolved Solana program map. Empty when no `programs` was set.
+    #[cfg(feature = "solana")]
+    pub solana_programs: SolanaPrograms,
+    /// Resolved Solana commitment level. Defaults to `Confirmed`.
+    #[cfg(feature = "solana")]
+    pub commitment: SolanaCommitment,
 }
 
 pub fn resolve_chain_config(
@@ -126,6 +145,20 @@ pub fn resolve_chain_config(
         None => FactoryCollections::new(),
     };
 
+    #[cfg(feature = "solana")]
+    let solana_programs = match raw_config.programs {
+        Some(InlineOrPath::Inline(programs)) => programs,
+        Some(InlineOrPath::Path(p)) => {
+            load_solana_programs_from_path(base_dir, &p).map_err(|e| {
+                anyhow::anyhow!("Failed to load Solana programs from path {}: {}", p, e)
+            })?
+        }
+        None => SolanaPrograms::new(),
+    };
+
+    #[cfg(feature = "solana")]
+    let commitment = raw_config.commitment.unwrap_or_default();
+
     Ok(ChainConfig {
         name: raw_config.name,
         chain_id: raw_config.chain_id,
@@ -137,6 +170,10 @@ pub fn resolve_chain_config(
         block_receipts_method: raw_config.block_receipts_method,
         factory_collections,
         rpc: raw_config.rpc,
+        #[cfg(feature = "solana")]
+        solana_programs,
+        #[cfg(feature = "solana")]
+        commitment,
     })
 }
 
@@ -192,6 +229,10 @@ mod tests {
             block_receipts_method: None,
             factory_collections: None,
             rpc: RpcConfig::default(),
+            #[cfg(feature = "solana")]
+            programs: None,
+            #[cfg(feature = "solana")]
+            commitment: None,
         };
         let result = resolve_chain_config(raw, Path::new("/tmp"));
         assert!(result.is_err());
@@ -210,6 +251,10 @@ mod tests {
             block_receipts_method: Some(BlockReceiptsMethod::EthGetBlockReceipts),
             factory_collections: None,
             rpc: RpcConfig::default(),
+            #[cfg(feature = "solana")]
+            programs: None,
+            #[cfg(feature = "solana")]
+            commitment: None,
         };
         let result = resolve_chain_config(raw, Path::new("/tmp"));
         assert!(result.is_ok());
@@ -260,5 +305,129 @@ mod tests {
 
         let raw: ChainConfigRaw = serde_json::from_str(json).unwrap();
         assert_eq!(raw.chain_type, ChainType::Solana);
+    }
+
+    #[cfg(feature = "solana")]
+    mod solana_tests {
+        use super::*;
+        use crate::types::config::solana::SolanaCommitment;
+
+        #[test]
+        fn chain_config_raw_solana_with_inline_programs_deserializes() {
+            let json = r#"{
+                "name": "solana-mainnet",
+                "chain_id": 101,
+                "chain_type": "solana",
+                "rpc_url_env_var": "SOLANA_RPC_URL",
+                "contracts": {},
+                "commitment": "finalized",
+                "programs": {
+                    "whirlpool": {
+                        "program_id": "whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc",
+                        "events": [{ "name": "Traded" }]
+                    }
+                }
+            }"#;
+
+            let raw: ChainConfigRaw = serde_json::from_str(json).unwrap();
+            assert_eq!(raw.chain_type, ChainType::Solana);
+            assert_eq!(raw.commitment, Some(SolanaCommitment::Finalized));
+            let programs = raw.programs.expect("programs present");
+            match programs {
+                InlineOrPath::Inline(map) => {
+                    assert_eq!(map.len(), 1);
+                    assert!(map.contains_key("whirlpool"));
+                }
+                InlineOrPath::Path(_) => panic!("expected inline programs"),
+            }
+        }
+
+        #[test]
+        fn chain_config_raw_solana_fields_default_to_none() {
+            let json = r#"{
+                "name": "test",
+                "chain_id": 1,
+                "rpc_url_env_var": "RPC_URL",
+                "contracts": {}
+            }"#;
+
+            let raw: ChainConfigRaw = serde_json::from_str(json).unwrap();
+            assert!(raw.programs.is_none());
+            assert!(raw.commitment.is_none());
+        }
+
+        #[test]
+        fn resolve_chain_config_solana_programs_inline() {
+            let json = r#"{
+                "name": "solana",
+                "chain_id": 101,
+                "chain_type": "solana",
+                "rpc_url_env_var": "SOLANA_RPC_URL",
+                "contracts": {},
+                "commitment": "processed",
+                "programs": {
+                    "whirlpool": {
+                        "program_id": "whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc"
+                    }
+                }
+            }"#;
+
+            let raw: ChainConfigRaw = serde_json::from_str(json).unwrap();
+            let resolved = resolve_chain_config(raw, Path::new("/tmp")).unwrap();
+            assert_eq!(resolved.chain_type, ChainType::Solana);
+            assert_eq!(resolved.commitment, SolanaCommitment::Processed);
+            assert_eq!(resolved.solana_programs.len(), 1);
+            let program = resolved
+                .solana_programs
+                .get("whirlpool")
+                .expect("whirlpool present");
+            assert_eq!(
+                program.program_id,
+                "whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc"
+            );
+        }
+
+        #[test]
+        fn resolve_chain_config_solana_programs_missing_path_returns_err() {
+            let raw = ChainConfigRaw {
+                name: "solana".to_string(),
+                chain_id: 101,
+                chain_type: ChainType::Solana,
+                rpc_url_env_var: "SOLANA_RPC_URL".to_string(),
+                ws_url_env_var: None,
+                start_block: None,
+                contracts: InlineOrPath::Inline(Contracts::new()),
+                block_receipts_method: None,
+                factory_collections: None,
+                rpc: RpcConfig::default(),
+                programs: Some(InlineOrPath::Path("nonexistent/programs.json".to_string())),
+                commitment: None,
+            };
+            let result = resolve_chain_config(raw, Path::new("/tmp"));
+            assert!(result.is_err());
+            let msg = result.unwrap_err().to_string();
+            assert!(msg.contains("Failed to load Solana programs from path"));
+        }
+
+        #[test]
+        fn resolve_chain_config_solana_commitment_defaults_to_confirmed() {
+            let raw = ChainConfigRaw {
+                name: "solana".to_string(),
+                chain_id: 101,
+                chain_type: ChainType::Solana,
+                rpc_url_env_var: "SOLANA_RPC_URL".to_string(),
+                ws_url_env_var: None,
+                start_block: None,
+                contracts: InlineOrPath::Inline(Contracts::new()),
+                block_receipts_method: None,
+                factory_collections: None,
+                rpc: RpcConfig::default(),
+                programs: None,
+                commitment: None,
+            };
+            let resolved = resolve_chain_config(raw, Path::new("/tmp")).unwrap();
+            assert_eq!(resolved.commitment, SolanaCommitment::Confirmed);
+            assert!(resolved.solana_programs.is_empty());
+        }
     }
 }

--- a/src/types/config/mod.rs
+++ b/src/types/config/mod.rs
@@ -7,5 +7,7 @@ pub mod indexer;
 pub mod loader;
 pub mod metrics;
 pub mod raw_data;
+#[cfg(feature = "solana")]
+pub mod solana;
 pub mod storage;
 pub mod transformations;

--- a/src/types/config/solana.rs
+++ b/src/types/config/solana.rs
@@ -1,0 +1,256 @@
+//! Solana program configuration types.
+//!
+//! Phase 3 of the Solana support roadmap (`docs/solana/roadmap.md`).
+//!
+//! These types are pure declarative configuration. They are deserialized from
+//! the same chain config JSON that EVM chains use, and resolved into a
+//! `SolanaPrograms` map alongside the rest of `ChainConfig`. Nothing in this
+//! module touches RPC, decoding, or runtime state — those land in Phases 4–8.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::types::config::eth_call::Frequency;
+use crate::types::config::loader::load_config_from_path;
+
+/// Map of program key (a human-friendly name chosen by the user) to its
+/// configuration. Mirrors the `Contracts` type used by EVM chains.
+pub type SolanaPrograms = HashMap<String, SolanaProgramConfig>;
+
+/// Configuration for one Solana program the indexer should follow.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SolanaProgramConfig {
+    /// Base58-encoded program id pubkey. Validated lazily by the Phase 4
+    /// RPC layer; we keep it as a string here so config loading does not
+    /// depend on a base58 decoder.
+    pub program_id: String,
+
+    /// Optional path to an Anchor IDL JSON file. Resolved against the
+    /// config base directory by the Phase 6 IDL loader.
+    #[serde(default)]
+    pub idl_path: Option<String>,
+
+    /// Events to decode and dispatch to handlers.
+    #[serde(default)]
+    pub events: Option<Vec<SolanaEventConfig>>,
+
+    /// Account state reads. Live-mode-only — see roadmap §8.3.
+    #[serde(default)]
+    pub accounts: Option<Vec<SolanaAccountReadConfig>>,
+
+    /// Address discovery rules — events whose decoded fields contain new
+    /// account addresses to track.
+    #[serde(default)]
+    pub discovery: Option<Vec<SolanaDiscoveryConfig>>,
+
+    /// First slot to start indexing from. Defaults to the chain's
+    /// `start_block` (interpreted as a slot) if absent.
+    #[serde(default)]
+    pub start_slot: Option<u64>,
+}
+
+/// One event to subscribe to within a program.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SolanaEventConfig {
+    /// Anchor event name (e.g. `"Traded"`).
+    pub name: String,
+    /// 8-byte hex discriminator. If absent, computed by the Phase 6 IDL
+    /// loader as `sha256("event:<name>")[..8]`.
+    #[serde(default)]
+    pub discriminator: Option<String>,
+}
+
+/// One account state read to perform in live mode.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SolanaAccountReadConfig {
+    /// Logical name for this account read (used as parquet/source key).
+    pub name: String,
+    /// IDL account type to deserialize the raw account data as.
+    pub account_type: String,
+    /// Reuses the existing `Frequency` enum from eth_call config. The
+    /// expected variants for Solana account reads are `OnEvents` (the common
+    /// case — read after a decoded event triggers it) and `Once`. Block-
+    /// cadence variants will be mapped to slot cadence by the Phase 8 live
+    /// account reader.
+    #[serde(default)]
+    pub frequency: Frequency,
+}
+
+/// Address discovery rule: when a particular event fires, treat the named
+/// field as the address of a newly created account to start tracking.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SolanaDiscoveryConfig {
+    /// Decoded event name that triggers discovery (e.g. `"PoolInitialized"`).
+    pub event_name: String,
+    /// Field in the decoded event whose `DecodedValue::Pubkey` value is the
+    /// newly created account address.
+    pub address_field: String,
+    /// Optional IDL account type to associate with the discovered address.
+    #[serde(default)]
+    pub account_type: Option<String>,
+}
+
+/// Solana commitment level. Replaces the roadmap's `Option<String>` so that
+/// invalid values are rejected at deserialization time rather than at first
+/// RPC call. Default is `Confirmed`, the Solana ecosystem default and the
+/// safest middle ground for the Phase 8 reorg detector.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum SolanaCommitment {
+    Processed,
+    #[default]
+    Confirmed,
+    Finalized,
+}
+
+/// Load Solana programs from a path (file or directory). Mirrors
+/// `load_contracts_from_path` in `contract.rs` and inherits HashMap-based
+/// merging plus duplicate-key detection from `loader::MergeableConfig`.
+pub fn load_solana_programs_from_path(
+    base_dir: &Path,
+    path: &str,
+) -> anyhow::Result<SolanaPrograms> {
+    load_config_from_path::<SolanaPrograms>(base_dir, path)
+        .map_err(|e| anyhow::anyhow!("Failed to load Solana programs: {}", e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn solana_commitment_default_is_confirmed() {
+        assert_eq!(SolanaCommitment::default(), SolanaCommitment::Confirmed);
+    }
+
+    #[test]
+    fn solana_commitment_serde_roundtrip() {
+        for (json, variant) in [
+            (r#""processed""#, SolanaCommitment::Processed),
+            (r#""confirmed""#, SolanaCommitment::Confirmed),
+            (r#""finalized""#, SolanaCommitment::Finalized),
+        ] {
+            let parsed: SolanaCommitment = serde_json::from_str(json).unwrap();
+            assert_eq!(parsed, variant);
+            let serialized = serde_json::to_string(&variant).unwrap();
+            assert_eq!(serialized, json);
+        }
+    }
+
+    #[test]
+    fn solana_commitment_rejects_unknown_value() {
+        let result: Result<SolanaCommitment, _> = serde_json::from_str(r#""safe""#);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn solana_program_config_minimal_deserializes() {
+        let json = r#"{ "program_id": "whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc" }"#;
+        let cfg: SolanaProgramConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.program_id, "whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc");
+        assert!(cfg.idl_path.is_none());
+        assert!(cfg.events.is_none());
+        assert!(cfg.accounts.is_none());
+        assert!(cfg.discovery.is_none());
+        assert!(cfg.start_slot.is_none());
+    }
+
+    #[test]
+    fn solana_program_config_full_deserializes() {
+        let json = r#"{
+            "program_id": "whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc",
+            "idl_path": "idls/whirlpool.json",
+            "start_slot": 200000000,
+            "events": [
+                { "name": "Traded" },
+                { "name": "PoolInitialized", "discriminator": "0102030405060708" }
+            ],
+            "accounts": [
+                { "name": "whirlpool_state", "account_type": "Whirlpool", "frequency": "once" }
+            ],
+            "discovery": [
+                {
+                    "event_name": "PoolInitialized",
+                    "address_field": "whirlpool",
+                    "account_type": "Whirlpool"
+                }
+            ]
+        }"#;
+
+        let cfg: SolanaProgramConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.idl_path.as_deref(), Some("idls/whirlpool.json"));
+        assert_eq!(cfg.start_slot, Some(200_000_000));
+
+        let events = cfg.events.expect("events present");
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].name, "Traded");
+        assert!(events[0].discriminator.is_none());
+        assert_eq!(events[1].name, "PoolInitialized");
+        assert_eq!(events[1].discriminator.as_deref(), Some("0102030405060708"));
+
+        let accounts = cfg.accounts.expect("accounts present");
+        assert_eq!(accounts.len(), 1);
+        assert_eq!(accounts[0].name, "whirlpool_state");
+        assert_eq!(accounts[0].account_type, "Whirlpool");
+        assert!(accounts[0].frequency.is_once());
+
+        let discovery = cfg.discovery.expect("discovery present");
+        assert_eq!(discovery.len(), 1);
+        assert_eq!(discovery[0].event_name, "PoolInitialized");
+        assert_eq!(discovery[0].address_field, "whirlpool");
+        assert_eq!(discovery[0].account_type.as_deref(), Some("Whirlpool"));
+    }
+
+    #[test]
+    fn solana_account_read_config_accepts_on_events_frequency() {
+        let json = r#"{
+            "name": "whirlpool_state",
+            "account_type": "Whirlpool",
+            "frequency": {
+                "on_events": [
+                    { "source": "whirlpool", "event": "Traded" }
+                ]
+            }
+        }"#;
+
+        let cfg: SolanaAccountReadConfig = serde_json::from_str(json).unwrap();
+        assert!(cfg.frequency.is_on_events());
+        let triggers = cfg.frequency.event_configs();
+        assert_eq!(triggers.len(), 1);
+        assert_eq!(triggers[0].source, "whirlpool");
+        assert_eq!(triggers[0].event, "Traded");
+    }
+
+    #[test]
+    fn load_solana_programs_from_path_missing_file_returns_err() {
+        let result = load_solana_programs_from_path(Path::new("/tmp"), "nonexistent/programs.json");
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("Failed to load Solana programs"));
+    }
+
+    #[test]
+    fn load_solana_programs_from_path_inline_file_succeeds() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let file_path = dir.path().join("programs.json");
+        std::fs::write(
+            &file_path,
+            r#"{
+                "whirlpool": {
+                    "program_id": "whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc"
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let programs = load_solana_programs_from_path(dir.path(), "programs.json").unwrap();
+        assert_eq!(programs.len(), 1);
+        let entry = programs.get("whirlpool").expect("whirlpool present");
+        assert_eq!(
+            entry.program_id,
+            "whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Phase 3 of the Solana support roadmap (`docs/solana/roadmap.md`): adds the
declarative config layer so a chain entry can carry Solana program/event/
account/discovery configuration alongside the existing EVM fields.

- New `solana` Cargo feature (empty marker — no runtime crates yet; those land in Phase 4). EVM-only builds remain bit-identical.
- New `src/types/config/solana.rs` with `SolanaPrograms`, `SolanaProgramConfig`, `SolanaEventConfig`, `SolanaAccountReadConfig`, `SolanaDiscoveryConfig`, the `SolanaCommitment` typed enum, and `load_solana_programs_from_path` (mirrors `load_contracts_from_path`, inherits HashMap merging + duplicate-key detection from `loader::MergeableConfig`).
- `ChainConfigRaw` / `ChainConfig` gain feature-gated `programs: Option<InlineOrPath<SolanaPrograms>>` and `commitment: Option<SolanaCommitment>` fields. `resolve_chain_config` loads programs (inline or path) and defaults `commitment` to `Confirmed`.
- 3 unrelated `test_chain()` test fixtures (`live/collector.rs`, `live/eth_calls.rs`, `raw_data/.../range_processor.rs`) get feature-gated additions so they keep compiling under `--features solana`.

## Design notes

- **`commitment` is a typed enum**, not the roadmap's `Option<String>`. `SolanaCommitment::{Processed, Confirmed, Finalized}` with `#[serde(rename_all = \"lowercase\")]` and `Default = Confirmed`. Invalid values fail at deserialization rather than first RPC call.
- **`Frequency` is reused** for `SolanaAccountReadConfig` as the roadmap specifies. The `OnEvents` and `Once` variants are the ones live-mode account reads need; if the block-cadence variants prove confusing in Phase 8, swap to a dedicated `SolanaFrequency` then.
- **Option A feature gating**: feature-gated all new types and fields now even though Phases 1–2 didn't gate Solana types. Default builds stay EVM-only and bit-identical; the cost is a few `#[cfg(feature = \"solana\")]` annotations and three test fixture additions.

## Test coverage

- 8 unit tests in `solana.rs`: `SolanaCommitment` default / serde roundtrip / rejects unknown / minimal + full `SolanaProgramConfig` deserialization / `Frequency::OnEvents` inside `SolanaAccountReadConfig` / missing-path error / inline-file load success.
- 5 unit tests in `chain.rs::tests::solana_tests`: full Solana raw config deserializes / Solana fields default to `None` when absent / `resolve_chain_config` with inline programs / missing-path error / commitment defaults to `Confirmed`.
- `cargo test`: 527/527 pass (EVM-only, identical to baseline)
- `cargo test --features solana`: 540/540 pass (+13 new)
- Clippy: zero new errors/warnings introduced; only expected dead-code warnings on the new struct fields, which Phases 4–8 will consume.

## Out of scope (later phases)

- Solana RPC client / raw collectors / decoder / pipeline / live mode (Phases 4–8)
- IDL parsing or discriminator computation (Phase 6)
- Wiring `commitment` into any RPC call (Phase 4)
- `chain_type` ↔ field-presence cross-validation (Phase 7 dispatch)
- Making `contracts` optional so a Solana-only chain config doesn't need `"contracts": {}` (Phase 7)