### PR TITLE
feat: optimize event-triggered call catchup

### DIFF
--- a/src/raw_data/historical/catchup/eth_calls.rs
+++ b/src/raw_data/historical/catchup/eth_calls.rs
@@ -25,7 +25,8 @@ use crate::raw_data::historical::eth_calls::{
 };
 use crate::raw_data::historical::factories::{get_factory_call_configs, FactoryAddressData};
 use crate::raw_data::historical::receipts::{
-    build_event_trigger_matchers, extract_event_triggers_from_batches, EventTriggerMatcher,
+    build_event_trigger_matchers, extract_event_triggers_from_batches, EventTriggerData,
+    EventTriggerMatcher,
 };
 use crate::rpc::UnifiedRpcClient;
 use crate::storage::contract_index::{
@@ -36,7 +37,7 @@ use crate::storage::factory_data::{
     load_factory_addresses_by_collection, load_factory_addresses_with_metadata,
 };
 use crate::storage::parquet_readers::read_event_call_row_keys_from_parquet;
-use crate::storage::paths::raw_eth_calls_dir;
+use crate::storage::paths::{factories_dir as factories_dir_path, raw_eth_calls_dir};
 use crate::storage::{upload_sidecar_to_s3, DataLoader, S3Manifest, StorageManager};
 use crate::types::config::chain::ChainConfig;
 use crate::types::config::contract::{AddressOrAddresses, Contracts};
@@ -151,6 +152,33 @@ fn filter_event_trigger_matchers(
             active_keys.contains(&(matcher.source_name.clone(), matcher.event_topic0))
         })
         .collect()
+}
+
+fn filter_ready_factory_event_triggers(
+    triggers: Vec<EventTriggerData>,
+    factory_addresses: &HashMap<String, HashSet<Address>>,
+    ready_factory_sources_for_range: &HashSet<String>,
+) -> (Vec<EventTriggerData>, usize) {
+    if triggers.is_empty() || ready_factory_sources_for_range.is_empty() {
+        return (triggers, 0);
+    }
+
+    let original_len = triggers.len();
+    let filtered = triggers
+        .into_iter()
+        .filter(|trigger| {
+            if !ready_factory_sources_for_range.contains(&trigger.source_name) {
+                return true;
+            }
+
+            factory_addresses
+                .get(&trigger.source_name)
+                .is_some_and(|known| known.contains(&Address::from(trigger.emitter_address)))
+        })
+        .collect::<Vec<_>>();
+
+    let filtered_out = original_len.saturating_sub(filtered.len());
+    (filtered, filtered_out)
 }
 
 type EventRowKeyCounts = HashMap<(u64, u32), usize>;
@@ -884,6 +912,15 @@ pub async fn collect_eth_calls(
                 .extend(addrs);
         }
 
+        let factories_dir = factories_dir_path(&chain.name);
+        let mut factory_contract_indexes = HashMap::new();
+        for collection_name in &factory_collections {
+            factory_contract_indexes.insert(
+                collection_name.clone(),
+                read_contract_index(&factories_dir.join(collection_name)),
+            );
+        }
+
         let log_ranges =
             get_existing_log_ranges_async(chain.name.clone(), s3_manifest.as_ref().cloned()).await;
         let total_log_ranges = log_ranges.len();
@@ -946,6 +983,17 @@ pub async fn collect_eth_calls(
 
                 let range_start = log_range.start;
                 let inclusive_end = log_range.end - 1;
+                let factory_range_key = range_key(range_start, inclusive_end);
+                let ready_factory_sources_for_range: HashSet<String> = factory_collections
+                    .iter()
+                    .filter(|collection_name| {
+                        factory_contract_indexes
+                            .get(*collection_name)
+                            .is_some_and(|index| index.contains_key(&factory_range_key))
+                            && factory_addresses.contains_key(*collection_name)
+                    })
+                    .cloned()
+                    .collect();
 
                 // === Skip check (non-repair only, before any I/O) ===
                 if !repair {
@@ -1025,7 +1073,21 @@ pub async fn collect_eth_calls(
 
                 let triggers =
                     extract_event_triggers_from_batches(&batches, event_matchers_arc.as_ref());
+                let (triggers, filtered_factory_triggers) = filter_ready_factory_event_triggers(
+                    triggers,
+                    &factory_addresses,
+                    &ready_factory_sources_for_range,
+                );
                 drop(batches);
+
+                if filtered_factory_triggers > 0 {
+                    tracing::debug!(
+                        "Catchup: filtered {} factory event triggers for blocks {}-{} using pre-loaded factory addresses",
+                        filtered_factory_triggers,
+                        range_start,
+                        inclusive_end
+                    );
+                }
 
                 // === Repair validation (repair only, after extraction) ===
                 if repair {

--- a/src/raw_data/historical/catchup/eth_calls.rs
+++ b/src/raw_data/historical/catchup/eth_calls.rs
@@ -18,26 +18,25 @@ use crate::raw_data::historical::eth_calls::{
     build_once_call_configs, event_output_exists_async, expected_event_call_key_counts_by_output,
     get_existing_log_ranges_async, process_event_triggers, process_event_triggers_multicall,
     process_factory_once_calls, process_once_calls_multicall, process_once_calls_regular,
-    process_range, process_range_multicall, read_event_trigger_log_batches_from_parquet_async,
-    scan_existing_parquet_files_async, AbortOnDropHandles, BlockInfo, BlockRange,
-    EthCallCatchupState, EthCallCollectionError, EthCallContext, EventCallKey,
-    EventTriggeredCallConfig, FrequencyState, OnceCallConfig,
+    process_range, process_range_multicall,
+    read_event_trigger_log_batches_from_parquet_async, scan_existing_parquet_files_async,
+    AbortOnDropHandles, BlockInfo, BlockRange, EthCallCatchupState, EthCallCollectionError,
+    EthCallContext, EventCallKey, EventTriggeredCallConfig, FrequencyState, OnceCallConfig,
 };
 use crate::raw_data::historical::factories::{get_factory_call_configs, FactoryAddressData};
 use crate::raw_data::historical::receipts::{
-    build_event_trigger_matchers, extract_event_triggers, extract_event_triggers_from_batches,
-    EventTriggerData, EventTriggerMatcher,
+    build_event_trigger_matchers, extract_event_triggers_from_batches, EventTriggerMatcher,
 };
 use crate::rpc::UnifiedRpcClient;
 use crate::storage::contract_index::{
     build_expected_factory_contracts_for_range, get_missing_contracts, range_key,
-    read_contract_index,
+    read_contract_index, update_contract_index, write_contract_index,
 };
 use crate::storage::factory_data::{
     load_factory_addresses_by_collection, load_factory_addresses_with_metadata,
 };
-use crate::storage::parquet_readers::read_event_calls_from_parquet;
-use crate::storage::paths::{factories_dir as factories_dir_path, raw_eth_calls_dir};
+use crate::storage::parquet_readers::read_event_call_row_keys_from_parquet;
+use crate::storage::paths::raw_eth_calls_dir;
 use crate::storage::{upload_sidecar_to_s3, DataLoader, S3Manifest, StorageManager};
 use crate::types::config::chain::ChainConfig;
 use crate::types::config::contract::{AddressOrAddresses, Contracts};
@@ -154,33 +153,6 @@ fn filter_event_trigger_matchers(
         .collect()
 }
 
-fn filter_ready_factory_event_triggers(
-    triggers: Vec<EventTriggerData>,
-    factory_addresses: &HashMap<String, HashSet<Address>>,
-    ready_factory_sources_for_range: &HashSet<String>,
-) -> (Vec<EventTriggerData>, usize) {
-    if triggers.is_empty() || ready_factory_sources_for_range.is_empty() {
-        return (triggers, 0);
-    }
-
-    let original_len = triggers.len();
-    let filtered = triggers
-        .into_iter()
-        .filter(|trigger| {
-            if !ready_factory_sources_for_range.contains(&trigger.source_name) {
-                return true;
-            }
-
-            factory_addresses
-                .get(&trigger.source_name)
-                .is_some_and(|known| known.contains(&Address::from(trigger.emitter_address)))
-        })
-        .collect::<Vec<_>>();
-
-    let filtered_out = original_len.saturating_sub(filtered.len());
-    (filtered, filtered_out)
-}
-
 type EventRowKeyCounts = HashMap<(u64, u32), usize>;
 
 fn active_event_output_pairs_for_range(
@@ -218,10 +190,9 @@ where
 
 async fn read_raw_event_row_key_counts(output_path: PathBuf) -> Result<EventRowKeyCounts, String> {
     tokio::task::spawn_blocking(move || {
-        let results = read_event_calls_from_parquet(&output_path).map_err(|e| e.to_string())?;
-        Ok::<_, String>(build_event_row_key_counts(
-            results.into_iter().map(|r| (r.block_number, r.log_index)),
-        ))
+        let keys =
+            read_event_call_row_keys_from_parquet(&output_path).map_err(|e| e.to_string())?;
+        Ok::<_, String>(build_event_row_key_counts(keys.into_iter()))
     })
     .await
     .map_err(|e| e.to_string())?
@@ -913,15 +884,6 @@ pub async fn collect_eth_calls(
                 .extend(addrs);
         }
 
-        let factories_dir = factories_dir_path(&chain.name);
-        let mut factory_contract_indexes = HashMap::new();
-        for collection_name in &factory_collections {
-            factory_contract_indexes.insert(
-                collection_name.clone(),
-                read_contract_index(&factories_dir.join(collection_name)),
-            );
-        }
-
         let log_ranges =
             get_existing_log_ranges_async(chain.name.clone(), s3_manifest.as_ref().cloned()).await;
         let total_log_ranges = log_ranges.len();
@@ -965,7 +927,6 @@ pub async fn collect_eth_calls(
         let mut processed_event_ranges: Vec<(u64, u64)> = Vec::new();
         {
             let semaphore = Arc::new(tokio::sync::Semaphore::new(event_call_concurrency));
-            let ci_mutex = Arc::new(tokio::sync::Mutex::new(()));
             let mut join_set: tokio::task::JoinSet<
                 Result<Option<(u64, u64)>, EthCallCollectionError>,
             > = tokio::task::JoinSet::new();
@@ -985,215 +946,14 @@ pub async fn collect_eth_calls(
 
                 let range_start = log_range.start;
                 let inclusive_end = log_range.end - 1;
-                let factory_range_key = range_key(range_start, inclusive_end);
-                let mut ready_factory_sources_for_range: HashSet<String> = HashSet::new();
-                for collection_name in &factory_collections {
-                    let range_is_indexed = factory_contract_indexes
-                        .get(collection_name)
-                        .is_some_and(|index| index.contains_key(&factory_range_key));
-                    if !range_is_indexed {
-                        continue;
-                    }
 
-                    if factory_addresses.contains_key(collection_name) {
-                        ready_factory_sources_for_range.insert(collection_name.clone());
-                    } else {
-                        tracing::warn!(
-                            "Factory range {}-{} for collection {} is marked complete in contract index, but no pre-loaded factory addresses were available; skipping catchup pre-filter for this collection",
-                            range_start,
-                            inclusive_end,
-                            collection_name
-                        );
-                    }
-                }
-
-                if repair {
-                    let permit = semaphore.clone().acquire_owned().await.unwrap();
-
-                    while let Some(result) = join_set.try_join_next() {
-                        match result {
-                            Ok(Ok(Some((start, end)))) => {
-                                processed_event_ranges.push((start, end));
-                            }
-                            Ok(Ok(None)) => {}
-                            Ok(Err(e)) => return Err(e),
-                            Err(e) => {
-                                return Err(EthCallCollectionError::JoinError(e.to_string()));
-                            }
-                        }
-                    }
-
-                    let event_matchers = event_matchers_arc.clone();
-                    let event_call_configs = event_call_configs_arc.clone();
-                    let factory_addresses = factory_addresses_arc.clone();
-                    let existing_files = existing_files_arc.clone();
-                    let contracts = contracts_arc.clone();
-                    let base_output_dir = base_output_dir_arc.clone();
-                    let s3_manifest = s3_manifest.clone();
-                    let storage_manager: Option<Arc<StorageManager>> = storage_manager_arc.clone();
-                    let chain_name = chain_name_arc.clone();
-                    let client = client.clone();
-                    let decoder_tx = decoder_tx.clone();
-                    let log_file_path = log_range.file_path.clone();
-                    let ci_mutex = ci_mutex.clone();
-                    let ready_factory_sources_for_range = ready_factory_sources_for_range.clone();
-
-                    join_set.spawn(async move {
-                        let (skipped, mut pending_writes) = {
-                            let _permit = permit;
-
-                            let batches = match read_event_trigger_log_batches_from_parquet_async(
-                                log_file_path.clone(),
-                            )
-                            .await
-                            {
-                                Ok(batches) => batches,
-                                Err(e) => {
-                                    tracing::warn!(
-                                        "Failed to read projected logs from {}: {}",
-                                        log_file_path.display(),
-                                        e
-                                    );
-                                    return Ok(None);
-                                }
-                            };
-
-                            let log_count: usize = batches.iter().map(|b| b.num_rows()).sum();
-                            if log_count == 0 {
-                                return Ok(None);
-                            }
-
-                            tracing::info!(
-                                "Auditing event-triggered calls for blocks {}-{} ({} logs)",
-                                range_start,
-                                inclusive_end,
-                                log_count
-                            );
-
-                            let triggers =
-                                extract_event_triggers_from_batches(&batches, &event_matchers);
-                            let (triggers, filtered_factory_triggers) =
-                                filter_ready_factory_event_triggers(
-                                    triggers,
-                                    &factory_addresses,
-                                    &ready_factory_sources_for_range,
-                                );
-                            drop(batches);
-
-                            if filtered_factory_triggers > 0 {
-                                tracing::debug!(
-                                    "Catchup: filtered {} factory event triggers for blocks {}-{} using pre-loaded factory addresses",
-                                    filtered_factory_triggers,
-                                    range_start,
-                                    inclusive_end
-                                );
-                            }
-
-                            let needs_processing = repair_needs_event_recollection(
-                                &base_output_dir,
-                                &event_call_configs,
-                                &factory_addresses,
-                                &contracts,
-                                &triggers,
-                                range_start,
-                                inclusive_end,
-                            )
-                            .await?;
-
-                            if !needs_processing {
-                                tracing::debug!(
-                                    "Skipping event-triggered calls for blocks {}-{} (already verified)",
-                                    range_start,
-                                    inclusive_end
-                                );
-                                return Ok(None);
-                            }
-
-                            if !triggers.is_empty() {
-                                tracing::info!(
-                                    "Repair recollecting event-triggered calls for blocks {}-{} ({} triggers)",
-                                    range_start,
-                                    inclusive_end,
-                                    triggers.len()
-                                );
-                            }
-
-                            let event_ctx = EthCallContext {
-                                client: &client,
-                                output_dir: &base_output_dir,
-                                existing_files: &existing_files,
-                                rpc_batch_size,
-                                repair,
-                                decoder_tx: &decoder_tx,
-                                chain_name: &chain_name,
-                                storage_manager: storage_manager.as_ref(),
-                                s3_manifest: &s3_manifest,
-                            };
-                            if let Some(multicall_addr) = multicall3_address {
-                                process_event_triggers_multicall(
-                                    triggers,
-                                    &event_call_configs,
-                                    &factory_addresses,
-                                    &event_ctx,
-                                    multicall_addr,
-                                    range_start,
-                                    inclusive_end,
-                                    &contracts,
-                                    Some(ci_mutex.clone()),
-                                )
-                                .await?
-                            } else {
-                                process_event_triggers(
-                                    triggers,
-                                    &event_call_configs,
-                                    &factory_addresses,
-                                    &event_ctx,
-                                    range_start,
-                                    inclusive_end,
-                                    &contracts,
-                                    Some(ci_mutex.clone()),
-                                )
-                                .await?
-                            }
-                        };
-
-                        if !skipped.is_empty() {
-                            tracing::warn!(
-                                "Unexpected skipped factory triggers during catchup ({} triggers) — factory addresses should be pre-loaded",
-                                skipped.len()
-                            );
-                        }
-
-                        while let Some(result) = pending_writes.join_next().await {
-                            match result {
-                                Ok(Ok(())) => {}
-                                Ok(Err(e)) => return Err(e),
-                                Err(e) => {
-                                    return Err(EthCallCollectionError::JoinError(e.to_string()))
-                                }
-                            }
-                        }
-
-                        tracing::debug!(
-                            "Event-triggered calls catchup: processed range {}/{} (blocks {}-{})",
-                            idx + 1,
-                            total_log_ranges,
-                            range_start,
-                            inclusive_end
-                        );
-
-                        Ok(Some((range_start, inclusive_end)))
-                    });
-
-                    continue;
-                }
-
-                let mut needs_processing = false;
+                // === Skip check (non-repair only, before any I/O) ===
                 if !repair {
                     let event_expected_for_range =
                         build_expected_factory_contracts_for_range(&chain.contracts, log_range.end);
 
-                    for configs in catchup_event_call_configs.values() {
+                    let mut all_exist = true;
+                    'outer: for configs in catchup_event_call_configs.values() {
                         for config in configs {
                             if let Some(sb) = config.start_block {
                                 if log_range.end <= sb {
@@ -1216,45 +976,43 @@ pub async fn collect_eth_calls(
                             )
                             .await?
                             {
-                                needs_processing = true;
-                                break;
+                                all_exist = false;
+                                break 'outer;
                             }
                         }
-                        if needs_processing {
-                            break;
-                        }
+                    }
+
+                    if all_exist {
+                        tracing::debug!(
+                            "Skipping event-triggered calls for blocks {}-{} (already exists)",
+                            range_start,
+                            inclusive_end
+                        );
+                        continue;
                     }
                 }
 
-                if !repair && !needs_processing {
-                    tracing::debug!(
-                        "Skipping event-triggered calls for blocks {}-{} (already exists)",
-                        log_range.start,
-                        log_range.end - 1
-                    );
-                    continue;
-                }
+                // === Sequential phase: read projected parquet + extract triggers ===
+                // Read only the 6 columns needed for event matching (one file at a time
+                // to avoid holding N large log files in memory concurrently).
+                let batches = match read_event_trigger_log_batches_from_parquet_async(
+                    log_range.file_path.clone(),
+                )
+                .await
+                {
+                    Ok(batches) => batches,
+                    Err(e) => {
+                        tracing::warn!(
+                            "Failed to read projected logs from {}: {}",
+                            log_range.file_path.display(),
+                            e
+                        );
+                        continue;
+                    }
+                };
 
-                // --- Sequential phase: read parquet + extract triggers (one file at a time) ---
-                // This avoids holding N large log files in memory concurrently.
-                let logs =
-                    match crate::raw_data::historical::eth_calls::read_logs_from_parquet_async(
-                        log_range.file_path.clone(),
-                    )
-                    .await
-                    {
-                        Ok(logs) => logs,
-                        Err(e) => {
-                            tracing::warn!(
-                                "Failed to read logs from {}: {}",
-                                log_range.file_path.display(),
-                                e
-                            );
-                            continue;
-                        }
-                    };
-
-                if logs.is_empty() {
+                let log_count: usize = batches.iter().map(|b| b.num_rows()).sum();
+                if log_count == 0 {
                     continue;
                 }
 
@@ -1262,29 +1020,16 @@ pub async fn collect_eth_calls(
                     "Catchup: processing event-triggered calls for blocks {}-{} ({} logs)",
                     range_start,
                     inclusive_end,
-                    logs.len()
+                    log_count
                 );
 
-                let triggers = extract_event_triggers(&logs, event_matchers_arc.as_ref());
-                let (triggers, filtered_factory_triggers) = filter_ready_factory_event_triggers(
-                    triggers,
-                    &factory_addresses,
-                    &ready_factory_sources_for_range,
-                );
-                // Drop logs immediately — only triggers (much smaller) are kept for RPC work
-                drop(logs);
+                let triggers =
+                    extract_event_triggers_from_batches(&batches, event_matchers_arc.as_ref());
+                drop(batches);
 
-                if filtered_factory_triggers > 0 {
-                    tracing::debug!(
-                        "Catchup: filtered {} factory event triggers for blocks {}-{} using pre-loaded factory addresses",
-                        filtered_factory_triggers,
-                        range_start,
-                        inclusive_end
-                    );
-                }
-
+                // === Repair validation (repair only, after extraction) ===
                 if repair {
-                    needs_processing = repair_needs_event_recollection(
+                    let needs_processing = repair_needs_event_recollection(
                         &base_output_dir,
                         &catchup_event_call_configs,
                         &factory_addresses,
@@ -1294,15 +1039,15 @@ pub async fn collect_eth_calls(
                         inclusive_end,
                     )
                     .await?;
-                }
 
-                if !needs_processing {
-                    tracing::debug!(
-                        "Skipping event-triggered calls for blocks {}-{} (already verified)",
-                        range_start,
-                        inclusive_end
-                    );
-                    continue;
+                    if !needs_processing {
+                        tracing::debug!(
+                            "Skipping event-triggered calls for blocks {}-{} (already verified)",
+                            range_start,
+                            inclusive_end
+                        );
+                        continue;
+                    }
                 }
 
                 if !triggers.is_empty() {
@@ -1314,7 +1059,7 @@ pub async fn collect_eth_calls(
                     );
                 }
 
-                // --- Concurrent phase: acquire permit and spawn RPC work ---
+                // === Concurrent phase: acquire permit and spawn RPC work ===
                 let permit = semaphore.clone().acquire_owned().await.unwrap();
 
                 // Drain completed tasks to collect results eagerly
@@ -1341,7 +1086,6 @@ pub async fn collect_eth_calls(
                 let chain_name = chain_name_arc.clone();
                 let client = client.clone();
                 let decoder_tx = decoder_tx.clone();
-                let ci_mutex = ci_mutex.clone();
 
                 join_set.spawn(async move {
                     // RPC phase — hold permit to limit concurrent RPC work
@@ -1369,7 +1113,7 @@ pub async fn collect_eth_calls(
                                 range_start,
                                 inclusive_end,
                                 &contracts,
-                                Some(ci_mutex.clone()),
+                                true,
                             )
                             .await?
                         } else {
@@ -1381,7 +1125,7 @@ pub async fn collect_eth_calls(
                                 range_start,
                                 inclusive_end,
                                 &contracts,
-                                Some(ci_mutex.clone()),
+                                true,
                             )
                             .await?
                         }
@@ -1432,6 +1176,55 @@ pub async fn collect_eth_calls(
             }
         }
         let event_catchup_count = processed_event_ranges.len();
+
+        // Batch-write contract indexes for all processed ranges (deferred from concurrent phase)
+        if !processed_event_ranges.is_empty() {
+            let factory_pairs: HashSet<(String, String)> = catchup_event_call_configs
+                .values()
+                .flatten()
+                .filter(|c| c.is_factory)
+                .map(|c| (c.contract_name.clone(), c.function_name.clone()))
+                .collect();
+
+            for (contract_name, function_name) in &factory_pairs {
+                let sub_dir = base_output_dir
+                    .join(contract_name)
+                    .join(function_name)
+                    .join("on_events");
+                let mut ci = read_contract_index(&sub_dir);
+                let mut wrote_any = false;
+
+                for &(start, end) in &processed_event_ranges {
+                    let expected =
+                        build_expected_factory_contracts_for_range(&chain.contracts, end + 1);
+                    if let Some(exp) = expected.get(contract_name.as_str()) {
+                        update_contract_index(&mut ci, &range_key(start, end), exp);
+                        wrote_any = true;
+                    }
+                }
+
+                if wrote_any {
+                    if let Err(e) = write_contract_index(&sub_dir, &ci) {
+                        tracing::warn!(
+                            "Failed to batch-write contract index for {}.{}/on_events: {}",
+                            contract_name,
+                            function_name,
+                            e
+                        );
+                    } else if let Some(sm) = storage_manager.as_ref() {
+                        let index_path = sub_dir.join("contract_index.json");
+                        if let Err(e) = upload_sidecar_to_s3(sm, &index_path).await {
+                            tracing::warn!(
+                                "Failed to upload contract index sidecar for {}.{}/on_events: {}",
+                                contract_name,
+                                function_name,
+                                e
+                            );
+                        }
+                    }
+                }
+            }
+        }
 
         if event_catchup_count > 0 {
             tracing::info!(

--- a/src/raw_data/historical/current/eth_calls/events.rs
+++ b/src/raw_data/historical/current/eth_calls/events.rs
@@ -70,7 +70,7 @@ pub(super) async fn handle_event_trigger_message(
                             range_start,
                             inclusive_end,
                             &state.contracts,
-                            None,
+                            false,
                         )
                         .await?
                     } else {
@@ -82,7 +82,7 @@ pub(super) async fn handle_event_trigger_message(
                             range_start,
                             inclusive_end,
                             &state.contracts,
-                            None,
+                            false,
                         )
                         .await?
                     };

--- a/src/raw_data/historical/current/eth_calls/factory.rs
+++ b/src/raw_data/historical/current/eth_calls/factory.rs
@@ -98,7 +98,7 @@ pub(super) async fn handle_factory_message(
                                     buf_range_start,
                                     buf_range_end,
                                     &state.contracts,
-                                    None,
+                                    false,
                                 )
                                 .await?
                             } else {
@@ -110,7 +110,7 @@ pub(super) async fn handle_factory_message(
                                     buf_range_start,
                                     buf_range_end,
                                     &state.contracts,
-                                    None,
+                                    false,
                                 )
                                 .await?
                             };

--- a/src/raw_data/historical/eth_calls/event_triggers.rs
+++ b/src/raw_data/historical/eth_calls/event_triggers.rs
@@ -592,7 +592,7 @@ pub(crate) async fn process_event_triggers(
     range_start: u64,
     range_end: u64,
     contracts: &Contracts,
-    contract_index_mutex: Option<Arc<tokio::sync::Mutex<()>>>,
+    skip_contract_index: bool,
 ) -> Result<(Vec<SkippedFactoryTrigger>, PendingWrites), EthCallCollectionError> {
     let mut skipped_factory_triggers: Vec<SkippedFactoryTrigger> = Vec::new();
     let empty_writes = PendingWrites::new();
@@ -616,12 +616,7 @@ pub(crate) async fn process_event_triggers(
                 range_end,
             )
             .await?;
-            {
-                let _guard = if let Some(ref m) = contract_index_mutex {
-                    Some(m.lock().await)
-                } else {
-                    None
-                };
+            if !skip_contract_index {
                 let sub_dir = ctx
                     .output_dir
                     .join(contract_name)
@@ -872,7 +867,7 @@ pub(crate) async fn process_event_triggers(
             let storage_manager = ctx.storage_manager.cloned();
             let chain_name = ctx.chain_name.to_string();
             let decoder_tx = ctx.decoder_tx.clone();
-            let ci_mutex = contract_index_mutex.clone();
+            let skip_ci = skip_contract_index;
             let contracts = contracts.clone();
 
             write_set.spawn(async move {
@@ -905,12 +900,7 @@ pub(crate) async fn process_event_triggers(
                         })?;
                 }
 
-                {
-                    let _guard = if let Some(ref m) = ci_mutex {
-                        Some(m.lock().await)
-                    } else {
-                        None
-                    };
+                if !skip_ci {
                     let expected_for_range =
                         build_expected_factory_contracts_for_range(&contracts, range_end + 1);
                     if let Some(expected) = expected_for_range.get(&contract_name) {
@@ -958,7 +948,7 @@ pub(crate) async fn process_event_triggers(
         for (contract_name, function_name) in configured_pairs {
             if !written_pairs.contains(&(contract_name.clone(), function_name.clone())) {
                 let output_dir = ctx.output_dir.to_path_buf();
-                let ci_mutex = contract_index_mutex.clone();
+                let skip_ci = skip_contract_index;
                 let contracts = contracts.clone();
                 write_set.spawn(async move {
                     write_empty_event_call_file(
@@ -969,12 +959,7 @@ pub(crate) async fn process_event_triggers(
                         range_end,
                     )
                     .await?;
-                    {
-                        let _guard = if let Some(ref m) = ci_mutex {
-                            Some(m.lock().await)
-                        } else {
-                            None
-                        };
+                    if !skip_ci {
                         let sub_dir = output_dir
                             .join(&contract_name)
                             .join(&function_name)
@@ -1042,7 +1027,7 @@ pub(crate) async fn process_event_triggers_multicall(
     range_start: u64,
     range_end: u64,
     contracts: &Contracts,
-    contract_index_mutex: Option<Arc<tokio::sync::Mutex<()>>>,
+    skip_contract_index: bool,
 ) -> Result<(Vec<SkippedFactoryTrigger>, PendingWrites), EthCallCollectionError> {
     let mut skipped_factory_triggers: Vec<SkippedFactoryTrigger> = Vec::new();
     let empty_writes = PendingWrites::new();
@@ -1066,12 +1051,7 @@ pub(crate) async fn process_event_triggers_multicall(
                 range_end,
             )
             .await?;
-            {
-                let _guard = if let Some(ref m) = contract_index_mutex {
-                    Some(m.lock().await)
-                } else {
-                    None
-                };
+            if !skip_contract_index {
                 let sub_dir = ctx
                     .output_dir
                     .join(contract_name)
@@ -1393,7 +1373,7 @@ pub(crate) async fn process_event_triggers_multicall(
         let storage_manager = ctx.storage_manager.cloned();
         let chain_name = ctx.chain_name.to_string();
         let decoder_tx = ctx.decoder_tx.clone();
-        let ci_mutex = contract_index_mutex.clone();
+        let skip_ci = skip_contract_index;
         let contracts = contracts.clone();
 
         write_set.spawn(async move {
@@ -1427,12 +1407,7 @@ pub(crate) async fn process_event_triggers_multicall(
                 .map_err(|e| EthCallCollectionError::Io(std::io::Error::other(e.to_string())))?;
             }
 
-            {
-                let _guard = if let Some(ref m) = ci_mutex {
-                    Some(m.lock().await)
-                } else {
-                    None
-                };
+            if !skip_ci {
                 let expected_for_range =
                     build_expected_factory_contracts_for_range(&contracts, range_end + 1);
                 if let Some(expected) = expected_for_range.get(&contract_name) {
@@ -1484,7 +1459,7 @@ pub(crate) async fn process_event_triggers_multicall(
     for (contract_name, function_name) in configured_pairs {
         if !written_pairs.contains(&(contract_name.clone(), function_name.clone())) {
             let output_dir = ctx.output_dir.to_path_buf();
-            let ci_mutex = contract_index_mutex.clone();
+            let skip_ci = skip_contract_index;
             let contracts = contracts.clone();
             write_set.spawn(async move {
                 write_empty_event_call_file(
@@ -1495,12 +1470,7 @@ pub(crate) async fn process_event_triggers_multicall(
                     range_end,
                 )
                 .await?;
-                {
-                    let _guard = if let Some(ref m) = ci_mutex {
-                        Some(m.lock().await)
-                    } else {
-                        None
-                    };
+                if !skip_ci {
                     let sub_dir = output_dir
                         .join(&contract_name)
                         .join(&function_name)

--- a/src/storage/parquet_readers.rs
+++ b/src/storage/parquet_readers.rs
@@ -219,6 +219,45 @@ pub fn read_event_trigger_log_batches_from_parquet(
     Ok(batches)
 }
 
+/// Read only (block_number, log_index) pairs from an event-triggered eth_call parquet file.
+///
+/// Uses column projection to avoid reading target_address, value, is_reverted, etc.
+pub fn read_event_call_row_keys_from_parquet(
+    path: &Path,
+) -> Result<Vec<(u64, u32)>, ParquetReadError> {
+    let file = File::open(path)?;
+    let builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
+    let arrow_schema = builder.schema().clone();
+
+    let needed = ["block_number", "log_index"];
+    let root_indices: Vec<usize> = needed
+        .iter()
+        .filter_map(|name| arrow_schema.index_of(name).ok())
+        .collect();
+
+    let mask = ProjectionMask::roots(builder.parquet_schema(), root_indices);
+    let reader = builder.with_projection(mask).build()?;
+
+    let mut keys = Vec::new();
+    for batch_result in reader {
+        let batch = batch_result?;
+        let block_numbers = batch
+            .column_by_name("block_number")
+            .and_then(|c| c.as_any().downcast_ref::<UInt64Array>());
+        let log_indexes = batch
+            .column_by_name("log_index")
+            .and_then(|c| c.as_any().downcast_ref::<UInt32Array>());
+
+        if let (Some(bns), Some(lis)) = (block_numbers, log_indexes) {
+            for i in 0..batch.num_rows() {
+                keys.push((bns.value(i), lis.value(i)));
+            }
+        }
+    }
+
+    Ok(keys)
+}
+
 /// Read factory addresses from a parquet file, returning a set of raw 20-byte addresses.
 ///
 /// Reads the `factory_address` column from a factory parquet file.


### PR DESCRIPTION
## Summary

- **Unified repair/non-repair paths** into a single flow for event-triggered call catchup, removing ~200 lines of duplicated logic
- **Switched to projected parquet reads** (6 columns via `read_event_trigger_log_batches_from_parquet_async`) for all catchup paths — previously the non-repair path read all columns and materialized full `LogData` structs (~5x memory reduction per range)
- **Added `read_event_call_row_keys_from_parquet`** — projects only `block_number` + `log_index` when validating output files during repair, avoiding deserialization of target_address, value, revert data, and param columns
- **Replaced `contract_index_mutex` with `skip_contract_index: bool`** — catchup defers contract index writes to a batch phase after all ranges complete, eliminating mutex contention between concurrent tasks

## Flow (unified)

```
for each log range:
  1. Skip-check (non-repair only): event_output_exists_async per config
  2. Read projected parquet (6 columns, Arrow batches)
  3. Extract triggers from batches
  4. Repair validation (repair only): repair_needs_event_recollection
  5. Acquire semaphore, spawn RPC task with skip_contract_index=true
after all ranges:
  6. Batch-write contract indexes for all processed ranges
```