### PR TITLE
fix: align testnet decay_multicurve getState output_type with base

### DIFF
--- a/config/contracts/baseSepolia/decay_multicurve.json
+++ b/config/contracts/baseSepolia/decay_multicurve.json
@@ -10,7 +10,7 @@
         "calls": [
             {
                 "function": "getState(address)",
-                "output_type": "(address numeraire, uint256 totalTokensOnBondingCurve, address dopplerHook, bytes graduationDopplerHookCalldata, uint8 status, (address currency0, address currency1, uint24 fee, int24 tickSpacing, address hooks) poolKey, int24 farTick)",
+                "output_type": "(address numeraire, uint8 status, (address currency0, address currency1, uint24 fee, int24 tickSpacing, address hooks) poolKey, int24 farTick)",
                 "frequency": {
                     "on_events": {
                         "source": "DecayMulticurveInitializer",

--- a/config/contracts/sepolia/decay_multicurve.json
+++ b/config/contracts/sepolia/decay_multicurve.json
@@ -7,7 +7,7 @@
         "calls": [
             {
                 "function": "getState(address)",
-                "output_type": "(address numeraire, uint256 totalTokensOnBondingCurve, address dopplerHook, bytes graduationDopplerHookCalldata, uint8 status, (address currency0, address currency1, uint24 fee, int24 tickSpacing, address hooks) poolKey, int24 farTick)",
+                "output_type": "(address numeraire, uint8 status, (address currency0, address currency1, uint24 fee, int24 tickSpacing, address hooks) poolKey, int24 farTick)",
                 "frequency": {
                     "on_events": {
                         "source": "DecayMulticurveInitializer",


### PR DESCRIPTION
## Summary

The `baseSepolia` and `sepolia` `decay_multicurve.json` configs had a 7-field `getState` output_type tuple:

```
(address numeraire, uint256 totalTokensOnBondingCurve, address dopplerHook, bytes graduationDopplerHookCalldata, uint8 status, (...) poolKey, int24 farTick)
```

This didn't match the deployed contract's actual 4-field struct used by the `base` config:

```
(address numeraire, uint8 status, (...) poolKey, int24 farTick)
```

The extra fields (`totalTokensOnBondingCurve`, `dopplerHook`, `graduationDopplerHookCalldata`) caused ABI field misalignment when decoding `getState` call results on testnets.

- Fixed `config/contracts/baseSepolia/decay_multicurve.json`
- Fixed `config/contracts/sepolia/decay_multicurve.json`