### PR TITLE
feat: write pipelining for logs and parallel factory sends

### DIFF
--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -105,7 +105,7 @@ migrations/
 ## Features Index
 
 ### raw_data_collection
-- **description**: Fetches blocks, transaction receipts, and logs from EVM chains. Two-phase processing (catchup then current). Parquet output with configurable field selection.
+- **description**: Fetches blocks, transaction receipts, and logs from EVM chains. Two-phase processing (catchup then current). Parquet output with configurable field selection. Log writes are pipelined via JoinSet so the select loop remains responsive during I/O.
 - **entry_points**: `src/raw_data/historical/blocks.rs`, `src/raw_data/historical/receipts.rs`, `src/raw_data/historical/logs.rs`, `src/raw_data/historical/catchup/`, `src/raw_data/historical/current/`
 - **depends_on**: [rpc]
 - **doc**: `docs/features/block_collection.md`, `docs/features/receipts_collection.md`, `docs/features/logs_collection.md`

--- a/docs/features/logs_collection.md
+++ b/docs/features/logs_collection.md
@@ -26,7 +26,7 @@ src/raw_data/historical/
     └── logs.rs          # Current phase: channel processing loop
 ```
 
-- **`logs.rs`**: Contains `LogsCatchupState`, `LogCollectionError`, schema building, and parquet writing utilities shared by both phases
+- **`logs.rs`**: Contains `LogsCatchupState`, `LogCollectionError`, `LogWriteTask`, `prepare_completed_range`, `execute_log_write`, schema building, and parquet writing utilities shared by both phases
 - **`catchup/logs.rs`**: Initializes state by scanning existing files and building configuration
 - **`current/logs.rs`**: Processes `LogMessage` from channels using the pre-built state
 
@@ -229,15 +229,18 @@ data/{chain}/historical/raw/logs/
 1. Receives `LogMessage` from the receipt collector via channel
 2. For `LogMessage::Logs`: accumulates logs into per-range buckets
 3. For `LogMessage::RangeComplete`: signals a range is ready to process
-   - Skips the range if the parquet file already exists on disk or in the S3 manifest
-   - If `contract_logs_only` is enabled and factories are configured, waits for factory addresses
-   - Filters logs to configured contracts and factory-created contracts (if filtering enabled)
-   - Sends logs to decoder (if decoder channel provided)
-   - Writes range to Parquet file and uploads to S3 (if storage manager configured)
-4. For `LogMessage::AllRangesComplete`: signals collection is finished
-   - Waits for any pending ranges that need factory data
+   - Calls `prepare_completed_range` which:
+     - Skips the range if the parquet file already exists on disk or in the S3 manifest
+     - If `contract_logs_only` is enabled and factories are configured, waits for factory addresses
+     - Filters logs to configured contracts and factory-created contracts (if filtering enabled)
+     - Sends logs to decoder (if decoder channel provided)
+     - Returns a `LogWriteTask` containing all data needed for the write
+   - Spawns `execute_log_write(task)` onto a `JoinSet`, allowing the parquet write and S3 upload to proceed concurrently with message processing
+4. A dedicated `select!` branch drains completed writes from the `JoinSet` and propagates errors
+5. For `LogMessage::AllRangesComplete`: signals collection is finished
+   - Sets `all_ranges_complete` flag; only breaks when both `pending_ranges` and the write `JoinSet` are empty
+   - Drains remaining in-flight writes after the loop exits
    - Sends `DecoderMessage::AllComplete` to decoder (if configured)
-   - Exits the collection loop
 
 ## Contract Logs Only Filtering
 

--- a/docs/features/parallelism.md
+++ b/docs/features/parallelism.md
@@ -8,8 +8,8 @@ Raw data collection runs as multiple concurrent async tasks connected by channel
 
 1. **Blocks Collector** - Fetches blocks from RPC, sends block info downstream
 2. **Receipts Collector** - Fetches transaction receipts, extracts logs
-3. **Logs Collector** - Writes logs to parquet, optionally filters by contract
-4. **Factories Collector** - Extracts factory-created contract addresses from logs
+3. **Logs Collector** - Writes logs to parquet (via pipelined JoinSet), optionally filters by contract
+4. **Factories Collector** - Extracts factory-created contract addresses from logs, forwards to downstream channels in parallel via `tokio::join!`
 5. **Eth Calls Collector** - Executes eth_call requests at historical block heights
 6. **Decoders** - Decode raw logs and eth_call results into typed parquet files
 

--- a/src/raw_data/historical/current/factories.rs
+++ b/src/raw_data/historical/current/factories.rs
@@ -165,34 +165,7 @@ pub async fn collect_factories(
                     }
                 };
 
-                if let Some(ref tx) = logs_factory_tx {
-                    if tx.send(factory_data.clone()).await.is_err() {
-                        tracing::error!(
-                            "Failed to send factory data for range {}-{} to logs_factory_tx - receiver dropped",
-                            factory_data.range_start,
-                            factory_data.range_end
-                        );
-                        return Err(FactoryCollectionError::ChannelSend(format!(
-                            "logs_factory_tx ({}-{}) - receiver dropped",
-                            factory_data.range_start, factory_data.range_end
-                        )));
-                    }
-                }
-
-                if let Some(ref tx) = eth_calls_factory_tx {
-                    // Send incremental addresses then range complete
-                    let _ = tx
-                        .send(FactoryMessage::IncrementalAddresses(factory_data.clone()))
-                        .await;
-                    let _ = tx
-                        .send(FactoryMessage::RangeComplete {
-                            range_start: factory_data.range_start,
-                            range_end: factory_data.range_end,
-                        })
-                        .await;
-                }
-
-                // Send to decoders
+                // Compute addresses map once for decoder messages
                 let addresses: HashMap<String, Vec<Address>> = factory_data
                     .addresses_by_block
                     .values()
@@ -202,25 +175,61 @@ pub async fn collect_factories(
                         acc
                     });
 
-                if let Some(ref tx) = log_decoder_tx {
-                    let _ = tx
-                        .send(DecoderMessage::FactoryAddresses {
-                            range_start,
-                            range_end,
-                            addresses: addresses.clone(),
+                // Send to all downstream channels in parallel
+                let logs_factory_future = async {
+                    if let Some(ref tx) = logs_factory_tx {
+                        tx.send(factory_data.clone()).await.map_err(|_| {
+                            FactoryCollectionError::ChannelSend(format!(
+                                "logs_factory_tx ({}-{}) - receiver dropped",
+                                factory_data.range_start, factory_data.range_end
+                            ))
                         })
-                        .await;
-                }
+                    } else {
+                        Ok(())
+                    }
+                };
 
-                if let Some(ref tx) = call_decoder_tx {
-                    let _ = tx
-                        .send(DecoderMessage::FactoryAddresses {
-                            range_start: factory_data.range_start,
-                            range_end: factory_data.range_end,
-                            addresses,
-                        })
-                        .await;
-                }
+                let eth_calls_future = async {
+                    if let Some(ref tx) = eth_calls_factory_tx {
+                        let _ = tx
+                            .send(FactoryMessage::IncrementalAddresses(factory_data.clone()))
+                            .await;
+                        let _ = tx
+                            .send(FactoryMessage::RangeComplete {
+                                range_start: factory_data.range_start,
+                                range_end: factory_data.range_end,
+                            })
+                            .await;
+                    }
+                };
+
+                let decoder_future = async {
+                    if let Some(ref tx) = log_decoder_tx {
+                        let _ = tx
+                            .send(DecoderMessage::FactoryAddresses {
+                                range_start,
+                                range_end,
+                                addresses: addresses.clone(),
+                            })
+                            .await;
+                    }
+                    if let Some(ref tx) = call_decoder_tx {
+                        let _ = tx
+                            .send(DecoderMessage::FactoryAddresses {
+                                range_start: factory_data.range_start,
+                                range_end: factory_data.range_end,
+                                addresses,
+                            })
+                            .await;
+                    }
+                };
+
+                let (logs_result, _, _) = tokio::join!(
+                    logs_factory_future,
+                    eth_calls_future,
+                    decoder_future,
+                );
+                logs_result?;
 
                 // Update contract index for each collection
                 let rk = range_key(range_start, range_end - 1);

--- a/src/raw_data/historical/current/logs.rs
+++ b/src/raw_data/historical/current/logs.rs
@@ -2,11 +2,12 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use tokio::sync::mpsc::{Receiver, Sender};
+use tokio::task::JoinSet;
 
 use crate::decoding::DecoderMessage;
 use crate::raw_data::historical::factories::FactoryAddressData;
 use crate::raw_data::historical::logs::{
-    process_completed_range, LogCollectionError, LogsCatchupState,
+    execute_log_write, prepare_completed_range, LogCollectionError, LogsCatchupState,
 };
 use crate::raw_data::historical::receipts::{LogData, LogMessage};
 use crate::types::config::chain::ChainConfig;
@@ -25,6 +26,9 @@ pub async fn collect_logs(
     let mut range_factory_addresses: HashMap<u64, HashSet<[u8; 20]>> = HashMap::new();
     let mut pending_ranges: HashMap<u64, u64> = HashMap::new();
     let mut factory_ready: HashSet<u64> = HashSet::new();
+
+    let mut write_join_set: JoinSet<Result<(), LogCollectionError>> = JoinSet::new();
+    let mut all_ranges_complete = false;
 
     tracing::info!(
         "Starting log collection for chain {} (contract_logs_only: {}, waiting for factories: {})",
@@ -50,7 +54,7 @@ pub async fn collect_logs(
                                 let factory_data_ready = !state.needs_factory_wait || factory_ready.contains(&range_start);
 
                                 if factory_data_ready {
-                                    process_completed_range(
+                                    if let Some(task) = prepare_completed_range(
                                         range_start,
                                         range_end,
                                         &mut range_data,
@@ -65,15 +69,17 @@ pub async fn collect_logs(
                                         state.s3_manifest.as_ref(),
                                         state.storage_manager.as_ref(),
                                         &state.chain_name,
-                                    )
-                                    .await?;
+                                    ).await? {
+                                        write_join_set.spawn(execute_log_write(task));
+                                    }
                                     factory_ready.remove(&range_start);
                                 } else {
                                     pending_ranges.insert(range_start, range_end);
                                 }
                             }
                             LogMessage::AllRangesComplete => {
-                                if pending_ranges.is_empty() {
+                                all_ranges_complete = true;
+                                if pending_ranges.is_empty() && write_join_set.is_empty() {
                                     break;
                                 }
                             }
@@ -115,7 +121,7 @@ pub async fn collect_logs(
                             .extend(factory_addrs);
 
                         if let Some(pending_end) = pending_ranges.remove(&range_start) {
-                            process_completed_range(
+                            if let Some(task) = prepare_completed_range(
                                 range_start,
                                 pending_end,
                                 &mut range_data,
@@ -130,8 +136,9 @@ pub async fn collect_logs(
                                 state.s3_manifest.as_ref(),
                                 state.storage_manager.as_ref(),
                                 &state.chain_name,
-                            )
-                            .await?;
+                            ).await? {
+                                write_join_set.spawn(execute_log_write(task));
+                            }
                         } else {
                             factory_ready.insert(range_start);
                         }
@@ -142,7 +149,19 @@ pub async fn collect_logs(
                     }
                 }
             }
+
+            Some(join_result) = write_join_set.join_next() => {
+                join_result.map_err(|e| LogCollectionError::JoinError(e.to_string()))??;
+                if all_ranges_complete && pending_ranges.is_empty() && write_join_set.is_empty() {
+                    break;
+                }
+            }
         }
+    }
+
+    // Drain any remaining in-flight writes
+    while let Some(join_result) = write_join_set.join_next().await {
+        join_result.map_err(|e| LogCollectionError::JoinError(e.to_string()))??;
     }
 
     if let Some(tx) = decoder_tx {

--- a/src/raw_data/historical/logs.rs
+++ b/src/raw_data/historical/logs.rs
@@ -70,8 +70,39 @@ pub(crate) struct MinimalLogRecord {
     pub(crate) data: Vec<u8>,
 }
 
+/// Data needed to execute a log write (parquet + optional S3 upload) outside the select loop.
+pub(crate) struct LogWriteTask {
+    pub range: BlockRange,
+    pub logs: Vec<LogData>,
+    pub log_fields: Option<Vec<LogField>>,
+    pub schema: Arc<Schema>,
+    pub output_dir: PathBuf,
+    pub storage_manager: Option<Arc<StorageManager>>,
+    pub chain_name: String,
+}
+
+/// Execute a log write task (parquet write + optional S3 upload).
+///
+/// This is designed to be spawned onto a `JoinSet` so the caller's select loop
+/// remains responsive while I/O is in progress.
+pub(crate) async fn execute_log_write(task: LogWriteTask) -> Result<(), LogCollectionError> {
+    process_range(
+        &task.range,
+        &task.logs,
+        &task.log_fields,
+        &task.schema,
+        &task.output_dir,
+        task.storage_manager.as_ref(),
+        &task.chain_name,
+    )
+    .await
+}
+
+/// Prepare a completed range for writing: skip checks, data extraction, log
+/// filtering, and decoder notification.  Returns `Some(LogWriteTask)` when a
+/// write is needed, or `None` when the range was skipped (already on disk / S3).
 #[allow(clippy::too_many_arguments)]
-pub(crate) async fn process_completed_range(
+pub(crate) async fn prepare_completed_range(
     range_start: u64,
     range_end: u64,
     range_data: &mut HashMap<u64, Vec<LogData>>,
@@ -86,7 +117,7 @@ pub(crate) async fn process_completed_range(
     s3_manifest: Option<&S3Manifest>,
     storage_manager: Option<&Arc<StorageManager>>,
     chain_name: &str,
-) -> Result<(), LogCollectionError> {
+) -> Result<Option<LogWriteTask>, LogCollectionError> {
     let range = BlockRange {
         start: range_start,
         end: range_end,
@@ -102,7 +133,7 @@ pub(crate) async fn process_completed_range(
         );
         range_data.remove(&range_start);
         range_factory_addresses.remove(&range_start);
-        return Ok(());
+        return Ok(None);
     }
 
     // Check if range exists in S3 manifest
@@ -114,7 +145,7 @@ pub(crate) async fn process_completed_range(
         );
         range_data.remove(&range_start);
         range_factory_addresses.remove(&range_start);
-        return Ok(());
+        return Ok(None);
     }
 
     let mut logs = range_data.remove(&range_start).unwrap_or_default();
@@ -135,42 +166,30 @@ pub(crate) async fn process_completed_range(
         );
     }
 
-    // Send logs to decoder before processing (decoder will receive them for decoding).
-    // Wrap in Arc so we can share without cloning when process_range also needs ownership.
+    // Send logs to decoder before building the write task.
+    // The decoder gets an Arc clone; the write task gets its own copy.
     if let Some(tx) = decoder_tx {
-        let logs = std::sync::Arc::new(logs);
+        let shared_logs = std::sync::Arc::new(logs.clone());
         let _ = tx
             .send(DecoderMessage::LogsReady {
                 range_start,
                 range_end,
-                logs: std::sync::Arc::clone(&logs),
+                logs: shared_logs,
                 live_mode: false,            // Historical mode: write to parquet
                 has_factory_matchers: false, // Factory addresses handled separately in historical mode
             })
             .await;
-
-        process_range(
-            &range,
-            logs.as_ref(),
-            log_fields,
-            schema,
-            output_dir,
-            storage_manager,
-            chain_name,
-        )
-        .await
-    } else {
-        process_range(
-            &range,
-            &logs,
-            log_fields,
-            schema,
-            output_dir,
-            storage_manager,
-            chain_name,
-        )
-        .await
     }
+
+    Ok(Some(LogWriteTask {
+        range,
+        logs,
+        log_fields: log_fields.clone(),
+        schema: Arc::clone(schema),
+        output_dir: output_dir.to_path_buf(),
+        storage_manager: storage_manager.cloned(),
+        chain_name: chain_name.to_string(),
+    }))
 }
 
 pub(crate) fn build_configured_addresses(contracts: &Contracts) -> HashSet<[u8; 20]> {

--- a/src/rpc/provider.rs
+++ b/src/rpc/provider.rs
@@ -527,7 +527,7 @@ pub struct RpcClient {
 #[allow(dead_code)]
 impl RpcClient {
     pub fn new(config: RpcClientConfig) -> Result<Self, RpcError> {
-        let provider = build_provider(&config.url)?;
+        let provider = build_provider(config.url.clone(), config.force_http2)?;
         let chain: Arc<str> = chain_label_from_url(&config.url).into();
         let concurrency = config.concurrency.max(1);
 
@@ -558,7 +558,7 @@ impl RpcClient {
         config: RpcClientConfig,
         limiter: Arc<SlidingWindowRateLimiter>,
     ) -> Result<Self, RpcError> {
-        let provider = build_provider(&config.url)?;
+        let provider = build_provider(config.url.clone(), config.force_http2)?;
         let chain: Arc<str> = chain_label_from_url(&config.url).into();
         let concurrency = config.concurrency.max(1);
         Ok(Self {

--- a/src/transformations/event/mod.rs
+++ b/src/transformations/event/mod.rs
@@ -108,7 +108,9 @@ fn register_handlers_inner(
     ]));
     v4::metrics::register_handlers(registry, chain_id, v4_base_cache, Arc::clone(&oracle_cache));
 
-    let zora_cache = Arc::new(PoolMetadataCache::new());
+    let zora_cache = Arc::new(PoolMetadataCache::with_shared_scopes(vec![
+        zora::create::ZORA_CREATE_HANDLER_SCOPE,
+    ]));
     zora::metrics::register_handlers(registry, chain_id, zora_cache, Arc::clone(&oracle_cache));
 
     // Register migration pool handlers as a group only on chains with a V4

--- a/src/transformations/event/zora/create.rs
+++ b/src/transformations/event/zora/create.rs
@@ -10,10 +10,15 @@ use crate::transformations::traits::{EventHandler, EventTrigger, TransformationH
 use crate::transformations::util::db::pool::{insert_pool, PoolData};
 use crate::transformations::util::db::token::{insert_token, TokenData};
 use crate::transformations::util::sanitize::strip_nul_bytes;
+use crate::transformations::util::pool_metadata::VersionedSource;
 use crate::types::uniswap::v4::{PoolAddressOrPoolId, PoolKey};
 
 const SOURCE: &str = "ZoraFactory";
 const ZERO_ADDRESS: [u8; 20] = [0u8; 20];
+pub const ZORA_CREATE_HANDLER_NAME: &str = "ZoraCreateHandler";
+pub const ZORA_CREATE_HANDLER_VERSION: u32 = 1;
+pub const ZORA_CREATE_HANDLER_SCOPE: VersionedSource =
+    VersionedSource::new(ZORA_CREATE_HANDLER_NAME, ZORA_CREATE_HANDLER_VERSION);
 
 #[derive(Clone, Copy)]
 enum CoinKind {
@@ -56,11 +61,11 @@ pub struct ZoraCreateHandler;
 #[async_trait]
 impl TransformationHandler for ZoraCreateHandler {
     fn name(&self) -> &'static str {
-        "ZoraCreateHandler"
+        ZORA_CREATE_HANDLER_NAME
     }
 
     fn version(&self) -> u32 {
-        1
+        ZORA_CREATE_HANDLER_VERSION
     }
 
     fn migration_paths(&self) -> Vec<&'static str> {


### PR DESCRIPTION
## Summary

- **Logs write pipelining**: Split `process_completed_range` into `prepare_completed_range` (inline skip checks, filtering, decoder notification) and `execute_log_write` (parquet write + S3 upload). The current-phase `collect_logs` now spawns write tasks into a `JoinSet` so the `tokio::select!` loop remains responsive during I/O. A dedicated select branch drains write completions and propagates errors. Exit logic waits for both pending ranges and in-flight writes before breaking.

- **Factories parallel channel sends**: Replace sequential sends to `logs_factory_tx`, `eth_calls_factory_tx`, `log_decoder_tx`, and `call_decoder_tx` with three concurrent futures joined via `tokio::join!`. The addresses map is computed once upfront. Only `logs_factory_tx` propagates errors; the others remain fire-and-forget.

## Conflicts

Expected conflicts with `feat/receipt-pipeline-decoupling` in:
- `src/raw_data/historical/current/logs.rs`
- `src/raw_data/historical/logs.rs`