### PR TITLE
perf: memory optimizations for historical catchup mode

### DIFF
--- a/src/decoding/catchup/eth_calls.rs
+++ b/src/decoding/catchup/eth_calls.rs
@@ -845,6 +845,7 @@ mod tests {
             reorg_depth: None,
             compaction_interval_secs: None,
             transform_retry_grace_period_secs: None,
+            max_receipt_ranges: None,
         }
     }
 

--- a/src/decoding/current/eth_calls/mod.rs
+++ b/src/decoding/current/eth_calls/mod.rs
@@ -280,6 +280,7 @@ mod tests {
             reorg_depth: None,
             compaction_interval_secs: None,
             transform_retry_grace_period_secs: None,
+            max_receipt_ranges: None,
         }
     }
 

--- a/src/raw_data/historical/blocks.rs
+++ b/src/raw_data/historical/blocks.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use alloy::primitives::B256;
 use alloy::rpc::types::Block;
 use arrow::array::{
-    ArrayRef, BinaryArray, FixedSizeBinaryArray, ListBuilder, StringBuilder, UInt32Array,
-    UInt64Array,
+    ArrayRef, BinaryArray, FixedSizeBinaryArray, FixedSizeBinaryBuilder, ListBuilder, StringBuilder,
+    UInt32Array, UInt64Array,
 };
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
@@ -67,7 +67,7 @@ pub(crate) struct FullBlockRecord {
     pub excess_blob_gas: Option<u64>,
     pub parent_beacon_block_root: Option<[u8; 32]>,
     pub transaction_count: u32,
-    pub transaction_hashes: Vec<String>,
+    pub transaction_hashes: Vec<B256>,
     pub uncle_count: u32,
     pub size: Option<u64>,
 }
@@ -77,7 +77,7 @@ pub(crate) struct MinimalBlockRecord {
     pub number: u64,
     pub timestamp: u64,
     pub transaction_count: u32,
-    pub transaction_hashes: Vec<String>,
+    pub transaction_hashes: Vec<B256>,
     pub uncle_count: u32,
 }
 
@@ -87,11 +87,7 @@ pub(crate) fn process_single_block_full(
 ) -> Result<FullBlockRecord, BlockCollectionError> {
     let header = &block.header;
     let inner = &header.inner;
-    let tx_hashes: Vec<String> = block
-        .transactions
-        .hashes()
-        .map(|h| format!("{h:?}"))
-        .collect();
+    let tx_hashes: Vec<B256> = block.transactions.hashes().collect();
 
     Ok(FullBlockRecord {
         number: block_number,
@@ -140,7 +136,11 @@ pub(crate) fn build_block_schema(fields: &Option<Vec<BlockField>>) -> Arc<Schema
                         arrow_fields.push(Field::new("transaction_count", DataType::UInt32, false));
                         arrow_fields.push(Field::new(
                             "transaction_hashes",
-                            DataType::List(Arc::new(Field::new("item", DataType::Utf8, true))),
+                            DataType::List(Arc::new(Field::new(
+                                "item",
+                                DataType::FixedSizeBinary(32),
+                                true,
+                            ))),
                             false,
                         ));
                     }
@@ -182,7 +182,11 @@ pub(crate) fn build_block_schema(fields: &Option<Vec<BlockField>>) -> Arc<Schema
             Field::new("transaction_count", DataType::UInt32, false),
             Field::new(
                 "transaction_hashes",
-                DataType::List(Arc::new(Field::new("item", DataType::Utf8, true))),
+                DataType::List(Arc::new(Field::new(
+                    "item",
+                    DataType::FixedSizeBinary(32),
+                    true,
+                ))),
                 false,
             ),
             Field::new("uncle_count", DataType::UInt32, false),
@@ -214,10 +218,14 @@ pub(crate) fn write_minimal_blocks_to_parquet(
                     records.iter().map(|r| Some(r.transaction_count)).collect();
                 arrays.push(Arc::new(count_arr));
 
-                let mut list_builder = ListBuilder::new(StringBuilder::new());
+                let mut list_builder =
+                    ListBuilder::new(FixedSizeBinaryBuilder::new(32));
                 for record in records {
                     for hash in &record.transaction_hashes {
-                        list_builder.values().append_value(hash);
+                        list_builder
+                            .values()
+                            .append_value(hash.as_slice())
+                            .unwrap();
                     }
                     list_builder.append(true);
                 }
@@ -337,10 +345,13 @@ pub(crate) fn write_full_blocks_to_parquet(
     let arr: UInt32Array = records.iter().map(|r| Some(r.transaction_count)).collect();
     arrays.push(Arc::new(arr));
 
-    let mut list_builder = ListBuilder::new(StringBuilder::new());
+    let mut list_builder = ListBuilder::new(FixedSizeBinaryBuilder::new(32));
     for record in records {
         for hash in &record.transaction_hashes {
-            list_builder.values().append_value(hash);
+            list_builder
+                .values()
+                .append_value(hash.as_slice())
+                .unwrap();
         }
         list_builder.append(true);
     }
@@ -524,15 +535,33 @@ pub fn read_block_info_from_parquet(
                 let timestamp = times.value(i);
 
                 // Extract transaction hashes from the list column
+                // Supports both new FixedSizeBinary(32) and legacy Utf8 formats
                 let tx_hashes: Vec<B256> = if let Some(col) = tx_hashes_col {
                     if let Some(list_array) = col.as_any().downcast_ref::<ListArray>() {
                         let values = list_array.value(i);
-                        if let Some(string_array) = values.as_any().downcast_ref::<StringArray>() {
+                        // Try new format (FixedSizeBinary) first
+                        if let Some(binary_array) =
+                            values.as_any().downcast_ref::<FixedSizeBinaryArray>()
+                        {
+                            (0..binary_array.len())
+                                .filter_map(|j| {
+                                    let bytes = binary_array.value(j);
+                                    if bytes.len() == 32 {
+                                        Some(B256::from_slice(bytes))
+                                    } else {
+                                        None
+                                    }
+                                })
+                                .collect()
+                        // Fall back to old format (Utf8 strings)
+                        } else if let Some(string_array) =
+                            values.as_any().downcast_ref::<StringArray>()
+                        {
                             (0..string_array.len())
                                 .filter_map(|j| {
                                     let hash_str = string_array.value(j);
-                                    // Parse "0x..." format
-                                    let hash_str = hash_str.strip_prefix("0x").unwrap_or(hash_str);
+                                    let hash_str =
+                                        hash_str.strip_prefix("0x").unwrap_or(hash_str);
                                     let bytes = hex::decode(hash_str).ok()?;
                                     if bytes.len() == 32 {
                                         Some(B256::from_slice(&bytes))

--- a/src/raw_data/historical/catchup/blocks.rs
+++ b/src/raw_data/historical/catchup/blocks.rs
@@ -262,10 +262,7 @@ async fn collect_blocks_streaming(
                                 number: block_number,
                                 timestamp,
                                 transaction_count: tx_hashes.len() as u32,
-                                transaction_hashes: tx_hashes
-                                    .iter()
-                                    .map(|h| format!("{:?}", h))
-                                    .collect(),
+                                transaction_hashes: tx_hashes,
                                 uncle_count: block.uncles.len() as u32,
                             },
                         );

--- a/src/raw_data/historical/catchup/eth_calls.rs
+++ b/src/raw_data/historical/catchup/eth_calls.rs
@@ -461,7 +461,6 @@ pub async fn collect_eth_calls(
 
     let existing_files = scan_existing_parquet_files_async(base_output_dir.clone()).await;
 
-    let mut range_data: HashMap<u64, Vec<BlockInfo>> = HashMap::new();
     let range_factory_data: HashMap<u64, FactoryAddressData> = HashMap::new();
     let mut range_regular_done: HashSet<u64> = HashSet::new();
     let range_factory_done: HashSet<u64> = HashSet::new();
@@ -670,8 +669,6 @@ pub async fn collect_eth_calls(
                 })
                 .collect();
 
-            range_data.insert(range.start, blocks.clone());
-
             let catchup_ctx = EthCallContext {
                 client,
                 output_dir: &base_output_dir,
@@ -688,7 +685,7 @@ pub async fn collect_eth_calls(
                 if let Some(multicall_addr) = multicall3_address {
                     process_range_multicall(
                         &range,
-                        blocks.clone(),
+                        &blocks,
                         &catchup_ctx,
                         &catchup_call_configs,
                         max_params,
@@ -700,7 +697,7 @@ pub async fn collect_eth_calls(
                 } else {
                     process_range(
                         &range,
-                        blocks.clone(),
+                        &blocks,
                         &catchup_ctx,
                         &catchup_call_configs,
                         max_params,
@@ -1480,7 +1477,7 @@ pub async fn collect_eth_calls(
         s3_manifest,
         factory_addresses,
         frequency_state,
-        range_data,
+        range_data: HashMap::new(),
         range_factory_data,
         range_regular_done,
         range_factory_done,

--- a/src/raw_data/historical/current/eth_calls/collector.rs
+++ b/src/raw_data/historical/current/eth_calls/collector.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::sync::Arc;
 
 use tokio::sync::mpsc::{Receiver, Sender};
@@ -186,12 +185,7 @@ pub async fn collect_eth_calls(
                         });
 
                         if let Some(blocks) = state.range_data.get(&range_start) {
-                            let expected_blocks: HashSet<u64> =
-                                (range_start..range_start + state.range_size).collect();
-                            let received_blocks: HashSet<u64> =
-                                blocks.iter().map(|b| b.block_number).collect();
-
-                            let range_complete = expected_blocks.is_subset(&received_blocks);
+                            let range_complete = blocks.len() == state.range_size as usize;
                             let needs_processing = !state.range_regular_done.contains(&range_start)
                                 || ((state.has_factory_calls || state.has_factory_once_calls)
                                     && !state.range_factory_done.contains(&range_start));

--- a/src/raw_data/historical/current/eth_calls/range_processor.rs
+++ b/src/raw_data/historical/current/eth_calls/range_processor.rs
@@ -56,7 +56,7 @@ pub(super) async fn process_complete_range(
             if let Some(multicall_addr) = state.multicall3_address {
                 process_range_multicall(
                     &range,
-                    blocks.clone(),
+                    blocks,
                     &ctx,
                     &state.call_configs,
                     state.max_params,
@@ -68,7 +68,7 @@ pub(super) async fn process_complete_range(
             } else {
                 process_range(
                     &range,
-                    blocks.clone(),
+                    blocks,
                     &ctx,
                     &state.call_configs,
                     state.max_params,
@@ -221,7 +221,7 @@ pub(super) async fn process_incomplete_range(
         if let Some(multicall_addr) = state.multicall3_address {
             process_range_multicall(
                 &range,
-                blocks.clone(),
+                &blocks,
                 &ctx,
                 &state.call_configs,
                 state.max_params,
@@ -233,7 +233,7 @@ pub(super) async fn process_incomplete_range(
         } else {
             process_range(
                 &range,
-                blocks.clone(),
+                &blocks,
                 &ctx,
                 &state.call_configs,
                 state.max_params,

--- a/src/raw_data/historical/current/receipts.rs
+++ b/src/raw_data/historical/current/receipts.rs
@@ -302,6 +302,7 @@ pub async fn collect_receipts(
 
     // Batch states for per-block receipt fetching
     let mut batch_states: HashMap<u64, ReceiptBatchState> = HashMap::new();
+    let max_concurrent_ranges = raw_data_config.max_receipt_ranges.unwrap_or(5);
 
     // Build output channels and metrics structs
     let channels = ReceiptOutputChannels {
@@ -370,12 +371,14 @@ pub async fn collect_receipts(
             // Fallback mode: backpressure via pending tx/block buffer caps.
             // Both caps scale with fetch concurrency so sparse chains can queue
             // enough work to keep multiple micro-batches in flight.
-            block_result = block_rx.recv(), if !block_rx_closed && if is_block_receipt_mode {
-                receipt_join_set.len() < receipt_fetch_concurrency
-            } else {
-                pending_tx_count < rpc_batch_size * receipt_fetch_concurrency * 2
-                    && pending_fallback_blocks.len() < rpc_batch_size * receipt_fetch_concurrency * 2
-            } => {
+            block_result = block_rx.recv(), if !block_rx_closed
+                && batch_states.len() < max_concurrent_ranges
+                && if is_block_receipt_mode {
+                    receipt_join_set.len() < receipt_fetch_concurrency
+                } else {
+                    pending_tx_count < rpc_batch_size * receipt_fetch_concurrency * 2
+                        && pending_fallback_blocks.len() < rpc_batch_size * receipt_fetch_concurrency * 2
+                } => {
                 match block_result {
                     Some((block_number, timestamp, tx_hashes)) => {
                         let range_start = (block_number / range_size) * range_size;

--- a/src/raw_data/historical/current/receipts.rs
+++ b/src/raw_data/historical/current/receipts.rs
@@ -184,10 +184,9 @@ async fn try_finalize_range(
     };
 
     let range_end = state.range_end;
-    let expected: HashSet<u64> = (range_start..range_end).collect();
-    let received: HashSet<u64> = state.blocks_received.keys().copied().collect();
-    let all_received = expected.is_subset(&received);
-    let all_completed = all_received && expected.is_subset(&state.blocks_completed);
+    let range_len = (range_end - range_start) as usize;
+    let all_received = state.blocks_received.len() == range_len;
+    let all_completed = all_received && state.blocks_completed.len() == range_len;
 
     if !all_completed {
         return Ok(false);
@@ -411,9 +410,7 @@ pub async fn collect_receipts(
                             state.blocks_completed.insert(block_number);
 
                             // Check if range is now complete
-                            let expected: HashSet<u64> = (range_start..range_end).collect();
-                            let received: HashSet<u64> = state.blocks_received.keys().copied().collect();
-                            if expected.is_subset(&received) {
+                            if state.blocks_received.len() == (range_end - range_start) as usize {
                                 tracing::info!(
                                     "Skipping receipts for blocks {}-{} (already exists)",
                                     range.start,

--- a/src/raw_data/historical/eth_calls/regular_calls.rs
+++ b/src/raw_data/historical/eth_calls/regular_calls.rs
@@ -628,7 +628,7 @@ pub(crate) async fn process_factory_range_multicall(
 
 pub(crate) async fn process_range(
     range: &BlockRange,
-    blocks: Vec<BlockInfo>,
+    blocks: &[BlockInfo],
     ctx: &EthCallContext<'_>,
     call_configs: &[CallConfig],
     max_params: usize,
@@ -818,7 +818,7 @@ pub(crate) async fn process_range(
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn process_range_multicall(
     range: &BlockRange,
-    blocks: Vec<BlockInfo>,
+    blocks: &[BlockInfo],
     ctx: &EthCallContext<'_>,
     call_configs: &[CallConfig],
     max_params: usize,

--- a/src/types/config/raw_data.rs
+++ b/src/types/config/raw_data.rs
@@ -40,6 +40,10 @@ pub struct RawDataCollectionConfig {
     /// Grace period in seconds before retrying stuck transformations.
     /// Default: 300
     pub transform_retry_grace_period_secs: Option<u64>,
+    /// Maximum number of concurrent receipt batch ranges held in memory.
+    /// Lower values reduce peak memory at the cost of throughput.
+    /// Default: 5
+    pub max_receipt_ranges: Option<usize>,
 }
 
 #[derive(Debug, Clone, Deserialize)]


### PR DESCRIPTION
## Summary

Four memory optimizations targeting the historical catchup pipeline, ordered by risk (lowest first):

- **HashSet completion checks replaced with count comparisons** — eliminates ~2 GB of transient HashSet allocation churn per skipped 10k-block range by replacing `(range_start..range_end).collect::<HashSet>()` + `is_subset()` with simple `.len()` equality checks. Applies to receipt and eth_call collectors.

- **Bounded concurrent receipt batch states** — adds a configurable `max_receipt_ranges` cap (default 5) on in-memory `ReceiptBatchState` entries, each of which holds ~200 MB for a 10k-block range. Backpressure is applied via the existing `tokio::select!` guard without risk of deadlock.

- **Eliminated range_data accumulation in eth_calls catchup** — stopped inserting block data into the `range_data` HashMap during catchup, since it is never read during that phase. Changed `process_range` and `process_range_multicall` signatures from `Vec<BlockInfo>` to `&[BlockInfo]` to avoid cloning. Returns empty `range_data` to the current phase which independently populates it.

- **Transaction hashes stored as B256 instead of hex strings** — replaces `Vec<String>` (90 bytes/hash with `"0x..."` format) with `Vec<B256>` (32 bytes/hash) in block records, saving ~87 MB per 10k-block range. Parquet schema changed from `List<Utf8>` to `List<FixedSizeBinary(32)>`. Reader is backwards-compatible with both old and new formats.