### PR TITLE
fix: add source columns to proceeds upsert and safe decimal exponentiation

### DIFF
--- a/src/transformations/event/v4/metrics.rs
+++ b/src/transformations/event/v4/metrics.rs
@@ -226,6 +226,8 @@ impl TransformationHandler for V4BaseMetricsHandler {
                 pool_id,
                 total_proceeds,
                 total_tokens_sold,
+                SOURCE,
+                self.version(),
             ));
         }
 
@@ -740,6 +742,8 @@ fn upsert_proceeds_state(
     pool_id: &[u8; 32],
     total_proceeds: &U256,
     total_tokens_sold: &U256,
+    source: &str,
+    source_version: u32,
 ) -> DbOperation {
     DbOperation::Upsert {
         table: "v4_base_proceeds_state".to_string(),
@@ -757,12 +761,16 @@ fn upsert_proceeds_state(
         columns: vec![
             "chain_id".to_string(),
             "pool_id".to_string(),
+            "source".to_string(),
+            "source_version".to_string(),
             "total_proceeds".to_string(),
             "total_tokens_sold".to_string(),
         ],
         values: vec![
             DbValue::Int64(chain_id as i64),
             DbValue::Bytes32(*pool_id),
+            DbValue::VarChar(source.to_string()),
+            DbValue::Int32(source_version as i32),
             DbValue::Numeric(total_proceeds.to_string()),
             DbValue::Numeric(total_tokens_sold.to_string()),
         ],
@@ -1062,7 +1070,7 @@ mod tests {
     #[test]
     fn test_upsert_proceeds_state_op() {
         let pool_id = make_pool_id(0xFF);
-        let op = upsert_proceeds_state(8453, &pool_id, &U256::from(9999u64), &U256::from(1234u64));
+        let op = upsert_proceeds_state(8453, &pool_id, &U256::from(9999u64), &U256::from(1234u64), "DopplerV4Hook", 1);
         match op {
             DbOperation::Upsert {
                 table,

--- a/src/transformations/util/usd_price.rs
+++ b/src/transformations/util/usd_price.rs
@@ -470,7 +470,14 @@ pub(crate) fn u256_to_decimal_adjusted(value: &U256, decimals: u8) -> BigDecimal
     if decimals == 0 {
         return raw;
     }
-    let divisor = BigDecimal::from(10u64.pow(decimals as u32));
+    let divisor: BigDecimal = {
+        let mut d = BigDecimal::from(1u64);
+        let ten = BigDecimal::from(10u64);
+        for _ in 0..decimals {
+            d = &d * &ten;
+        }
+        d
+    };
     raw / divisor
 }
 


### PR DESCRIPTION
## Summary

- **upsert_proceeds_state missing source/source_version columns**: The `upsert_proceeds_state` function listed `source` and `source_version` in its `conflict_columns` but omitted them from `columns` and `values`. Since these are NOT NULL columns in `v4_base_proceeds_state`, every INSERT would fail with a constraint violation. Added `source` and `source_version` parameters to the function signature, included them in `columns`/`values`, and updated the call site and test.

- **10u64.pow(decimals) overflow panic for decimals >= 20**: `u256_to_decimal_adjusted` used `10u64.pow(decimals as u32)` to build the divisor, which panics for any token with 20+ decimals since `10^20 > u64::MAX`. Replaced with overflow-safe iterative BigDecimal multiplication, matching the safe pattern already used in `price.rs::apply_decimal_exp`.