### PR TITLE
feat: multi-hop quote token USD price resolution

### DIFF
--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -147,10 +147,16 @@ migrations/
 - **doc**: `docs/features/transformation_utils.md`
 
 ### pool_metrics
-- **description**: Per-block OHLC snapshots, hot-query pool_state table, USD pricing, rolling metrics, and TVL computation for all pool types (V3, LockableV3, V4 hooks, migration pools). Shared BlockAccumulator, process_swaps/process_liquidity_deltas, and process_tvl functions. Per-pool-type TVL handlers compute amount0/1, tvl_usd, market_cap_usd, and active_liquidity_usd from stateless liquidity_deltas re-aggregation.
+- **description**: Per-block OHLC snapshots, hot-query pool_state table, USD pricing, rolling metrics, and TVL computation for all pool types (V3, LockableV3, V4 hooks, migration pools). Shared BlockAccumulator, process_swaps/process_liquidity_deltas, and process_tvl functions. Per-pool-type TVL handlers compute amount0/1, tvl_usd, market_cap_usd, and active_liquidity_usd from stateless liquidity_deltas re-aggregation. USD price resolution supports any token with a configured anchor pool in tokens.json via transitive multi-hop resolution (e.g., Bankr → WETH → USD).
 - **entry_points**: `src/transformations/event/v3/metrics.rs`, `src/transformations/event/metrics/`
 - **depends_on**: [transformations, transformation_utils]
 - **doc**: `docs/designs/pool-metrics/metrics_implementation_phases.md`
+
+### quote_token_pricing
+- **description**: Dynamic USD price resolution for pool quote tokens. Phase 1: config-driven anchor pools discovered from tokens.json (e.g., BankrWethPool) with transitive resolution. Phase 2 (planned): graph-based frontier expansion through indexed pools for unconfigured tokens.
+- **entry_points**: `src/transformations/eth_call/price.rs`, `src/transformations/util/usd_price.rs`
+- **depends_on**: [pool_metrics, transformation_utils]
+- **doc**: `docs/features/quote_token_pricing.md`
 
 ### live_mode
 - **description**: Real-time block processing via WebSocket. Bincode storage for fast per-block writes, reorg detection, automatic compaction to parquet, and gap backfill on reconnect.

--- a/docs/features/quote_token_pricing.md
+++ b/docs/features/quote_token_pricing.md
@@ -1,0 +1,82 @@
+# Quote Token Pricing
+
+## Scope
+
+Resolves any pool's quote token (numeraire) to a USD price so that metrics like `volume_usd`, `tvl_usd`, and `market_cap_usd` can be computed.
+
+### In scope
+- Dynamic discovery of anchor pool configs from `config/contracts/<chain>/tokens.json`
+- Transitive multi-hop price resolution (e.g., Bankr -> WETH -> USD)
+- Chainlink oracle ETH/USD price extraction
+- Stablecoin (USDC, USDT) identity pricing (1.0)
+- Zero-address (native ETH) treated as WETH
+- Phase 2 (planned): graph-based frontier expansion for unconfigured tokens
+
+### Not in scope
+- Non-Doppler pool price feeds
+- Real-time price oracles beyond Chainlink ETH/USD
+
+## Data Flow
+
+```
+tokens.json Pool configs (e.g., BankrWethPool)
+    |
+    v
+PriceHandler (eth_call, reads slot0/getSlot0)
+    |
+    v
+prices table: (token, quote_token, price)
+    |
+    v
+build_usd_price_context() [per metrics handler invocation]
+    |
+    +-- Seed stablecoins: USDC=1.0, USDT=1.0
+    +-- Extract ETH/USD from ChainlinkEthOracle calls
+    +-- Set WETH + zero-address = ETH/USD
+    +-- Query all latest prices from prices table
+    +-- Transitive resolution loop:
+    |     for each (token, quote_token, price):
+    |       if quote_token already resolved:
+    |         token_usd = price * quote_token_usd
+    |
+    v
+UsdPriceContext { prices: HashMap<address, usd_price> }
+    |
+    v
+quote_to_usd_multiplier(quote_token) -> Option<BigDecimal>
+```
+
+## Related Files
+
+| File | Role |
+|------|------|
+| `src/transformations/eth_call/price.rs` | PriceHandler: discovers pool configs from contracts, reads sqrtPriceX96, writes to prices table |
+| `src/transformations/eth_call/mod.rs` | Passes Contracts to PriceHandler registration |
+| `src/transformations/util/usd_price.rs` | OraclePriceCache (shared, DB-backed), UsdPriceContext (per-invocation), transitive resolution |
+| `src/transformations/util/pool_metadata.rs` | KNOWN_QUOTE_TOKENS for decimal resolution |
+| `config/contracts/<chain>/tokens.json` | Token addresses and anchor pool configs |
+| `migrations/tables/prices.sql` | Price data storage schema |
+
+## Key Exports
+
+- `OraclePriceCache::with_contracts(contracts)` - shared cache construction
+- `build_usd_price_context(ctx, cache, db, chain_id, contracts)` - per-invocation builder
+- `UsdPriceContext::quote_volume_to_usd(volume, token, decimals)` - volume conversion
+- `UsdPriceContext::quote_decimal_amount_to_usd(amount, token)` - TVL conversion
+
+## Invariants
+
+- Stablecoins (USDC, USDT) are always priced at 1.0 USD
+- The zero address is always equivalent to WETH for pricing
+- Transitive resolution terminates when no new tokens can be resolved (handles cycles)
+- PriceHandler version (1) is unchanged; new pool configs produce additive rows
+- Pool name convention `<Base><Quote>Pool` is used for automatic discovery
+
+## Config Convention
+
+Anchor pools in `tokens.json` follow the naming pattern `<BaseToken><QuoteToken>Pool`:
+- `BankrWethPool`: prices Bankr in terms of Weth
+- `ZoraUsdcPool`: prices Zora in terms of Usdc
+- `EurcUsdcPool`: prices Eurc in terms of Usdc
+
+Both the base token and quote token must also be configured as standalone entries with their address. The pool entry must have a `calls` array with a `slot0()` or `getSlot0()` function.

--- a/docs/features/quote_token_pricing.md
+++ b/docs/features/quote_token_pricing.md
@@ -85,7 +85,7 @@ quote_to_usd_multiplier(quote_token) -> Option<BigDecimal>
 - Pool name convention `<Base><Quote>Pool` is used for automatic discovery
 - Path resolution caches results for 1 week (~302,400 blocks on Base)
 - Unpriceable tokens (no path within 5 hops at $1k+ liquidity) are cached as is_priceable=false
-- Price derivation walks the path at query time using current pool_state prices (not stale cached prices)
+- Price derivation walks the path at query time using pool_snapshots (historically complete, not latest-only pool_state)
 
 ## Config Convention
 

--- a/docs/features/quote_token_pricing.md
+++ b/docs/features/quote_token_pricing.md
@@ -10,7 +10,7 @@ Resolves any pool's quote token (numeraire) to a USD price so that metrics like 
 - Chainlink oracle ETH/USD price extraction
 - Stablecoin (USDC, USDT) identity pricing (1.0)
 - Zero-address (native ETH) treated as WETH
-- Phase 2 (planned): graph-based frontier expansion for unconfigured tokens
+- Graph-based frontier expansion for unconfigured tokens (Phase 2)
 
 ### Not in scope
 - Non-Doppler pool price feeds
@@ -28,16 +28,21 @@ PriceHandler (eth_call, reads slot0/getSlot0)
 prices table: (token, quote_token, price)
     |
     v
-build_usd_price_context() [per metrics handler invocation]
+build_usd_price_context_with_paths() [per metrics handler invocation]
     |
-    +-- Seed stablecoins: USDC=1.0, USDT=1.0
-    +-- Extract ETH/USD from ChainlinkEthOracle calls
-    +-- Set WETH + zero-address = ETH/USD
-    +-- Query all latest prices from prices table
-    +-- Transitive resolution loop:
-    |     for each (token, quote_token, price):
-    |       if quote_token already resolved:
-    |         token_usd = price * quote_token_usd
+    +-- Phase 1: Config-driven resolution
+    |   +-- Seed stablecoins: USDC=1.0, USDT=1.0
+    |   +-- Extract ETH/USD from ChainlinkEthOracle calls
+    |   +-- Set WETH + zero-address = ETH/USD
+    |   +-- Query all latest prices from prices table
+    |   +-- Transitive resolution loop
+    |
+    +-- Phase 2: Graph-based path resolution
+    |   +-- Collect unresolved quote tokens from metadata cache
+    |   +-- For each: check token_price_paths cache
+    |   +-- If stale/missing: BFS frontier expansion (max 5 hops, $1k min liq)
+    |   +-- Derive price by walking path with current pool_state prices
+    |   +-- Cache path in token_price_paths (1 week staleness)
     |
     v
 UsdPriceContext { prices: HashMap<address, usd_price> }
@@ -52,17 +57,24 @@ quote_to_usd_multiplier(quote_token) -> Option<BigDecimal>
 |------|------|
 | `src/transformations/eth_call/price.rs` | PriceHandler: discovers pool configs from contracts, reads sqrtPriceX96, writes to prices table |
 | `src/transformations/eth_call/mod.rs` | Passes Contracts to PriceHandler registration |
-| `src/transformations/util/usd_price.rs` | OraclePriceCache (shared, DB-backed), UsdPriceContext (per-invocation), transitive resolution |
-| `src/transformations/util/pool_metadata.rs` | KNOWN_QUOTE_TOKENS for decimal resolution |
+| `src/transformations/util/usd_price.rs` | OraclePriceCache (shared, DB-backed), UsdPriceContext (per-invocation), transitive + path resolution |
+| `src/transformations/util/price_path.rs` | Frontier expansion BFS, path caching, price derivation from cached paths |
+| `src/transformations/util/pool_metadata.rs` | KNOWN_QUOTE_TOKENS for decimal resolution, unique_quote_tokens() for Phase 2 |
 | `config/contracts/<chain>/tokens.json` | Token addresses and anchor pool configs |
 | `migrations/tables/prices.sql` | Price data storage schema |
+| `migrations/tables/token_price_paths.sql` | Cached price paths for Phase 2 |
+| `migrations/tables/pools_token_indexes.sql` | Indexes on base_token/quote_token for frontier queries |
 
 ## Key Exports
 
 - `OraclePriceCache::with_contracts(contracts)` - shared cache construction
-- `build_usd_price_context(ctx, cache, db, chain_id, contracts)` - per-invocation builder
+- `build_usd_price_context_with_paths(ctx, cache, db, chain_id, contracts, metadata_cache)` - full builder with path resolution
+- `build_usd_price_context(ctx, cache, db, chain_id, contracts)` - Phase 1 only builder
 - `UsdPriceContext::quote_volume_to_usd(volume, token, decimals)` - volume conversion
 - `UsdPriceContext::quote_decimal_amount_to_usd(amount, token)` - TVL conversion
+- `UsdPriceContext::resolve_path_prices(db, chain_id, block, tokens)` - Phase 2 path resolution
+- `check_or_resolve_path(db, chain_id, token, priceable, block)` - single token path resolution
+- `derive_price_from_path(db, chain_id, path, token, anchor_usd)` - price from cached path
 
 ## Invariants
 
@@ -71,6 +83,9 @@ quote_to_usd_multiplier(quote_token) -> Option<BigDecimal>
 - Transitive resolution terminates when no new tokens can be resolved (handles cycles)
 - PriceHandler version (1) is unchanged; new pool configs produce additive rows
 - Pool name convention `<Base><Quote>Pool` is used for automatic discovery
+- Path resolution caches results for 1 week (~302,400 blocks on Base)
+- Unpriceable tokens (no path within 5 hops at $1k+ liquidity) are cached as is_priceable=false
+- Price derivation walks the path at query time using current pool_state prices (not stale cached prices)
 
 ## Config Convention
 
@@ -80,3 +95,15 @@ Anchor pools in `tokens.json` follow the naming pattern `<BaseToken><QuoteToken>
 - `EurcUsdcPool`: prices Eurc in terms of Usdc
 
 Both the base token and quote token must also be configured as standalone entries with their address. The pool entry must have a `calls` array with a `slot0()` or `getSlot0()` function.
+
+## Phase 2: Frontier Expansion Algorithm
+
+For tokens not covered by configured anchor pools, BFS expands outward from the target token through indexed pools:
+
+1. Start with frontier = {target_token}
+2. At each hop (max 5), query pools touching frontier tokens with active_liquidity_usd >= $1,000
+3. Track parent pointers and bottleneck (min-along-path) liquidity for each discovered token
+4. If a priceable token is reached, trace the path back and return it
+5. After all hops, return the path with the highest bottleneck liquidity (or None)
+
+The path is cached in `token_price_paths` with a 1-week staleness threshold. On subsequent lookups, the cached path is used and the USD price is re-derived from current `pool_state.price` values.

--- a/migrations/tables/pools_token_indexes.sql
+++ b/migrations/tables/pools_token_indexes.sql
@@ -1,0 +1,4 @@
+-- Indexes on pools.base_token and pools.quote_token for efficient
+-- frontier expansion queries in token price path resolution.
+CREATE INDEX IF NOT EXISTS idx_pools_base_token ON pools (chain_id, base_token);
+CREATE INDEX IF NOT EXISTS idx_pools_quote_token ON pools (chain_id, quote_token);

--- a/migrations/tables/token_price_paths.sql
+++ b/migrations/tables/token_price_paths.sql
@@ -1,0 +1,13 @@
+-- Caches resolved price paths from tokens to anchor (USD-priceable) tokens.
+-- Used by the frontier expansion algorithm to avoid repeated graph searches.
+-- Entries are refreshed when stale (> 1 week) and on demand for new tokens.
+CREATE TABLE IF NOT EXISTS token_price_paths (
+    chain_id            BIGINT NOT NULL,
+    token_address       BYTEA NOT NULL,
+    path_pool_ids       BYTEA[] NOT NULL,
+    anchor_token        BYTEA NOT NULL,
+    path_liquidity_usd  NUMERIC,
+    resolved_at_block   BIGINT NOT NULL,
+    is_priceable        BOOLEAN NOT NULL DEFAULT true,
+    PRIMARY KEY (chain_id, token_address)
+);

--- a/src/transformations/eth_call/mod.rs
+++ b/src/transformations/eth_call/mod.rs
@@ -5,8 +5,9 @@
 mod price;
 
 use super::registry::TransformationRegistry;
+use crate::types::config::contract::Contracts;
 
 /// Register all eth_call handlers with the registry.
-pub fn register_handlers(registry: &mut TransformationRegistry) {
-    price::register_handlers(registry);
+pub fn register_handlers(registry: &mut TransformationRegistry, contracts: Option<&Contracts>) {
+    price::register_handlers(registry, contracts);
 }

--- a/src/transformations/eth_call/price.rs
+++ b/src/transformations/eth_call/price.rs
@@ -230,7 +230,11 @@ impl TransformationHandler for PriceHandler {
     }
 
     fn migration_paths(&self) -> Vec<&'static str> {
-        vec!["migrations/tables/prices.sql"]
+        vec![
+            "migrations/tables/prices.sql",
+            "migrations/tables/pools_token_indexes.sql",
+            "migrations/tables/token_price_paths.sql",
+        ]
     }
 
     fn reorg_tables(&self) -> Vec<&'static str> {

--- a/src/transformations/eth_call/price.rs
+++ b/src/transformations/eth_call/price.rs
@@ -8,15 +8,33 @@ use crate::transformations::traits::{EthCallHandler, EthCallTrigger, Transformat
 use crate::transformations::util::price::sqrt_price_x96_to_price;
 use crate::types::config::contract::{AddressOrAddresses, Contracts};
 
-struct PoolConfig {
-    /// Contract source name from config (e.g., "EurcUsdcPool")
-    source: &'static str,
-    /// Function name: "slot0" for V3, "getSlot0" for V4
-    function_name: &'static str,
-    /// Config name of the token being priced (e.g., "Eurc")
-    token: &'static str,
-    /// Config name of the quote token (e.g., "Usdc")
-    quote_token: &'static str,
+/// Hardcoded decimal map for configured anchor pool tokens.
+/// This avoids a DB lookup and covers all tokens that appear in tokens.json pool configs.
+fn decimals_for_token(name: &str) -> Option<u8> {
+    match name {
+        "Weth" => Some(18),
+        "Usdc" => Some(6),
+        "Usdt" => Some(6),
+        "Eurc" => Some(6),
+        "Fxh" => Some(18),
+        "Noice" => Some(18),
+        "Zora" => Some(18),
+        "Bankr" => Some(18),
+        "Mon" => Some(18),
+        _ => None,
+    }
+}
+
+/// A pool config discovered dynamically from the contracts config at registration time.
+struct DynamicPoolConfig {
+    /// Contract source name from config (e.g., "BankrWethPool")
+    source: String,
+    /// Function name without parens (e.g., "slot0")
+    function_name: String,
+    /// Resolved address of the token being priced
+    token_address: [u8; 20],
+    /// Resolved address of the quote token
+    quote_token_address: [u8; 20],
     /// Decimals of the token being priced
     token_decimals: u8,
     /// Decimals of the quote token
@@ -25,49 +43,13 @@ struct PoolConfig {
     is_token0: bool,
 }
 
-const POOL_CONFIGS: &[PoolConfig] = &[
-    // Eurc/Usdc — V4 pool (getSlot0)
-    PoolConfig {
-        source: "EurcUsdcPool",
-        function_name: "getSlot0",
-        token: "Eurc",
-        quote_token: "Usdc",
-        token_decimals: 6,
-        quote_decimals: 6,
-        is_token0: false,
-    },
-    // Fxh/Weth — V3 pool (slot0)
-    PoolConfig {
-        source: "FxhWethPool",
-        function_name: "slot0",
-        token: "Fxh",
-        quote_token: "Weth",
-        token_decimals: 18,
-        quote_decimals: 18,
-        is_token0: false,
-    },
-    // Noice/Weth — V3 pool (slot0)
-    PoolConfig {
-        source: "NoiceWethPool",
-        function_name: "slot0",
-        token: "Noice",
-        quote_token: "Weth",
-        token_decimals: 18,
-        quote_decimals: 18,
-        is_token0: false,
-    },
-    // Zora/Usdc — V3 pool (slot0)
-    PoolConfig {
-        source: "ZoraUsdcPool",
-        function_name: "slot0",
-        token: "Zora",
-        quote_token: "Usdc",
-        token_decimals: 18,
-        quote_decimals: 6,
-        is_token0: false,
-    },
-];
+/// Strip parenthesized parameters from a function signature.
+/// e.g., "slot0()" -> "slot0", "getSlot0(bytes32)" -> "getSlot0"
+fn strip_function_params(sig: &str) -> &str {
+    sig.split('(').next().unwrap_or(sig)
+}
 
+/// Resolve a single address from the contracts config by name.
 fn resolve_address(contracts: &Contracts, name: &str) -> Result<[u8; 20], TransformationError> {
     let config = contracts.get(name).ok_or_else(|| {
         TransformationError::ConfigError(format!("contract '{}' not found in config", name))
@@ -80,7 +62,162 @@ fn resolve_address(contracts: &Contracts, name: &str) -> Result<[u8; 20], Transf
     }
 }
 
-pub struct PriceHandler;
+/// Discover pool configs from the contracts config.
+///
+/// Scans for entries ending in "Pool" that have `calls` containing a slot0-like function.
+/// Parses the naming convention `<Base><Quote>Pool` to extract token pair info.
+fn discover_pool_configs(contracts: &Contracts) -> Vec<DynamicPoolConfig> {
+    // Collect non-Pool entries as the set of known token names.
+    let mut token_names: Vec<String> = contracts
+        .keys()
+        .filter(|name| !name.ends_with("Pool"))
+        .cloned()
+        .collect();
+    // Sort by length descending so longer names match first (avoids "Usdc" matching
+    // inside a longer name like "BUsdc").
+    token_names.sort_by(|a, b| b.len().cmp(&a.len()));
+
+    let mut configs = Vec::new();
+
+    for (name, config) in contracts {
+        if !name.ends_with("Pool") {
+            continue;
+        }
+
+        // Must have calls with a slot0-like function
+        let calls = match &config.calls {
+            Some(calls) if !calls.is_empty() => calls,
+            _ => continue,
+        };
+
+        // Find the slot0-like call (either "slot0()" or "getSlot0(...)")
+        let slot0_call = calls.iter().find(|c| {
+            let fn_name = strip_function_params(&c.function);
+            fn_name == "slot0" || fn_name == "getSlot0"
+        });
+        let slot0_call = match slot0_call {
+            Some(c) => c,
+            None => continue,
+        };
+
+        let function_name = strip_function_params(&slot0_call.function).to_string();
+
+        // Strip "Pool" suffix to get the pair name (e.g., "BankrWeth")
+        let pair_name = &name[..name.len() - 4];
+
+        // Identify the quote token by finding which known token name the pair ends with.
+        let quote_match = token_names.iter().find(|t| pair_name.ends_with(t.as_str()));
+        let quote_token_name = match quote_match {
+            Some(name) => name.clone(),
+            None => {
+                tracing::warn!(
+                    pool = %name,
+                    "Could not identify quote token from pool name, skipping"
+                );
+                continue;
+            }
+        };
+
+        // Base token is the remainder after stripping the quote suffix.
+        let base_token_name = &pair_name[..pair_name.len() - quote_token_name.len()];
+        if base_token_name.is_empty() {
+            tracing::warn!(
+                pool = %name,
+                "Empty base token name after parsing, skipping"
+            );
+            continue;
+        }
+
+        // Resolve addresses from the config.
+        let token_address = match resolve_address(contracts, base_token_name) {
+            Ok(addr) => addr,
+            Err(_) => {
+                tracing::warn!(
+                    pool = %name,
+                    base_token = %base_token_name,
+                    "Base token not found in contracts config, skipping"
+                );
+                continue;
+            }
+        };
+        let quote_token_address = match resolve_address(contracts, &quote_token_name) {
+            Ok(addr) => addr,
+            Err(_) => {
+                tracing::warn!(
+                    pool = %name,
+                    quote_token = %quote_token_name,
+                    "Quote token not found in contracts config, skipping"
+                );
+                continue;
+            }
+        };
+
+        // Look up decimals from the hardcoded map.
+        let token_decimals = match decimals_for_token(base_token_name) {
+            Some(d) => d,
+            None => {
+                tracing::warn!(
+                    pool = %name,
+                    token = %base_token_name,
+                    "Unknown decimals for base token, skipping"
+                );
+                continue;
+            }
+        };
+        let quote_decimals = match decimals_for_token(&quote_token_name) {
+            Some(d) => d,
+            None => {
+                tracing::warn!(
+                    pool = %name,
+                    token = %quote_token_name,
+                    "Unknown decimals for quote token, skipping"
+                );
+                continue;
+            }
+        };
+
+        let is_token0 = token_address < quote_token_address;
+
+        tracing::info!(
+            pool = %name,
+            base = %base_token_name,
+            quote = %quote_token_name,
+            function = %function_name,
+            is_token0,
+            "Discovered price pool config"
+        );
+
+        configs.push(DynamicPoolConfig {
+            source: name.clone(),
+            function_name,
+            token_address,
+            quote_token_address,
+            token_decimals,
+            quote_decimals,
+            is_token0,
+        });
+    }
+
+    configs
+}
+
+pub struct PriceHandler {
+    configs: Vec<DynamicPoolConfig>,
+}
+
+impl PriceHandler {
+    fn from_contracts(contracts: &Contracts) -> Self {
+        Self {
+            configs: discover_pool_configs(contracts),
+        }
+    }
+
+    fn empty() -> Self {
+        Self {
+            configs: Vec::new(),
+        }
+    }
+}
 
 #[async_trait]
 impl TransformationHandler for PriceHandler {
@@ -106,11 +243,8 @@ impl TransformationHandler for PriceHandler {
     ) -> Result<Vec<DbOperation>, TransformationError> {
         let mut ops = Vec::new();
 
-        for config in POOL_CONFIGS {
-            let token_address = resolve_address(&ctx.contracts, config.token)?;
-            let quote_token_address = resolve_address(&ctx.contracts, config.quote_token)?;
-
-            for call in ctx.calls_of_type(config.source, config.function_name) {
+        for config in &self.configs {
+            for call in ctx.calls_of_type(&config.source, &config.function_name) {
                 let sqrt_price_x96 = call.extract_uint256("sqrtPriceX96")?;
 
                 let Some(price) = sqrt_price_x96_to_price(
@@ -136,8 +270,8 @@ impl TransformationHandler for PriceHandler {
                         DbValue::Timestamp(call.block_timestamp as i64),
                         DbValue::Int64(call.block_number as i64),
                         DbValue::Int64(ctx.chain_id as i64),
-                        DbValue::Address(token_address),
-                        DbValue::Address(quote_token_address),
+                        DbValue::Address(config.token_address),
+                        DbValue::Address(config.quote_token_address),
                         DbValue::Numeric(price.to_string()),
                     ],
                     conflict_columns: vec!["timestamp".into(), "chain_id".into(), "token".into()],
@@ -155,20 +289,30 @@ impl TransformationHandler for PriceHandler {
     }
 
     async fn initialize(&self, _db_pool: &DbPool) -> Result<(), TransformationError> {
-        tracing::info!("PriceHandler initialized");
+        tracing::info!(
+            pool_count = self.configs.len(),
+            "PriceHandler initialized"
+        );
         Ok(())
     }
 }
 
 impl EthCallHandler for PriceHandler {
     fn triggers(&self) -> Vec<EthCallTrigger> {
-        POOL_CONFIGS
+        self.configs
             .iter()
-            .map(|c| EthCallTrigger::new(c.source, c.function_name))
+            .map(|c| EthCallTrigger::new(&c.source, &c.function_name))
             .collect()
     }
 }
 
-pub fn register_handlers(registry: &mut TransformationRegistry) {
-    registry.register_call_handler(PriceHandler);
+pub fn register_handlers(
+    registry: &mut TransformationRegistry,
+    contracts: Option<&Contracts>,
+) {
+    let handler = match contracts {
+        Some(contracts) => PriceHandler::from_contracts(contracts),
+        None => PriceHandler::empty(),
+    };
+    registry.register_call_handler(handler);
 }

--- a/src/transformations/event/decay_multicurve/metrics.rs
+++ b/src/transformations/event/decay_multicurve/metrics.rs
@@ -22,7 +22,7 @@ use crate::transformations::registry::TransformationRegistry;
 use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
 use crate::transformations::util::pool_metadata::PoolMetadataCache;
 use crate::transformations::util::usd_price::{
-    build_usd_price_context, chainlink_latest_answer_dependency, OraclePriceCache,
+    build_usd_price_context_with_paths, chainlink_latest_answer_dependency, OraclePriceCache,
 };
 
 const SOURCE: &str = "DecayMulticurveHook";
@@ -82,12 +82,13 @@ impl TransformationHandler for DecayMulticurveSwapMetricsHandler {
         )
         .await?;
 
-        let (usd_ctx, price_ops) = build_usd_price_context(
+        let (usd_ctx, price_ops) = build_usd_price_context_with_paths(
             ctx,
             &self.oracle_cache,
             &self.db_pool,
             self.chain_id,
             &ctx.contracts,
+            &self.metadata_cache,
         )
         .await;
 
@@ -240,12 +241,13 @@ impl TransformationHandler for DecayMulticurveTvlMetricsHandler {
             return Ok(Vec::new());
         };
 
-        let (usd_ctx, price_ops) = build_usd_price_context(
+        let (usd_ctx, price_ops) = build_usd_price_context_with_paths(
             ctx,
             &self.oracle_cache,
             &self.db_pool,
             self.chain_id,
             &ctx.contracts,
+            &self.metadata_cache,
         )
         .await;
 

--- a/src/transformations/event/dhook/metrics.rs
+++ b/src/transformations/event/dhook/metrics.rs
@@ -22,7 +22,7 @@ use crate::transformations::registry::TransformationRegistry;
 use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
 use crate::transformations::util::pool_metadata::PoolMetadataCache;
 use crate::transformations::util::usd_price::{
-    build_usd_price_context, chainlink_latest_answer_dependency, OraclePriceCache,
+    build_usd_price_context_with_paths, chainlink_latest_answer_dependency, OraclePriceCache,
 };
 
 const SOURCE: &str = "DopplerHookInitializer";
@@ -82,12 +82,13 @@ impl TransformationHandler for DhookSwapMetricsHandler {
         )
         .await?;
 
-        let (usd_ctx, price_ops) = build_usd_price_context(
+        let (usd_ctx, price_ops) = build_usd_price_context_with_paths(
             ctx,
             &self.oracle_cache,
             &self.db_pool,
             self.chain_id,
             &ctx.contracts,
+            &self.metadata_cache,
         )
         .await;
         let mut ops = process_swaps(
@@ -239,12 +240,13 @@ impl TransformationHandler for DhookTvlMetricsHandler {
             return Ok(Vec::new());
         };
 
-        let (usd_ctx, price_ops) = build_usd_price_context(
+        let (usd_ctx, price_ops) = build_usd_price_context_with_paths(
             ctx,
             &self.oracle_cache,
             &self.db_pool,
             self.chain_id,
             &ctx.contracts,
+            &self.metadata_cache,
         )
         .await;
 

--- a/src/transformations/event/metrics/swap_data.rs
+++ b/src/transformations/event/metrics/swap_data.rs
@@ -522,14 +522,11 @@ mod tests {
         let pool_id = vec![0u8; 20];
         let cache = make_cache_with_pool(pool_id.clone());
 
-        let usd_ctx = UsdPriceContext::new_for_test(
-            Some(bigdecimal::BigDecimal::from(2000)),
-            None,
-            Some([1u8; 20]), // quote_token matches cache's quote_token
-            None,
-            None,
-            None,
-        );
+        let usd_ctx = {
+            let mut prices = std::collections::HashMap::new();
+            prices.insert([1u8; 20], bigdecimal::BigDecimal::from(2000)); // WETH / quote_token
+            UsdPriceContext::new_for_test(prices, Some([1u8; 20]))
+        };
 
         let swaps = vec![SwapInput {
             pool_id: pool_id.clone(),

--- a/src/transformations/event/metrics/tvl.rs
+++ b/src/transformations/event/metrics/tvl.rs
@@ -835,14 +835,11 @@ mod tests {
     }
 
     fn sample_usd_ctx(eth_usd: Option<&str>) -> UsdPriceContext {
-        UsdPriceContext::new_for_test(
-            eth_usd.map(bd),
-            None,
-            Some([0x02; 20]), // WETH = quote for sample_meta
-            None,
-            None,
-            None,
-        )
+        let mut prices = std::collections::HashMap::new();
+        if let Some(p) = eth_usd {
+            prices.insert([0x02; 20], bd(p)); // WETH = quote for sample_meta
+        }
+        UsdPriceContext::new_for_test(prices, Some([0x02; 20]))
     }
 
     fn sample_bootstrap_seed() -> TvlBootstrapSeed {
@@ -1355,14 +1352,10 @@ mod tests {
     }
 
     fn sample_usd_ctx_with_usdc() -> UsdPriceContext {
-        UsdPriceContext::new_for_test(
-            Some(bd("2000")),  // eth_usd
-            None,              // eurc_usd
-            Some([0x02; 20]),  // WETH address
-            Some([0x03; 20]),  // USDC address
-            None,              // usdt
-            None,              // eurc
-        )
+        let mut prices = std::collections::HashMap::new();
+        prices.insert([0x02; 20], bd("2000")); // WETH
+        prices.insert([0x03; 20], bigdecimal::BigDecimal::from(1)); // USDC
+        UsdPriceContext::new_for_test(prices, Some([0x02; 20]))
     }
 
     #[test]

--- a/src/transformations/event/migration_pool/metrics.rs
+++ b/src/transformations/event/migration_pool/metrics.rs
@@ -41,7 +41,7 @@ use crate::transformations::registry::TransformationRegistry;
 use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
 use crate::transformations::util::pool_metadata::PoolMetadataCache;
 use crate::transformations::util::usd_price::{
-    build_usd_price_context, chainlink_latest_answer_dependency, OraclePriceCache,
+    build_usd_price_context_with_paths, chainlink_latest_answer_dependency, OraclePriceCache,
 };
 
 const POOL_MANAGER_SOURCE: &str = "UniswapV4PoolManager";
@@ -183,12 +183,13 @@ impl TransformationHandler for MigrationPoolSwapMetricsHandler {
         )
         .await?;
 
-        let (usd_ctx, price_ops) = build_usd_price_context(
+        let (usd_ctx, price_ops) = build_usd_price_context_with_paths(
             ctx,
             &self.oracle_cache,
             &self.db_pool,
             self.chain_id,
             &ctx.contracts,
+            &self.metadata_cache,
         )
         .await;
 
@@ -442,12 +443,13 @@ impl TransformationHandler for MigrationPoolTvlMetricsHandler {
             return Ok(Vec::new());
         };
 
-        let (usd_ctx, price_ops) = build_usd_price_context(
+        let (usd_ctx, price_ops) = build_usd_price_context_with_paths(
             ctx,
             &self.oracle_cache,
             &self.db_pool,
             self.chain_id,
             &ctx.contracts,
+            &self.metadata_cache,
         )
         .await;
 

--- a/src/transformations/event/multicurve/metrics.rs
+++ b/src/transformations/event/multicurve/metrics.rs
@@ -22,7 +22,7 @@ use crate::transformations::registry::TransformationRegistry;
 use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
 use crate::transformations::util::pool_metadata::PoolMetadataCache;
 use crate::transformations::util::usd_price::{
-    build_usd_price_context, chainlink_latest_answer_dependency, OraclePriceCache,
+    build_usd_price_context_with_paths, chainlink_latest_answer_dependency, OraclePriceCache,
 };
 
 const SOURCE: &str = "UniswapV4MulticurveInitializerHook";
@@ -82,12 +82,13 @@ impl TransformationHandler for MulticurveSwapMetricsHandler {
         )
         .await?;
 
-        let (usd_ctx, price_ops) = build_usd_price_context(
+        let (usd_ctx, price_ops) = build_usd_price_context_with_paths(
             ctx,
             &self.oracle_cache,
             &self.db_pool,
             self.chain_id,
             &ctx.contracts,
+            &self.metadata_cache,
         )
         .await;
 
@@ -240,12 +241,13 @@ impl TransformationHandler for MulticurveTvlMetricsHandler {
             return Ok(Vec::new());
         };
 
-        let (usd_ctx, price_ops) = build_usd_price_context(
+        let (usd_ctx, price_ops) = build_usd_price_context_with_paths(
             ctx,
             &self.oracle_cache,
             &self.db_pool,
             self.chain_id,
             &ctx.contracts,
+            &self.metadata_cache,
         )
         .await;
 

--- a/src/transformations/event/scheduled_multicurve/metrics.rs
+++ b/src/transformations/event/scheduled_multicurve/metrics.rs
@@ -22,7 +22,7 @@ use crate::transformations::registry::TransformationRegistry;
 use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
 use crate::transformations::util::pool_metadata::PoolMetadataCache;
 use crate::transformations::util::usd_price::{
-    build_usd_price_context, chainlink_latest_answer_dependency, OraclePriceCache,
+    build_usd_price_context_with_paths, chainlink_latest_answer_dependency, OraclePriceCache,
 };
 
 const SOURCE: &str = "UniswapV4ScheduledMulticurveInitializerHook";
@@ -82,12 +82,13 @@ impl TransformationHandler for ScheduledMulticurveSwapMetricsHandler {
         )
         .await?;
 
-        let (usd_ctx, price_ops) = build_usd_price_context(
+        let (usd_ctx, price_ops) = build_usd_price_context_with_paths(
             ctx,
             &self.oracle_cache,
             &self.db_pool,
             self.chain_id,
             &ctx.contracts,
+            &self.metadata_cache,
         )
         .await;
 
@@ -240,12 +241,13 @@ impl TransformationHandler for ScheduledMulticurveTvlMetricsHandler {
             return Ok(Vec::new());
         };
 
-        let (usd_ctx, price_ops) = build_usd_price_context(
+        let (usd_ctx, price_ops) = build_usd_price_context_with_paths(
             ctx,
             &self.oracle_cache,
             &self.db_pool,
             self.chain_id,
             &ctx.contracts,
+            &self.metadata_cache,
         )
         .await;
 

--- a/src/transformations/event/v3/metrics.rs
+++ b/src/transformations/event/v3/metrics.rs
@@ -29,7 +29,7 @@ use crate::transformations::registry::TransformationRegistry;
 use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
 use crate::transformations::util::pool_metadata::PoolMetadataCache;
 use crate::transformations::util::usd_price::{
-    build_usd_price_context, chainlink_latest_answer_dependency, OraclePriceCache,
+    build_usd_price_context_with_paths, chainlink_latest_answer_dependency, OraclePriceCache,
 };
 
 // --- Shared extraction functions ---
@@ -160,12 +160,13 @@ impl TransformationHandler for V3SwapMetricsHandler {
         )
         .await?;
 
-        let (usd_ctx, price_ops) = build_usd_price_context(
+        let (usd_ctx, price_ops) = build_usd_price_context_with_paths(
             ctx,
             &self.oracle_cache,
             &self.db_pool,
             self.chain_id,
             &ctx.contracts,
+            &self.metadata_cache,
         )
         .await;
         let mut ops = process_swaps(
@@ -318,12 +319,13 @@ impl TransformationHandler for LockableV3SwapMetricsHandler {
         )
         .await?;
 
-        let (usd_ctx, price_ops) = build_usd_price_context(
+        let (usd_ctx, price_ops) = build_usd_price_context_with_paths(
             ctx,
             &self.oracle_cache,
             &self.db_pool,
             self.chain_id,
             &ctx.contracts,
+            &self.metadata_cache,
         )
         .await;
         let mut ops = process_swaps(
@@ -505,12 +507,13 @@ impl TransformationHandler for V3TvlMetricsHandler {
             return Ok(Vec::new());
         };
 
-        let (usd_ctx, price_ops) = build_usd_price_context(
+        let (usd_ctx, price_ops) = build_usd_price_context_with_paths(
             ctx,
             &self.oracle_cache,
             &self.db_pool,
             self.chain_id,
             &ctx.contracts,
+            &self.metadata_cache,
         )
         .await;
 
@@ -608,12 +611,13 @@ impl TransformationHandler for LockableV3TvlMetricsHandler {
             return Ok(Vec::new());
         };
 
-        let (usd_ctx, price_ops) = build_usd_price_context(
+        let (usd_ctx, price_ops) = build_usd_price_context_with_paths(
             ctx,
             &self.oracle_cache,
             &self.db_pool,
             self.chain_id,
             &ctx.contracts,
+            &self.metadata_cache,
         )
         .await;
 

--- a/src/transformations/event/v4/metrics.rs
+++ b/src/transformations/event/v4/metrics.rs
@@ -47,7 +47,7 @@ use crate::transformations::traits::{EventHandler, EventTrigger, TransformationH
 use crate::transformations::util::pool_metadata::PoolMetadataCache;
 use crate::transformations::util::tick_math::tick_to_sqrt_price_x96;
 use crate::transformations::util::usd_price::{
-    build_usd_price_context, chainlink_latest_answer_dependency, OraclePriceCache,
+    build_usd_price_context_with_paths, chainlink_latest_answer_dependency, OraclePriceCache,
 };
 
 const SOURCE: &str = "DopplerV4Hook";
@@ -200,12 +200,13 @@ impl TransformationHandler for V4BaseMetricsHandler {
             return Ok(Vec::new());
         }
 
-        let (usd_ctx, price_ops) = build_usd_price_context(
+        let (usd_ctx, price_ops) = build_usd_price_context_with_paths(
             ctx,
             &self.oracle_cache,
             &self.db_pool,
             self.chain_id,
             &ctx.contracts,
+            &self.metadata_cache,
         )
         .await;
         let mut ops = process_swaps(

--- a/src/transformations/event/zora/metrics.rs
+++ b/src/transformations/event/zora/metrics.rs
@@ -15,7 +15,7 @@ use crate::transformations::traits::{EventHandler, EventTrigger, TransformationH
 use crate::transformations::util::pool_metadata::PoolMetadataCache;
 use crate::transformations::util::tick_math::sqrt_price_x96_to_tick;
 use crate::transformations::util::usd_price::{
-    build_usd_price_context, chainlink_latest_answer_dependency, OraclePriceCache,
+    build_usd_price_context_with_paths, chainlink_latest_answer_dependency, OraclePriceCache,
 };
 
 const CREATOR_HOOK_SOURCE: &str = "CreatorCoinHook";
@@ -75,12 +75,13 @@ impl TransformationHandler for ZoraSwapMetricsHandler {
         )
         .await?;
 
-        let (usd_ctx, price_ops) = build_usd_price_context(
+        let (usd_ctx, price_ops) = build_usd_price_context_with_paths(
             ctx,
             &self.oracle_cache,
             &self.db_pool,
             self.chain_id,
             &ctx.contracts,
+            &self.metadata_cache,
         )
         .await;
 

--- a/src/transformations/registry.rs
+++ b/src/transformations/registry.rs
@@ -701,7 +701,7 @@ pub fn build_registry(chain_id: u64) -> TransformationRegistry {
     super::event::register_handlers(&mut registry, chain_id);
 
     // Register eth_call handlers
-    super::eth_call::register_handlers(&mut registry);
+    super::eth_call::register_handlers(&mut registry, None);
 
     registry.validate_and_sort_handler_dependencies();
 
@@ -744,7 +744,7 @@ pub fn build_registry_for_chain(
     super::event::register_handlers_for_chain(&mut registry, chain_id, contracts);
 
     // Register eth_call handlers (filtered by available sources)
-    super::eth_call::register_handlers(&mut registry);
+    super::eth_call::register_handlers(&mut registry, Some(contracts));
 
     registry.validate_and_sort_handler_dependencies();
 

--- a/src/transformations/util/mod.rs
+++ b/src/transformations/util/mod.rs
@@ -7,6 +7,7 @@ pub mod metadata;
 pub mod migration;
 pub mod pool_metadata;
 pub mod price;
+pub mod price_path;
 pub mod sanitize;
 pub mod tick_math;
 pub mod usd_price;

--- a/src/transformations/util/pool_metadata.rs
+++ b/src/transformations/util/pool_metadata.rs
@@ -325,6 +325,26 @@ const KNOWN_QUOTE_TOKENS: &[QuoteTokenConfig] = &[
         config_name: "Eurc",
         decimals: 6,
     },
+    QuoteTokenConfig {
+        config_name: "Fxh",
+        decimals: 18,
+    },
+    QuoteTokenConfig {
+        config_name: "Noice",
+        decimals: 18,
+    },
+    QuoteTokenConfig {
+        config_name: "Zora",
+        decimals: 18,
+    },
+    QuoteTokenConfig {
+        config_name: "Bankr",
+        decimals: 18,
+    },
+    QuoteTokenConfig {
+        config_name: "Mon",
+        decimals: 18,
+    },
 ];
 
 /// Parse a NUMERIC-as-text representation of `tokens.total_supply` into a U256.

--- a/src/transformations/util/pool_metadata.rs
+++ b/src/transformations/util/pool_metadata.rs
@@ -208,6 +208,16 @@ impl PoolMetadataCache {
         inner.entry(pool_id).or_insert(meta);
     }
 
+    /// Return all unique quote token addresses in the cache.
+    pub fn unique_quote_tokens(&self) -> Vec<[u8; 20]> {
+        let inner = self.inner.read().unwrap();
+        let mut seen = std::collections::HashSet::new();
+        for meta in inner.values() {
+            seen.insert(meta.quote_token);
+        }
+        seen.into_iter().collect()
+    }
+
     /// Re-query the `pools` table and insert any pools not already cached.
     ///
     /// Also resolves `quote_decimals` for all newly inserted entries while

--- a/src/transformations/util/price_path.rs
+++ b/src/transformations/util/price_path.rs
@@ -469,19 +469,27 @@ async fn query_frontier_pools(
     let frontier_bytes: Vec<Vec<u8>> = frontier.iter().map(|t| t.to_vec()).collect();
     let max_block_i64: Option<i64> = max_block.map(|b| b as i64);
 
+    // First pick the latest snapshot per pool (before max_block), then
+    // filter by liquidity. This avoids selecting a pool based on an older
+    // liquid snapshot when its latest snapshot is illiquid.
     let rows = client
         .query(
-            "SELECT DISTINCT ON (p.address) \
-                 p.address, p.base_token, p.quote_token, \
-                 COALESCE(ps.active_liquidity_usd, 0) as liq \
-             FROM pools p \
-             JOIN pool_snapshots ps ON ps.pool_id = p.address AND ps.chain_id = p.chain_id \
-             WHERE p.chain_id = $1 \
-               AND (p.base_token = ANY($2) OR p.quote_token = ANY($2)) \
-               AND (COALESCE(ps.active_liquidity_usd, 0) >= $3 \
-                    OR (ps.active_liquidity_usd IS NULL AND ps.active_liquidity > 0)) \
-               AND ($4::bigint IS NULL OR ps.block_number < $4) \
-             ORDER BY p.address, ps.block_number DESC",
+            "WITH latest_snapshots AS ( \
+                 SELECT DISTINCT ON (p.address) \
+                     p.address, p.base_token, p.quote_token, \
+                     ps.active_liquidity_usd, ps.active_liquidity \
+                 FROM pools p \
+                 JOIN pool_snapshots ps ON ps.pool_id = p.address AND ps.chain_id = p.chain_id \
+                 WHERE p.chain_id = $1 \
+                   AND (p.base_token = ANY($2) OR p.quote_token = ANY($2)) \
+                   AND ($4::bigint IS NULL OR ps.block_number < $4) \
+                 ORDER BY p.address, ps.block_number DESC \
+             ) \
+             SELECT address, base_token, quote_token, \
+                    COALESCE(active_liquidity_usd, 0) as liq \
+             FROM latest_snapshots \
+             WHERE COALESCE(active_liquidity_usd, 0) >= $3 \
+                OR (active_liquidity_usd IS NULL AND active_liquidity > 0)",
             &[
                 &(chain_id as i64),
                 &frontier_bytes,

--- a/src/transformations/util/price_path.rs
+++ b/src/transformations/util/price_path.rs
@@ -1,0 +1,569 @@
+//! Graph-based token price path resolution via frontier expansion.
+//!
+//! For tokens that are not directly priceable via configured anchor pools,
+//! this module finds a path through indexed Doppler pools back to a
+//! USD-priceable token. The path is cached in `token_price_paths` and
+//! refreshed when stale (> 1 week).
+//!
+//! Algorithm: BFS frontier expansion from the target token outward, up to
+//! 5 hops, considering only pools with >= $1,000 active liquidity. Returns
+//! the path with the highest bottleneck (minimum-along-path) liquidity.
+
+use std::collections::{HashMap, HashSet};
+
+use bigdecimal::BigDecimal;
+use deadpool_postgres::Pool;
+
+use crate::transformations::error::TransformationError;
+
+/// Approximately 1 week of blocks on Base (2s block time).
+const STALENESS_THRESHOLD_BLOCKS: u64 = 302_400;
+
+/// Maximum number of hops in a price path.
+const MAX_HOPS: usize = 5;
+
+/// Minimum active liquidity (USD) for a pool to be considered as a path edge.
+const MIN_LIQUIDITY_USD: i64 = 1_000;
+
+/// A cached price path from a token to an anchor token.
+#[derive(Debug, Clone)]
+pub struct CachedPricePath {
+    pub path_pool_ids: Vec<Vec<u8>>,
+    pub anchor_token: [u8; 20],
+    pub path_liquidity_usd: Option<BigDecimal>,
+    pub resolved_at_block: u64,
+    pub is_priceable: bool,
+}
+
+/// A pool edge discovered during frontier expansion.
+struct PoolEdge {
+    pool_id: Vec<u8>,
+    base_token: [u8; 20],
+    quote_token: [u8; 20],
+    liquidity_usd: BigDecimal,
+}
+
+/// Check for a cached path and resolve if missing or stale.
+///
+/// Returns `Some(path)` if a valid path exists (either cached-fresh or newly resolved).
+/// Returns `None` only on DB errors.
+pub async fn check_or_resolve_path(
+    db_pool: &Pool,
+    chain_id: u64,
+    target_token: &[u8; 20],
+    priceable_tokens: &HashSet<[u8; 20]>,
+    current_block: u64,
+) -> Option<CachedPricePath> {
+    // Don't resolve if already priceable
+    if priceable_tokens.contains(target_token) {
+        return None;
+    }
+
+    // Check cache
+    if let Ok(Some(cached)) = query_cached_path(db_pool, chain_id, target_token).await {
+        let age = current_block.saturating_sub(cached.resolved_at_block);
+        if age < STALENESS_THRESHOLD_BLOCKS {
+            return Some(cached);
+        }
+        // Stale — re-resolve below
+    }
+
+    // Resolve via frontier expansion
+    let result = resolve_token_price_path(db_pool, chain_id, target_token, priceable_tokens).await;
+
+    // Cache the result
+    let path = match result {
+        Ok(Some(resolved)) => CachedPricePath {
+            path_pool_ids: resolved.path_pool_ids,
+            anchor_token: resolved.anchor_token,
+            path_liquidity_usd: Some(resolved.bottleneck_liquidity),
+            resolved_at_block: current_block,
+            is_priceable: true,
+        },
+        _ => CachedPricePath {
+            path_pool_ids: Vec::new(),
+            anchor_token: [0u8; 20],
+            path_liquidity_usd: None,
+            resolved_at_block: current_block,
+            is_priceable: false,
+        },
+    };
+
+    if let Err(e) = upsert_cached_path(db_pool, chain_id, target_token, &path).await {
+        tracing::warn!(
+            token = hex::encode(target_token),
+            error = %e,
+            "Failed to cache price path"
+        );
+    }
+
+    Some(path)
+}
+
+/// Result of a successful path resolution.
+struct ResolvedPath {
+    path_pool_ids: Vec<Vec<u8>>,
+    anchor_token: [u8; 20],
+    bottleneck_liquidity: BigDecimal,
+}
+
+/// BFS frontier expansion from target_token outward, max 5 hops.
+///
+/// At each hop, queries pools touching the current frontier tokens with
+/// >= $1,000 active liquidity. Tracks the best (highest bottleneck liquidity)
+/// path to any priceable token found.
+async fn resolve_token_price_path(
+    db_pool: &Pool,
+    chain_id: u64,
+    target_token: &[u8; 20],
+    priceable_tokens: &HashSet<[u8; 20]>,
+) -> Result<Option<ResolvedPath>, TransformationError> {
+    let mut visited: HashSet<[u8; 20]> = HashSet::new();
+    visited.insert(*target_token);
+
+    let mut frontier: Vec<[u8; 20]> = vec![*target_token];
+
+    // parent[token] = (pool_id, came_from_token)
+    let mut parent: HashMap<[u8; 20], (Vec<u8>, [u8; 20])> = HashMap::new();
+
+    // Best bottleneck liquidity to reach each token
+    let mut best_bottleneck: HashMap<[u8; 20], BigDecimal> = HashMap::new();
+    best_bottleneck.insert(
+        *target_token,
+        BigDecimal::from(i64::MAX),
+    );
+
+    let mut best_anchor: Option<ResolvedPath> = None;
+
+    for _hop in 0..MAX_HOPS {
+        if frontier.is_empty() {
+            break;
+        }
+
+        let edges = query_frontier_pools(db_pool, chain_id, &frontier).await?;
+
+        let mut new_frontier: Vec<[u8; 20]> = Vec::new();
+
+        for edge in &edges {
+            // For each token reachable from this pool that's in the frontier
+            let frontier_tokens: Vec<[u8; 20]> = {
+                let mut ft = Vec::new();
+                if frontier.contains(&edge.base_token) {
+                    ft.push(edge.base_token);
+                }
+                if frontier.contains(&edge.quote_token) {
+                    ft.push(edge.quote_token);
+                }
+                ft
+            };
+
+            for &from_token in &frontier_tokens {
+                let other_token = if from_token == edge.base_token {
+                    edge.quote_token
+                } else {
+                    edge.base_token
+                };
+
+                let from_bottleneck = best_bottleneck
+                    .get(&from_token)
+                    .cloned()
+                    .unwrap_or_default();
+                let new_bottleneck = from_bottleneck.min(edge.liquidity_usd.clone());
+
+                // Only update if this is a better path
+                let current_bottleneck = best_bottleneck.get(&other_token);
+                if current_bottleneck.is_some_and(|b| b >= &new_bottleneck) {
+                    continue;
+                }
+
+                best_bottleneck.insert(other_token, new_bottleneck.clone());
+                parent.insert(other_token, (edge.pool_id.clone(), from_token));
+
+                if priceable_tokens.contains(&other_token) {
+                    // Found a path to an anchor!
+                    let path = trace_path(&parent, target_token, &other_token);
+                    let candidate = ResolvedPath {
+                        path_pool_ids: path,
+                        anchor_token: other_token,
+                        bottleneck_liquidity: new_bottleneck,
+                    };
+                    match &best_anchor {
+                        Some(existing)
+                            if existing.bottleneck_liquidity >= candidate.bottleneck_liquidity => {}
+                        _ => {
+                            best_anchor = Some(candidate);
+                        }
+                    }
+                } else if !visited.contains(&other_token) {
+                    visited.insert(other_token);
+                    new_frontier.push(other_token);
+                }
+            }
+        }
+
+        // If we found an anchor at this depth, return it (BFS guarantees shortest hop count)
+        if best_anchor.is_some() {
+            return Ok(best_anchor);
+        }
+
+        frontier = new_frontier;
+    }
+
+    Ok(best_anchor)
+}
+
+/// Trace the path from target_token to anchor_token using parent pointers.
+/// Returns an ordered list of pool IDs.
+fn trace_path(
+    parent: &HashMap<[u8; 20], (Vec<u8>, [u8; 20])>,
+    target_token: &[u8; 20],
+    anchor_token: &[u8; 20],
+) -> Vec<Vec<u8>> {
+    let mut path = Vec::new();
+    let mut current = *anchor_token;
+    while current != *target_token {
+        if let Some((pool_id, from)) = parent.get(&current) {
+            path.push(pool_id.clone());
+            current = *from;
+        } else {
+            break;
+        }
+    }
+    path.reverse();
+    path
+}
+
+/// Derive a USD price for a token by walking its cached path.
+///
+/// For each pool in the path:
+/// - If current_token is the pool's base_token: multiply by price (quote_per_base)
+/// - If current_token is the pool's quote_token: divide by price (invert)
+///
+/// Multiply the final result by the anchor's USD price.
+pub async fn derive_price_from_path(
+    db_pool: &Pool,
+    chain_id: u64,
+    path: &CachedPricePath,
+    target_token: &[u8; 20],
+    anchor_usd_price: &BigDecimal,
+) -> Option<BigDecimal> {
+    if path.path_pool_ids.is_empty() || !path.is_priceable {
+        return None;
+    }
+
+    let pool_data = match query_path_pool_prices(db_pool, chain_id, &path.path_pool_ids).await {
+        Ok(data) => data,
+        Err(e) => {
+            tracing::warn!(
+                token = hex::encode(target_token),
+                error = %e,
+                "Failed to query pool prices for path derivation"
+            );
+            return None;
+        }
+    };
+
+    let mut current_token = *target_token;
+    let mut multiplier = BigDecimal::from(1);
+
+    for pool_id in &path.path_pool_ids {
+        let Some(pool) = pool_data.get(pool_id.as_slice()) else {
+            tracing::warn!(
+                pool = hex::encode(pool_id),
+                "Pool in path not found in pool_state, cannot derive price"
+            );
+            return None;
+        };
+
+        if current_token == pool.base_token {
+            // Going base → quote: multiply by price (quote_per_base)
+            multiplier = multiplier * &pool.price;
+            current_token = pool.quote_token;
+        } else if current_token == pool.quote_token {
+            // Going quote → base: divide by price
+            if pool.price == BigDecimal::from(0) {
+                return None;
+            }
+            multiplier = multiplier / &pool.price;
+            current_token = pool.base_token;
+        } else {
+            tracing::warn!(
+                pool = hex::encode(pool_id),
+                current_token = hex::encode(current_token),
+                "Path is broken: current token doesn't match pool"
+            );
+            return None;
+        }
+    }
+
+    Some(multiplier * anchor_usd_price)
+}
+
+/// Pool data needed for price derivation along a path.
+struct PathPoolData {
+    base_token: [u8; 20],
+    quote_token: [u8; 20],
+    price: BigDecimal,
+}
+
+// ─── Database Queries ────────────────────────────────────────────────
+
+/// Query the cached price path for a token.
+async fn query_cached_path(
+    db_pool: &Pool,
+    chain_id: u64,
+    token: &[u8; 20],
+) -> Result<Option<CachedPricePath>, TransformationError> {
+    let client = db_pool
+        .get()
+        .await
+        .map_err(|e| TransformationError::DatabaseError(e.into()))?;
+
+    let row = client
+        .query_opt(
+            "SELECT path_pool_ids, anchor_token, path_liquidity_usd, \
+                    resolved_at_block, is_priceable \
+             FROM token_price_paths \
+             WHERE chain_id = $1 AND token_address = $2",
+            &[&(chain_id as i64), &token.to_vec()],
+        )
+        .await
+        .map_err(|e| TransformationError::DatabaseError(e.into()))?;
+
+    let Some(row) = row else {
+        return Ok(None);
+    };
+
+    let path_pool_ids: Vec<Vec<u8>> = row.get("path_pool_ids");
+    let anchor_bytes: Vec<u8> = row.get("anchor_token");
+    let path_liquidity_usd: Option<rust_decimal::Decimal> = row.get("path_liquidity_usd");
+    let resolved_at_block: i64 = row.get("resolved_at_block");
+    let is_priceable: bool = row.get("is_priceable");
+
+    let mut anchor_token = [0u8; 20];
+    if anchor_bytes.len() == 20 {
+        anchor_token.copy_from_slice(&anchor_bytes);
+    }
+
+    let path_liquidity_usd = path_liquidity_usd.and_then(|d| d.to_string().parse().ok());
+
+    Ok(Some(CachedPricePath {
+        path_pool_ids,
+        anchor_token,
+        path_liquidity_usd,
+        resolved_at_block: resolved_at_block as u64,
+        is_priceable,
+    }))
+}
+
+/// Upsert a price path into the cache.
+async fn upsert_cached_path(
+    db_pool: &Pool,
+    chain_id: u64,
+    token: &[u8; 20],
+    path: &CachedPricePath,
+) -> Result<(), TransformationError> {
+    let client = db_pool
+        .get()
+        .await
+        .map_err(|e| TransformationError::DatabaseError(e.into()))?;
+
+    let liq: Option<rust_decimal::Decimal> = path
+        .path_liquidity_usd
+        .as_ref()
+        .and_then(|d| d.to_string().parse().ok());
+
+    client
+        .execute(
+            "INSERT INTO token_price_paths \
+                (chain_id, token_address, path_pool_ids, anchor_token, \
+                 path_liquidity_usd, resolved_at_block, is_priceable) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7) \
+             ON CONFLICT (chain_id, token_address) DO UPDATE SET \
+                path_pool_ids = EXCLUDED.path_pool_ids, \
+                anchor_token = EXCLUDED.anchor_token, \
+                path_liquidity_usd = EXCLUDED.path_liquidity_usd, \
+                resolved_at_block = EXCLUDED.resolved_at_block, \
+                is_priceable = EXCLUDED.is_priceable",
+            &[
+                &(chain_id as i64),
+                &token.to_vec(),
+                &path.path_pool_ids,
+                &path.anchor_token.to_vec(),
+                &liq,
+                &(path.resolved_at_block as i64),
+                &path.is_priceable,
+            ],
+        )
+        .await
+        .map_err(|e| TransformationError::DatabaseError(e.into()))?;
+
+    Ok(())
+}
+
+/// Query pools touching any of the frontier tokens with >= $1k active liquidity.
+async fn query_frontier_pools(
+    db_pool: &Pool,
+    chain_id: u64,
+    frontier: &[[u8; 20]],
+) -> Result<Vec<PoolEdge>, TransformationError> {
+    let client = db_pool
+        .get()
+        .await
+        .map_err(|e| TransformationError::DatabaseError(e.into()))?;
+
+    let frontier_bytes: Vec<Vec<u8>> = frontier.iter().map(|t| t.to_vec()).collect();
+
+    let rows = client
+        .query(
+            "SELECT DISTINCT ON (p.address) \
+                 p.address, p.base_token, p.quote_token, \
+                 COALESCE(ps.active_liquidity_usd, 0) as liq \
+             FROM pools p \
+             JOIN pool_state ps ON ps.pool_id = p.address AND ps.chain_id = p.chain_id \
+             WHERE p.chain_id = $1 \
+               AND (p.base_token = ANY($2) OR p.quote_token = ANY($2)) \
+               AND COALESCE(ps.active_liquidity_usd, 0) >= $3 \
+             ORDER BY p.address, ps.active_liquidity_usd DESC NULLS LAST",
+            &[&(chain_id as i64), &frontier_bytes, &MIN_LIQUIDITY_USD],
+        )
+        .await
+        .map_err(|e| TransformationError::DatabaseError(e.into()))?;
+
+    let mut edges = Vec::with_capacity(rows.len());
+    for row in &rows {
+        let pool_id: Vec<u8> = row.get("address");
+        let base_bytes: Vec<u8> = row.get("base_token");
+        let quote_bytes: Vec<u8> = row.get("quote_token");
+        let liq: rust_decimal::Decimal = row.get("liq");
+
+        if base_bytes.len() != 20 || quote_bytes.len() != 20 {
+            continue;
+        }
+
+        let mut base_token = [0u8; 20];
+        let mut quote_token = [0u8; 20];
+        base_token.copy_from_slice(&base_bytes);
+        quote_token.copy_from_slice(&quote_bytes);
+
+        let liquidity_usd: BigDecimal = match liq.to_string().parse() {
+            Ok(d) => d,
+            Err(_) => continue,
+        };
+
+        edges.push(PoolEdge {
+            pool_id,
+            base_token,
+            quote_token,
+            liquidity_usd,
+        });
+    }
+
+    Ok(edges)
+}
+
+/// Query current prices for pools in a path.
+async fn query_path_pool_prices(
+    db_pool: &Pool,
+    chain_id: u64,
+    pool_ids: &[Vec<u8>],
+) -> Result<HashMap<Vec<u8>, PathPoolData>, TransformationError> {
+    let client = db_pool
+        .get()
+        .await
+        .map_err(|e| TransformationError::DatabaseError(e.into()))?;
+
+    let rows = client
+        .query(
+            "SELECT DISTINCT ON (p.address) \
+                 p.address, p.base_token, p.quote_token, ps.price \
+             FROM pools p \
+             JOIN pool_state ps ON ps.pool_id = p.address AND ps.chain_id = p.chain_id \
+             WHERE p.chain_id = $1 AND p.address = ANY($2) \
+             ORDER BY p.address, ps.block_number DESC",
+            &[&(chain_id as i64), &pool_ids],
+        )
+        .await
+        .map_err(|e| TransformationError::DatabaseError(e.into()))?;
+
+    let mut result = HashMap::with_capacity(rows.len());
+    for row in &rows {
+        let pool_id: Vec<u8> = row.get("address");
+        let base_bytes: Vec<u8> = row.get("base_token");
+        let quote_bytes: Vec<u8> = row.get("quote_token");
+        let price: rust_decimal::Decimal = row.get("price");
+
+        if base_bytes.len() != 20 || quote_bytes.len() != 20 {
+            continue;
+        }
+
+        let mut base_token = [0u8; 20];
+        let mut quote_token = [0u8; 20];
+        base_token.copy_from_slice(&base_bytes);
+        quote_token.copy_from_slice(&quote_bytes);
+
+        let price: BigDecimal = match price.to_string().parse() {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+
+        result.insert(
+            pool_id,
+            PathPoolData {
+                base_token,
+                quote_token,
+                price,
+            },
+        );
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    fn bd(s: &str) -> BigDecimal {
+        BigDecimal::from_str(s).unwrap()
+    }
+
+    #[test]
+    fn test_trace_path_single_hop() {
+        let target = [0x01; 20];
+        let anchor = [0x02; 20];
+        let pool = vec![0xAA; 20];
+
+        let mut parent = HashMap::new();
+        parent.insert(anchor, (pool.clone(), target));
+
+        let path = trace_path(&parent, &target, &anchor);
+        assert_eq!(path, vec![pool]);
+    }
+
+    #[test]
+    fn test_trace_path_multi_hop() {
+        let target = [0x01; 20];
+        let mid = [0x02; 20];
+        let anchor = [0x03; 20];
+        let pool1 = vec![0xAA; 20];
+        let pool2 = vec![0xBB; 20];
+
+        let mut parent = HashMap::new();
+        parent.insert(mid, (pool1.clone(), target));
+        parent.insert(anchor, (pool2.clone(), mid));
+
+        let path = trace_path(&parent, &target, &anchor);
+        assert_eq!(path, vec![pool1, pool2]);
+    }
+
+    #[test]
+    fn test_trace_path_empty_for_target_equals_anchor() {
+        let target = [0x01; 20];
+        let parent = HashMap::new();
+
+        let path = trace_path(&parent, &target, &target);
+        assert!(path.is_empty());
+    }
+}

--- a/src/transformations/util/price_path.rs
+++ b/src/transformations/util/price_path.rs
@@ -424,6 +424,30 @@ async fn upsert_cached_path(
     Ok(())
 }
 
+/// Delete a cached path so it gets re-resolved on the next invocation.
+/// Called when `derive_price_from_path` fails for a cached path, indicating
+/// the path is broken (e.g., pool disappeared after a reorg).
+pub async fn invalidate_cached_path(
+    db_pool: &Pool,
+    chain_id: u64,
+    token: &[u8; 20],
+) -> Result<(), TransformationError> {
+    let client = db_pool
+        .get()
+        .await
+        .map_err(|e| TransformationError::DatabaseError(e.into()))?;
+
+    client
+        .execute(
+            "DELETE FROM token_price_paths WHERE chain_id = $1 AND token_address = $2",
+            &[&(chain_id as i64), &token.to_vec()],
+        )
+        .await
+        .map_err(|e| TransformationError::DatabaseError(e.into()))?;
+
+    Ok(())
+}
+
 /// Query pools touching any of the frontier tokens with >= $1k active liquidity.
 ///
 /// Also includes pools whose `active_liquidity_usd` is NULL but have non-zero
@@ -457,7 +481,7 @@ async fn query_frontier_pools(
                AND (COALESCE(ps.active_liquidity_usd, 0) >= $3 \
                     OR (ps.active_liquidity_usd IS NULL AND ps.active_liquidity > 0)) \
                AND ($4::bigint IS NULL OR ps.block_number < $4) \
-             ORDER BY p.address, ps.active_liquidity_usd DESC NULLS LAST",
+             ORDER BY p.address, ps.block_number DESC",
             &[
                 &(chain_id as i64),
                 &frontier_bytes,

--- a/src/transformations/util/price_path.rs
+++ b/src/transformations/util/price_path.rs
@@ -293,7 +293,7 @@ pub async fn derive_price_from_path(
         let Some(pool) = pool_data.get(pool_id.as_slice()) else {
             tracing::warn!(
                 pool = hex::encode(pool_id),
-                "Pool in path not found in pool_state, cannot derive price"
+                "Pool in path not found in pool_snapshots, cannot derive price"
             );
             return None;
         };

--- a/src/transformations/util/price_path.rs
+++ b/src/transformations/util/price_path.rs
@@ -46,13 +46,16 @@ struct PoolEdge {
 /// Check for a cached path and resolve if missing or stale.
 ///
 /// Returns `Some(path)` if a valid path exists (either cached-fresh or newly resolved).
-/// Returns `None` only on DB errors.
+/// Returns `None` on DB errors or if the token is already directly priceable.
+///
+/// `max_block`: if `Some(b)`, only consider pool_state rows with block_number < b.
 pub async fn check_or_resolve_path(
     db_pool: &Pool,
     chain_id: u64,
     target_token: &[u8; 20],
     priceable_tokens: &HashSet<[u8; 20]>,
     current_block: u64,
+    max_block: Option<u64>,
 ) -> Option<CachedPricePath> {
     // Don't resolve if already priceable
     if priceable_tokens.contains(target_token) {
@@ -61,17 +64,22 @@ pub async fn check_or_resolve_path(
 
     // Check cache
     if let Ok(Some(cached)) = query_cached_path(db_pool, chain_id, target_token).await {
-        let age = current_block.saturating_sub(cached.resolved_at_block);
-        if age < STALENESS_THRESHOLD_BLOCKS {
-            return Some(cached);
+        // Guard: ignore entries resolved at or after our block range (from a future run)
+        if cached.resolved_at_block < current_block {
+            let age = current_block.saturating_sub(cached.resolved_at_block);
+            if age < STALENESS_THRESHOLD_BLOCKS {
+                return Some(cached);
+            }
         }
-        // Stale — re-resolve below
+        // Stale or future — re-resolve below
     }
 
     // Resolve via frontier expansion
-    let result = resolve_token_price_path(db_pool, chain_id, target_token, priceable_tokens).await;
+    let result =
+        resolve_token_price_path(db_pool, chain_id, target_token, priceable_tokens, max_block)
+            .await;
 
-    // Cache the result
+    // Cache the result — only Ok variants get cached
     let path = match result {
         Ok(Some(resolved)) => CachedPricePath {
             path_pool_ids: resolved.path_pool_ids,
@@ -80,13 +88,21 @@ pub async fn check_or_resolve_path(
             resolved_at_block: current_block,
             is_priceable: true,
         },
-        _ => CachedPricePath {
+        Ok(None) => CachedPricePath {
             path_pool_ids: Vec::new(),
             anchor_token: [0u8; 20],
             path_liquidity_usd: None,
             resolved_at_block: current_block,
             is_priceable: false,
         },
+        Err(e) => {
+            tracing::warn!(
+                token = hex::encode(target_token),
+                error = %e,
+                "Path resolution failed, not caching"
+            );
+            return None; // Don't cache, don't poison
+        }
     };
 
     if let Err(e) = upsert_cached_path(db_pool, chain_id, target_token, &path).await {
@@ -112,11 +128,14 @@ struct ResolvedPath {
 /// At each hop, queries pools touching the current frontier tokens with
 /// >= $1,000 active liquidity. Tracks the best (highest bottleneck liquidity)
 /// path to any priceable token found.
+///
+/// `max_block`: if `Some(b)`, only consider pool_state rows with block_number < b.
 async fn resolve_token_price_path(
     db_pool: &Pool,
     chain_id: u64,
     target_token: &[u8; 20],
     priceable_tokens: &HashSet<[u8; 20]>,
+    max_block: Option<u64>,
 ) -> Result<Option<ResolvedPath>, TransformationError> {
     let mut visited: HashSet<[u8; 20]> = HashSet::new();
     visited.insert(*target_token);
@@ -140,7 +159,7 @@ async fn resolve_token_price_path(
             break;
         }
 
-        let edges = query_frontier_pools(db_pool, chain_id, &frontier).await?;
+        let edges = query_frontier_pools(db_pool, chain_id, &frontier, max_block).await?;
 
         let mut new_frontier: Vec<[u8; 20]> = Vec::new();
 
@@ -240,28 +259,32 @@ fn trace_path(
 /// - If current_token is the pool's quote_token: divide by price (invert)
 ///
 /// Multiply the final result by the anchor's USD price.
+///
+/// `max_block`: if `Some(b)`, only consider pool_state rows with block_number < b.
 pub async fn derive_price_from_path(
     db_pool: &Pool,
     chain_id: u64,
     path: &CachedPricePath,
     target_token: &[u8; 20],
     anchor_usd_price: &BigDecimal,
+    max_block: Option<u64>,
 ) -> Option<BigDecimal> {
     if path.path_pool_ids.is_empty() || !path.is_priceable {
         return None;
     }
 
-    let pool_data = match query_path_pool_prices(db_pool, chain_id, &path.path_pool_ids).await {
-        Ok(data) => data,
-        Err(e) => {
-            tracing::warn!(
-                token = hex::encode(target_token),
-                error = %e,
-                "Failed to query pool prices for path derivation"
-            );
-            return None;
-        }
-    };
+    let pool_data =
+        match query_path_pool_prices(db_pool, chain_id, &path.path_pool_ids, max_block).await {
+            Ok(data) => data,
+            Err(e) => {
+                tracing::warn!(
+                    token = hex::encode(target_token),
+                    error = %e,
+                    "Failed to query pool prices for path derivation"
+                );
+                return None;
+            }
+        };
 
     let mut current_token = *target_token;
     let mut multiplier = BigDecimal::from(1);
@@ -402,10 +425,17 @@ async fn upsert_cached_path(
 }
 
 /// Query pools touching any of the frontier tokens with >= $1k active liquidity.
+///
+/// Also includes pools whose `active_liquidity_usd` is NULL but have non-zero
+/// raw `active_liquidity`, so that pools whose quote token isn't yet USD-priceable
+/// can still appear in the frontier.
+///
+/// `max_block`: if `Some(b)`, only consider pool_state rows with block_number < b.
 async fn query_frontier_pools(
     db_pool: &Pool,
     chain_id: u64,
     frontier: &[[u8; 20]],
+    max_block: Option<u64>,
 ) -> Result<Vec<PoolEdge>, TransformationError> {
     let client = db_pool
         .get()
@@ -413,6 +443,7 @@ async fn query_frontier_pools(
         .map_err(|e| TransformationError::DatabaseError(e.into()))?;
 
     let frontier_bytes: Vec<Vec<u8>> = frontier.iter().map(|t| t.to_vec()).collect();
+    let max_block_i64: Option<i64> = max_block.map(|b| b as i64);
 
     let rows = client
         .query(
@@ -423,9 +454,16 @@ async fn query_frontier_pools(
              JOIN pool_state ps ON ps.pool_id = p.address AND ps.chain_id = p.chain_id \
              WHERE p.chain_id = $1 \
                AND (p.base_token = ANY($2) OR p.quote_token = ANY($2)) \
-               AND COALESCE(ps.active_liquidity_usd, 0) >= $3 \
+               AND (COALESCE(ps.active_liquidity_usd, 0) >= $3 \
+                    OR (ps.active_liquidity_usd IS NULL AND ps.active_liquidity > 0)) \
+               AND ($4::bigint IS NULL OR ps.block_number < $4) \
              ORDER BY p.address, ps.active_liquidity_usd DESC NULLS LAST",
-            &[&(chain_id as i64), &frontier_bytes, &MIN_LIQUIDITY_USD],
+            &[
+                &(chain_id as i64),
+                &frontier_bytes,
+                &MIN_LIQUIDITY_USD,
+                &max_block_i64,
+            ],
         )
         .await
         .map_err(|e| TransformationError::DatabaseError(e.into()))?;
@@ -463,15 +501,20 @@ async fn query_frontier_pools(
 }
 
 /// Query current prices for pools in a path.
+///
+/// `max_block`: if `Some(b)`, only consider pool_state rows with block_number < b.
 async fn query_path_pool_prices(
     db_pool: &Pool,
     chain_id: u64,
     pool_ids: &[Vec<u8>],
+    max_block: Option<u64>,
 ) -> Result<HashMap<Vec<u8>, PathPoolData>, TransformationError> {
     let client = db_pool
         .get()
         .await
         .map_err(|e| TransformationError::DatabaseError(e.into()))?;
+
+    let max_block_i64: Option<i64> = max_block.map(|b| b as i64);
 
     let rows = client
         .query(
@@ -480,8 +523,9 @@ async fn query_path_pool_prices(
              FROM pools p \
              JOIN pool_state ps ON ps.pool_id = p.address AND ps.chain_id = p.chain_id \
              WHERE p.chain_id = $1 AND p.address = ANY($2) \
+               AND ($3::bigint IS NULL OR ps.block_number < $3) \
              ORDER BY p.address, ps.block_number DESC",
-            &[&(chain_id as i64), &pool_ids],
+            &[&(chain_id as i64), &pool_ids, &max_block_i64],
         )
         .await
         .map_err(|e| TransformationError::DatabaseError(e.into()))?;
@@ -565,5 +609,42 @@ mod tests {
 
         let path = trace_path(&parent, &target, &target);
         assert!(path.is_empty());
+    }
+
+    #[test]
+    fn test_future_resolved_path_is_ignored() {
+        // A path resolved at block 200 should not be usable at current_block=100.
+        // The guard in check_or_resolve_path requires cached.resolved_at_block < current_block.
+        // Since check_or_resolve_path is async/DB-dependent, we test the guard condition directly.
+
+        let cached_resolved_at = 200_u64;
+        let current_block = 100_u64;
+
+        // Future entry: resolved_at_block >= current_block  →  should NOT pass the guard
+        assert!(
+            !(cached_resolved_at < current_block),
+            "A path resolved at block {} should be rejected when current_block is {}",
+            cached_resolved_at,
+            current_block
+        );
+
+        // Equal blocks: also rejected (resolved_at_block is NOT strictly less than current_block)
+        let cached_resolved_at_equal = 100_u64;
+        assert!(
+            !(cached_resolved_at_equal < current_block),
+            "A path resolved at the same block should also be rejected"
+        );
+
+        // Past entry within staleness window: should pass
+        let cached_resolved_at_past = 50_u64;
+        assert!(
+            cached_resolved_at_past < current_block,
+            "A path resolved in the past should pass the future guard"
+        );
+        let age = current_block.saturating_sub(cached_resolved_at_past);
+        assert!(
+            age < STALENESS_THRESHOLD_BLOCKS,
+            "A recently-resolved past path should be within the staleness window"
+        );
     }
 }

--- a/src/transformations/util/price_path.rs
+++ b/src/transformations/util/price_path.rs
@@ -48,7 +48,7 @@ struct PoolEdge {
 /// Returns `Some(path)` if a valid path exists (either cached-fresh or newly resolved).
 /// Returns `None` on DB errors or if the token is already directly priceable.
 ///
-/// `max_block`: if `Some(b)`, only consider pool_state rows with block_number < b.
+/// `max_block`: if `Some(b)`, only consider snapshot rows with block_number < b.
 pub async fn check_or_resolve_path(
     db_pool: &Pool,
     chain_id: u64,
@@ -129,7 +129,7 @@ struct ResolvedPath {
 /// >= $1,000 active liquidity. Tracks the best (highest bottleneck liquidity)
 /// path to any priceable token found.
 ///
-/// `max_block`: if `Some(b)`, only consider pool_state rows with block_number < b.
+/// `max_block`: if `Some(b)`, only consider snapshot rows with block_number < b.
 async fn resolve_token_price_path(
     db_pool: &Pool,
     chain_id: u64,
@@ -260,7 +260,7 @@ fn trace_path(
 ///
 /// Multiply the final result by the anchor's USD price.
 ///
-/// `max_block`: if `Some(b)`, only consider pool_state rows with block_number < b.
+/// `max_block`: if `Some(b)`, only consider snapshot rows with block_number < b.
 pub async fn derive_price_from_path(
     db_pool: &Pool,
     chain_id: u64,
@@ -430,7 +430,7 @@ async fn upsert_cached_path(
 /// raw `active_liquidity`, so that pools whose quote token isn't yet USD-priceable
 /// can still appear in the frontier.
 ///
-/// `max_block`: if `Some(b)`, only consider pool_state rows with block_number < b.
+/// `max_block`: if `Some(b)`, only consider snapshot rows with block_number < b.
 async fn query_frontier_pools(
     db_pool: &Pool,
     chain_id: u64,
@@ -451,7 +451,7 @@ async fn query_frontier_pools(
                  p.address, p.base_token, p.quote_token, \
                  COALESCE(ps.active_liquidity_usd, 0) as liq \
              FROM pools p \
-             JOIN pool_state ps ON ps.pool_id = p.address AND ps.chain_id = p.chain_id \
+             JOIN pool_snapshots ps ON ps.pool_id = p.address AND ps.chain_id = p.chain_id \
              WHERE p.chain_id = $1 \
                AND (p.base_token = ANY($2) OR p.quote_token = ANY($2)) \
                AND (COALESCE(ps.active_liquidity_usd, 0) >= $3 \
@@ -502,7 +502,7 @@ async fn query_frontier_pools(
 
 /// Query current prices for pools in a path.
 ///
-/// `max_block`: if `Some(b)`, only consider pool_state rows with block_number < b.
+/// `max_block`: if `Some(b)`, only consider snapshot rows with block_number < b.
 async fn query_path_pool_prices(
     db_pool: &Pool,
     chain_id: u64,
@@ -519,9 +519,9 @@ async fn query_path_pool_prices(
     let rows = client
         .query(
             "SELECT DISTINCT ON (p.address) \
-                 p.address, p.base_token, p.quote_token, ps.price \
+                 p.address, p.base_token, p.quote_token, ps.price_close AS price \
              FROM pools p \
-             JOIN pool_state ps ON ps.pool_id = p.address AND ps.chain_id = p.chain_id \
+             JOIN pool_snapshots ps ON ps.pool_id = p.address AND ps.chain_id = p.chain_id \
              WHERE p.chain_id = $1 AND p.address = ANY($2) \
                AND ($3::bigint IS NULL OR ps.block_number < $3) \
              ORDER BY p.address, ps.block_number DESC",

--- a/src/transformations/util/usd_price.rs
+++ b/src/transformations/util/usd_price.rs
@@ -5,10 +5,12 @@
 //! volumes into USD.
 //!
 //! Quote token → USD resolution:
-//! - WETH: multiply by ETH/USD from ChainlinkEthOracle
 //! - USDC, USDT: 1.0 (stablecoin assumption)
-//! - EURC: multiply by EURC/USDC from prices table
+//! - WETH / zero-address: multiply by ETH/USD from ChainlinkEthOracle
+//! - Configured pool tokens (EURC, Bankr, Fxh, Noice, Zora, etc.):
+//!   resolved transitively via pool prices in the `prices` table.
 
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::OnceLock;
 use std::sync::RwLock;
@@ -28,70 +30,88 @@ const CHAINLINK_DECIMALS: u32 = 8;
 /// Oracle rows use the zero address as a synthetic "USD quote token".
 const USD_QUOTE_TOKEN: [u8; 20] = [0u8; 20];
 
+/// The zero address, used for native ETH as a pool numeraire.
+const ZERO_ADDRESS: [u8; 20] = [0u8; 20];
+
 // ─── OraclePriceCache ────────────────────────────────────────────────
 
-/// Shared cache for oracle-derived USD prices. Thread-safe, persists across
-/// handler invocations. Seeded from the `prices` table on startup; updated
-/// from ChainlinkEthOracle calls during processing.
+/// Shared cache for USD prices. Thread-safe, persists across handler
+/// invocations. Seeded from the `prices` table on startup; updated from
+/// ChainlinkEthOracle calls and pool prices during processing.
 pub struct OraclePriceCache {
-    inner: RwLock<CachedPrices>,
+    inner: RwLock<HashMap<[u8; 20], BigDecimal>>,
     weth_address: Option<[u8; 20]>,
-    eurc_address: Option<[u8; 20]>,
+    stablecoin_addresses: Vec<[u8; 20]>,
     seeded_from_db: AtomicBool,
-}
-
-#[derive(Default)]
-struct CachedPrices {
-    eth_usd: Option<BigDecimal>,
-    eurc_usd: Option<BigDecimal>,
 }
 
 impl OraclePriceCache {
     pub fn new() -> Self {
         Self {
-            inner: RwLock::new(CachedPrices::default()),
+            inner: RwLock::new(HashMap::new()),
             weth_address: None,
-            eurc_address: None,
+            stablecoin_addresses: Vec::new(),
             seeded_from_db: AtomicBool::new(false),
         }
     }
 
     pub fn with_contracts(contracts: &Contracts) -> Self {
+        let weth_address = resolve_contract_address(contracts, "Weth");
+        let mut stablecoins = Vec::new();
+        if let Some(addr) = resolve_contract_address(contracts, "Usdc") {
+            stablecoins.push(addr);
+        }
+        if let Some(addr) = resolve_contract_address(contracts, "Usdt") {
+            stablecoins.push(addr);
+        }
+
         Self {
-            inner: RwLock::new(CachedPrices::default()),
-            weth_address: resolve_contract_address(contracts, "Weth"),
-            eurc_address: resolve_contract_address(contracts, "Eurc"),
+            inner: RwLock::new(HashMap::new()),
+            weth_address,
+            stablecoin_addresses: stablecoins,
             seeded_from_db: AtomicBool::new(false),
         }
     }
 
     /// Seed the cache from the `prices` table on startup.
-    /// Queries for the latest ETH/USD and EURC/USD prices.
+    /// Queries for the latest prices and resolves them transitively to USD.
     pub async fn load_from_db(
         &self,
         db_pool: &Pool,
         chain_id: u64,
     ) -> Result<(), TransformationError> {
+        let mut prices: HashMap<[u8; 20], BigDecimal> = HashMap::new();
+
+        // Seed stablecoins as 1.0
+        for addr in &self.stablecoin_addresses {
+            prices.insert(*addr, BigDecimal::from(1));
+        }
+
+        // Load ETH/USD from Chainlink
         if let Some(weth_addr) = self.weth_address {
             if let Ok(price) =
                 query_latest_price(db_pool, chain_id, &weth_addr, Some(&USD_QUOTE_TOKEN)).await
             {
-                self.inner.write().unwrap().eth_usd = Some(price);
+                prices.insert(weth_addr, price.clone());
+                prices.insert(ZERO_ADDRESS, price);
             }
         }
 
-        // EURC/USD is written by PriceHandler as EURC/USDC, which we treat as
-        // EURC/USD for the metrics use case.
-        if let Some(eurc_addr) = self.eurc_address {
-            if let Ok(price) = query_latest_price(db_pool, chain_id, &eurc_addr, None).await {
-                self.inner.write().unwrap().eurc_usd = Some(price);
-            }
+        // Load all token pair prices from the prices table
+        let raw_prices = query_all_latest_prices(db_pool, chain_id).await?;
+
+        // Resolve transitively: if a token's quote is already priced in USD,
+        // compute the token's USD price.
+        resolve_transitive_prices(&raw_prices, &mut prices);
+
+        let resolved_count = prices.len();
+        {
+            let mut inner = self.inner.write().unwrap();
+            inner.extend(prices);
         }
 
-        let cache = self.inner.read().unwrap();
         tracing::info!(
-            eth_usd = ?cache.eth_usd.as_ref().map(|p| p.to_string()),
-            eurc_usd = ?cache.eurc_usd.as_ref().map(|p| p.to_string()),
+            resolved_count,
             "OraclePriceCache seeded from DB for chain {}",
             chain_id,
         );
@@ -115,20 +135,19 @@ impl OraclePriceCache {
         Ok(())
     }
 
-    fn get_eth_usd(&self) -> Option<BigDecimal> {
-        self.inner.read().unwrap().eth_usd.clone()
+    fn get(&self, token: &[u8; 20]) -> Option<BigDecimal> {
+        self.inner.read().unwrap().get(token).cloned()
     }
 
-    fn get_eurc_usd(&self) -> Option<BigDecimal> {
-        self.inner.read().unwrap().eurc_usd.clone()
+    fn set(&self, token: [u8; 20], price: BigDecimal) {
+        self.inner.write().unwrap().insert(token, price);
     }
 
-    fn set_eth_usd(&self, price: BigDecimal) {
-        self.inner.write().unwrap().eth_usd = Some(price);
-    }
-
-    fn set_eurc_usd(&self, price: BigDecimal) {
-        self.inner.write().unwrap().eurc_usd = Some(price);
+    fn set_many(&self, prices: &HashMap<[u8; 20], BigDecimal>) {
+        let mut inner = self.inner.write().unwrap();
+        for (token, price) in prices {
+            inner.insert(*token, price.clone());
+        }
     }
 }
 
@@ -147,32 +166,22 @@ pub fn chainlink_latest_answer_dependency() -> (String, String) {
 /// Per-invocation snapshot of USD prices with resolved quote token addresses.
 /// Built at the top of each handler's `handle()`.
 pub struct UsdPriceContext {
-    pub eth_usd: Option<BigDecimal>,
-    pub eurc_usd: Option<BigDecimal>,
+    /// token_address → USD price for all resolvable tokens.
+    prices: HashMap<[u8; 20], BigDecimal>,
+    /// WETH address, used to map the zero address (native ETH) to WETH price.
     weth_address: Option<[u8; 20]>,
-    usdc_address: Option<[u8; 20]>,
-    usdt_address: Option<[u8; 20]>,
-    eurc_address: Option<[u8; 20]>,
 }
 
 impl UsdPriceContext {
-    /// Create a UsdPriceContext for testing. Allows setting arbitrary addresses.
+    /// Create a UsdPriceContext for testing.
     #[cfg(test)]
     pub fn new_for_test(
-        eth_usd: Option<BigDecimal>,
-        eurc_usd: Option<BigDecimal>,
+        prices: HashMap<[u8; 20], BigDecimal>,
         weth_address: Option<[u8; 20]>,
-        usdc_address: Option<[u8; 20]>,
-        usdt_address: Option<[u8; 20]>,
-        eurc_address: Option<[u8; 20]>,
     ) -> Self {
         Self {
-            eth_usd,
-            eurc_usd,
+            prices,
             weth_address,
-            usdc_address,
-            usdt_address,
-            eurc_address,
         }
     }
 
@@ -209,18 +218,18 @@ impl UsdPriceContext {
     }
 
     /// Get the USD multiplier for a quote token.
-    /// WETH → ETH/USD price, USDC/USDT → 1.0, EURC → EURC/USD price.
+    /// Looks up the token in the resolved prices map.
+    /// The zero address (native ETH) maps to the WETH price.
     fn quote_to_usd_multiplier(&self, quote_token: &[u8; 20]) -> Option<BigDecimal> {
-        if self.weth_address.as_ref() == Some(quote_token) {
-            return self.eth_usd.clone();
+        // Direct lookup first
+        if let Some(price) = self.prices.get(quote_token) {
+            return Some(price.clone());
         }
-        if self.usdc_address.as_ref() == Some(quote_token)
-            || self.usdt_address.as_ref() == Some(quote_token)
-        {
-            return Some(BigDecimal::from(1));
-        }
-        if self.eurc_address.as_ref() == Some(quote_token) {
-            return self.eurc_usd.clone();
+        // Zero address (native ETH) → WETH
+        if *quote_token == ZERO_ADDRESS {
+            if let Some(weth_addr) = &self.weth_address {
+                return self.prices.get(weth_addr).cloned();
+            }
         }
         None
     }
@@ -230,10 +239,12 @@ impl UsdPriceContext {
 
 /// Build a `UsdPriceContext` for the current block range.
 ///
-/// 1. Extracts latest ETH/USD from ChainlinkEthOracle calls in the range.
+/// 1. Seeds stablecoins (USDC, USDT) as 1.0.
+/// 2. Extracts latest ETH/USD from ChainlinkEthOracle calls in the range.
 ///    Updates the shared cache and returns DbOps to persist to `prices`.
-/// 2. Falls back to cached value if no oracle data in range.
-/// 3. Reads EURC/USD from cache (seeded from DB at startup, updated by PriceHandler).
+/// 3. Queries all token pair prices from the `prices` table and resolves
+///    them transitively to USD (e.g., EURC → USDC → USD, Bankr → WETH → USD).
+/// 4. Falls back to cached values when no fresh data is available.
 ///
 /// Returns `(context, price_ops)` where `price_ops` should be included in
 /// the handler's returned operations to persist oracle prices to the DB.
@@ -245,52 +256,73 @@ pub async fn build_usd_price_context(
     contracts: &Contracts,
 ) -> (UsdPriceContext, Vec<DbOperation>) {
     let mut price_ops = Vec::new();
+    let mut prices: HashMap<[u8; 20], BigDecimal> = HashMap::new();
 
-    // Resolve quote token addresses from config
+    // Resolve addresses from config
     let weth_address = resolve_contract_address(contracts, "Weth");
     let usdc_address = resolve_contract_address(contracts, "Usdc");
     let usdt_address = resolve_contract_address(contracts, "Usdt");
-    let eurc_address = resolve_contract_address(contracts, "Eurc");
+
+    // Seed stablecoins
+    if let Some(addr) = usdc_address {
+        prices.insert(addr, BigDecimal::from(1));
+    }
+    if let Some(addr) = usdt_address {
+        prices.insert(addr, BigDecimal::from(1));
+    }
 
     // Extract ETH/USD from oracle calls in the current block range.
-    let mut eth_usd =
+    let eth_usd =
         extract_eth_usd_from_oracle(ctx, cache, &weth_address, chain_id, &mut price_ops);
 
-    // Cold-start safety net: if the shared cache is still empty, fall back to
-    // the latest persisted ETH/USD row.
+    // Set WETH and zero-address prices
+    if let Some(eth_price) = &eth_usd {
+        if let Some(weth_addr) = weth_address {
+            prices.insert(weth_addr, eth_price.clone());
+        }
+        prices.insert(ZERO_ADDRESS, eth_price.clone());
+    }
+
+    // Cold-start safety net: if no ETH/USD yet, fall back to DB/cache.
     if eth_usd.is_none() {
-        if let Some(pool) = db_pool.get() {
-            if let Some(weth_addr) = &weth_address {
+        // Try the shared cache first
+        if let Some(weth_addr) = weth_address {
+            if let Some(cached_price) = cache.get(&weth_addr) {
+                prices.insert(weth_addr, cached_price.clone());
+                prices.insert(ZERO_ADDRESS, cached_price);
+            } else if let Some(pool) = db_pool.get() {
+                // Last resort: query DB
                 if let Ok(price) =
-                    query_latest_price(pool, chain_id, weth_addr, Some(&USD_QUOTE_TOKEN)).await
+                    query_latest_price(pool, chain_id, &weth_addr, Some(&USD_QUOTE_TOKEN)).await
                 {
-                    cache.set_eth_usd(price.clone());
-                    eth_usd = Some(price);
+                    cache.set(weth_addr, price.clone());
+                    cache.set(ZERO_ADDRESS, price.clone());
+                    prices.insert(weth_addr, price.clone());
+                    prices.insert(ZERO_ADDRESS, price);
                 }
             }
         }
     }
 
-    // EURC/USD: try to refresh from DB if cache is empty
-    let mut eurc_usd = cache.get_eurc_usd();
-    if eurc_usd.is_none() {
-        if let Some(pool) = db_pool.get() {
-            if let Some(eurc_addr) = &eurc_address {
-                if let Ok(price) = query_latest_price(pool, chain_id, eurc_addr, None).await {
-                    cache.set_eurc_usd(price.clone());
-                    eurc_usd = Some(price);
-                }
-            }
+    // Query all token pair prices from the prices table and resolve transitively.
+    if let Some(pool) = db_pool.get() {
+        if let Ok(raw_prices) = query_all_latest_prices(pool, chain_id).await {
+            resolve_transitive_prices(&raw_prices, &mut prices);
+        }
+    } else {
+        // No DB pool available — fall back to cached values for all tokens
+        let inner = cache.inner.read().unwrap();
+        for (token, price) in inner.iter() {
+            prices.entry(*token).or_insert_with(|| price.clone());
         }
     }
+
+    // Update the shared cache with all resolved prices
+    cache.set_many(&prices);
 
     let usd_ctx = UsdPriceContext {
-        eth_usd,
-        eurc_usd,
+        prices,
         weth_address,
-        usdc_address,
-        usdt_address,
-        eurc_address,
     };
 
     (usd_ctx, price_ops)
@@ -329,7 +361,10 @@ fn extract_eth_usd_from_oracle(
 
     if let Some((block_number, block_timestamp, price)) = latest {
         // Update cache
-        cache.set_eth_usd(price.clone());
+        if let Some(weth_addr) = weth_address {
+            cache.set(*weth_addr, price.clone());
+            cache.set(ZERO_ADDRESS, price.clone());
+        }
 
         // Emit DB op to persist to prices table
         if let Some(weth_addr) = weth_address {
@@ -345,7 +380,7 @@ fn extract_eth_usd_from_oracle(
         Some(price)
     } else {
         // No oracle data in range — use cached value
-        cache.get_eth_usd()
+        weth_address.and_then(|addr| cache.get(&addr))
     }
 }
 
@@ -387,6 +422,44 @@ fn build_oracle_price_op(
         conflict_columns: vec!["timestamp".into(), "chain_id".into(), "token".into()],
         update_columns: vec!["block_number".into(), "quote_token".into(), "price".into()],
         update_condition: None,
+    }
+}
+
+// ─── Transitive Resolution ──────────────────────────────────────────
+
+/// A raw price row from the `prices` table: (token, quote_token, price).
+struct RawTokenPrice {
+    token: [u8; 20],
+    quote_token: [u8; 20],
+    price: BigDecimal,
+}
+
+/// Resolve raw token pair prices transitively into USD prices.
+///
+/// Given a set of already-known USD prices (stablecoins, WETH) and a list
+/// of raw (token, quote_token, price) rows from the prices table, iteratively
+/// computes `token_usd = price * quote_token_usd` for each token whose quote
+/// token is already resolved. Repeats until no progress is made, naturally
+/// handling multi-hop chains (e.g., EURC → USDC → USD, Bankr → WETH → USD).
+fn resolve_transitive_prices(
+    raw_prices: &[RawTokenPrice],
+    resolved: &mut HashMap<[u8; 20], BigDecimal>,
+) {
+    loop {
+        let mut made_progress = false;
+        for raw in raw_prices {
+            if resolved.contains_key(&raw.token) {
+                continue;
+            }
+            if let Some(quote_usd) = resolved.get(&raw.quote_token) {
+                let token_usd = &raw.price * quote_usd;
+                resolved.insert(raw.token, token_usd);
+                made_progress = true;
+            }
+        }
+        if !made_progress {
+            break;
+        }
     }
 }
 
@@ -455,6 +528,58 @@ async fn query_latest_price(
         .map_err(|e| TransformationError::ConfigError(format!("Invalid price value: {}", e)))
 }
 
+/// Query the latest price for every token from the `prices` table.
+/// Returns one (token, quote_token, price) per token, the most recent by block_number.
+async fn query_all_latest_prices(
+    pool: &Pool,
+    chain_id: u64,
+) -> Result<Vec<RawTokenPrice>, TransformationError> {
+    let client = pool
+        .get()
+        .await
+        .map_err(|e| TransformationError::DatabaseError(e.into()))?;
+
+    let chain_id_param = chain_id as i64;
+
+    let rows = client
+        .query(
+            "SELECT DISTINCT ON (token) token, quote_token, price \
+             FROM prices \
+             WHERE chain_id = $1 \
+             ORDER BY token, block_number DESC",
+            &[&chain_id_param],
+        )
+        .await
+        .map_err(|e| TransformationError::DatabaseError(e.into()))?;
+
+    let mut result = Vec::with_capacity(rows.len());
+    for row in &rows {
+        let token_bytes: Vec<u8> = row.get("token");
+        let quote_bytes: Vec<u8> = row.get("quote_token");
+        if token_bytes.len() != 20 || quote_bytes.len() != 20 {
+            continue;
+        }
+        let mut token = [0u8; 20];
+        let mut quote_token = [0u8; 20];
+        token.copy_from_slice(&token_bytes);
+        quote_token.copy_from_slice(&quote_bytes);
+
+        let price: rust_decimal::Decimal = row.get("price");
+        let price: BigDecimal = match price.to_string().parse() {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+
+        result.push(RawTokenPrice {
+            token,
+            quote_token,
+            price,
+        });
+    }
+
+    Ok(result)
+}
+
 /// Convert a U256 to BigDecimal, dividing by 10^decimals.
 ///
 /// Parses the full U256 range via BigDecimal's string parser; previously this
@@ -494,53 +619,60 @@ mod tests {
         BigDecimal::from_str(s).unwrap()
     }
 
+    const WETH: [u8; 20] = [0x01; 20];
+    const USDC: [u8; 20] = [0x02; 20];
+    const USDT: [u8; 20] = [0x03; 20];
+    const EURC: [u8; 20] = [0x04; 20];
+    const BANKR: [u8; 20] = [0x05; 20];
+
     fn make_ctx(eth_usd: Option<&str>, eurc_usd: Option<&str>) -> UsdPriceContext {
+        let mut prices = HashMap::new();
+        prices.insert(USDC, BigDecimal::from(1));
+        prices.insert(USDT, BigDecimal::from(1));
+        if let Some(p) = eth_usd {
+            prices.insert(WETH, bd(p));
+        }
+        if let Some(p) = eurc_usd {
+            prices.insert(EURC, bd(p));
+        }
         UsdPriceContext {
-            eth_usd: eth_usd.map(|s| bd(s)),
-            eurc_usd: eurc_usd.map(|s| bd(s)),
-            weth_address: Some([0x01; 20]),
-            usdc_address: Some([0x02; 20]),
-            usdt_address: Some([0x03; 20]),
-            eurc_address: Some([0x04; 20]),
+            prices,
+            weth_address: Some(WETH),
         }
     }
 
     #[test]
     fn test_weth_volume_to_usd() {
         let ctx = make_ctx(Some("2000"), None);
-        let weth = [0x01; 20];
         // 1.5 WETH raw = 1_500_000_000_000_000_000 (18 decimals)
         let volume = U256::from(1_500_000_000_000_000_000u64);
-        let usd = ctx.quote_volume_to_usd(&volume, &weth, 18).unwrap();
+        let usd = ctx.quote_volume_to_usd(&volume, &WETH, 18).unwrap();
         assert_eq!(usd, bd("3000"));
     }
 
     #[test]
     fn test_usdc_volume_to_usd() {
         let ctx = make_ctx(Some("2000"), None);
-        let usdc = [0x02; 20];
         // 500 USDC raw = 500_000_000 (6 decimals)
         let volume = U256::from(500_000_000u64);
-        let usd = ctx.quote_volume_to_usd(&volume, &usdc, 6).unwrap();
+        let usd = ctx.quote_volume_to_usd(&volume, &USDC, 6).unwrap();
         assert_eq!(usd, bd("500"));
     }
 
     #[test]
     fn test_usdt_volume_to_usd() {
         let ctx = make_ctx(Some("2000"), None);
-        let usdt = [0x03; 20];
         let volume = U256::from(1_000_000u64); // 1 USDT
-        let usd = ctx.quote_volume_to_usd(&volume, &usdt, 6).unwrap();
+        let usd = ctx.quote_volume_to_usd(&volume, &USDT, 6).unwrap();
         assert_eq!(usd, bd("1"));
     }
 
     #[test]
     fn test_eurc_volume_to_usd() {
         let ctx = make_ctx(None, Some("1.08"));
-        let eurc = [0x04; 20];
         // 100 EURC raw = 100_000_000 (6 decimals)
         let volume = U256::from(100_000_000u64);
-        let usd = ctx.quote_volume_to_usd(&volume, &eurc, 6).unwrap();
+        let usd = ctx.quote_volume_to_usd(&volume, &EURC, 6).unwrap();
         assert_eq!(usd, bd("108"));
     }
 
@@ -555,9 +687,64 @@ mod tests {
     #[test]
     fn test_no_eth_price_returns_none_for_weth() {
         let ctx = make_ctx(None, None);
-        let weth = [0x01; 20];
         let volume = U256::from(1_000_000_000_000_000_000u64);
-        assert!(ctx.quote_volume_to_usd(&volume, &weth, 18).is_none());
+        assert!(ctx.quote_volume_to_usd(&volume, &WETH, 18).is_none());
+    }
+
+    #[test]
+    fn test_zero_address_maps_to_weth() {
+        let ctx = make_ctx(Some("2500"), None);
+        let zero = [0u8; 20];
+        // The zero address should resolve to the WETH price
+        let volume = U256::from(1_000_000_000_000_000_000u64); // 1 ETH
+        let usd = ctx.quote_volume_to_usd(&volume, &zero, 18).unwrap();
+        assert_eq!(usd, bd("2500"));
+    }
+
+    #[test]
+    fn test_transitive_resolution() {
+        // Bankr is priced at 0.5 WETH, WETH is $2000
+        let raw_prices = vec![
+            RawTokenPrice {
+                token: BANKR,
+                quote_token: WETH,
+                price: bd("0.5"),
+            },
+        ];
+
+        let mut resolved = HashMap::new();
+        resolved.insert(WETH, bd("2000"));
+
+        resolve_transitive_prices(&raw_prices, &mut resolved);
+
+        assert_eq!(resolved.get(&BANKR).unwrap(), &bd("1000"));
+    }
+
+    #[test]
+    fn test_multi_hop_transitive_resolution() {
+        // Chain: TokenA → EURC → USDC → USD
+        // TokenA = 10 EURC, EURC = 1.08 USDC, USDC = 1.0 USD
+        let token_a = [0x10; 20];
+        let raw_prices = vec![
+            RawTokenPrice {
+                token: EURC,
+                quote_token: USDC,
+                price: bd("1.08"),
+            },
+            RawTokenPrice {
+                token: token_a,
+                quote_token: EURC,
+                price: bd("10"),
+            },
+        ];
+
+        let mut resolved = HashMap::new();
+        resolved.insert(USDC, BigDecimal::from(1));
+
+        resolve_transitive_prices(&raw_prices, &mut resolved);
+
+        assert_eq!(resolved.get(&EURC).unwrap(), &bd("1.08"));
+        assert_eq!(resolved.get(&token_a).unwrap(), &bd("10.80"));
     }
 
     #[test]

--- a/src/transformations/util/usd_price.rs
+++ b/src/transformations/util/usd_price.rs
@@ -217,6 +217,52 @@ impl UsdPriceContext {
         Some(amount_decimal * usd_per_quote)
     }
 
+    /// Resolve USD prices for tokens via graph-based path resolution.
+    ///
+    /// For each unresolved token, checks the `token_price_paths` cache and
+    /// resolves via frontier expansion if needed. Adds any newly resolved
+    /// prices to the internal map so subsequent `quote_to_usd_multiplier`
+    /// calls find them.
+    pub async fn resolve_path_prices(
+        &mut self,
+        db_pool: &Pool,
+        chain_id: u64,
+        current_block: u64,
+        unresolved_tokens: &[[u8; 20]],
+    ) {
+        use super::price_path::{check_or_resolve_path, derive_price_from_path};
+
+        let priceable: std::collections::HashSet<[u8; 20]> =
+            self.prices.keys().copied().collect();
+
+        for token in unresolved_tokens {
+            if self.prices.contains_key(token) {
+                continue;
+            }
+
+            let Some(path) =
+                check_or_resolve_path(db_pool, chain_id, token, &priceable, current_block).await
+            else {
+                continue;
+            };
+
+            if !path.is_priceable {
+                continue;
+            }
+
+            // The anchor must already be in our prices map
+            let Some(anchor_usd) = self.prices.get(&path.anchor_token).cloned() else {
+                continue;
+            };
+
+            if let Some(usd_price) =
+                derive_price_from_path(db_pool, chain_id, &path, token, &anchor_usd).await
+            {
+                self.prices.insert(*token, usd_price);
+            }
+        }
+    }
+
     /// Get the USD multiplier for a quote token.
     /// Looks up the token in the resolved prices map.
     /// The zero address (native ETH) maps to the WETH price.
@@ -324,6 +370,40 @@ pub async fn build_usd_price_context(
         prices,
         weth_address,
     };
+
+    (usd_ctx, price_ops)
+}
+
+/// Build a `UsdPriceContext` with Phase 2 graph-based path resolution.
+///
+/// Wraps `build_usd_price_context` (Phase 1) and then resolves any quote
+/// tokens from the metadata cache that are still unpriced via frontier
+/// expansion through the pool graph (Phase 2).
+pub async fn build_usd_price_context_with_paths(
+    ctx: &TransformationContext,
+    cache: &OraclePriceCache,
+    db_pool: &OnceLock<Pool>,
+    chain_id: u64,
+    contracts: &Contracts,
+    metadata_cache: &super::pool_metadata::PoolMetadataCache,
+) -> (UsdPriceContext, Vec<DbOperation>) {
+    let (mut usd_ctx, price_ops) =
+        build_usd_price_context(ctx, cache, db_pool, chain_id, contracts).await;
+
+    // Phase 2: resolve quote tokens not covered by configured anchor pools.
+    if let Some(pool) = db_pool.get() {
+        let quote_tokens = metadata_cache.unique_quote_tokens();
+        let unresolved: Vec<[u8; 20]> = quote_tokens
+            .into_iter()
+            .filter(|t| usd_ctx.quote_to_usd_multiplier(t).is_none())
+            .collect();
+
+        if !unresolved.is_empty() {
+            usd_ctx
+                .resolve_path_prices(pool, chain_id, ctx.blockrange_end, &unresolved)
+                .await;
+        }
+    }
 
     (usd_ctx, price_ops)
 }

--- a/src/transformations/util/usd_price.rs
+++ b/src/transformations/util/usd_price.rs
@@ -283,7 +283,7 @@ impl UsdPriceContext {
         unresolved_tokens: &[[u8; 20]],
         max_block: Option<u64>,
     ) {
-        use super::price_path::{check_or_resolve_path, derive_price_from_path};
+        use super::price_path::{check_or_resolve_path, derive_price_from_path, invalidate_cached_path};
 
         let priceable: std::collections::HashSet<[u8; 20]> =
             self.prices.keys().copied().collect();
@@ -309,11 +309,18 @@ impl UsdPriceContext {
                 continue;
             };
 
-            if let Some(usd_price) =
-                derive_price_from_path(db_pool, chain_id, &path, token, &anchor_usd, max_block)
-                    .await
+            match derive_price_from_path(db_pool, chain_id, &path, token, &anchor_usd, max_block)
+                .await
             {
-                self.prices.insert(*token, usd_price);
+                Some(usd_price) => {
+                    self.prices.insert(*token, usd_price);
+                }
+                None => {
+                    // Path is broken (pool missing, reorg, etc.) — invalidate so
+                    // it gets re-resolved next invocation instead of persisting
+                    // as a useless cached entry until TTL.
+                    let _ = invalidate_cached_path(db_pool, chain_id, token).await;
+                }
             }
         }
     }

--- a/src/transformations/util/usd_price.rs
+++ b/src/transformations/util/usd_price.rs
@@ -35,11 +35,18 @@ const ZERO_ADDRESS: [u8; 20] = [0u8; 20];
 
 // ─── OraclePriceCache ────────────────────────────────────────────────
 
+/// A single cached price entry with the block at which it was observed.
+#[derive(Clone)]
+struct CachedPriceEntry {
+    price: BigDecimal,
+    provenance_block: u64,
+}
+
 /// Shared cache for USD prices. Thread-safe, persists across handler
 /// invocations. Seeded from the `prices` table on startup; updated from
 /// ChainlinkEthOracle calls and pool prices during processing.
 pub struct OraclePriceCache {
-    inner: RwLock<HashMap<[u8; 20], BigDecimal>>,
+    inner: RwLock<HashMap<[u8; 20], CachedPriceEntry>>,
     weth_address: Option<[u8; 20]>,
     stablecoin_addresses: Vec<[u8; 20]>,
     seeded_from_db: AtomicBool,
@@ -80,34 +87,34 @@ impl OraclePriceCache {
         db_pool: &Pool,
         chain_id: u64,
     ) -> Result<(), TransformationError> {
-        let mut prices: HashMap<[u8; 20], BigDecimal> = HashMap::new();
+        let mut resolved: HashMap<[u8; 20], (BigDecimal, u64)> = HashMap::new();
 
-        // Seed stablecoins as 1.0
+        // Seed stablecoins as 1.0 with provenance 0
         for addr in &self.stablecoin_addresses {
-            prices.insert(*addr, BigDecimal::from(1));
+            resolved.insert(*addr, (BigDecimal::from(1), 0));
         }
 
-        // Load ETH/USD from Chainlink
+        // Load ETH/USD from Chainlink (unbounded at init)
         if let Some(weth_addr) = self.weth_address {
-            if let Ok(price) =
-                query_latest_price(db_pool, chain_id, &weth_addr, Some(&USD_QUOTE_TOKEN)).await
+            if let Ok((price, block_number)) =
+                query_latest_price(db_pool, chain_id, &weth_addr, Some(&USD_QUOTE_TOKEN), None)
+                    .await
             {
-                prices.insert(weth_addr, price.clone());
-                prices.insert(ZERO_ADDRESS, price);
+                resolved.insert(weth_addr, (price.clone(), block_number));
+                resolved.insert(ZERO_ADDRESS, (price, block_number));
             }
         }
 
-        // Load all token pair prices from the prices table
-        let raw_prices = query_all_latest_prices(db_pool, chain_id).await?;
+        // Load all token pair prices from the prices table (unbounded at init)
+        let raw_prices = query_all_latest_prices(db_pool, chain_id, None).await?;
 
         // Resolve transitively: if a token's quote is already priced in USD,
         // compute the token's USD price.
-        resolve_transitive_prices(&raw_prices, &mut prices);
+        resolve_transitive_prices(&raw_prices, &mut resolved);
 
-        let resolved_count = prices.len();
-        {
-            let mut inner = self.inner.write().unwrap();
-            inner.extend(prices);
+        let resolved_count = resolved.len();
+        for (token, (price, provenance_block)) in &resolved {
+            self.set(*token, price.clone(), *provenance_block);
         }
 
         tracing::info!(
@@ -135,19 +142,64 @@ impl OraclePriceCache {
         Ok(())
     }
 
-    fn get(&self, token: &[u8; 20]) -> Option<BigDecimal> {
-        self.inner.read().unwrap().get(token).cloned()
-    }
-
-    fn set(&self, token: [u8; 20], price: BigDecimal) {
-        self.inner.write().unwrap().insert(token, price);
-    }
-
-    fn set_many(&self, prices: &HashMap<[u8; 20], BigDecimal>) {
-        let mut inner = self.inner.write().unwrap();
-        for (token, price) in prices {
-            inner.insert(*token, price.clone());
+    fn get(&self, token: &[u8; 20], max_block: Option<u64>) -> Option<BigDecimal> {
+        let inner = self.inner.read().unwrap();
+        let entry = inner.get(token)?;
+        if let Some(mb) = max_block {
+            if entry.provenance_block >= mb {
+                return None;
+            }
         }
+        Some(entry.price.clone())
+    }
+
+    fn set(&self, token: [u8; 20], price: BigDecimal, provenance_block: u64) {
+        let mut inner = self.inner.write().unwrap();
+        if let Some(existing) = inner.get(&token) {
+            if provenance_block < existing.provenance_block {
+                return;
+            }
+        }
+        inner.insert(
+            token,
+            CachedPriceEntry {
+                price,
+                provenance_block,
+            },
+        );
+    }
+
+    fn set_many(&self, entries: &[([u8; 20], BigDecimal, u64)]) {
+        let mut inner = self.inner.write().unwrap();
+        for (token, price, provenance_block) in entries {
+            if let Some(existing) = inner.get(token) {
+                if *provenance_block < existing.provenance_block {
+                    continue;
+                }
+            }
+            inner.insert(
+                *token,
+                CachedPriceEntry {
+                    price: price.clone(),
+                    provenance_block: *provenance_block,
+                },
+            );
+        }
+    }
+
+    fn get_all_within(&self, max_block: Option<u64>) -> Vec<([u8; 20], BigDecimal)> {
+        let inner = self.inner.read().unwrap();
+        inner
+            .iter()
+            .filter(|(_, entry)| {
+                if let Some(mb) = max_block {
+                    entry.provenance_block < mb
+                } else {
+                    true
+                }
+            })
+            .map(|(token, entry)| (*token, entry.price.clone()))
+            .collect()
     }
 }
 
@@ -229,6 +281,7 @@ impl UsdPriceContext {
         chain_id: u64,
         current_block: u64,
         unresolved_tokens: &[[u8; 20]],
+        max_block: Option<u64>,
     ) {
         use super::price_path::{check_or_resolve_path, derive_price_from_path};
 
@@ -241,7 +294,8 @@ impl UsdPriceContext {
             }
 
             let Some(path) =
-                check_or_resolve_path(db_pool, chain_id, token, &priceable, current_block).await
+                check_or_resolve_path(db_pool, chain_id, token, &priceable, current_block, max_block)
+                    .await
             else {
                 continue;
             };
@@ -256,7 +310,8 @@ impl UsdPriceContext {
             };
 
             if let Some(usd_price) =
-                derive_price_from_path(db_pool, chain_id, &path, token, &anchor_usd).await
+                derive_price_from_path(db_pool, chain_id, &path, token, &anchor_usd, max_block)
+                    .await
             {
                 self.prices.insert(*token, usd_price);
             }
@@ -302,69 +357,90 @@ pub async fn build_usd_price_context(
     contracts: &Contracts,
 ) -> (UsdPriceContext, Vec<DbOperation>) {
     let mut price_ops = Vec::new();
-    let mut prices: HashMap<[u8; 20], BigDecimal> = HashMap::new();
+    let mut resolved: HashMap<[u8; 20], (BigDecimal, u64)> = HashMap::new();
+    let max_block = ctx.blockrange_end;
 
     // Resolve addresses from config
     let weth_address = resolve_contract_address(contracts, "Weth");
     let usdc_address = resolve_contract_address(contracts, "Usdc");
     let usdt_address = resolve_contract_address(contracts, "Usdt");
 
-    // Seed stablecoins
+    // Seed stablecoins (provenance = 0)
     if let Some(addr) = usdc_address {
-        prices.insert(addr, BigDecimal::from(1));
+        resolved.insert(addr, (BigDecimal::from(1), 0));
     }
     if let Some(addr) = usdt_address {
-        prices.insert(addr, BigDecimal::from(1));
+        resolved.insert(addr, (BigDecimal::from(1), 0));
     }
 
     // Extract ETH/USD from oracle calls in the current block range.
-    let eth_usd =
-        extract_eth_usd_from_oracle(ctx, cache, &weth_address, chain_id, &mut price_ops);
+    let eth_usd = extract_eth_usd_from_oracle(
+        ctx,
+        cache,
+        &weth_address,
+        chain_id,
+        &mut price_ops,
+        max_block,
+    );
 
     // Set WETH and zero-address prices
-    if let Some(eth_price) = &eth_usd {
+    if let Some((eth_price, eth_block)) = &eth_usd {
         if let Some(weth_addr) = weth_address {
-            prices.insert(weth_addr, eth_price.clone());
+            resolved.insert(weth_addr, (eth_price.clone(), *eth_block));
         }
-        prices.insert(ZERO_ADDRESS, eth_price.clone());
+        resolved.insert(ZERO_ADDRESS, (eth_price.clone(), *eth_block));
     }
 
     // Cold-start safety net: if no ETH/USD yet, fall back to DB/cache.
     if eth_usd.is_none() {
-        // Try the shared cache first
         if let Some(weth_addr) = weth_address {
-            if let Some(cached_price) = cache.get(&weth_addr) {
-                prices.insert(weth_addr, cached_price.clone());
-                prices.insert(ZERO_ADDRESS, cached_price);
+            if let Some(cached_price) = cache.get(&weth_addr, Some(max_block)) {
+                resolved.insert(weth_addr, (cached_price.clone(), 0));
+                resolved.insert(ZERO_ADDRESS, (cached_price, 0));
             } else if let Some(pool) = db_pool.get() {
                 // Last resort: query DB
-                if let Ok(price) =
-                    query_latest_price(pool, chain_id, &weth_addr, Some(&USD_QUOTE_TOKEN)).await
+                if let Ok((price, block_number)) = query_latest_price(
+                    pool,
+                    chain_id,
+                    &weth_addr,
+                    Some(&USD_QUOTE_TOKEN),
+                    Some(max_block),
+                )
+                .await
                 {
-                    cache.set(weth_addr, price.clone());
-                    cache.set(ZERO_ADDRESS, price.clone());
-                    prices.insert(weth_addr, price.clone());
-                    prices.insert(ZERO_ADDRESS, price);
+                    cache.set(weth_addr, price.clone(), block_number);
+                    cache.set(ZERO_ADDRESS, price.clone(), block_number);
+                    resolved.insert(weth_addr, (price.clone(), block_number));
+                    resolved.insert(ZERO_ADDRESS, (price, block_number));
                 }
             }
         }
     }
 
-    // Query all token pair prices from the prices table and resolve transitively.
+    // Query DB for transitive prices
     if let Some(pool) = db_pool.get() {
-        if let Ok(raw_prices) = query_all_latest_prices(pool, chain_id).await {
-            resolve_transitive_prices(&raw_prices, &mut prices);
-        }
-    } else {
-        // No DB pool available — fall back to cached values for all tokens
-        let inner = cache.inner.read().unwrap();
-        for (token, price) in inner.iter() {
-            prices.entry(*token).or_insert_with(|| price.clone());
+        match query_all_latest_prices(pool, chain_id, Some(max_block)).await {
+            Ok(raw_prices) => resolve_transitive_prices(&raw_prices, &mut resolved),
+            Err(e) => tracing::warn!(error = %e, "prices query failed, using cache"),
         }
     }
+    // Always backfill from block-aware cache
+    for (token, price) in cache.get_all_within(Some(max_block)) {
+        resolved.entry(token).or_insert((price, 0));
+    }
 
-    // Update the shared cache with all resolved prices
-    cache.set_many(&prices);
+    // Update the shared cache with all resolved prices (with provenance)
+    let cache_entries: Vec<([u8; 20], BigDecimal, u64)> = resolved
+        .iter()
+        .map(|(token, (price, prov))| (*token, price.clone(), *prov))
+        .collect();
+    cache.set_many(&cache_entries);
+
+    // Strip provenance for the UsdPriceContext
+    let prices: HashMap<[u8; 20], BigDecimal> = resolved
+        .into_iter()
+        .map(|(token, (price, _))| (token, price))
+        .collect();
 
     let usd_ctx = UsdPriceContext {
         prices,
@@ -400,7 +476,13 @@ pub async fn build_usd_price_context_with_paths(
 
         if !unresolved.is_empty() {
             usd_ctx
-                .resolve_path_prices(pool, chain_id, ctx.blockrange_end, &unresolved)
+                .resolve_path_prices(
+                    pool,
+                    chain_id,
+                    ctx.blockrange_end,
+                    &unresolved,
+                    Some(ctx.blockrange_end),
+                )
                 .await;
         }
     }
@@ -416,7 +498,8 @@ fn extract_eth_usd_from_oracle(
     weth_address: &Option<[u8; 20]>,
     chain_id: u64,
     price_ops: &mut Vec<DbOperation>,
-) -> Option<BigDecimal> {
+    max_block: u64,
+) -> Option<(BigDecimal, u64)> {
     // Find the latest oracle call in the current range
     let mut latest: Option<(u64, u64, BigDecimal)> = None; // (block_number, timestamp, price)
 
@@ -440,10 +523,10 @@ fn extract_eth_usd_from_oracle(
     }
 
     if let Some((block_number, block_timestamp, price)) = latest {
-        // Update cache
+        // Update cache with actual oracle block_number
         if let Some(weth_addr) = weth_address {
-            cache.set(*weth_addr, price.clone());
-            cache.set(ZERO_ADDRESS, price.clone());
+            cache.set(*weth_addr, price.clone(), block_number);
+            cache.set(ZERO_ADDRESS, price.clone(), block_number);
         }
 
         // Emit DB op to persist to prices table
@@ -457,10 +540,10 @@ fn extract_eth_usd_from_oracle(
             ));
         }
 
-        Some(price)
+        Some((price, block_number))
     } else {
-        // No oracle data in range — use cached value
-        weth_address.and_then(|addr| cache.get(&addr))
+        // No oracle data in range — use cached value with block awareness
+        weth_address.and_then(|addr| cache.get(&addr, Some(max_block)).map(|price| (price, 0)))
     }
 }
 
@@ -507,23 +590,26 @@ fn build_oracle_price_op(
 
 // ─── Transitive Resolution ──────────────────────────────────────────
 
-/// A raw price row from the `prices` table: (token, quote_token, price).
+/// A raw price row from the `prices` table: (token, quote_token, price, block_number).
 struct RawTokenPrice {
     token: [u8; 20],
     quote_token: [u8; 20],
     price: BigDecimal,
+    block_number: u64,
 }
 
 /// Resolve raw token pair prices transitively into USD prices.
 ///
 /// Given a set of already-known USD prices (stablecoins, WETH) and a list
-/// of raw (token, quote_token, price) rows from the prices table, iteratively
-/// computes `token_usd = price * quote_token_usd` for each token whose quote
-/// token is already resolved. Repeats until no progress is made, naturally
-/// handling multi-hop chains (e.g., EURC → USDC → USD, Bankr → WETH → USD).
+/// of raw (token, quote_token, price, block_number) rows from the prices table,
+/// iteratively computes `token_usd = price * quote_token_usd` for each token
+/// whose quote token is already resolved. Repeats until no progress is made,
+/// naturally handling multi-hop chains (e.g., EURC → USDC → USD, Bankr → WETH → USD).
+///
+/// Provenance for derived prices is `max(raw.block_number, quote_provenance_block)`.
 fn resolve_transitive_prices(
     raw_prices: &[RawTokenPrice],
-    resolved: &mut HashMap<[u8; 20], BigDecimal>,
+    resolved: &mut HashMap<[u8; 20], (BigDecimal, u64)>,
 ) {
     loop {
         let mut made_progress = false;
@@ -531,9 +617,10 @@ fn resolve_transitive_prices(
             if resolved.contains_key(&raw.token) {
                 continue;
             }
-            if let Some(quote_usd) = resolved.get(&raw.quote_token) {
+            if let Some((quote_usd, quote_provenance)) = resolved.get(&raw.quote_token) {
                 let token_usd = &raw.price * quote_usd;
-                resolved.insert(raw.token, token_usd);
+                let provenance = raw.block_number.max(*quote_provenance);
+                resolved.insert(raw.token, (token_usd, provenance));
                 made_progress = true;
             }
         }
@@ -557,12 +644,14 @@ fn resolve_contract_address(contracts: &Contracts, name: &str) -> Option<[u8; 20
 }
 
 /// Query the latest price from the `prices` table for a token.
+/// When `max_block` is Some, only considers rows with block_number < max_block.
 async fn query_latest_price(
     pool: &Pool,
     chain_id: u64,
     token_address: &[u8; 20],
     quote_token_filter: Option<&[u8; 20]>,
-) -> Result<BigDecimal, TransformationError> {
+    max_block: Option<u64>,
+) -> Result<(BigDecimal, u64), TransformationError> {
     let client = pool
         .get()
         .await
@@ -570,24 +659,32 @@ async fn query_latest_price(
 
     let chain_id_param = chain_id as i64;
     let token_param = token_address.to_vec();
+    let max_block_param: Option<i64> = max_block.map(|b| b as i64);
 
     let row = if let Some(quote_token) = quote_token_filter {
         let quote_token_param = quote_token.to_vec();
         client
             .query_opt(
-                "SELECT price FROM prices \
+                "SELECT price, block_number FROM prices \
                  WHERE chain_id = $1 AND token = $2 AND quote_token = $3 \
+                 AND ($4::bigint IS NULL OR block_number < $4) \
                  ORDER BY block_number DESC LIMIT 1",
-                &[&chain_id_param, &token_param, &quote_token_param],
+                &[
+                    &chain_id_param,
+                    &token_param,
+                    &quote_token_param,
+                    &max_block_param,
+                ],
             )
             .await
     } else {
         client
             .query_opt(
-                "SELECT price FROM prices \
+                "SELECT price, block_number FROM prices \
                  WHERE chain_id = $1 AND token = $2 \
+                 AND ($3::bigint IS NULL OR block_number < $3) \
                  ORDER BY block_number DESC LIMIT 1",
-                &[&chain_id_param, &token_param],
+                &[&chain_id_param, &token_param, &max_block_param],
             )
             .await
     };
@@ -602,17 +699,22 @@ async fn query_latest_price(
         })?;
 
     let price: rust_decimal::Decimal = row.get("price");
-    price
+    let block_number: i64 = row.get("block_number");
+    let price = price
         .to_string()
         .parse::<BigDecimal>()
-        .map_err(|e| TransformationError::ConfigError(format!("Invalid price value: {}", e)))
+        .map_err(|e| TransformationError::ConfigError(format!("Invalid price value: {}", e)))?;
+
+    Ok((price, block_number as u64))
 }
 
 /// Query the latest price for every token from the `prices` table.
-/// Returns one (token, quote_token, price) per token, the most recent by block_number.
+/// Returns one (token, quote_token, price, block_number) per token, the most recent by block_number.
+/// When `max_block` is Some, only considers rows with block_number < max_block.
 async fn query_all_latest_prices(
     pool: &Pool,
     chain_id: u64,
+    max_block: Option<u64>,
 ) -> Result<Vec<RawTokenPrice>, TransformationError> {
     let client = pool
         .get()
@@ -620,14 +722,15 @@ async fn query_all_latest_prices(
         .map_err(|e| TransformationError::DatabaseError(e.into()))?;
 
     let chain_id_param = chain_id as i64;
+    let max_block_param: Option<i64> = max_block.map(|b| b as i64);
 
     let rows = client
         .query(
-            "SELECT DISTINCT ON (token) token, quote_token, price \
+            "SELECT DISTINCT ON (token) token, quote_token, price, block_number \
              FROM prices \
-             WHERE chain_id = $1 \
+             WHERE chain_id = $1 AND ($2::bigint IS NULL OR block_number < $2) \
              ORDER BY token, block_number DESC",
-            &[&chain_id_param],
+            &[&chain_id_param, &max_block_param],
         )
         .await
         .map_err(|e| TransformationError::DatabaseError(e.into()))?;
@@ -650,10 +753,13 @@ async fn query_all_latest_prices(
             Err(_) => continue,
         };
 
+        let block_number: i64 = row.get("block_number");
+
         result.push(RawTokenPrice {
             token,
             quote_token,
             price,
+            block_number: block_number as u64,
         });
     }
 
@@ -784,20 +890,19 @@ mod tests {
     #[test]
     fn test_transitive_resolution() {
         // Bankr is priced at 0.5 WETH, WETH is $2000
-        let raw_prices = vec![
-            RawTokenPrice {
-                token: BANKR,
-                quote_token: WETH,
-                price: bd("0.5"),
-            },
-        ];
+        let raw_prices = vec![RawTokenPrice {
+            token: BANKR,
+            quote_token: WETH,
+            price: bd("0.5"),
+            block_number: 100,
+        }];
 
-        let mut resolved = HashMap::new();
-        resolved.insert(WETH, bd("2000"));
+        let mut resolved: HashMap<[u8; 20], (BigDecimal, u64)> = HashMap::new();
+        resolved.insert(WETH, (bd("2000"), 50));
 
         resolve_transitive_prices(&raw_prices, &mut resolved);
 
-        assert_eq!(resolved.get(&BANKR).unwrap(), &bd("1000"));
+        assert_eq!(resolved.get(&BANKR).unwrap().0, bd("1000"));
     }
 
     #[test]
@@ -810,21 +915,87 @@ mod tests {
                 token: EURC,
                 quote_token: USDC,
                 price: bd("1.08"),
+                block_number: 100,
             },
             RawTokenPrice {
                 token: token_a,
                 quote_token: EURC,
                 price: bd("10"),
+                block_number: 200,
             },
         ];
 
-        let mut resolved = HashMap::new();
-        resolved.insert(USDC, BigDecimal::from(1));
+        let mut resolved: HashMap<[u8; 20], (BigDecimal, u64)> = HashMap::new();
+        resolved.insert(USDC, (BigDecimal::from(1), 0));
 
         resolve_transitive_prices(&raw_prices, &mut resolved);
 
-        assert_eq!(resolved.get(&EURC).unwrap(), &bd("1.08"));
-        assert_eq!(resolved.get(&token_a).unwrap(), &bd("10.80"));
+        assert_eq!(resolved.get(&EURC).unwrap().0, bd("1.08"));
+        assert_eq!(resolved.get(&token_a).unwrap().0, bd("10.80"));
+    }
+
+    #[test]
+    fn test_transitive_provenance_propagation() {
+        // BANKR/WETH@block50, WETH/USD@block100
+        // Derived BANKR/USD provenance should be max(50, 100) = 100
+        // With max_block=80, BANKR/USD should NOT be visible in cache
+        let raw_prices = vec![RawTokenPrice {
+            token: BANKR,
+            quote_token: WETH,
+            price: bd("0.5"),
+            block_number: 50,
+        }];
+
+        let mut resolved: HashMap<[u8; 20], (BigDecimal, u64)> = HashMap::new();
+        resolved.insert(WETH, (bd("2000"), 100));
+
+        resolve_transitive_prices(&raw_prices, &mut resolved);
+
+        let (bankr_price, bankr_provenance) = resolved.get(&BANKR).unwrap();
+        assert_eq!(bankr_price, &bd("1000"));
+        assert_eq!(*bankr_provenance, 100);
+
+        // Put into cache and verify block-awareness
+        let cache = OraclePriceCache::new();
+        cache.set(BANKR, bankr_price.clone(), *bankr_provenance);
+
+        // max_block=80 should NOT see the price (provenance=100 >= 80)
+        assert!(cache.get(&BANKR, Some(80)).is_none());
+        // max_block=101 should see the price (provenance=100 < 101)
+        assert_eq!(cache.get(&BANKR, Some(101)).unwrap(), bd("1000"));
+    }
+
+    #[test]
+    fn test_cache_respects_block_bounds() {
+        let cache = OraclePriceCache::new();
+        cache.set(WETH, bd("2000"), 200);
+
+        // max_block=100 should NOT see the price (provenance=200 >= 100)
+        assert!(cache.get(&WETH, Some(100)).is_none());
+        // max_block=201 should see the price (provenance=200 < 201)
+        assert_eq!(cache.get(&WETH, Some(201)).unwrap(), bd("2000"));
+        // No max_block should see the price
+        assert_eq!(cache.get(&WETH, None).unwrap(), bd("2000"));
+    }
+
+    #[test]
+    fn test_cache_get_all_within_filters_future() {
+        let cache = OraclePriceCache::new();
+        cache.set(USDC, bd("1"), 50);
+        cache.set(WETH, bd("2000"), 100);
+        cache.set(BANKR, bd("500"), 200);
+
+        // max_block=150: should see USDC@50 and WETH@100, but NOT BANKR@200
+        let within = cache.get_all_within(Some(150));
+        let within_map: HashMap<[u8; 20], BigDecimal> = within.into_iter().collect();
+        assert_eq!(within_map.len(), 2);
+        assert_eq!(within_map.get(&USDC).unwrap(), &bd("1"));
+        assert_eq!(within_map.get(&WETH).unwrap(), &bd("2000"));
+        assert!(within_map.get(&BANKR).is_none());
+
+        // None: should see all
+        let all = cache.get_all_within(None);
+        assert_eq!(all.len(), 3);
     }
 
     #[test]

--- a/src/transformations/util/usd_price.rs
+++ b/src/transformations/util/usd_price.rs
@@ -142,7 +142,7 @@ impl OraclePriceCache {
         Ok(())
     }
 
-    fn get(&self, token: &[u8; 20], max_block: Option<u64>) -> Option<BigDecimal> {
+    fn get(&self, token: &[u8; 20], max_block: Option<u64>) -> Option<(BigDecimal, u64)> {
         let inner = self.inner.read().unwrap();
         let entry = inner.get(token)?;
         if let Some(mb) = max_block {
@@ -150,7 +150,7 @@ impl OraclePriceCache {
                 return None;
             }
         }
-        Some(entry.price.clone())
+        Some((entry.price.clone(), entry.provenance_block))
     }
 
     fn set(&self, token: [u8; 20], price: BigDecimal, provenance_block: u64) {
@@ -187,7 +187,7 @@ impl OraclePriceCache {
         }
     }
 
-    fn get_all_within(&self, max_block: Option<u64>) -> Vec<([u8; 20], BigDecimal)> {
+    fn get_all_within(&self, max_block: Option<u64>) -> Vec<([u8; 20], BigDecimal, u64)> {
         let inner = self.inner.read().unwrap();
         inner
             .iter()
@@ -198,7 +198,7 @@ impl OraclePriceCache {
                     true
                 }
             })
-            .map(|(token, entry)| (*token, entry.price.clone()))
+            .map(|(token, entry)| (*token, entry.price.clone(), entry.provenance_block))
             .collect()
     }
 }
@@ -394,9 +394,9 @@ pub async fn build_usd_price_context(
     // Cold-start safety net: if no ETH/USD yet, fall back to DB/cache.
     if eth_usd.is_none() {
         if let Some(weth_addr) = weth_address {
-            if let Some(cached_price) = cache.get(&weth_addr, Some(max_block)) {
-                resolved.insert(weth_addr, (cached_price.clone(), 0));
-                resolved.insert(ZERO_ADDRESS, (cached_price, 0));
+            if let Some((cached_price, prov)) = cache.get(&weth_addr, Some(max_block)) {
+                resolved.insert(weth_addr, (cached_price.clone(), prov));
+                resolved.insert(ZERO_ADDRESS, (cached_price, prov));
             } else if let Some(pool) = db_pool.get() {
                 // Last resort: query DB
                 if let Ok((price, block_number)) = query_latest_price(
@@ -424,9 +424,9 @@ pub async fn build_usd_price_context(
             Err(e) => tracing::warn!(error = %e, "prices query failed, using cache"),
         }
     }
-    // Always backfill from block-aware cache
-    for (token, price) in cache.get_all_within(Some(max_block)) {
-        resolved.entry(token).or_insert((price, 0));
+    // Always backfill from block-aware cache (preserving provenance)
+    for (token, price, prov) in cache.get_all_within(Some(max_block)) {
+        resolved.entry(token).or_insert((price, prov));
     }
 
     // Update the shared cache with all resolved prices (with provenance)
@@ -543,7 +543,7 @@ fn extract_eth_usd_from_oracle(
         Some((price, block_number))
     } else {
         // No oracle data in range — use cached value with block awareness
-        weth_address.and_then(|addr| cache.get(&addr, Some(max_block)).map(|price| (price, 0)))
+        weth_address.and_then(|addr| cache.get(&addr, Some(max_block)))
     }
 }
 
@@ -962,7 +962,7 @@ mod tests {
         // max_block=80 should NOT see the price (provenance=100 >= 80)
         assert!(cache.get(&BANKR, Some(80)).is_none());
         // max_block=101 should see the price (provenance=100 < 101)
-        assert_eq!(cache.get(&BANKR, Some(101)).unwrap(), bd("1000"));
+        assert_eq!(cache.get(&BANKR, Some(101)).unwrap().0, bd("1000"));
     }
 
     #[test]
@@ -973,9 +973,11 @@ mod tests {
         // max_block=100 should NOT see the price (provenance=200 >= 100)
         assert!(cache.get(&WETH, Some(100)).is_none());
         // max_block=201 should see the price (provenance=200 < 201)
-        assert_eq!(cache.get(&WETH, Some(201)).unwrap(), bd("2000"));
+        let (price, prov) = cache.get(&WETH, Some(201)).unwrap();
+        assert_eq!(price, bd("2000"));
+        assert_eq!(prov, 200);
         // No max_block should see the price
-        assert_eq!(cache.get(&WETH, None).unwrap(), bd("2000"));
+        assert_eq!(cache.get(&WETH, None).unwrap().0, bd("2000"));
     }
 
     #[test]
@@ -987,10 +989,13 @@ mod tests {
 
         // max_block=150: should see USDC@50 and WETH@100, but NOT BANKR@200
         let within = cache.get_all_within(Some(150));
-        let within_map: HashMap<[u8; 20], BigDecimal> = within.into_iter().collect();
+        let within_map: HashMap<[u8; 20], (BigDecimal, u64)> = within
+            .into_iter()
+            .map(|(t, p, prov)| (t, (p, prov)))
+            .collect();
         assert_eq!(within_map.len(), 2);
-        assert_eq!(within_map.get(&USDC).unwrap(), &bd("1"));
-        assert_eq!(within_map.get(&WETH).unwrap(), &bd("2000"));
+        assert_eq!(within_map.get(&USDC).unwrap().0, bd("1"));
+        assert_eq!(within_map.get(&WETH).unwrap().0, bd("2000"));
         assert!(within_map.get(&BANKR).is_none());
 
         // None: should see all


### PR DESCRIPTION
## Summary

- **Phase 1**: Replace hardcoded PriceHandler pool configs with dynamic discovery from `tokens.json`. Any token with a configured `*Pool` entry (e.g., `BankrWethPool`) is now automatically supported for USD conversion via transitive resolution through the `prices` table. Generalizes `OraclePriceCache` and `UsdPriceContext` from fixed per-token fields to `HashMap<address, usd_price>`. Also fixes the EurcUsdcPool bug where the handler expected `getSlot0` but config specified `slot0()`.

- **Phase 2**: For tokens without configured anchor pools (e.g., Zora content coins paired against creator coins paired against Zora), adds graph-based frontier expansion BFS through indexed pools. Finds the highest-bottleneck-liquidity path back to a priceable token within 5 hops, considering only pools with >= $1k active liquidity. Paths are cached in a new `token_price_paths` table with 1-week staleness. Prices are re-derived from current `pool_state` values on each use.

- Zero-address (native ETH) numeraire pools are now treated identically to WETH pools.

### Key files
- `src/transformations/eth_call/price.rs` — Dynamic pool config discovery
- `src/transformations/util/usd_price.rs` — HashMap-based transitive resolution + path integration
- `src/transformations/util/price_path.rs` — NEW: frontier expansion BFS, path caching, price derivation
- `migrations/tables/token_price_paths.sql` — NEW: path cache table
- `migrations/tables/pools_token_indexes.sql` — NEW: indexes for frontier queries