### PR TITLE
fix: write contract indexes incrementally in catchup and per-block in live

### DIFF
--- a/src/live/collector.rs
+++ b/src/live/collector.rs
@@ -1208,6 +1208,14 @@ impl LiveCollector {
             self.storage.write_eth_calls(block_number, &batch.calls)?;
         }
 
+        // Write per-block contract index for factory completeness tracking
+        if let Some(ref collector) = self.eth_call_collector {
+            let expected = collector.expected_factory_contracts();
+            if !expected.is_empty() {
+                self.storage.write_contract_index(block_number, expected)?;
+            }
+        }
+
         let no_decoder = eth_call_decoder_tx.is_none();
         let expectations = &self.expectations;
         self.storage.update_status_atomic(block_number, |status| {

--- a/src/live/compaction.rs
+++ b/src/live/compaction.rs
@@ -465,6 +465,72 @@ impl CompactionService {
             );
         }
 
+        // Merge per-block contract indexes into historical format
+        {
+            use crate::storage::contract_index::{
+                range_key, read_contract_index as read_historical_ci,
+                update_contract_index as update_ci, write_contract_index as write_ci,
+                ExpectedContracts,
+            };
+
+            let mut merged: HashMap<String, ExpectedContracts> = HashMap::new();
+            for block_number in range.start..=range.end {
+                if let Ok(block_ci) = self.storage.read_contract_index(block_number) {
+                    for (collection_name, contracts) in block_ci {
+                        let entry = merged.entry(collection_name).or_default();
+                        for (contract_name, addresses) in contracts {
+                            let addr_entry = entry.entry(contract_name).or_default();
+                            for addr in addresses {
+                                if !addr_entry.contains(&addr) {
+                                    addr_entry.push(addr);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            for contracts in merged.values_mut() {
+                for addresses in contracts.values_mut() {
+                    addresses.sort();
+                }
+            }
+
+            if !merged.is_empty() {
+                let rk = range_key(range.start, range.end);
+                let base_dir = PathBuf::from(format!(
+                    "data/{}/historical/raw/eth_calls",
+                    self.chain_name
+                ));
+
+                for (collection_name, expected) in &merged {
+                    let collection_dir = base_dir.join(collection_name);
+                    if !collection_dir.exists() {
+                        continue;
+                    }
+
+                    if let Ok(entries) = std::fs::read_dir(&collection_dir) {
+                        for entry in entries.flatten() {
+                            if entry.path().is_dir() {
+                                let on_events_dir = entry.path().join("on_events");
+                                if on_events_dir.exists() {
+                                    let mut ci = read_historical_ci(&on_events_dir);
+                                    update_ci(&mut ci, &rk, expected);
+                                    if let Err(e) = write_ci(&on_events_dir, &ci) {
+                                        tracing::warn!(
+                                            "Failed to write compacted contract index for {}: {}",
+                                            on_events_dir.display(),
+                                            e
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         // Compact decoded logs
         // Note: Full decoded data compaction requires schema information from the event
         // parser. For now, we just delete the decoded bincode files when compacting.

--- a/src/live/eth_calls.rs
+++ b/src/live/eth_calls.rs
@@ -23,6 +23,7 @@ use crate::raw_data::historical::eth_calls::{
 };
 use crate::raw_data::historical::factories::get_factory_call_configs;
 use crate::raw_data::historical::receipts::EventTriggerData;
+use crate::storage::contract_index::build_expected_factory_contracts;
 use crate::rpc::UnifiedRpcClient;
 use crate::types::config::chain::ChainConfig;
 use crate::types::config::eth_call::encode_call_with_params;
@@ -45,6 +46,8 @@ pub struct LiveEthCallCollector {
     frequency_state: FrequencyState,
     _multicall3_address: Option<Address>,
     rpc_batch_size: usize,
+    /// Precomputed expected factory contracts from config, for writing per-block contract indexes.
+    expected_factory_contracts: HashMap<String, HashMap<String, Vec<String>>>,
 }
 
 #[derive(Debug, Default)]
@@ -73,6 +76,7 @@ impl LiveEthCallCollector {
         let factory_once_configs =
             build_factory_once_call_configs(&factory_call_configs, &chain.contracts);
         let event_call_configs = build_event_triggered_call_configs(&chain.contracts);
+        let expected_factory_contracts = build_expected_factory_contracts(&chain.contracts);
 
         tracing::info!(
             "LiveEthCallCollector initialized: {} regular calls, {} once configs, {} factory configs, {} event configs",
@@ -98,6 +102,7 @@ impl LiveEthCallCollector {
             },
             _multicall3_address: multicall3_address,
             rpc_batch_size,
+            expected_factory_contracts,
         }
     }
 
@@ -107,6 +112,11 @@ impl LiveEthCallCollector {
             || !self.once_configs.is_empty()
             || !self.factory_call_configs.is_empty()
             || !self.event_call_configs.is_empty()
+    }
+
+    /// Get the precomputed expected factory contracts for writing per-block contract indexes.
+    pub fn expected_factory_contracts(&self) -> &HashMap<String, HashMap<String, Vec<String>>> {
+        &self.expected_factory_contracts
     }
 
     /// Update factory addresses with newly discovered ones.

--- a/src/live/storage.rs
+++ b/src/live/storage.rs
@@ -19,6 +19,7 @@
 //! └── status/{block_number}.json
 //! ```
 
+use std::collections::HashMap;
 use std::fs;
 use std::io::{BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
@@ -196,6 +197,7 @@ impl LiveStorage {
             "raw/logs",
             "raw/eth_calls",
             "factories",
+            "contract_index",
             "status",
             "decoded/logs",
             "decoded/eth_calls",
@@ -731,6 +733,49 @@ impl LiveStorage {
     }
 
     // =========================================================================
+    // Contract index operations
+    // =========================================================================
+
+    /// Path for per-block contract index.
+    fn contract_index_path(&self, block_number: u64) -> PathBuf {
+        self.base_dir.join(format!("contract_index/{}.json", block_number))
+    }
+
+    /// Write per-block contract index recording which factory source contracts
+    /// were active when this block was collected.
+    pub fn write_contract_index(
+        &self,
+        block_number: u64,
+        index: &HashMap<String, HashMap<String, Vec<String>>>,
+    ) -> Result<(), StorageError> {
+        let path = self.contract_index_path(block_number);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let content = serde_json::to_string(index)?;
+        let mut f = BufWriter::new(fs::File::create(&path)?);
+        f.write_all(content.as_bytes())?;
+        Ok(())
+    }
+
+    /// Read per-block contract index.
+    pub fn read_contract_index(
+        &self,
+        block_number: u64,
+    ) -> Result<HashMap<String, HashMap<String, Vec<String>>>, StorageError> {
+        let path = self.contract_index_path(block_number);
+        let file = BufReader::new(
+            fs::File::open(&path).map_err(|_| StorageError::NotFound(block_number))?,
+        );
+        Ok(serde_json::from_reader(file)?)
+    }
+
+    /// Delete per-block contract index.
+    pub fn delete_contract_index(&self, block_number: u64) -> Result<(), StorageError> {
+        safe_delete(&self.contract_index_path(block_number))
+    }
+
+    // =========================================================================
     // Bulk operations
     // =========================================================================
 
@@ -741,6 +786,7 @@ impl LiveStorage {
         self.delete_logs(block_number)?;
         self.delete_eth_calls(block_number)?;
         self.delete_factories(block_number)?;
+        self.delete_contract_index(block_number)?;
         self.delete_status(block_number)?;
         self.delete_all_decoded_logs(block_number)?;
         self.delete_all_decoded_calls(block_number)?;

--- a/src/raw_data/historical/catchup/eth_calls.rs
+++ b/src/raw_data/historical/catchup/eth_calls.rs
@@ -31,14 +31,14 @@ use crate::raw_data::historical::receipts::{
 use crate::rpc::UnifiedRpcClient;
 use crate::storage::contract_index::{
     build_expected_factory_contracts_for_range, get_missing_contracts, range_key,
-    read_contract_index, update_contract_index, write_contract_index,
+    read_contract_index,
 };
 use crate::storage::factory_data::{
     load_factory_addresses_by_collection, load_factory_addresses_with_metadata,
 };
 use crate::storage::parquet_readers::read_event_calls_from_parquet;
 use crate::storage::paths::raw_eth_calls_dir;
-use crate::storage::{upload_sidecar_to_s3, DataLoader, S3Manifest, StorageManager};
+use crate::storage::{DataLoader, S3Manifest, StorageManager};
 use crate::types::config::chain::ChainConfig;
 use crate::types::config::contract::{AddressOrAddresses, Contracts};
 use crate::types::config::raw_data::RawDataCollectionConfig;
@@ -929,6 +929,7 @@ pub async fn collect_eth_calls(
         let mut processed_event_ranges: Vec<(u64, u64)> = Vec::new();
         {
             let semaphore = Arc::new(tokio::sync::Semaphore::new(event_call_concurrency));
+            let ci_mutex = Arc::new(tokio::sync::Mutex::new(()));
             let mut join_set: tokio::task::JoinSet<
                 Result<Option<(u64, u64)>, EthCallCollectionError>,
             > = tokio::task::JoinSet::new();
@@ -977,6 +978,7 @@ pub async fn collect_eth_calls(
                     let client = client.clone();
                     let decoder_tx = decoder_tx.clone();
                     let log_file_path = log_range.file_path.clone();
+                    let ci_mutex = ci_mutex.clone();
 
                     join_set.spawn(async move {
                         let (skipped, mut pending_writes) = {
@@ -1064,7 +1066,7 @@ pub async fn collect_eth_calls(
                                     range_start,
                                     inclusive_end,
                                     &contracts,
-                                    true,
+                                    Some(ci_mutex.clone()),
                                 )
                                 .await?
                             } else {
@@ -1076,7 +1078,7 @@ pub async fn collect_eth_calls(
                                     range_start,
                                     inclusive_end,
                                     &contracts,
-                                    true,
+                                    Some(ci_mutex.clone()),
                                 )
                                 .await?
                             }
@@ -1252,6 +1254,7 @@ pub async fn collect_eth_calls(
                 let chain_name = chain_name_arc.clone();
                 let client = client.clone();
                 let decoder_tx = decoder_tx.clone();
+                let ci_mutex = ci_mutex.clone();
 
                 join_set.spawn(async move {
                     // RPC phase — hold permit to limit concurrent RPC work
@@ -1279,7 +1282,7 @@ pub async fn collect_eth_calls(
                                 range_start,
                                 inclusive_end,
                                 &contracts,
-                                true,
+                                Some(ci_mutex.clone()),
                             )
                             .await?
                         } else {
@@ -1291,7 +1294,7 @@ pub async fn collect_eth_calls(
                                 range_start,
                                 inclusive_end,
                                 &contracts,
-                                true,
+                                Some(ci_mutex.clone()),
                             )
                             .await?
                         }
@@ -1342,55 +1345,6 @@ pub async fn collect_eth_calls(
             }
         }
         let event_catchup_count = processed_event_ranges.len();
-
-        // Batch-write contract indexes for all processed ranges (deferred from concurrent phase)
-        if !processed_event_ranges.is_empty() {
-            let factory_pairs: HashSet<(String, String)> = catchup_event_call_configs
-                .values()
-                .flatten()
-                .filter(|c| c.is_factory)
-                .map(|c| (c.contract_name.clone(), c.function_name.clone()))
-                .collect();
-
-            for (contract_name, function_name) in &factory_pairs {
-                let sub_dir = base_output_dir
-                    .join(contract_name)
-                    .join(function_name)
-                    .join("on_events");
-                let mut ci = read_contract_index(&sub_dir);
-                let mut wrote_any = false;
-
-                for &(start, end) in &processed_event_ranges {
-                    let expected =
-                        build_expected_factory_contracts_for_range(&chain.contracts, end + 1);
-                    if let Some(exp) = expected.get(contract_name.as_str()) {
-                        update_contract_index(&mut ci, &range_key(start, end), exp);
-                        wrote_any = true;
-                    }
-                }
-
-                if wrote_any {
-                    if let Err(e) = write_contract_index(&sub_dir, &ci) {
-                        tracing::warn!(
-                            "Failed to batch-write contract index for {}.{}/on_events: {}",
-                            contract_name,
-                            function_name,
-                            e
-                        );
-                    } else if let Some(sm) = storage_manager.as_ref() {
-                        let index_path = sub_dir.join("contract_index.json");
-                        if let Err(e) = upload_sidecar_to_s3(sm, &index_path).await {
-                            tracing::warn!(
-                                "Failed to upload contract index sidecar for {}.{}/on_events: {}",
-                                contract_name,
-                                function_name,
-                                e
-                            );
-                        }
-                    }
-                }
-            }
-        }
 
         if event_catchup_count > 0 {
             tracing::info!(

--- a/src/raw_data/historical/current/eth_calls/events.rs
+++ b/src/raw_data/historical/current/eth_calls/events.rs
@@ -70,7 +70,7 @@ pub(super) async fn handle_event_trigger_message(
                             range_start,
                             inclusive_end,
                             &state.contracts,
-                            false,
+                            None,
                         )
                         .await?
                     } else {
@@ -82,7 +82,7 @@ pub(super) async fn handle_event_trigger_message(
                             range_start,
                             inclusive_end,
                             &state.contracts,
-                            false,
+                            None,
                         )
                         .await?
                     };

--- a/src/raw_data/historical/current/eth_calls/factory.rs
+++ b/src/raw_data/historical/current/eth_calls/factory.rs
@@ -98,7 +98,7 @@ pub(super) async fn handle_factory_message(
                                     buf_range_start,
                                     buf_range_end,
                                     &state.contracts,
-                                    false,
+                                    None,
                                 )
                                 .await?
                             } else {
@@ -110,7 +110,7 @@ pub(super) async fn handle_factory_message(
                                     buf_range_start,
                                     buf_range_end,
                                     &state.contracts,
-                                    false,
+                                    None,
                                 )
                                 .await?
                             };

--- a/src/raw_data/historical/eth_calls/event_triggers.rs
+++ b/src/raw_data/historical/eth_calls/event_triggers.rs
@@ -592,7 +592,7 @@ pub(crate) async fn process_event_triggers(
     range_start: u64,
     range_end: u64,
     contracts: &Contracts,
-    skip_contract_index: bool,
+    contract_index_mutex: Option<Arc<tokio::sync::Mutex<()>>>,
 ) -> Result<(Vec<SkippedFactoryTrigger>, PendingWrites), EthCallCollectionError> {
     let mut skipped_factory_triggers: Vec<SkippedFactoryTrigger> = Vec::new();
     let empty_writes = PendingWrites::new();
@@ -616,7 +616,12 @@ pub(crate) async fn process_event_triggers(
                 range_end,
             )
             .await?;
-            if !skip_contract_index {
+            {
+                let _guard = if let Some(ref m) = contract_index_mutex {
+                    Some(m.lock().await)
+                } else {
+                    None
+                };
                 let sub_dir = ctx
                     .output_dir
                     .join(contract_name)
@@ -867,7 +872,7 @@ pub(crate) async fn process_event_triggers(
             let storage_manager = ctx.storage_manager.cloned();
             let chain_name = ctx.chain_name.to_string();
             let decoder_tx = ctx.decoder_tx.clone();
-            let skip_ci = skip_contract_index;
+            let ci_mutex = contract_index_mutex.clone();
             let contracts = contracts.clone();
 
             write_set.spawn(async move {
@@ -900,7 +905,12 @@ pub(crate) async fn process_event_triggers(
                         })?;
                 }
 
-                if !skip_ci {
+                {
+                    let _guard = if let Some(ref m) = ci_mutex {
+                        Some(m.lock().await)
+                    } else {
+                        None
+                    };
                     let expected_for_range =
                         build_expected_factory_contracts_for_range(&contracts, range_end + 1);
                     if let Some(expected) = expected_for_range.get(&contract_name) {
@@ -948,7 +958,7 @@ pub(crate) async fn process_event_triggers(
         for (contract_name, function_name) in configured_pairs {
             if !written_pairs.contains(&(contract_name.clone(), function_name.clone())) {
                 let output_dir = ctx.output_dir.to_path_buf();
-                let skip_ci = skip_contract_index;
+                let ci_mutex = contract_index_mutex.clone();
                 let contracts = contracts.clone();
                 write_set.spawn(async move {
                     write_empty_event_call_file(
@@ -959,7 +969,12 @@ pub(crate) async fn process_event_triggers(
                         range_end,
                     )
                     .await?;
-                    if !skip_ci {
+                    {
+                        let _guard = if let Some(ref m) = ci_mutex {
+                            Some(m.lock().await)
+                        } else {
+                            None
+                        };
                         let sub_dir = output_dir
                             .join(&contract_name)
                             .join(&function_name)
@@ -1027,7 +1042,7 @@ pub(crate) async fn process_event_triggers_multicall(
     range_start: u64,
     range_end: u64,
     contracts: &Contracts,
-    skip_contract_index: bool,
+    contract_index_mutex: Option<Arc<tokio::sync::Mutex<()>>>,
 ) -> Result<(Vec<SkippedFactoryTrigger>, PendingWrites), EthCallCollectionError> {
     let mut skipped_factory_triggers: Vec<SkippedFactoryTrigger> = Vec::new();
     let empty_writes = PendingWrites::new();
@@ -1051,7 +1066,12 @@ pub(crate) async fn process_event_triggers_multicall(
                 range_end,
             )
             .await?;
-            if !skip_contract_index {
+            {
+                let _guard = if let Some(ref m) = contract_index_mutex {
+                    Some(m.lock().await)
+                } else {
+                    None
+                };
                 let sub_dir = ctx
                     .output_dir
                     .join(contract_name)
@@ -1373,7 +1393,7 @@ pub(crate) async fn process_event_triggers_multicall(
         let storage_manager = ctx.storage_manager.cloned();
         let chain_name = ctx.chain_name.to_string();
         let decoder_tx = ctx.decoder_tx.clone();
-        let skip_ci = skip_contract_index;
+        let ci_mutex = contract_index_mutex.clone();
         let contracts = contracts.clone();
 
         write_set.spawn(async move {
@@ -1407,7 +1427,12 @@ pub(crate) async fn process_event_triggers_multicall(
                 .map_err(|e| EthCallCollectionError::Io(std::io::Error::other(e.to_string())))?;
             }
 
-            if !skip_ci {
+            {
+                let _guard = if let Some(ref m) = ci_mutex {
+                    Some(m.lock().await)
+                } else {
+                    None
+                };
                 let expected_for_range =
                     build_expected_factory_contracts_for_range(&contracts, range_end + 1);
                 if let Some(expected) = expected_for_range.get(&contract_name) {
@@ -1459,7 +1484,7 @@ pub(crate) async fn process_event_triggers_multicall(
     for (contract_name, function_name) in configured_pairs {
         if !written_pairs.contains(&(contract_name.clone(), function_name.clone())) {
             let output_dir = ctx.output_dir.to_path_buf();
-            let skip_ci = skip_contract_index;
+            let ci_mutex = contract_index_mutex.clone();
             let contracts = contracts.clone();
             write_set.spawn(async move {
                 write_empty_event_call_file(
@@ -1470,7 +1495,12 @@ pub(crate) async fn process_event_triggers_multicall(
                     range_end,
                 )
                 .await?;
-                if !skip_ci {
+                {
+                    let _guard = if let Some(ref m) = ci_mutex {
+                        Some(m.lock().await)
+                    } else {
+                        None
+                    };
                     let sub_dir = output_dir
                         .join(&contract_name)
                         .join(&function_name)


### PR DESCRIPTION
## Summary

- **Catchup bug fix**: The deferred batch-write of contract indexes after the concurrent event-trigger phase was never persisted if the process was interrupted mid-batch. This caused an infinite retry loop on restart because the contract index check would always find missing entries. Fix: replace the `skip_contract_index: bool` parameter with `contract_index_mutex: Option<Arc<tokio::sync::Mutex<()>>>`. When `Some`, each concurrent task acquires the mutex before the read-modify-write cycle, ensuring indexes are written inline and durably. The deferred batch-write block is removed entirely.

- **Live mode addition**: Per-block contract indexes are now written during live collection (recording which factory source contracts were active when each block was processed). During compaction, these per-block indexes are merged and written into the historical `contract_index.json` format for each collection's `on_events` directory.

- **Current path**: No behavioral change -- `false` becomes `None` (no mutex, writes inline without locking, same as before).

## Changed files

- `src/raw_data/historical/eth_calls/event_triggers.rs` -- parameter change from `skip_contract_index: bool` to `contract_index_mutex: Option<Arc<tokio::sync::Mutex<()>>>` in both `process_event_triggers` and `process_event_triggers_multicall`; all 6 contract index write sites now always execute, acquiring the mutex when present
- `src/raw_data/historical/catchup/eth_calls.rs` -- creates shared mutex before JoinSet, passes `Some(ci_mutex.clone())` to all 4 call sites, removes the deferred batch-write block and its now-unused imports
- `src/raw_data/historical/current/eth_calls/events.rs` -- `false` to `None`
- `src/raw_data/historical/current/eth_calls/factory.rs` -- `false` to `None`
- `src/live/storage.rs` -- new `write_contract_index`, `read_contract_index`, `delete_contract_index` methods using JSON serialization; added to `ensure_dirs` and `delete_all`
- `src/live/eth_calls.rs` -- precomputes `expected_factory_contracts` from config in `new()`, exposes via getter
- `src/live/collector.rs` -- writes per-block contract index after eth_calls in `commit_eth_call_batch`
- `src/live/compaction.rs` -- merges per-block contract indexes into historical format during range compaction