### PR TITLE
feat: add Solana decoding layer (phase 6)

### DIFF
--- a/src/solana/decoding/accounts.rs
+++ b/src/solana/decoding/accounts.rs
@@ -1,0 +1,173 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tracing::warn;
+
+use crate::transformations::context::DecodedAccountState;
+use crate::types::chain::ChainAddress;
+
+use super::traits::ProgramDecoder;
+
+/// Routes raw account data to the appropriate `ProgramDecoder` by owner program
+/// and produces `DecodedAccountState` for the transformation engine.
+pub struct SolanaAccountDecoder {
+    /// program_id bytes -> decoder
+    decoders: HashMap<[u8; 32], Arc<dyn ProgramDecoder>>,
+}
+
+impl SolanaAccountDecoder {
+    pub fn new(decoders: Vec<Arc<dyn ProgramDecoder>>) -> Self {
+        let decoders = decoders
+            .into_iter()
+            .map(|d| (d.program_id(), d))
+            .collect();
+        Self { decoders }
+    }
+
+    pub fn decode_account(
+        &self,
+        owner_program: [u8; 32],
+        account_address: [u8; 32],
+        data: &[u8],
+        slot: u64,
+        block_time: Option<i64>,
+        source_name: &str,
+    ) -> Option<DecodedAccountState> {
+        let decoder = self.decoders.get(&owner_program)?;
+
+        match decoder.decode_account(data) {
+            Ok(Some(fields)) => Some(DecodedAccountState {
+                block_number: slot,
+                block_timestamp: block_time.unwrap_or(0) as u64,
+                account_address: ChainAddress::Solana(account_address),
+                owner_program: ChainAddress::Solana(owner_program),
+                source_name: source_name.to_string(),
+                account_type: fields.account_type,
+                fields: fields.fields,
+            }),
+            Ok(None) => None,
+            Err(e) => {
+                warn!(
+                    owner_program = hex::encode(owner_program),
+                    account_address = hex::encode(account_address),
+                    error = %e,
+                    "failed to decode Solana account"
+                );
+                None
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::solana::decoding::traits::{
+        DecodedAccountFields, DecodedEventFields, DecodedInstructionFields, SolanaDecodeError,
+    };
+    use crate::types::decoded::DecodedValue;
+
+    struct MockDecoder {
+        id: [u8; 32],
+        result: Result<Option<DecodedAccountFields>, SolanaDecodeError>,
+    }
+
+    impl ProgramDecoder for MockDecoder {
+        fn program_id(&self) -> [u8; 32] {
+            self.id
+        }
+        fn program_name(&self) -> &str {
+            "mock"
+        }
+        fn decode_event(
+            &self,
+            _discriminator: &[u8],
+            _data: &[u8],
+        ) -> Result<Option<DecodedEventFields>, SolanaDecodeError> {
+            Ok(None)
+        }
+        fn decode_instruction(
+            &self,
+            _data: &[u8],
+            _accounts: &[[u8; 32]],
+        ) -> Result<Option<DecodedInstructionFields>, SolanaDecodeError> {
+            Ok(None)
+        }
+        fn decode_account(
+            &self,
+            _data: &[u8],
+        ) -> Result<Option<DecodedAccountFields>, SolanaDecodeError> {
+            self.result.clone()
+        }
+        fn event_types(&self) -> Vec<String> {
+            vec![]
+        }
+        fn instruction_types(&self) -> Vec<String> {
+            vec![]
+        }
+        fn account_types(&self) -> Vec<String> {
+            vec![]
+        }
+    }
+
+    #[test]
+    fn test_decode_known_account() {
+        let program_id = [1u8; 32];
+        let account_addr = [2u8; 32];
+        let mut fields = HashMap::new();
+        fields.insert("supply".to_string(), DecodedValue::Uint64(1_000_000));
+        fields.insert("decimals".to_string(), DecodedValue::Uint8(6));
+
+        let decoder = MockDecoder {
+            id: program_id,
+            result: Ok(Some(DecodedAccountFields {
+                account_type: "Mint".to_string(),
+                fields: fields.clone(),
+            })),
+        };
+
+        let router = SolanaAccountDecoder::new(vec![Arc::new(decoder)]);
+        let result = router.decode_account(
+            program_id,
+            account_addr,
+            &[0u8; 82],
+            500,
+            Some(1_700_000_000),
+            "spl_token",
+        );
+
+        assert!(result.is_some());
+        let state = result.unwrap();
+        assert_eq!(state.block_number, 500);
+        assert_eq!(state.block_timestamp, 1_700_000_000);
+        assert_eq!(state.account_address, ChainAddress::Solana(account_addr));
+        assert_eq!(state.owner_program, ChainAddress::Solana(program_id));
+        assert_eq!(state.source_name, "spl_token");
+        assert_eq!(state.account_type, "Mint");
+        assert_eq!(
+            state.fields.get("supply"),
+            Some(&DecodedValue::Uint64(1_000_000))
+        );
+        assert_eq!(
+            state.fields.get("decimals"),
+            Some(&DecodedValue::Uint8(6))
+        );
+    }
+
+    #[test]
+    fn test_unknown_program_skipped() {
+        let decoder = MockDecoder {
+            id: [1u8; 32],
+            result: Ok(Some(DecodedAccountFields {
+                account_type: "Mint".to_string(),
+                fields: HashMap::new(),
+            })),
+        };
+
+        let router = SolanaAccountDecoder::new(vec![Arc::new(decoder)]);
+        // Use a different owner_program that has no decoder
+        let result = router.decode_account([99u8; 32], [2u8; 32], &[0u8; 82], 500, None, "test");
+
+        assert!(result.is_none());
+    }
+}

--- a/src/solana/decoding/borsh_dynamic.rs
+++ b/src/solana/decoding/borsh_dynamic.rs
@@ -147,7 +147,9 @@ pub fn deserialize_value(
         IdlType::Vec(inner) => {
             let len_bytes = read_le::<4>(cursor)?;
             let len = u32::from_le_bytes(len_bytes) as usize;
-            let mut items = Vec::with_capacity(len);
+            // Cap pre-allocation to remaining bytes to prevent OOM on malformed input.
+            let safe_cap = len.min(cursor.len());
+            let mut items = Vec::with_capacity(safe_cap);
             for _ in 0..len {
                 items.push(deserialize_value(cursor, inner, defined_types)?);
             }
@@ -900,5 +902,18 @@ mod tests {
         }
 
         assert!(cursor.is_empty());
+    }
+
+    #[test]
+    fn test_vec_malformed_length_does_not_oom() {
+        // 4-byte length claiming 1 billion elements, but only 2 bytes of actual data.
+        let mut data = Vec::new();
+        data.extend_from_slice(&1_000_000_000u32.to_le_bytes());
+        data.extend_from_slice(&[0x01, 0x02]);
+
+        let mut cursor: &[u8] = &data;
+        let result = deserialize_value(&mut cursor, &IdlType::Vec(Box::new(IdlType::U8)), &HashMap::new());
+        // Must fail with UnexpectedEof, not OOM.
+        assert!(matches!(result, Err(SolanaDecodeError::UnexpectedEof { .. })));
     }
 }

--- a/src/solana/decoding/borsh_dynamic.rs
+++ b/src/solana/decoding/borsh_dynamic.rs
@@ -1,0 +1,904 @@
+//! Runtime Borsh deserializer driven by IDL type definitions.
+//!
+//! Walks `IdlType` trees and produces `DecodedValue` without depending on
+//! the `borsh` crate -- all byte reading is done manually from a cursor.
+
+use std::collections::HashMap;
+
+use crate::types::chain::ChainAddress;
+use crate::types::decoded::DecodedValue;
+
+use super::idl::{IdlType, IdlTypeDef};
+use super::traits::SolanaDecodeError;
+
+// ---------------------------------------------------------------------------
+// Cursor helpers
+// ---------------------------------------------------------------------------
+
+fn read_u8(cursor: &mut &[u8]) -> Result<u8, SolanaDecodeError> {
+    if cursor.is_empty() {
+        return Err(SolanaDecodeError::UnexpectedEof {
+            needed: 1,
+            available: 0,
+        });
+    }
+    let val = cursor[0];
+    *cursor = &cursor[1..];
+    Ok(val)
+}
+
+fn read_bytes<'a>(cursor: &mut &'a [u8], len: usize) -> Result<&'a [u8], SolanaDecodeError> {
+    if cursor.len() < len {
+        return Err(SolanaDecodeError::UnexpectedEof {
+            needed: len,
+            available: cursor.len(),
+        });
+    }
+    let (head, tail) = cursor.split_at(len);
+    *cursor = tail;
+    Ok(head)
+}
+
+fn read_le<const N: usize>(cursor: &mut &[u8]) -> Result<[u8; N], SolanaDecodeError> {
+    let bytes = read_bytes(cursor, N)?;
+    let mut arr = [0u8; N];
+    arr.copy_from_slice(bytes);
+    Ok(arr)
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Deserialize a single value from a Borsh byte stream according to `idl_type`.
+pub fn deserialize_value(
+    cursor: &mut &[u8],
+    idl_type: &IdlType,
+    defined_types: &HashMap<String, IdlTypeDef>,
+) -> Result<DecodedValue, SolanaDecodeError> {
+    match idl_type {
+        IdlType::Bool => {
+            let byte = read_u8(cursor)?;
+            Ok(DecodedValue::Bool(byte != 0))
+        }
+
+        IdlType::U8 => {
+            let val = read_u8(cursor)?;
+            Ok(DecodedValue::Uint8(val))
+        }
+        IdlType::U16 => {
+            let bytes = read_le::<2>(cursor)?;
+            Ok(DecodedValue::Uint32(u16::from_le_bytes(bytes) as u32))
+        }
+        IdlType::U32 => {
+            let bytes = read_le::<4>(cursor)?;
+            Ok(DecodedValue::Uint32(u32::from_le_bytes(bytes)))
+        }
+        IdlType::U64 => {
+            let bytes = read_le::<8>(cursor)?;
+            Ok(DecodedValue::Uint64(u64::from_le_bytes(bytes)))
+        }
+        IdlType::U128 => {
+            let bytes = read_le::<16>(cursor)?;
+            Ok(DecodedValue::Uint128(u128::from_le_bytes(bytes)))
+        }
+
+        IdlType::I8 => {
+            let byte = read_u8(cursor)?;
+            Ok(DecodedValue::Int8(byte as i8))
+        }
+        IdlType::I16 => {
+            let bytes = read_le::<2>(cursor)?;
+            Ok(DecodedValue::Int32(i16::from_le_bytes(bytes) as i32))
+        }
+        IdlType::I32 => {
+            let bytes = read_le::<4>(cursor)?;
+            Ok(DecodedValue::Int32(i32::from_le_bytes(bytes)))
+        }
+        IdlType::I64 => {
+            let bytes = read_le::<8>(cursor)?;
+            Ok(DecodedValue::Int64(i64::from_le_bytes(bytes)))
+        }
+        IdlType::I128 => {
+            let bytes = read_le::<16>(cursor)?;
+            Ok(DecodedValue::Int128(i128::from_le_bytes(bytes)))
+        }
+
+        IdlType::F32 => {
+            let bytes = read_le::<4>(cursor)?;
+            Ok(DecodedValue::Float(f32::from_le_bytes(bytes) as f64))
+        }
+        IdlType::F64 => {
+            let bytes = read_le::<8>(cursor)?;
+            Ok(DecodedValue::Float(f64::from_le_bytes(bytes)))
+        }
+
+        IdlType::Pubkey => {
+            let bytes = read_le::<32>(cursor)?;
+            Ok(DecodedValue::ChainAddress(ChainAddress::Solana(bytes)))
+        }
+
+        IdlType::String => {
+            let len_bytes = read_le::<4>(cursor)?;
+            let len = u32::from_le_bytes(len_bytes) as usize;
+            let bytes = read_bytes(cursor, len)?;
+            let s = std::str::from_utf8(bytes).map_err(|e| {
+                SolanaDecodeError::IdlParse(format!("invalid UTF-8 in Borsh string: {}", e))
+            })?;
+            Ok(DecodedValue::String(s.to_owned()))
+        }
+
+        IdlType::Bytes => {
+            let len_bytes = read_le::<4>(cursor)?;
+            let len = u32::from_le_bytes(len_bytes) as usize;
+            let bytes = read_bytes(cursor, len)?;
+            Ok(DecodedValue::Bytes(bytes.to_vec()))
+        }
+
+        IdlType::Option(inner) => {
+            let tag = read_u8(cursor)?;
+            if tag == 0 {
+                Ok(DecodedValue::Null)
+            } else {
+                deserialize_value(cursor, inner, defined_types)
+            }
+        }
+
+        IdlType::Vec(inner) => {
+            let len_bytes = read_le::<4>(cursor)?;
+            let len = u32::from_le_bytes(len_bytes) as usize;
+            let mut items = Vec::with_capacity(len);
+            for _ in 0..len {
+                items.push(deserialize_value(cursor, inner, defined_types)?);
+            }
+            Ok(DecodedValue::Array(items))
+        }
+
+        IdlType::Array(inner, size) => {
+            let mut items = Vec::with_capacity(*size);
+            for _ in 0..*size {
+                items.push(deserialize_value(cursor, inner, defined_types)?);
+            }
+            Ok(DecodedValue::Array(items))
+        }
+
+        IdlType::Defined(name) => {
+            let type_def = defined_types.get(name).ok_or_else(|| {
+                SolanaDecodeError::UnknownType(name.clone())
+            })?;
+
+            match type_def {
+                IdlTypeDef::Struct { fields } => {
+                    let mut pairs = Vec::with_capacity(fields.len());
+                    for (field_name, field_type) in fields {
+                        let val = deserialize_value(cursor, field_type, defined_types)?;
+                        pairs.push((field_name.clone(), val));
+                    }
+                    Ok(DecodedValue::NamedTuple(pairs))
+                }
+
+                IdlTypeDef::Enum { variants } => {
+                    let variant_idx = read_u8(cursor)? as usize;
+                    if variant_idx >= variants.len() {
+                        return Err(SolanaDecodeError::InvalidEnumVariant(variant_idx));
+                    }
+                    let variant = &variants[variant_idx];
+
+                    match &variant.fields {
+                        None => Ok(DecodedValue::String(variant.name.clone())),
+                        Some(fields) => {
+                            let mut pairs = Vec::with_capacity(fields.len() + 1);
+                            pairs.push((
+                                "variant".to_owned(),
+                                DecodedValue::String(variant.name.clone()),
+                            ));
+                            for (field_name, field_type) in fields {
+                                let val =
+                                    deserialize_value(cursor, field_type, defined_types)?;
+                                pairs.push((field_name.clone(), val));
+                            }
+                            Ok(DecodedValue::NamedTuple(pairs))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Deserialize a sequence of named struct fields into a `HashMap`.
+///
+/// This is the primary entry point used by `AnchorDecoder` when decoding
+/// events, instruction args, and account state.
+pub fn deserialize_struct_fields(
+    cursor: &mut &[u8],
+    fields: &[(String, IdlType)],
+    defined_types: &HashMap<String, IdlTypeDef>,
+) -> Result<HashMap<String, DecodedValue>, SolanaDecodeError> {
+    let mut map = HashMap::with_capacity(fields.len());
+    for (name, idl_type) in fields {
+        let val = deserialize_value(cursor, idl_type, defined_types)?;
+        map.insert(name.clone(), val);
+    }
+    Ok(map)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -----------------------------------------------------------------------
+    // Bool
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_bool_true() {
+        let data: &[u8] = &[1];
+        let mut cursor: &[u8] = data;
+        let val = deserialize_value(&mut cursor, &IdlType::Bool, &HashMap::new()).unwrap();
+        assert_eq!(val.as_bool(), Some(true));
+        assert!(cursor.is_empty());
+    }
+
+    #[test]
+    fn test_bool_false() {
+        let data: &[u8] = &[0];
+        let mut cursor: &[u8] = data;
+        let val = deserialize_value(&mut cursor, &IdlType::Bool, &HashMap::new()).unwrap();
+        assert_eq!(val.as_bool(), Some(false));
+    }
+
+    // -----------------------------------------------------------------------
+    // Unsigned integers
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_u8() {
+        let data: &[u8] = &[42];
+        let mut cursor: &[u8] = data;
+        let val = deserialize_value(&mut cursor, &IdlType::U8, &HashMap::new()).unwrap();
+        assert_eq!(val.as_u8(), Some(42));
+    }
+
+    #[test]
+    fn test_u16_upcasts_to_u32() {
+        let data = 1000u16.to_le_bytes();
+        let mut cursor: &[u8] = &data;
+        let val = deserialize_value(&mut cursor, &IdlType::U16, &HashMap::new()).unwrap();
+        // U16 produces Uint32
+        assert_eq!(val.as_u32(), Some(1000));
+        assert!(cursor.is_empty());
+    }
+
+    #[test]
+    fn test_u32() {
+        let data = 70000u32.to_le_bytes();
+        let mut cursor: &[u8] = &data;
+        let val = deserialize_value(&mut cursor, &IdlType::U32, &HashMap::new()).unwrap();
+        assert_eq!(val.as_u32(), Some(70000));
+    }
+
+    #[test]
+    fn test_u64() {
+        let data = 123456789u64.to_le_bytes();
+        let mut cursor: &[u8] = &data;
+        let val = deserialize_value(&mut cursor, &IdlType::U64, &HashMap::new()).unwrap();
+        assert_eq!(val.as_u64(), Some(123456789));
+    }
+
+    #[test]
+    fn test_u128() {
+        let big: u128 = u128::MAX - 1;
+        let data = big.to_le_bytes();
+        let mut cursor: &[u8] = &data;
+        let val = deserialize_value(&mut cursor, &IdlType::U128, &HashMap::new()).unwrap();
+        match &val {
+            DecodedValue::Uint128(v) => assert_eq!(*v, big),
+            other => panic!("expected Uint128, got {:?}", other),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Signed integers
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_i8() {
+        let data: &[u8] = &[(-5i8) as u8];
+        let mut cursor: &[u8] = data;
+        let val = deserialize_value(&mut cursor, &IdlType::I8, &HashMap::new()).unwrap();
+        assert_eq!(val.as_i64(), Some(-5));
+    }
+
+    #[test]
+    fn test_i16_upcasts_to_i32() {
+        let data = (-300i16).to_le_bytes();
+        let mut cursor: &[u8] = &data;
+        let val = deserialize_value(&mut cursor, &IdlType::I16, &HashMap::new()).unwrap();
+        assert_eq!(val.as_i32(), Some(-300));
+        assert!(cursor.is_empty());
+    }
+
+    #[test]
+    fn test_i32() {
+        let data = (-100_000i32).to_le_bytes();
+        let mut cursor: &[u8] = &data;
+        let val = deserialize_value(&mut cursor, &IdlType::I32, &HashMap::new()).unwrap();
+        assert_eq!(val.as_i32(), Some(-100_000));
+    }
+
+    #[test]
+    fn test_i64() {
+        let data = (-999_999_999i64).to_le_bytes();
+        let mut cursor: &[u8] = &data;
+        let val = deserialize_value(&mut cursor, &IdlType::I64, &HashMap::new()).unwrap();
+        assert_eq!(val.as_i64(), Some(-999_999_999));
+    }
+
+    #[test]
+    fn test_i128() {
+        let big: i128 = i128::MIN + 1;
+        let data = big.to_le_bytes();
+        let mut cursor: &[u8] = &data;
+        let val = deserialize_value(&mut cursor, &IdlType::I128, &HashMap::new()).unwrap();
+        match &val {
+            DecodedValue::Int128(v) => assert_eq!(*v, big),
+            other => panic!("expected Int128, got {:?}", other),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Floats
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_f32() {
+        let data = 3.14f32.to_le_bytes();
+        let mut cursor: &[u8] = &data;
+        let val = deserialize_value(&mut cursor, &IdlType::F32, &HashMap::new()).unwrap();
+        let f = val.as_float().unwrap();
+        assert!((f - 3.14f32 as f64).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_f64() {
+        let data = std::f64::consts::PI.to_le_bytes();
+        let mut cursor: &[u8] = &data;
+        let val = deserialize_value(&mut cursor, &IdlType::F64, &HashMap::new()).unwrap();
+        let f = val.as_float().unwrap();
+        assert!((f - std::f64::consts::PI).abs() < 1e-15);
+    }
+
+    // -----------------------------------------------------------------------
+    // Pubkey
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_pubkey() {
+        let mut key = [0u8; 32];
+        key[0] = 0xAB;
+        key[31] = 0xCD;
+        let mut cursor: &[u8] = &key;
+        let val = deserialize_value(&mut cursor, &IdlType::Pubkey, &HashMap::new()).unwrap();
+        match &val {
+            DecodedValue::ChainAddress(ChainAddress::Solana(bytes)) => {
+                assert_eq!(bytes[0], 0xAB);
+                assert_eq!(bytes[31], 0xCD);
+            }
+            other => panic!("expected ChainAddress::Solana, got {:?}", other),
+        }
+        assert!(cursor.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // String
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_string() {
+        let s = "hello world";
+        let len = (s.len() as u32).to_le_bytes();
+        let mut data = Vec::new();
+        data.extend_from_slice(&len);
+        data.extend_from_slice(s.as_bytes());
+
+        let mut cursor: &[u8] = &data;
+        let val = deserialize_value(&mut cursor, &IdlType::String, &HashMap::new()).unwrap();
+        assert_eq!(val.as_string(), Some("hello world"));
+        assert!(cursor.is_empty());
+    }
+
+    #[test]
+    fn test_string_empty() {
+        let data = 0u32.to_le_bytes();
+        let mut cursor: &[u8] = &data;
+        let val = deserialize_value(&mut cursor, &IdlType::String, &HashMap::new()).unwrap();
+        assert_eq!(val.as_string(), Some(""));
+    }
+
+    // -----------------------------------------------------------------------
+    // Bytes
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_bytes() {
+        let payload = vec![0xDE, 0xAD, 0xBE, 0xEF];
+        let len = (payload.len() as u32).to_le_bytes();
+        let mut data = Vec::new();
+        data.extend_from_slice(&len);
+        data.extend_from_slice(&payload);
+
+        let mut cursor: &[u8] = &data;
+        let val = deserialize_value(&mut cursor, &IdlType::Bytes, &HashMap::new()).unwrap();
+        match &val {
+            DecodedValue::Bytes(b) => assert_eq!(b, &payload),
+            other => panic!("expected Bytes, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_bytes_empty() {
+        let data = 0u32.to_le_bytes();
+        let mut cursor: &[u8] = &data;
+        let val = deserialize_value(&mut cursor, &IdlType::Bytes, &HashMap::new()).unwrap();
+        match &val {
+            DecodedValue::Bytes(b) => assert!(b.is_empty()),
+            other => panic!("expected Bytes, got {:?}", other),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Option
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_option_some() {
+        let mut data = vec![1u8]; // tag = Some
+        data.extend_from_slice(&42u32.to_le_bytes());
+
+        let mut cursor: &[u8] = &data;
+        let val = deserialize_value(
+            &mut cursor,
+            &IdlType::Option(Box::new(IdlType::U32)),
+            &HashMap::new(),
+        )
+        .unwrap();
+        assert_eq!(val.as_u32(), Some(42));
+    }
+
+    #[test]
+    fn test_option_none() {
+        let data = vec![0u8]; // tag = None
+        let mut cursor: &[u8] = &data;
+        let val = deserialize_value(
+            &mut cursor,
+            &IdlType::Option(Box::new(IdlType::U32)),
+            &HashMap::new(),
+        )
+        .unwrap();
+        assert!(val.is_null());
+    }
+
+    // -----------------------------------------------------------------------
+    // Vec
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_vec() {
+        let mut data = Vec::new();
+        data.extend_from_slice(&3u32.to_le_bytes()); // len = 3
+        data.push(10);
+        data.push(20);
+        data.push(30);
+
+        let mut cursor: &[u8] = &data;
+        let val = deserialize_value(
+            &mut cursor,
+            &IdlType::Vec(Box::new(IdlType::U8)),
+            &HashMap::new(),
+        )
+        .unwrap();
+
+        match &val {
+            DecodedValue::Array(items) => {
+                assert_eq!(items.len(), 3);
+                assert_eq!(items[0].as_u8(), Some(10));
+                assert_eq!(items[1].as_u8(), Some(20));
+                assert_eq!(items[2].as_u8(), Some(30));
+            }
+            other => panic!("expected Array, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_vec_empty() {
+        let data = 0u32.to_le_bytes();
+        let mut cursor: &[u8] = &data;
+        let val = deserialize_value(
+            &mut cursor,
+            &IdlType::Vec(Box::new(IdlType::U64)),
+            &HashMap::new(),
+        )
+        .unwrap();
+        match &val {
+            DecodedValue::Array(items) => assert!(items.is_empty()),
+            other => panic!("expected Array, got {:?}", other),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Fixed-size array
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_fixed_array() {
+        let mut data = Vec::new();
+        data.extend_from_slice(&100u16.to_le_bytes());
+        data.extend_from_slice(&200u16.to_le_bytes());
+
+        let mut cursor: &[u8] = &data;
+        let val = deserialize_value(
+            &mut cursor,
+            &IdlType::Array(Box::new(IdlType::U16), 2),
+            &HashMap::new(),
+        )
+        .unwrap();
+
+        match &val {
+            DecodedValue::Array(items) => {
+                assert_eq!(items.len(), 2);
+                assert_eq!(items[0].as_u32(), Some(100));
+                assert_eq!(items[1].as_u32(), Some(200));
+            }
+            other => panic!("expected Array, got {:?}", other),
+        }
+        assert!(cursor.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // Struct (Defined)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_struct() {
+        let mut defined_types = HashMap::new();
+        defined_types.insert(
+            "Point".to_string(),
+            IdlTypeDef::Struct {
+                fields: vec![
+                    ("x".to_string(), IdlType::I32),
+                    ("y".to_string(), IdlType::I32),
+                ],
+            },
+        );
+
+        let mut data = Vec::new();
+        data.extend_from_slice(&10i32.to_le_bytes());
+        data.extend_from_slice(&(-20i32).to_le_bytes());
+
+        let mut cursor: &[u8] = &data;
+        let val =
+            deserialize_value(&mut cursor, &IdlType::Defined("Point".to_string()), &defined_types)
+                .unwrap();
+
+        match &val {
+            DecodedValue::NamedTuple(fields) => {
+                assert_eq!(fields.len(), 2);
+                assert_eq!(fields[0].0, "x");
+                assert_eq!(fields[0].1.as_i32(), Some(10));
+                assert_eq!(fields[1].0, "y");
+                assert_eq!(fields[1].1.as_i32(), Some(-20));
+            }
+            other => panic!("expected NamedTuple, got {:?}", other),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Enum — unit variant
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_enum_unit() {
+        let mut defined_types = HashMap::new();
+        defined_types.insert(
+            "Color".to_string(),
+            IdlTypeDef::Enum {
+                variants: vec![
+                    super::super::idl::IdlEnumVariant {
+                        name: "Red".to_string(),
+                        fields: None,
+                    },
+                    super::super::idl::IdlEnumVariant {
+                        name: "Green".to_string(),
+                        fields: None,
+                    },
+                    super::super::idl::IdlEnumVariant {
+                        name: "Blue".to_string(),
+                        fields: None,
+                    },
+                ],
+            },
+        );
+
+        // variant index = 1 => "Green"
+        let data = [1u8];
+        let mut cursor: &[u8] = &data;
+        let val =
+            deserialize_value(&mut cursor, &IdlType::Defined("Color".to_string()), &defined_types)
+                .unwrap();
+
+        assert_eq!(val.as_string(), Some("Green"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Enum — variant with fields
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_enum_with_fields() {
+        let mut defined_types = HashMap::new();
+        defined_types.insert(
+            "Shape".to_string(),
+            IdlTypeDef::Enum {
+                variants: vec![
+                    super::super::idl::IdlEnumVariant {
+                        name: "Circle".to_string(),
+                        fields: Some(vec![("radius".to_string(), IdlType::U32)]),
+                    },
+                    super::super::idl::IdlEnumVariant {
+                        name: "Rect".to_string(),
+                        fields: Some(vec![
+                            ("w".to_string(), IdlType::U32),
+                            ("h".to_string(), IdlType::U32),
+                        ]),
+                    },
+                ],
+            },
+        );
+
+        let mut data = Vec::new();
+        data.push(1); // variant index 1 => Rect
+        data.extend_from_slice(&5u32.to_le_bytes()); // w = 5
+        data.extend_from_slice(&10u32.to_le_bytes()); // h = 10
+
+        let mut cursor: &[u8] = &data;
+        let val =
+            deserialize_value(&mut cursor, &IdlType::Defined("Shape".to_string()), &defined_types)
+                .unwrap();
+
+        match &val {
+            DecodedValue::NamedTuple(fields) => {
+                assert_eq!(fields[0].0, "variant");
+                assert_eq!(fields[0].1.as_string(), Some("Rect"));
+                assert_eq!(fields[1].0, "w");
+                assert_eq!(fields[1].1.as_u32(), Some(5));
+                assert_eq!(fields[2].0, "h");
+                assert_eq!(fields[2].1.as_u32(), Some(10));
+            }
+            other => panic!("expected NamedTuple, got {:?}", other),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Nested struct
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_nested_struct() {
+        let mut defined_types = HashMap::new();
+        defined_types.insert(
+            "Inner".to_string(),
+            IdlTypeDef::Struct {
+                fields: vec![("val".to_string(), IdlType::U64)],
+            },
+        );
+        defined_types.insert(
+            "Outer".to_string(),
+            IdlTypeDef::Struct {
+                fields: vec![
+                    ("label".to_string(), IdlType::U8),
+                    ("inner".to_string(), IdlType::Defined("Inner".to_string())),
+                ],
+            },
+        );
+
+        let mut data = Vec::new();
+        data.push(7u8); // label = 7
+        data.extend_from_slice(&42u64.to_le_bytes()); // inner.val = 42
+
+        let mut cursor: &[u8] = &data;
+        let val =
+            deserialize_value(&mut cursor, &IdlType::Defined("Outer".to_string()), &defined_types)
+                .unwrap();
+
+        match &val {
+            DecodedValue::NamedTuple(fields) => {
+                assert_eq!(fields[0].0, "label");
+                assert_eq!(fields[0].1.as_u8(), Some(7));
+                assert_eq!(fields[1].0, "inner");
+                match &fields[1].1 {
+                    DecodedValue::NamedTuple(inner_fields) => {
+                        assert_eq!(inner_fields[0].0, "val");
+                        assert_eq!(inner_fields[0].1.as_u64(), Some(42));
+                    }
+                    other => panic!("expected NamedTuple for inner, got {:?}", other),
+                }
+            }
+            other => panic!("expected NamedTuple, got {:?}", other),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Error cases
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_unexpected_eof() {
+        let data: &[u8] = &[0x01]; // only 1 byte, but u32 needs 4
+        let mut cursor: &[u8] = data;
+        let result = deserialize_value(&mut cursor, &IdlType::U32, &HashMap::new());
+        match result {
+            Err(SolanaDecodeError::UnexpectedEof {
+                needed: 4,
+                available: 1,
+            }) => {}
+            other => panic!("expected UnexpectedEof, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_unknown_type() {
+        let data: &[u8] = &[];
+        let mut cursor: &[u8] = data;
+        let result = deserialize_value(
+            &mut cursor,
+            &IdlType::Defined("Nonexistent".to_string()),
+            &HashMap::new(),
+        );
+        match result {
+            Err(SolanaDecodeError::UnknownType(name)) => {
+                assert_eq!(name, "Nonexistent");
+            }
+            other => panic!("expected UnknownType, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_invalid_enum_variant() {
+        let mut defined_types = HashMap::new();
+        defined_types.insert(
+            "Small".to_string(),
+            IdlTypeDef::Enum {
+                variants: vec![super::super::idl::IdlEnumVariant {
+                    name: "Only".to_string(),
+                    fields: None,
+                }],
+            },
+        );
+
+        // variant index 5 is out of range (only 1 variant exists)
+        let data = [5u8];
+        let mut cursor: &[u8] = &data;
+        let result =
+            deserialize_value(&mut cursor, &IdlType::Defined("Small".to_string()), &defined_types);
+        match result {
+            Err(SolanaDecodeError::InvalidEnumVariant(5)) => {}
+            other => panic!("expected InvalidEnumVariant(5), got {:?}", other),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // deserialize_struct_fields
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_deserialize_struct_fields() {
+        let fields = vec![
+            ("enabled".to_string(), IdlType::Bool),
+            ("count".to_string(), IdlType::U64),
+            ("name".to_string(), IdlType::String),
+        ];
+
+        let mut data = Vec::new();
+        data.push(1u8); // enabled = true
+        data.extend_from_slice(&42u64.to_le_bytes()); // count = 42
+        let name = "test";
+        data.extend_from_slice(&(name.len() as u32).to_le_bytes());
+        data.extend_from_slice(name.as_bytes());
+
+        let mut cursor: &[u8] = &data;
+        let map = deserialize_struct_fields(&mut cursor, &fields, &HashMap::new()).unwrap();
+
+        assert_eq!(map.len(), 3);
+        assert_eq!(map["enabled"].as_bool(), Some(true));
+        assert_eq!(map["count"].as_u64(), Some(42));
+        assert_eq!(map["name"].as_string(), Some("test"));
+        assert!(cursor.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // Complex struct with mixed types
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_complex_struct() {
+        let mut defined_types = HashMap::new();
+        defined_types.insert(
+            "Complex".to_string(),
+            IdlTypeDef::Struct {
+                fields: vec![
+                    ("amount".to_string(), IdlType::U64),
+                    ("authority".to_string(), IdlType::Pubkey),
+                    ("maybe_fee".to_string(), IdlType::Option(Box::new(IdlType::U32))),
+                    ("tags".to_string(), IdlType::Vec(Box::new(IdlType::U8))),
+                ],
+            },
+        );
+
+        let mut data = Vec::new();
+
+        // amount = 1_000_000
+        data.extend_from_slice(&1_000_000u64.to_le_bytes());
+
+        // authority = [0xAA; 32]
+        data.extend_from_slice(&[0xAA; 32]);
+
+        // maybe_fee = Some(500)
+        data.push(1); // tag = Some
+        data.extend_from_slice(&500u32.to_le_bytes());
+
+        // tags = [1, 2, 3]
+        data.extend_from_slice(&3u32.to_le_bytes()); // len = 3
+        data.push(1);
+        data.push(2);
+        data.push(3);
+
+        let mut cursor: &[u8] = &data;
+        let val = deserialize_value(
+            &mut cursor,
+            &IdlType::Defined("Complex".to_string()),
+            &defined_types,
+        )
+        .unwrap();
+
+        match &val {
+            DecodedValue::NamedTuple(fields) => {
+                assert_eq!(fields.len(), 4);
+
+                // amount
+                assert_eq!(fields[0].0, "amount");
+                assert_eq!(fields[0].1.as_u64(), Some(1_000_000));
+
+                // authority
+                assert_eq!(fields[1].0, "authority");
+                assert_eq!(
+                    fields[1].1.as_pubkey(),
+                    Some([0xAA; 32])
+                );
+
+                // maybe_fee
+                assert_eq!(fields[2].0, "maybe_fee");
+                assert_eq!(fields[2].1.as_u32(), Some(500));
+
+                // tags
+                assert_eq!(fields[3].0, "tags");
+                match &fields[3].1 {
+                    DecodedValue::Array(items) => {
+                        assert_eq!(items.len(), 3);
+                        assert_eq!(items[0].as_u8(), Some(1));
+                        assert_eq!(items[1].as_u8(), Some(2));
+                        assert_eq!(items[2].as_u8(), Some(3));
+                    }
+                    other => panic!("expected Array for tags, got {:?}", other),
+                }
+            }
+            other => panic!("expected NamedTuple, got {:?}", other),
+        }
+
+        assert!(cursor.is_empty());
+    }
+}

--- a/src/solana/decoding/borsh_dynamic.rs
+++ b/src/solana/decoding/borsh_dynamic.rs
@@ -137,10 +137,13 @@ pub fn deserialize_value(
 
         IdlType::Option(inner) => {
             let tag = read_u8(cursor)?;
-            if tag == 0 {
-                Ok(DecodedValue::Null)
-            } else {
-                deserialize_value(cursor, inner, defined_types)
+            match tag {
+                0 => Ok(DecodedValue::Null),
+                1 => deserialize_value(cursor, inner, defined_types),
+                _ => Err(SolanaDecodeError::IdlParse(format!(
+                    "invalid Borsh Option tag: {}, expected 0 or 1",
+                    tag
+                ))),
             }
         }
 
@@ -915,5 +918,20 @@ mod tests {
         let result = deserialize_value(&mut cursor, &IdlType::Vec(Box::new(IdlType::U8)), &HashMap::new());
         // Must fail with UnexpectedEof, not OOM.
         assert!(matches!(result, Err(SolanaDecodeError::UnexpectedEof { .. })));
+    }
+
+    #[test]
+    fn test_invalid_option_tag_rejected() {
+        // Tag byte 2 is invalid for Borsh Option (only 0 and 1 are valid).
+        let data: &[u8] = &[2, 0xFF, 0xFF, 0xFF];
+        let mut cursor: &[u8] = data;
+        let result = deserialize_value(
+            &mut cursor,
+            &IdlType::Option(Box::new(IdlType::U8)),
+            &HashMap::new(),
+        );
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("invalid Borsh Option tag"));
     }
 }

--- a/src/solana/decoding/events.rs
+++ b/src/solana/decoding/events.rs
@@ -1,0 +1,251 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tracing::warn;
+
+use crate::solana::raw_data::types::SolanaEventRecord;
+use crate::transformations::context::DecodedEvent;
+use crate::types::chain::{ChainAddress, LogPosition, TxId};
+
+use super::traits::ProgramDecoder;
+
+/// Routes `SolanaEventRecord`s to the appropriate `ProgramDecoder` by program ID
+/// and produces `DecodedEvent`s for the transformation engine.
+pub struct SolanaEventDecoder {
+    /// program_id bytes -> decoder
+    decoders: HashMap<[u8; 32], Arc<dyn ProgramDecoder>>,
+}
+
+impl SolanaEventDecoder {
+    pub fn new(decoders: Vec<Arc<dyn ProgramDecoder>>) -> Self {
+        let decoders = decoders
+            .into_iter()
+            .map(|d| (d.program_id(), d))
+            .collect();
+        Self { decoders }
+    }
+
+    pub fn decode_event_batch(
+        &self,
+        events: &[SolanaEventRecord],
+        source_name: &str,
+    ) -> Vec<DecodedEvent> {
+        events
+            .iter()
+            .filter_map(|record| self.decode_single_event(record, source_name))
+            .collect()
+    }
+
+    fn decode_single_event(
+        &self,
+        record: &SolanaEventRecord,
+        source_name: &str,
+    ) -> Option<DecodedEvent> {
+        let decoder = self.decoders.get(&record.program_id)?;
+
+        match decoder.decode_event(&record.event_discriminator, &record.event_data) {
+            Ok(Some(fields)) => Some(DecodedEvent {
+                block_number: record.slot,
+                block_timestamp: record.block_time.unwrap_or(0) as u64,
+                transaction_id: TxId::Solana(record.transaction_signature),
+                position: LogPosition::Solana {
+                    instruction_index: record.instruction_index,
+                    inner_instruction_index: record.inner_instruction_index,
+                },
+                contract_address: ChainAddress::Solana(record.program_id),
+                source_name: source_name.to_string(),
+                event_name: fields.event_name.clone(),
+                event_signature: fields.event_name,
+                params: fields.params,
+            }),
+            Ok(None) => None,
+            Err(e) => {
+                warn!(
+                    program_id = hex::encode(record.program_id),
+                    discriminator = hex::encode(record.event_discriminator),
+                    error = %e,
+                    "failed to decode Solana event"
+                );
+                None
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::solana::decoding::traits::{
+        DecodedAccountFields, DecodedEventFields, DecodedInstructionFields, SolanaDecodeError,
+    };
+    use crate::types::decoded::DecodedValue;
+
+    struct MockDecoder {
+        id: [u8; 32],
+        result: Result<Option<DecodedEventFields>, SolanaDecodeError>,
+    }
+
+    impl ProgramDecoder for MockDecoder {
+        fn program_id(&self) -> [u8; 32] {
+            self.id
+        }
+        fn program_name(&self) -> &str {
+            "mock"
+        }
+        fn decode_event(
+            &self,
+            _discriminator: &[u8],
+            _data: &[u8],
+        ) -> Result<Option<DecodedEventFields>, SolanaDecodeError> {
+            self.result.clone()
+        }
+        fn decode_instruction(
+            &self,
+            _data: &[u8],
+            _accounts: &[[u8; 32]],
+        ) -> Result<Option<DecodedInstructionFields>, SolanaDecodeError> {
+            Ok(None)
+        }
+        fn decode_account(
+            &self,
+            _data: &[u8],
+        ) -> Result<Option<DecodedAccountFields>, SolanaDecodeError> {
+            Ok(None)
+        }
+        fn event_types(&self) -> Vec<String> {
+            vec![]
+        }
+        fn instruction_types(&self) -> Vec<String> {
+            vec![]
+        }
+        fn account_types(&self) -> Vec<String> {
+            vec![]
+        }
+    }
+
+    fn make_event_record(program_id: [u8; 32]) -> SolanaEventRecord {
+        SolanaEventRecord {
+            slot: 100,
+            block_time: Some(1_700_000_000),
+            transaction_signature: [0xAA; 64],
+            program_id,
+            event_discriminator: [1, 2, 3, 4, 5, 6, 7, 8],
+            event_data: vec![10, 20, 30],
+            log_index: 0,
+            instruction_index: 2,
+            inner_instruction_index: Some(5),
+        }
+    }
+
+    #[test]
+    fn test_decode_known_event() {
+        let program_id = [1u8; 32];
+        let mut params = HashMap::new();
+        params.insert("amount".to_string(), DecodedValue::Uint64(42));
+
+        let decoder = MockDecoder {
+            id: program_id,
+            result: Ok(Some(DecodedEventFields {
+                event_name: "Transfer".to_string(),
+                params: params.clone(),
+            })),
+        };
+
+        let router = SolanaEventDecoder::new(vec![Arc::new(decoder)]);
+        let record = make_event_record(program_id);
+        let results = router.decode_event_batch(&[record], "spl_token");
+
+        assert_eq!(results.len(), 1);
+        let event = &results[0];
+        assert_eq!(event.block_number, 100);
+        assert_eq!(event.block_timestamp, 1_700_000_000);
+        assert_eq!(event.event_name, "Transfer");
+        assert_eq!(event.source_name, "spl_token");
+        assert_eq!(event.contract_address, ChainAddress::Solana([1u8; 32]));
+        assert_eq!(
+            event.params.get("amount"),
+            Some(&DecodedValue::Uint64(42))
+        );
+    }
+
+    #[test]
+    fn test_unknown_program_skipped() {
+        let decoder = MockDecoder {
+            id: [1u8; 32],
+            result: Ok(Some(DecodedEventFields {
+                event_name: "Transfer".to_string(),
+                params: HashMap::new(),
+            })),
+        };
+
+        let router = SolanaEventDecoder::new(vec![Arc::new(decoder)]);
+        // Use a different program_id that has no decoder
+        let record = make_event_record([99u8; 32]);
+        let results = router.decode_event_batch(&[record], "test");
+
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_decode_error_logged() {
+        let program_id = [1u8; 32];
+        let decoder = MockDecoder {
+            id: program_id,
+            result: Err(SolanaDecodeError::UnexpectedEof {
+                needed: 8,
+                available: 2,
+            }),
+        };
+
+        let router = SolanaEventDecoder::new(vec![Arc::new(decoder)]);
+        let record = make_event_record(program_id);
+        let results = router.decode_event_batch(&[record], "test");
+
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_event_signature_equals_name() {
+        let program_id = [1u8; 32];
+        let decoder = MockDecoder {
+            id: program_id,
+            result: Ok(Some(DecodedEventFields {
+                event_name: "Swap".to_string(),
+                params: HashMap::new(),
+            })),
+        };
+
+        let router = SolanaEventDecoder::new(vec![Arc::new(decoder)]);
+        let record = make_event_record(program_id);
+        let results = router.decode_event_batch(&[record], "test");
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].event_signature, results[0].event_name);
+        assert_eq!(results[0].event_signature, "Swap");
+    }
+
+    #[test]
+    fn test_position_mapping() {
+        let program_id = [1u8; 32];
+        let decoder = MockDecoder {
+            id: program_id,
+            result: Ok(Some(DecodedEventFields {
+                event_name: "Test".to_string(),
+                params: HashMap::new(),
+            })),
+        };
+
+        let router = SolanaEventDecoder::new(vec![Arc::new(decoder)]);
+        let record = make_event_record(program_id);
+        let results = router.decode_event_batch(&[record], "test");
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results[0].position,
+            LogPosition::Solana {
+                instruction_index: 2,
+                inner_instruction_index: Some(5),
+            }
+        );
+    }
+}

--- a/src/solana/decoding/idl.rs
+++ b/src/solana/decoding/idl.rs
@@ -1,0 +1,1226 @@
+//! Anchor IDL parser and discriminator-indexed decoder.
+//!
+//! Parses both pre-0.30 and 0.30+ IDL JSON formats, builds discriminator lookup
+//! maps, and provides the `AnchorDecoder` which implements `ProgramDecoder`.
+
+use std::collections::HashMap;
+
+use solana_sdk::hash::hash as sha256;
+
+use super::borsh_dynamic;
+use super::traits::{
+    DecodedAccountFields, DecodedEventFields, DecodedInstructionFields, ProgramDecoder,
+    SolanaDecodeError,
+};
+
+// ---------------------------------------------------------------------------
+// IDL type model
+// ---------------------------------------------------------------------------
+
+/// Normalized IDL type, version-independent.
+#[derive(Debug, Clone, PartialEq)]
+pub enum IdlType {
+    Bool,
+    U8,
+    U16,
+    U32,
+    U64,
+    U128,
+    I8,
+    I16,
+    I32,
+    I64,
+    I128,
+    F32,
+    F64,
+    Pubkey,
+    String,
+    Bytes,
+    Option(Box<IdlType>),
+    Vec(Box<IdlType>),
+    Array(Box<IdlType>, usize),
+    Defined(String),
+}
+
+/// A type definition (struct or enum) from the IDL.
+#[derive(Debug, Clone)]
+pub enum IdlTypeDef {
+    Struct { fields: Vec<(String, IdlType)> },
+    Enum { variants: Vec<IdlEnumVariant> },
+}
+
+/// A variant of an IDL enum type.
+#[derive(Debug, Clone)]
+pub struct IdlEnumVariant {
+    pub name: String,
+    pub fields: Option<Vec<(String, IdlType)>>,
+}
+
+/// Parsed instruction definition from the IDL.
+pub struct InstructionDef {
+    pub name: String,
+    pub args: Vec<(String, IdlType)>,
+    pub account_names: Vec<String>,
+}
+
+/// Fully parsed IDL with discriminator-indexed lookup maps.
+pub struct ParsedIdl {
+    pub program_name: String,
+    pub defined_types: HashMap<String, IdlTypeDef>,
+    /// event discriminator -> (event_name, fields)
+    pub event_matchers: HashMap<[u8; 8], (String, Vec<(String, IdlType)>)>,
+    /// instruction discriminator -> InstructionDef
+    pub instruction_matchers: HashMap<[u8; 8], InstructionDef>,
+    /// account discriminator -> (account_type_name, fields)
+    pub account_matchers: HashMap<[u8; 8], (String, Vec<(String, IdlType)>)>,
+}
+
+// ---------------------------------------------------------------------------
+// IDL version detection
+// ---------------------------------------------------------------------------
+
+/// Detected IDL format version.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IdlVersion {
+    /// Pre-0.30 (legacy): `publicKey`, `{"defined": "Name"}`, no explicit discriminators.
+    Legacy,
+    /// 0.30+: `pubkey`, `{"defined": {"name": "Name"}}`, optional explicit discriminators.
+    V030,
+}
+
+fn detect_version(root: &serde_json::Value) -> IdlVersion {
+    // Check for metadata.spec (0.30+ marker).
+    if root
+        .get("metadata")
+        .and_then(|m| m.get("spec"))
+        .is_some()
+    {
+        return IdlVersion::V030;
+    }
+
+    // Check for explicit discriminator arrays in any entry.
+    for key in &["events", "instructions", "accounts"] {
+        if let Some(arr) = root.get(key).and_then(|v| v.as_array()) {
+            for item in arr {
+                if item.get("discriminator").is_some() {
+                    return IdlVersion::V030;
+                }
+            }
+        }
+    }
+
+    IdlVersion::Legacy
+}
+
+// ---------------------------------------------------------------------------
+// Discriminator computation
+// ---------------------------------------------------------------------------
+
+const DISCRIMINATOR_LEN: usize = 8;
+
+fn compute_event_discriminator(event_name: &str) -> [u8; DISCRIMINATOR_LEN] {
+    let preimage = format!("event:{}", event_name);
+    let hash = sha256(preimage.as_bytes());
+    let mut disc = [0u8; DISCRIMINATOR_LEN];
+    disc.copy_from_slice(&hash.to_bytes()[..DISCRIMINATOR_LEN]);
+    disc
+}
+
+fn compute_instruction_discriminator(instruction_name: &str) -> [u8; DISCRIMINATOR_LEN] {
+    let preimage = format!("global:{}", instruction_name);
+    let hash = sha256(preimage.as_bytes());
+    let mut disc = [0u8; DISCRIMINATOR_LEN];
+    disc.copy_from_slice(&hash.to_bytes()[..DISCRIMINATOR_LEN]);
+    disc
+}
+
+fn compute_account_discriminator(account_name: &str) -> [u8; DISCRIMINATOR_LEN] {
+    let preimage = format!("account:{}", account_name);
+    let hash = sha256(preimage.as_bytes());
+    let mut disc = [0u8; DISCRIMINATOR_LEN];
+    disc.copy_from_slice(&hash.to_bytes()[..DISCRIMINATOR_LEN]);
+    disc
+}
+
+/// Parse an explicit discriminator array from a 0.30+ IDL entry, if present.
+fn parse_explicit_discriminator(value: &serde_json::Value) -> Option<[u8; DISCRIMINATOR_LEN]> {
+    let arr = value.get("discriminator")?.as_array()?;
+    if arr.len() != DISCRIMINATOR_LEN {
+        return None;
+    }
+    let mut disc = [0u8; DISCRIMINATOR_LEN];
+    for (i, v) in arr.iter().enumerate() {
+        disc[i] = v.as_u64()? as u8;
+    }
+    Some(disc)
+}
+
+// ---------------------------------------------------------------------------
+// IDL type parsing
+// ---------------------------------------------------------------------------
+
+fn parse_idl_type(
+    value: &serde_json::Value,
+    version: IdlVersion,
+) -> Result<IdlType, SolanaDecodeError> {
+    // String form: primitive types.
+    if let Some(s) = value.as_str() {
+        return match s {
+            "bool" => Ok(IdlType::Bool),
+            "u8" => Ok(IdlType::U8),
+            "u16" => Ok(IdlType::U16),
+            "u32" => Ok(IdlType::U32),
+            "u64" => Ok(IdlType::U64),
+            "u128" => Ok(IdlType::U128),
+            "i8" => Ok(IdlType::I8),
+            "i16" => Ok(IdlType::I16),
+            "i32" => Ok(IdlType::I32),
+            "i64" => Ok(IdlType::I64),
+            "i128" => Ok(IdlType::I128),
+            "f32" => Ok(IdlType::F32),
+            "f64" => Ok(IdlType::F64),
+            "string" => Ok(IdlType::String),
+            "bytes" => Ok(IdlType::Bytes),
+            // 0.30+ uses "pubkey", legacy uses "publicKey"
+            "pubkey" => Ok(IdlType::Pubkey),
+            "publicKey" => Ok(IdlType::Pubkey),
+            other => Err(SolanaDecodeError::IdlParse(format!(
+                "unknown primitive type: {}",
+                other
+            ))),
+        };
+    }
+
+    // Object form: compound/reference types.
+    let obj = value.as_object().ok_or_else(|| {
+        SolanaDecodeError::IdlParse(format!("expected string or object for IDL type, got: {}", value))
+    })?;
+
+    if let Some(inner) = obj.get("option") {
+        let inner_type = parse_idl_type(inner, version)?;
+        return Ok(IdlType::Option(Box::new(inner_type)));
+    }
+
+    if let Some(inner) = obj.get("vec") {
+        let inner_type = parse_idl_type(inner, version)?;
+        return Ok(IdlType::Vec(Box::new(inner_type)));
+    }
+
+    if let Some(arr_val) = obj.get("array") {
+        let arr = arr_val.as_array().ok_or_else(|| {
+            SolanaDecodeError::IdlParse("array type must be a JSON array [type, size]".to_string())
+        })?;
+        if arr.len() != 2 {
+            return Err(SolanaDecodeError::IdlParse(
+                "array type must have exactly 2 elements".to_string(),
+            ));
+        }
+        let inner_type = parse_idl_type(&arr[0], version)?;
+        let size = arr[1].as_u64().ok_or_else(|| {
+            SolanaDecodeError::IdlParse("array size must be a number".to_string())
+        })? as usize;
+        return Ok(IdlType::Array(Box::new(inner_type), size));
+    }
+
+    if let Some(defined) = obj.get("defined") {
+        match version {
+            IdlVersion::V030 => {
+                // 0.30+: {"defined": {"name": "TypeName"}}
+                if let Some(name_obj) = defined.as_object() {
+                    let name = name_obj
+                        .get("name")
+                        .and_then(|n| n.as_str())
+                        .ok_or_else(|| {
+                            SolanaDecodeError::IdlParse(
+                                "defined type object must have 'name' field".to_string(),
+                            )
+                        })?;
+                    return Ok(IdlType::Defined(name.to_string()));
+                }
+                // Fallback: some 0.30+ IDLs may still use the string form.
+                if let Some(name) = defined.as_str() {
+                    return Ok(IdlType::Defined(name.to_string()));
+                }
+                return Err(SolanaDecodeError::IdlParse(
+                    "invalid defined type format in 0.30+ IDL".to_string(),
+                ));
+            }
+            IdlVersion::Legacy => {
+                // Legacy: {"defined": "TypeName"}
+                let name = defined.as_str().ok_or_else(|| {
+                    SolanaDecodeError::IdlParse(
+                        "legacy defined type must be a string".to_string(),
+                    )
+                })?;
+                return Ok(IdlType::Defined(name.to_string()));
+            }
+        }
+    }
+
+    Err(SolanaDecodeError::IdlParse(format!(
+        "unrecognized IDL type: {}",
+        value
+    )))
+}
+
+// ---------------------------------------------------------------------------
+// Type definition parsing
+// ---------------------------------------------------------------------------
+
+fn parse_type_def(
+    value: &serde_json::Value,
+    version: IdlVersion,
+) -> Result<(String, IdlTypeDef), SolanaDecodeError> {
+    let name = value
+        .get("name")
+        .and_then(|n| n.as_str())
+        .ok_or_else(|| SolanaDecodeError::IdlParse("type definition missing 'name'".to_string()))?
+        .to_string();
+
+    let type_obj = value.get("type").ok_or_else(|| {
+        SolanaDecodeError::IdlParse(format!("type definition '{}' missing 'type'", name))
+    })?;
+
+    let kind = type_obj
+        .get("kind")
+        .and_then(|k| k.as_str())
+        .ok_or_else(|| {
+            SolanaDecodeError::IdlParse(format!(
+                "type definition '{}' missing 'type.kind'",
+                name
+            ))
+        })?;
+
+    match kind {
+        "struct" => {
+            let fields_arr = type_obj
+                .get("fields")
+                .and_then(|f| f.as_array())
+                .ok_or_else(|| {
+                    SolanaDecodeError::IdlParse(format!(
+                        "struct '{}' missing 'fields' array",
+                        name
+                    ))
+                })?;
+
+            let mut fields = Vec::with_capacity(fields_arr.len());
+            for field in fields_arr {
+                let field_name = field
+                    .get("name")
+                    .and_then(|n| n.as_str())
+                    .ok_or_else(|| {
+                        SolanaDecodeError::IdlParse(format!(
+                            "field in struct '{}' missing 'name'",
+                            name
+                        ))
+                    })?
+                    .to_string();
+
+                let field_type_val = field.get("type").ok_or_else(|| {
+                    SolanaDecodeError::IdlParse(format!(
+                        "field '{}' in struct '{}' missing 'type'",
+                        field_name, name
+                    ))
+                })?;
+
+                let field_type = parse_idl_type(field_type_val, version)?;
+                fields.push((field_name, field_type));
+            }
+
+            Ok((name, IdlTypeDef::Struct { fields }))
+        }
+        "enum" => {
+            let variants_arr = type_obj
+                .get("variants")
+                .and_then(|v| v.as_array())
+                .ok_or_else(|| {
+                    SolanaDecodeError::IdlParse(format!(
+                        "enum '{}' missing 'variants' array",
+                        name
+                    ))
+                })?;
+
+            let mut variants = Vec::with_capacity(variants_arr.len());
+            for variant in variants_arr {
+                let variant_name = variant
+                    .get("name")
+                    .and_then(|n| n.as_str())
+                    .ok_or_else(|| {
+                        SolanaDecodeError::IdlParse(format!(
+                            "variant in enum '{}' missing 'name'",
+                            name
+                        ))
+                    })?
+                    .to_string();
+
+                let fields = if let Some(fields_arr) = variant.get("fields").and_then(|f| f.as_array())
+                {
+                    if fields_arr.is_empty() {
+                        None
+                    } else {
+                        let mut parsed = Vec::with_capacity(fields_arr.len());
+                        for field in fields_arr {
+                            let f_name = field
+                                .get("name")
+                                .and_then(|n| n.as_str())
+                                .ok_or_else(|| {
+                                    SolanaDecodeError::IdlParse(format!(
+                                        "variant field in enum '{}::{}' missing 'name'",
+                                        name, variant_name
+                                    ))
+                                })?
+                                .to_string();
+                            let f_type_val = field.get("type").ok_or_else(|| {
+                                SolanaDecodeError::IdlParse(format!(
+                                    "variant field '{}' in enum '{}::{}' missing 'type'",
+                                    f_name, name, variant_name
+                                ))
+                            })?;
+                            let f_type = parse_idl_type(f_type_val, version)?;
+                            parsed.push((f_name, f_type));
+                        }
+                        Some(parsed)
+                    }
+                } else {
+                    None
+                };
+
+                variants.push(IdlEnumVariant {
+                    name: variant_name,
+                    fields,
+                });
+            }
+
+            Ok((name, IdlTypeDef::Enum { variants }))
+        }
+        other => Err(SolanaDecodeError::IdlParse(format!(
+            "unknown type kind '{}' in type '{}'",
+            other, name
+        ))),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Top-level IDL parser
+// ---------------------------------------------------------------------------
+
+/// Parse an Anchor IDL JSON string into a `ParsedIdl`.
+///
+/// Supports both pre-0.30 and 0.30+ IDL formats.
+pub fn parse_idl(json: &str) -> Result<ParsedIdl, SolanaDecodeError> {
+    let root: serde_json::Value = serde_json::from_str(json)
+        .map_err(|e| SolanaDecodeError::IdlParse(format!("invalid JSON: {}", e)))?;
+
+    let version = detect_version(&root);
+
+    let program_name = root
+        .get("name")
+        .or_else(|| root.get("metadata").and_then(|m| m.get("name")))
+        .and_then(|n| n.as_str())
+        .unwrap_or("unknown")
+        .to_string();
+
+    // --- Parse type definitions ---
+    let mut defined_types = HashMap::new();
+    if let Some(types_arr) = root.get("types").and_then(|t| t.as_array()) {
+        for type_val in types_arr {
+            let (name, def) = parse_type_def(type_val, version)?;
+            defined_types.insert(name, def);
+        }
+    }
+
+    // Also parse accounts as type definitions (0.30+ puts struct defs in accounts).
+    // We do this first to populate defined_types before building matchers.
+    if let Some(accounts_arr) = root.get("accounts").and_then(|a| a.as_array()) {
+        for acc_val in accounts_arr {
+            // 0.30+ accounts have a nested "type" with struct fields.
+            // Legacy accounts may also have a "type" section.
+            if acc_val.get("type").is_some() {
+                if let Ok((name, def)) = parse_type_def(acc_val, version) {
+                    defined_types.insert(name, def);
+                }
+            }
+        }
+    }
+
+    // --- Parse events ---
+    let mut event_matchers = HashMap::new();
+    if let Some(events_arr) = root.get("events").and_then(|e| e.as_array()) {
+        for event_val in events_arr {
+            let event_name = event_val
+                .get("name")
+                .and_then(|n| n.as_str())
+                .ok_or_else(|| {
+                    SolanaDecodeError::IdlParse("event missing 'name'".to_string())
+                })?
+                .to_string();
+
+            let fields = parse_fields_array(event_val, version)?;
+
+            let disc = match parse_explicit_discriminator(event_val) {
+                Some(d) => d,
+                None => compute_event_discriminator(&event_name),
+            };
+
+            event_matchers.insert(disc, (event_name, fields));
+        }
+    }
+
+    // --- Parse instructions ---
+    let mut instruction_matchers = HashMap::new();
+    if let Some(ix_arr) = root.get("instructions").and_then(|i| i.as_array()) {
+        for ix_val in ix_arr {
+            let ix_name = ix_val
+                .get("name")
+                .and_then(|n| n.as_str())
+                .ok_or_else(|| {
+                    SolanaDecodeError::IdlParse("instruction missing 'name'".to_string())
+                })?
+                .to_string();
+
+            let args = parse_args_array(ix_val, version)?;
+
+            let account_names = parse_account_names(ix_val);
+
+            let disc = match parse_explicit_discriminator(ix_val) {
+                Some(d) => d,
+                None => compute_instruction_discriminator(&ix_name),
+            };
+
+            instruction_matchers.insert(
+                disc,
+                InstructionDef {
+                    name: ix_name,
+                    args,
+                    account_names,
+                },
+            );
+        }
+    }
+
+    // --- Parse accounts (as matchers) ---
+    let mut account_matchers = HashMap::new();
+    if let Some(accounts_arr) = root.get("accounts").and_then(|a| a.as_array()) {
+        for acc_val in accounts_arr {
+            let acc_name = acc_val
+                .get("name")
+                .and_then(|n| n.as_str())
+                .ok_or_else(|| {
+                    SolanaDecodeError::IdlParse("account missing 'name'".to_string())
+                })?
+                .to_string();
+
+            // Get fields from the type definition if present, or from the defined_types map.
+            let fields = if acc_val.get("type").is_some() {
+                // Extract fields from the inline type definition.
+                let type_obj = acc_val.get("type").unwrap();
+                if let Some(fields_arr) = type_obj.get("fields").and_then(|f| f.as_array()) {
+                    let mut parsed = Vec::with_capacity(fields_arr.len());
+                    for field in fields_arr {
+                        let field_name = field
+                            .get("name")
+                            .and_then(|n| n.as_str())
+                            .ok_or_else(|| {
+                                SolanaDecodeError::IdlParse(format!(
+                                    "field in account '{}' missing 'name'",
+                                    acc_name
+                                ))
+                            })?
+                            .to_string();
+                        let field_type_val = field.get("type").ok_or_else(|| {
+                            SolanaDecodeError::IdlParse(format!(
+                                "field '{}' in account '{}' missing 'type'",
+                                field_name, acc_name
+                            ))
+                        })?;
+                        let field_type = parse_idl_type(field_type_val, version)?;
+                        parsed.push((field_name, field_type));
+                    }
+                    parsed
+                } else {
+                    Vec::new()
+                }
+            } else if let Some(IdlTypeDef::Struct { fields }) = defined_types.get(&acc_name) {
+                fields.clone()
+            } else {
+                Vec::new()
+            };
+
+            let disc = match parse_explicit_discriminator(acc_val) {
+                Some(d) => d,
+                None => compute_account_discriminator(&acc_name),
+            };
+
+            account_matchers.insert(disc, (acc_name, fields));
+        }
+    }
+
+    Ok(ParsedIdl {
+        program_name,
+        defined_types,
+        event_matchers,
+        instruction_matchers,
+        account_matchers,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Field/arg parsing helpers
+// ---------------------------------------------------------------------------
+
+/// Parse the "fields" array from an event definition.
+fn parse_fields_array(
+    value: &serde_json::Value,
+    version: IdlVersion,
+) -> Result<Vec<(String, IdlType)>, SolanaDecodeError> {
+    let fields_arr = match value.get("fields").and_then(|f| f.as_array()) {
+        Some(arr) => arr,
+        None => return Ok(Vec::new()),
+    };
+
+    let mut fields = Vec::with_capacity(fields_arr.len());
+    for field in fields_arr {
+        let name = field
+            .get("name")
+            .and_then(|n| n.as_str())
+            .ok_or_else(|| SolanaDecodeError::IdlParse("field missing 'name'".to_string()))?
+            .to_string();
+        let type_val = field
+            .get("type")
+            .ok_or_else(|| SolanaDecodeError::IdlParse("field missing 'type'".to_string()))?;
+        let idl_type = parse_idl_type(type_val, version)?;
+        fields.push((name, idl_type));
+    }
+    Ok(fields)
+}
+
+/// Parse the "args" array from an instruction definition.
+fn parse_args_array(
+    value: &serde_json::Value,
+    version: IdlVersion,
+) -> Result<Vec<(String, IdlType)>, SolanaDecodeError> {
+    let args_arr = match value.get("args").and_then(|a| a.as_array()) {
+        Some(arr) => arr,
+        None => return Ok(Vec::new()),
+    };
+
+    let mut args = Vec::with_capacity(args_arr.len());
+    for arg in args_arr {
+        let name = arg
+            .get("name")
+            .and_then(|n| n.as_str())
+            .ok_or_else(|| SolanaDecodeError::IdlParse("arg missing 'name'".to_string()))?
+            .to_string();
+        let type_val = arg
+            .get("type")
+            .ok_or_else(|| SolanaDecodeError::IdlParse("arg missing 'type'".to_string()))?;
+        let idl_type = parse_idl_type(type_val, version)?;
+        args.push((name, idl_type));
+    }
+    Ok(args)
+}
+
+/// Extract account names from an instruction definition.
+fn parse_account_names(value: &serde_json::Value) -> Vec<String> {
+    let accounts_arr = match value.get("accounts").and_then(|a| a.as_array()) {
+        Some(arr) => arr,
+        None => return Vec::new(),
+    };
+
+    accounts_arr
+        .iter()
+        .filter_map(|acc| acc.get("name").and_then(|n| n.as_str()).map(String::from))
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// AnchorDecoder
+// ---------------------------------------------------------------------------
+
+/// IDL-driven decoder implementing `ProgramDecoder`.
+pub struct AnchorDecoder {
+    program_id: [u8; 32],
+    #[allow(dead_code)]
+    program_name: String,
+    parsed_idl: ParsedIdl,
+}
+
+impl AnchorDecoder {
+    /// Create a new `AnchorDecoder` from a program ID, human name, and IDL JSON.
+    pub fn new(
+        program_id: [u8; 32],
+        program_name: String,
+        idl_json: &str,
+    ) -> Result<Self, SolanaDecodeError> {
+        let parsed_idl = parse_idl(idl_json)?;
+        Ok(Self {
+            program_id,
+            program_name,
+            parsed_idl,
+        })
+    }
+}
+
+impl ProgramDecoder for AnchorDecoder {
+    fn program_id(&self) -> [u8; 32] {
+        self.program_id
+    }
+
+    fn program_name(&self) -> &str {
+        &self.parsed_idl.program_name
+    }
+
+    fn decode_event(
+        &self,
+        discriminator: &[u8],
+        data: &[u8],
+    ) -> Result<Option<DecodedEventFields>, SolanaDecodeError> {
+        if discriminator.len() < 8 {
+            return Ok(None);
+        }
+        let mut disc = [0u8; 8];
+        disc.copy_from_slice(&discriminator[..8]);
+
+        let (event_name, fields) = match self.parsed_idl.event_matchers.get(&disc) {
+            Some(entry) => entry,
+            None => return Ok(None),
+        };
+
+        let mut cursor: &[u8] = data;
+        let params =
+            borsh_dynamic::deserialize_struct_fields(&mut cursor, fields, &self.parsed_idl.defined_types)?;
+
+        Ok(Some(DecodedEventFields {
+            event_name: event_name.clone(),
+            params,
+        }))
+    }
+
+    fn decode_instruction(
+        &self,
+        data: &[u8],
+        accounts: &[[u8; 32]],
+    ) -> Result<Option<DecodedInstructionFields>, SolanaDecodeError> {
+        if data.len() < 8 {
+            return Ok(None);
+        }
+
+        let mut disc = [0u8; 8];
+        disc.copy_from_slice(&data[..8]);
+        let remaining = &data[8..];
+
+        let ix_def = match self.parsed_idl.instruction_matchers.get(&disc) {
+            Some(def) => def,
+            None => return Ok(None),
+        };
+
+        let mut cursor: &[u8] = remaining;
+        let args = borsh_dynamic::deserialize_struct_fields(
+            &mut cursor,
+            &ix_def.args,
+            &self.parsed_idl.defined_types,
+        )?;
+
+        let mut named_accounts = HashMap::new();
+        for (i, account_name) in ix_def.account_names.iter().enumerate() {
+            if let Some(pubkey) = accounts.get(i) {
+                named_accounts.insert(account_name.clone(), *pubkey);
+            }
+        }
+
+        Ok(Some(DecodedInstructionFields {
+            instruction_name: ix_def.name.clone(),
+            args,
+            named_accounts,
+        }))
+    }
+
+    fn decode_account(
+        &self,
+        data: &[u8],
+    ) -> Result<Option<DecodedAccountFields>, SolanaDecodeError> {
+        if data.len() < 8 {
+            return Ok(None);
+        }
+
+        let mut disc = [0u8; 8];
+        disc.copy_from_slice(&data[..8]);
+        let remaining = &data[8..];
+
+        let (account_type, field_defs) = match self.parsed_idl.account_matchers.get(&disc) {
+            Some(entry) => entry,
+            None => return Ok(None),
+        };
+
+        let mut cursor: &[u8] = remaining;
+        let fields = borsh_dynamic::deserialize_struct_fields(
+            &mut cursor,
+            field_defs,
+            &self.parsed_idl.defined_types,
+        )?;
+
+        Ok(Some(DecodedAccountFields {
+            account_type: account_type.clone(),
+            fields,
+        }))
+    }
+
+    fn event_types(&self) -> Vec<String> {
+        self.parsed_idl
+            .event_matchers
+            .values()
+            .map(|(name, _)| name.clone())
+            .collect()
+    }
+
+    fn instruction_types(&self) -> Vec<String> {
+        self.parsed_idl
+            .instruction_matchers
+            .values()
+            .map(|def| def.name.clone())
+            .collect()
+    }
+
+    fn account_types(&self) -> Vec<String> {
+        self.parsed_idl
+            .account_matchers
+            .values()
+            .map(|(name, _)| name.clone())
+            .collect()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -----------------------------------------------------------------------
+    // Minimal 0.30+ IDL JSON
+    // -----------------------------------------------------------------------
+
+    fn v030_idl_json() -> &'static str {
+        r#"{
+            "address": "whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc",
+            "metadata": {
+                "name": "test_program",
+                "spec": "0.1.0"
+            },
+            "instructions": [
+                {
+                    "name": "initialize",
+                    "discriminator": [175, 175, 109, 31, 13, 152, 155, 237],
+                    "accounts": [
+                        {"name": "pool", "writable": true},
+                        {"name": "authority", "signer": true}
+                    ],
+                    "args": [
+                        {"name": "tick_spacing", "type": "u16"},
+                        {"name": "initial_sqrt_price", "type": "u128"}
+                    ]
+                }
+            ],
+            "accounts": [
+                {
+                    "name": "Pool",
+                    "discriminator": [241, 154, 109, 4, 17, 177, 109, 188],
+                    "type": {
+                        "kind": "struct",
+                        "fields": [
+                            {"name": "authority", "type": "pubkey"},
+                            {"name": "tick_spacing", "type": "u16"},
+                            {"name": "liquidity", "type": "u128"}
+                        ]
+                    }
+                }
+            ],
+            "events": [
+                {
+                    "name": "PoolInitialized",
+                    "discriminator": [50, 40, 30, 20, 10, 5, 3, 1],
+                    "fields": [
+                        {"name": "pool", "type": "pubkey"},
+                        {"name": "tick_spacing", "type": "u16"}
+                    ]
+                }
+            ],
+            "types": [
+                {
+                    "name": "TickData",
+                    "type": {
+                        "kind": "struct",
+                        "fields": [
+                            {"name": "index", "type": "i32"},
+                            {"name": "liquidity_net", "type": "i128"}
+                        ]
+                    }
+                }
+            ]
+        }"#
+    }
+
+    // -----------------------------------------------------------------------
+    // Minimal legacy (pre-0.30) IDL JSON
+    // -----------------------------------------------------------------------
+
+    fn legacy_idl_json() -> &'static str {
+        r#"{
+            "version": "0.28.0",
+            "name": "legacy_program",
+            "instructions": [
+                {
+                    "name": "swap",
+                    "accounts": [
+                        {"name": "pool", "isMut": true, "isSigner": false},
+                        {"name": "user", "isMut": false, "isSigner": true}
+                    ],
+                    "args": [
+                        {"name": "amount", "type": "u64"},
+                        {"name": "other_amount_threshold", "type": "u64"},
+                        {"name": "sqrt_price_limit", "type": "u128"},
+                        {"name": "amount_specified_is_input", "type": "bool"},
+                        {"name": "a_to_b", "type": "bool"}
+                    ]
+                }
+            ],
+            "accounts": [
+                {
+                    "name": "Whirlpool",
+                    "type": {
+                        "kind": "struct",
+                        "fields": [
+                            {"name": "whirlpoolsConfig", "type": "publicKey"},
+                            {"name": "tickSpacing", "type": "u16"}
+                        ]
+                    }
+                }
+            ],
+            "events": [
+                {
+                    "name": "Swapped",
+                    "fields": [
+                        {"name": "pool", "type": "publicKey"},
+                        {"name": "amount", "type": "u64"}
+                    ]
+                }
+            ],
+            "types": [
+                {
+                    "name": "SwapParams",
+                    "type": {
+                        "kind": "struct",
+                        "fields": [
+                            {"name": "pool", "type": "publicKey"},
+                            {"name": "amount", "type": "u64"}
+                        ]
+                    }
+                }
+            ]
+        }"#
+    }
+
+    // -----------------------------------------------------------------------
+    // Test: parse 0.30+ IDL
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_v030_idl() {
+        let parsed = parse_idl(v030_idl_json()).unwrap();
+
+        assert_eq!(parsed.program_name, "test_program");
+
+        // Events
+        assert_eq!(parsed.event_matchers.len(), 1);
+        let disc = [50, 40, 30, 20, 10, 5, 3, 1];
+        let (event_name, event_fields) = &parsed.event_matchers[&disc];
+        assert_eq!(event_name, "PoolInitialized");
+        assert_eq!(event_fields.len(), 2);
+        assert_eq!(event_fields[0].0, "pool");
+        assert_eq!(event_fields[0].1, IdlType::Pubkey);
+        assert_eq!(event_fields[1].0, "tick_spacing");
+        assert_eq!(event_fields[1].1, IdlType::U16);
+
+        // Instructions
+        assert_eq!(parsed.instruction_matchers.len(), 1);
+        let ix_disc = [175, 175, 109, 31, 13, 152, 155, 237];
+        let ix = &parsed.instruction_matchers[&ix_disc];
+        assert_eq!(ix.name, "initialize");
+        assert_eq!(ix.args.len(), 2);
+        assert_eq!(ix.account_names, vec!["pool", "authority"]);
+
+        // Accounts
+        assert_eq!(parsed.account_matchers.len(), 1);
+        let acc_disc = [241, 154, 109, 4, 17, 177, 109, 188];
+        let (acc_name, acc_fields) = &parsed.account_matchers[&acc_disc];
+        assert_eq!(acc_name, "Pool");
+        assert_eq!(acc_fields.len(), 3);
+        assert_eq!(acc_fields[0].1, IdlType::Pubkey);
+
+        // Types
+        assert!(parsed.defined_types.contains_key("TickData"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Test: parse legacy IDL
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_legacy_idl() {
+        let parsed = parse_idl(legacy_idl_json()).unwrap();
+
+        assert_eq!(parsed.program_name, "legacy_program");
+
+        // Events (discriminators are computed, not explicit).
+        assert_eq!(parsed.event_matchers.len(), 1);
+        let expected_disc = compute_event_discriminator("Swapped");
+        let (event_name, event_fields) = &parsed.event_matchers[&expected_disc];
+        assert_eq!(event_name, "Swapped");
+        assert_eq!(event_fields.len(), 2);
+        // Legacy "publicKey" should parse to Pubkey.
+        assert_eq!(event_fields[0].1, IdlType::Pubkey);
+
+        // Instructions (discriminators are computed).
+        assert_eq!(parsed.instruction_matchers.len(), 1);
+        let swap_disc = compute_instruction_discriminator("swap");
+        let ix = &parsed.instruction_matchers[&swap_disc];
+        assert_eq!(ix.name, "swap");
+        assert_eq!(ix.args.len(), 5);
+        assert_eq!(ix.account_names, vec!["pool", "user"]);
+
+        // Accounts.
+        let whirlpool_disc = compute_account_discriminator("Whirlpool");
+        let (acc_name, acc_fields) = &parsed.account_matchers[&whirlpool_disc];
+        assert_eq!(acc_name, "Whirlpool");
+        assert_eq!(acc_fields.len(), 2);
+        assert_eq!(acc_fields[0].0, "whirlpoolsConfig");
+        assert_eq!(acc_fields[0].1, IdlType::Pubkey);
+
+        // Types with publicKey.
+        if let Some(IdlTypeDef::Struct { fields }) = parsed.defined_types.get("SwapParams") {
+            assert_eq!(fields[0].1, IdlType::Pubkey);
+        } else {
+            panic!("SwapParams should be a struct in defined_types");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Test: version detection
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_version_detection() {
+        let v030_root: serde_json::Value = serde_json::from_str(v030_idl_json()).unwrap();
+        assert_eq!(detect_version(&v030_root), IdlVersion::V030);
+
+        let legacy_root: serde_json::Value = serde_json::from_str(legacy_idl_json()).unwrap();
+        assert_eq!(detect_version(&legacy_root), IdlVersion::Legacy);
+
+        // A minimal object with no metadata.spec and no discriminator arrays => Legacy.
+        let minimal: serde_json::Value =
+            serde_json::from_str(r#"{"name": "test", "instructions": []}"#).unwrap();
+        assert_eq!(detect_version(&minimal), IdlVersion::Legacy);
+    }
+
+    // -----------------------------------------------------------------------
+    // Test: discriminator computation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_discriminator_computation() {
+        // Event discriminators.
+        let event_disc = compute_event_discriminator("PoolInitialized");
+        let expected_hash = sha256(b"event:PoolInitialized");
+        let expected: [u8; 8] = expected_hash.to_bytes()[..8].try_into().unwrap();
+        assert_eq!(event_disc, expected);
+
+        // Instruction discriminators.
+        let ix_disc = compute_instruction_discriminator("initialize");
+        let expected_hash = sha256(b"global:initialize");
+        let expected: [u8; 8] = expected_hash.to_bytes()[..8].try_into().unwrap();
+        assert_eq!(ix_disc, expected);
+
+        // Account discriminators.
+        let acc_disc = compute_account_discriminator("Whirlpool");
+        let expected_hash = sha256(b"account:Whirlpool");
+        let expected: [u8; 8] = expected_hash.to_bytes()[..8].try_into().unwrap();
+        assert_eq!(acc_disc, expected);
+
+        // Different names yield different discriminators.
+        assert_ne!(
+            compute_event_discriminator("Foo"),
+            compute_event_discriminator("Bar")
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Test: defined type resolution
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_defined_type_resolution() {
+        let idl_json = r#"{
+            "name": "ref_test",
+            "instructions": [],
+            "events": [
+                {
+                    "name": "MyEvent",
+                    "fields": [
+                        {"name": "data", "type": {"defined": "MyData"}}
+                    ]
+                }
+            ],
+            "types": [
+                {
+                    "name": "MyData",
+                    "type": {
+                        "kind": "struct",
+                        "fields": [
+                            {"name": "value", "type": "u64"}
+                        ]
+                    }
+                }
+            ]
+        }"#;
+
+        let parsed = parse_idl(idl_json).unwrap();
+
+        // The event field should reference Defined("MyData").
+        let disc = compute_event_discriminator("MyEvent");
+        let (_name, fields) = &parsed.event_matchers[&disc];
+        assert_eq!(fields[0].1, IdlType::Defined("MyData".to_string()));
+
+        // The defined type should be in defined_types.
+        assert!(parsed.defined_types.contains_key("MyData"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Test: AnchorDecoder decode_event
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_anchor_decoder_decode_event() {
+        let idl_json = r#"{
+            "name": "test_decoder",
+            "instructions": [],
+            "events": [
+                {
+                    "name": "Transfer",
+                    "fields": [
+                        {"name": "amount", "type": "u64"},
+                        {"name": "sender", "type": "publicKey"}
+                    ]
+                }
+            ],
+            "types": []
+        }"#;
+
+        let decoder = AnchorDecoder::new([0u8; 32], "test".to_string(), idl_json).unwrap();
+
+        // Build event data: amount(u64) + sender(pubkey).
+        let mut event_data = Vec::new();
+        event_data.extend_from_slice(&1000u64.to_le_bytes());
+        event_data.extend_from_slice(&[0xAA; 32]);
+
+        let disc = compute_event_discriminator("Transfer");
+        let result = decoder.decode_event(&disc, &event_data).unwrap();
+
+        let decoded = result.expect("should decode known event");
+        assert_eq!(decoded.event_name, "Transfer");
+        assert_eq!(decoded.params["amount"].as_u64(), Some(1000));
+        assert_eq!(decoded.params["sender"].as_pubkey(), Some([0xAA; 32]));
+    }
+
+    // -----------------------------------------------------------------------
+    // Test: AnchorDecoder unknown discriminator
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_anchor_decoder_unknown_discriminator() {
+        let idl_json = r#"{
+            "name": "test_decoder",
+            "instructions": [],
+            "events": [
+                {
+                    "name": "Transfer",
+                    "fields": [
+                        {"name": "amount", "type": "u64"}
+                    ]
+                }
+            ],
+            "types": []
+        }"#;
+
+        let decoder = AnchorDecoder::new([0u8; 32], "test".to_string(), idl_json).unwrap();
+
+        let unknown_disc = [0xFF; 8];
+        let result = decoder.decode_event(&unknown_disc, &[]).unwrap();
+        assert!(result.is_none());
+
+        // Unknown instruction (data with bogus discriminator).
+        let mut bogus_data = Vec::new();
+        bogus_data.extend_from_slice(&[0xFF; 8]); // discriminator
+        let ix_result = decoder.decode_instruction(&bogus_data, &[]).unwrap();
+        assert!(ix_result.is_none());
+
+        // Unknown account.
+        let mut bogus_account = Vec::new();
+        bogus_account.extend_from_slice(&[0xFF; 8]); // discriminator
+        let acc_result = decoder.decode_account(&bogus_account).unwrap();
+        assert!(acc_result.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Test: AnchorDecoder decode_instruction
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_anchor_decoder_decode_instruction() {
+        let idl_json = r#"{
+            "name": "test_decoder",
+            "instructions": [
+                {
+                    "name": "transfer",
+                    "accounts": [
+                        {"name": "source", "isMut": true, "isSigner": false},
+                        {"name": "destination", "isMut": true, "isSigner": false},
+                        {"name": "authority", "isMut": false, "isSigner": true}
+                    ],
+                    "args": [
+                        {"name": "amount", "type": "u64"},
+                        {"name": "bump", "type": "u8"}
+                    ]
+                }
+            ],
+            "events": [],
+            "types": []
+        }"#;
+
+        let decoder = AnchorDecoder::new([0u8; 32], "test".to_string(), idl_json).unwrap();
+
+        // Build instruction data: discriminator + amount(u64) + bump(u8).
+        let disc = compute_instruction_discriminator("transfer");
+        let mut ix_data = Vec::new();
+        ix_data.extend_from_slice(&disc);
+        ix_data.extend_from_slice(&500u64.to_le_bytes());
+        ix_data.push(255u8);
+
+        let accounts = [
+            [1u8; 32], // source
+            [2u8; 32], // destination
+            [3u8; 32], // authority
+        ];
+
+        let result = decoder.decode_instruction(&ix_data, &accounts).unwrap();
+        let decoded = result.expect("should decode known instruction");
+
+        assert_eq!(decoded.instruction_name, "transfer");
+        assert_eq!(decoded.args["amount"].as_u64(), Some(500));
+        assert_eq!(decoded.args["bump"].as_u8(), Some(255));
+        assert_eq!(decoded.named_accounts["source"], [1u8; 32]);
+        assert_eq!(decoded.named_accounts["destination"], [2u8; 32]);
+        assert_eq!(decoded.named_accounts["authority"], [3u8; 32]);
+    }
+}

--- a/src/solana/decoding/idl.rs
+++ b/src/solana/decoding/idl.rs
@@ -359,25 +359,32 @@ fn parse_type_def(
                         None
                     } else {
                         let mut parsed = Vec::with_capacity(fields_arr.len());
-                        for field in fields_arr {
-                            let f_name = field
-                                .get("name")
-                                .and_then(|n| n.as_str())
-                                .ok_or_else(|| {
+                        for (idx, field) in fields_arr.iter().enumerate() {
+                            if field.is_object() {
+                                // Named field: {"name": "x", "type": "u64"}
+                                let f_name = field
+                                    .get("name")
+                                    .and_then(|n| n.as_str())
+                                    .unwrap_or("")
+                                    .to_string();
+                                let f_name = if f_name.is_empty() {
+                                    format!("field_{}", idx)
+                                } else {
+                                    f_name
+                                };
+                                let f_type_val = field.get("type").ok_or_else(|| {
                                     SolanaDecodeError::IdlParse(format!(
-                                        "variant field in enum '{}::{}' missing 'name'",
-                                        name, variant_name
+                                        "variant field '{}' in enum '{}::{}' missing 'type'",
+                                        f_name, name, variant_name
                                     ))
-                                })?
-                                .to_string();
-                            let f_type_val = field.get("type").ok_or_else(|| {
-                                SolanaDecodeError::IdlParse(format!(
-                                    "variant field '{}' in enum '{}::{}' missing 'type'",
-                                    f_name, name, variant_name
-                                ))
-                            })?;
-                            let f_type = parse_idl_type(f_type_val, version)?;
-                            parsed.push((f_name, f_type));
+                                })?;
+                                let f_type = parse_idl_type(f_type_val, version)?;
+                                parsed.push((f_name, f_type));
+                            } else {
+                                // Unnamed/tuple field: bare type like "u64" or {"vec": "u8"}
+                                let f_type = parse_idl_type(field, version)?;
+                                parsed.push((format!("field_{}", idx), f_type));
+                            }
                         }
                         Some(parsed)
                     }
@@ -620,17 +627,28 @@ fn parse_args_array(
     Ok(args)
 }
 
-/// Extract account names from an instruction definition.
+/// Extract account names from an instruction definition, flattening composite
+/// account groups (nested `accounts` arrays) into leaf accounts.
 fn parse_account_names(value: &serde_json::Value) -> Vec<String> {
     let accounts_arr = match value.get("accounts").and_then(|a| a.as_array()) {
         Some(arr) => arr,
         None => return Vec::new(),
     };
 
-    accounts_arr
-        .iter()
-        .filter_map(|acc| acc.get("name").and_then(|n| n.as_str()).map(String::from))
-        .collect()
+    let mut names = Vec::new();
+    collect_leaf_account_names(accounts_arr, &mut names);
+    names
+}
+
+fn collect_leaf_account_names(accounts: &[serde_json::Value], out: &mut Vec<String>) {
+    for acc in accounts {
+        // Composite group: has nested "accounts" array — recurse into it.
+        if let Some(nested) = acc.get("accounts").and_then(|a| a.as_array()) {
+            collect_leaf_account_names(nested, out);
+        } else if let Some(name) = acc.get("name").and_then(|n| n.as_str()) {
+            out.push(name.to_string());
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1222,5 +1240,117 @@ mod tests {
         assert_eq!(decoded.named_accounts["source"], [1u8; 32]);
         assert_eq!(decoded.named_accounts["destination"], [2u8; 32]);
         assert_eq!(decoded.named_accounts["authority"], [3u8; 32]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Test: composite instruction accounts are flattened
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_composite_account_flattening() {
+        let idl_json = r#"{
+            "name": "composite_test",
+            "instructions": [
+                {
+                    "name": "swap",
+                    "accounts": [
+                        {"name": "pool", "isMut": true, "isSigner": false},
+                        {
+                            "name": "tokenGroup",
+                            "accounts": [
+                                {"name": "tokenA", "isMut": true, "isSigner": false},
+                                {"name": "tokenB", "isMut": true, "isSigner": false}
+                            ]
+                        },
+                        {"name": "authority", "isMut": false, "isSigner": true}
+                    ],
+                    "args": [
+                        {"name": "amount", "type": "u64"}
+                    ]
+                }
+            ],
+            "events": [],
+            "types": []
+        }"#;
+
+        let decoder = AnchorDecoder::new([0u8; 32], "test".to_string(), idl_json).unwrap();
+        let disc = compute_instruction_discriminator("swap");
+        let mut ix_data = Vec::new();
+        ix_data.extend_from_slice(&disc);
+        ix_data.extend_from_slice(&100u64.to_le_bytes());
+
+        let accounts = [
+            [1u8; 32], // pool
+            [2u8; 32], // tokenA (inside tokenGroup)
+            [3u8; 32], // tokenB (inside tokenGroup)
+            [4u8; 32], // authority
+        ];
+
+        let result = decoder.decode_instruction(&ix_data, &accounts).unwrap();
+        let decoded = result.expect("should decode");
+
+        // Composite group "tokenGroup" should be flattened to leaf accounts.
+        assert_eq!(decoded.named_accounts.len(), 4);
+        assert_eq!(decoded.named_accounts["pool"], [1u8; 32]);
+        assert_eq!(decoded.named_accounts["tokenA"], [2u8; 32]);
+        assert_eq!(decoded.named_accounts["tokenB"], [3u8; 32]);
+        assert_eq!(decoded.named_accounts["authority"], [4u8; 32]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Test: unnamed enum variant fields (tuple-style)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_unnamed_enum_variant_fields() {
+        let idl_json = r#"{
+            "name": "enum_test",
+            "instructions": [],
+            "events": [],
+            "types": [
+                {
+                    "name": "OrderStatus",
+                    "type": {
+                        "kind": "enum",
+                        "variants": [
+                            {"name": "Pending"},
+                            {"name": "Filled", "fields": ["u64", "u64"]},
+                            {"name": "Partial", "fields": [
+                                {"name": "filled", "type": "u64"},
+                                {"name": "remaining", "type": "u64"}
+                            ]}
+                        ]
+                    }
+                }
+            ]
+        }"#;
+
+        let parsed = parse_idl(idl_json).unwrap();
+        let type_def = parsed.defined_types.get("OrderStatus").expect("type present");
+
+        if let IdlTypeDef::Enum { variants } = type_def {
+            assert_eq!(variants.len(), 3);
+
+            // Unit variant
+            assert_eq!(variants[0].name, "Pending");
+            assert!(variants[0].fields.is_none());
+
+            // Unnamed/tuple variant
+            assert_eq!(variants[1].name, "Filled");
+            let fields = variants[1].fields.as_ref().unwrap();
+            assert_eq!(fields.len(), 2);
+            assert_eq!(fields[0].0, "field_0");
+            assert_eq!(fields[0].1, IdlType::U64);
+            assert_eq!(fields[1].0, "field_1");
+            assert_eq!(fields[1].1, IdlType::U64);
+
+            // Named variant (still works)
+            assert_eq!(variants[2].name, "Partial");
+            let fields = variants[2].fields.as_ref().unwrap();
+            assert_eq!(fields[0].0, "filled");
+            assert_eq!(fields[1].0, "remaining");
+        } else {
+            panic!("OrderStatus should be an enum");
+        }
     }
 }

--- a/src/solana/decoding/idl.rs
+++ b/src/solana/decoding/idl.rs
@@ -304,27 +304,29 @@ fn parse_type_def(
                 })?;
 
             let mut fields = Vec::with_capacity(fields_arr.len());
-            for field in fields_arr {
-                let field_name = field
-                    .get("name")
-                    .and_then(|n| n.as_str())
-                    .ok_or_else(|| {
+            for (idx, field) in fields_arr.iter().enumerate() {
+                if field.is_object() {
+                    // Named field: {"name": "x", "type": "u64"}
+                    let field_name = field
+                        .get("name")
+                        .and_then(|n| n.as_str())
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(|| format!("field_{}", idx));
+
+                    let field_type_val = field.get("type").ok_or_else(|| {
                         SolanaDecodeError::IdlParse(format!(
-                            "field in struct '{}' missing 'name'",
-                            name
+                            "field '{}' in struct '{}' missing 'type'",
+                            field_name, name
                         ))
-                    })?
-                    .to_string();
+                    })?;
 
-                let field_type_val = field.get("type").ok_or_else(|| {
-                    SolanaDecodeError::IdlParse(format!(
-                        "field '{}' in struct '{}' missing 'type'",
-                        field_name, name
-                    ))
-                })?;
-
-                let field_type = parse_idl_type(field_type_val, version)?;
-                fields.push((field_name, field_type));
+                    let field_type = parse_idl_type(field_type_val, version)?;
+                    fields.push((field_name, field_type));
+                } else {
+                    // Unnamed/tuple field: bare type like "u64" or {"vec": "u8"}
+                    let field_type = parse_idl_type(field, version)?;
+                    fields.push((format!("field_{}", idx), field_type));
+                }
             }
 
             Ok((name, IdlTypeDef::Struct { fields }))
@@ -1351,6 +1353,67 @@ mod tests {
             assert_eq!(fields[1].0, "remaining");
         } else {
             panic!("OrderStatus should be an enum");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Test: tuple-style struct definitions
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_tuple_struct_fields() {
+        let idl_json = r#"{
+            "name": "tuple_test",
+            "instructions": [],
+            "events": [],
+            "types": [
+                {
+                    "name": "Pair",
+                    "type": {
+                        "kind": "struct",
+                        "fields": ["u64", "pubkey"]
+                    }
+                },
+                {
+                    "name": "Mixed",
+                    "type": {
+                        "kind": "struct",
+                        "fields": [
+                            "u64",
+                            {"name": "label", "type": "string"},
+                            "bool"
+                        ]
+                    }
+                }
+            ]
+        }"#;
+
+        let parsed = parse_idl(idl_json).unwrap();
+
+        // Pure tuple struct
+        let pair = parsed.defined_types.get("Pair").expect("Pair present");
+        if let IdlTypeDef::Struct { fields } = pair {
+            assert_eq!(fields.len(), 2);
+            assert_eq!(fields[0].0, "field_0");
+            assert_eq!(fields[0].1, IdlType::U64);
+            assert_eq!(fields[1].0, "field_1");
+            assert_eq!(fields[1].1, IdlType::Pubkey);
+        } else {
+            panic!("Pair should be a struct");
+        }
+
+        // Mixed named + unnamed fields
+        let mixed = parsed.defined_types.get("Mixed").expect("Mixed present");
+        if let IdlTypeDef::Struct { fields } = mixed {
+            assert_eq!(fields.len(), 3);
+            assert_eq!(fields[0].0, "field_0");
+            assert_eq!(fields[0].1, IdlType::U64);
+            assert_eq!(fields[1].0, "label");
+            assert_eq!(fields[1].1, IdlType::String);
+            assert_eq!(fields[2].0, "field_2");
+            assert_eq!(fields[2].1, IdlType::Bool);
+        } else {
+            panic!("Mixed should be a struct");
         }
     }
 }

--- a/src/solana/decoding/idl.rs
+++ b/src/solana/decoding/idl.rs
@@ -638,17 +638,32 @@ fn parse_account_names(value: &serde_json::Value) -> Vec<String> {
     };
 
     let mut names = Vec::new();
-    collect_leaf_account_names(accounts_arr, &mut names);
+    collect_leaf_account_names(accounts_arr, "", &mut names);
     names
 }
 
-fn collect_leaf_account_names(accounts: &[serde_json::Value], out: &mut Vec<String>) {
+fn collect_leaf_account_names(
+    accounts: &[serde_json::Value],
+    prefix: &str,
+    out: &mut Vec<String>,
+) {
     for acc in accounts {
-        // Composite group: has nested "accounts" array — recurse into it.
+        let name = acc.get("name").and_then(|n| n.as_str()).unwrap_or("");
+        // Composite group: has nested "accounts" array — recurse with prefix.
         if let Some(nested) = acc.get("accounts").and_then(|a| a.as_array()) {
-            collect_leaf_account_names(nested, out);
-        } else if let Some(name) = acc.get("name").and_then(|n| n.as_str()) {
-            out.push(name.to_string());
+            let child_prefix = if prefix.is_empty() {
+                name.to_string()
+            } else {
+                format!("{}.{}", prefix, name)
+            };
+            collect_leaf_account_names(nested, &child_prefix, out);
+        } else if !name.is_empty() {
+            let qualified = if prefix.is_empty() {
+                name.to_string()
+            } else {
+                format!("{}.{}", prefix, name)
+            };
+            out.push(qualified);
         }
     }
 }
@@ -1291,11 +1306,11 @@ mod tests {
         let result = decoder.decode_instruction(&ix_data, &accounts).unwrap();
         let decoded = result.expect("should decode");
 
-        // Composite group "tokenGroup" should be flattened to leaf accounts.
+        // Composite group leaves are prefixed with parent group name.
         assert_eq!(decoded.named_accounts.len(), 4);
         assert_eq!(decoded.named_accounts["pool"], [1u8; 32]);
-        assert_eq!(decoded.named_accounts["tokenA"], [2u8; 32]);
-        assert_eq!(decoded.named_accounts["tokenB"], [3u8; 32]);
+        assert_eq!(decoded.named_accounts["tokenGroup.tokenA"], [2u8; 32]);
+        assert_eq!(decoded.named_accounts["tokenGroup.tokenB"], [3u8; 32]);
         assert_eq!(decoded.named_accounts["authority"], [4u8; 32]);
     }
 
@@ -1415,5 +1430,55 @@ mod tests {
         } else {
             panic!("Mixed should be a struct");
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Test: duplicate leaf names under different groups get unique keys
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_composite_accounts_duplicate_leaf_names() {
+        let idl_json = r#"{
+            "name": "dup_test",
+            "instructions": [
+                {
+                    "name": "transfer",
+                    "accounts": [
+                        {
+                            "name": "source",
+                            "accounts": [
+                                {"name": "token", "isMut": true, "isSigner": false},
+                                {"name": "authority", "isMut": false, "isSigner": true}
+                            ]
+                        },
+                        {
+                            "name": "destination",
+                            "accounts": [
+                                {"name": "token", "isMut": true, "isSigner": false},
+                                {"name": "authority", "isMut": false, "isSigner": false}
+                            ]
+                        }
+                    ],
+                    "args": []
+                }
+            ],
+            "events": [],
+            "types": []
+        }"#;
+
+        let decoder = AnchorDecoder::new([0u8; 32], "test".to_string(), idl_json).unwrap();
+        let disc = compute_instruction_discriminator("transfer");
+        let ix_data = disc.to_vec();
+
+        let accounts = [[1u8; 32], [2u8; 32], [3u8; 32], [4u8; 32]];
+        let result = decoder.decode_instruction(&ix_data, &accounts).unwrap();
+        let decoded = result.expect("should decode");
+
+        // Both groups have "token" and "authority" but they must be distinct keys.
+        assert_eq!(decoded.named_accounts.len(), 4);
+        assert_eq!(decoded.named_accounts["source.token"], [1u8; 32]);
+        assert_eq!(decoded.named_accounts["source.authority"], [2u8; 32]);
+        assert_eq!(decoded.named_accounts["destination.token"], [3u8; 32]);
+        assert_eq!(decoded.named_accounts["destination.authority"], [4u8; 32]);
     }
 }

--- a/src/solana/decoding/instructions.rs
+++ b/src/solana/decoding/instructions.rs
@@ -50,10 +50,12 @@ impl SolanaInstructionDecoder {
         match decoder.decode_instruction(&record.data, &record.accounts) {
             Ok(Some(fields)) => {
                 // Merge args and named_accounts into one params map.
+                // Account names are prefixed with "accounts." to avoid
+                // collisions with instruction arguments of the same name.
                 let mut params = fields.args;
                 for (name, pubkey) in fields.named_accounts {
                     params.insert(
-                        name,
+                        format!("accounts.{}", name),
                         DecodedValue::ChainAddress(ChainAddress::Solana(pubkey)),
                     );
                 }
@@ -182,15 +184,15 @@ mod tests {
             event.params.get("amount"),
             Some(&DecodedValue::Uint64(100))
         );
-        // Named accounts are merged in as ChainAddress
+        // Named accounts are merged in as ChainAddress with "accounts." prefix
         assert_eq!(
-            event.params.get("source"),
+            event.params.get("accounts.source"),
             Some(&DecodedValue::ChainAddress(ChainAddress::Solana(
                 [10u8; 32]
             )))
         );
         assert_eq!(
-            event.params.get("destination"),
+            event.params.get("accounts.destination"),
             Some(&DecodedValue::ChainAddress(ChainAddress::Solana(
                 [20u8; 32]
             )))
@@ -218,7 +220,7 @@ mod tests {
         let results = router.decode_instruction_batch(&[record], "test");
 
         assert_eq!(results.len(), 1);
-        let val = results[0].params.get("authority").unwrap();
+        let val = results[0].params.get("accounts.authority").unwrap();
         match val {
             DecodedValue::ChainAddress(ChainAddress::Solana(bytes)) => {
                 assert_eq!(*bytes, pubkey);

--- a/src/solana/decoding/instructions.rs
+++ b/src/solana/decoding/instructions.rs
@@ -1,0 +1,248 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tracing::warn;
+
+use crate::solana::raw_data::types::SolanaInstructionRecord;
+use crate::transformations::context::DecodedEvent;
+use crate::types::chain::{ChainAddress, LogPosition, TxId};
+use crate::types::decoded::DecodedValue;
+
+use super::traits::ProgramDecoder;
+
+/// Routes `SolanaInstructionRecord`s to the appropriate `ProgramDecoder` by
+/// program ID and produces `DecodedEvent`s for the transformation engine.
+///
+/// Instruction args and named accounts are merged into a single `params` map,
+/// with named accounts stored as `DecodedValue::ChainAddress(ChainAddress::Solana(...))`.
+pub struct SolanaInstructionDecoder {
+    /// program_id bytes -> decoder
+    decoders: HashMap<[u8; 32], Arc<dyn ProgramDecoder>>,
+}
+
+impl SolanaInstructionDecoder {
+    pub fn new(decoders: Vec<Arc<dyn ProgramDecoder>>) -> Self {
+        let decoders = decoders
+            .into_iter()
+            .map(|d| (d.program_id(), d))
+            .collect();
+        Self { decoders }
+    }
+
+    pub fn decode_instruction_batch(
+        &self,
+        instructions: &[SolanaInstructionRecord],
+        source_name: &str,
+    ) -> Vec<DecodedEvent> {
+        instructions
+            .iter()
+            .filter_map(|record| self.decode_single_instruction(record, source_name))
+            .collect()
+    }
+
+    fn decode_single_instruction(
+        &self,
+        record: &SolanaInstructionRecord,
+        source_name: &str,
+    ) -> Option<DecodedEvent> {
+        let decoder = self.decoders.get(&record.program_id)?;
+
+        match decoder.decode_instruction(&record.data, &record.accounts) {
+            Ok(Some(fields)) => {
+                // Merge args and named_accounts into one params map.
+                let mut params = fields.args;
+                for (name, pubkey) in fields.named_accounts {
+                    params.insert(
+                        name,
+                        DecodedValue::ChainAddress(ChainAddress::Solana(pubkey)),
+                    );
+                }
+
+                Some(DecodedEvent {
+                    block_number: record.slot,
+                    block_timestamp: record.block_time.unwrap_or(0) as u64,
+                    transaction_id: TxId::Solana(record.transaction_signature),
+                    position: LogPosition::Solana {
+                        instruction_index: record.instruction_index,
+                        inner_instruction_index: record.inner_instruction_index,
+                    },
+                    contract_address: ChainAddress::Solana(record.program_id),
+                    source_name: source_name.to_string(),
+                    event_name: fields.instruction_name.clone(),
+                    event_signature: fields.instruction_name,
+                    params,
+                })
+            }
+            Ok(None) => None,
+            Err(e) => {
+                warn!(
+                    program_id = hex::encode(record.program_id),
+                    error = %e,
+                    "failed to decode Solana instruction"
+                );
+                None
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::solana::decoding::traits::{
+        DecodedAccountFields, DecodedEventFields, DecodedInstructionFields, SolanaDecodeError,
+    };
+
+    struct MockDecoder {
+        id: [u8; 32],
+        result: Result<Option<DecodedInstructionFields>, SolanaDecodeError>,
+    }
+
+    impl ProgramDecoder for MockDecoder {
+        fn program_id(&self) -> [u8; 32] {
+            self.id
+        }
+        fn program_name(&self) -> &str {
+            "mock"
+        }
+        fn decode_event(
+            &self,
+            _discriminator: &[u8],
+            _data: &[u8],
+        ) -> Result<Option<DecodedEventFields>, SolanaDecodeError> {
+            Ok(None)
+        }
+        fn decode_instruction(
+            &self,
+            _data: &[u8],
+            _accounts: &[[u8; 32]],
+        ) -> Result<Option<DecodedInstructionFields>, SolanaDecodeError> {
+            self.result.clone()
+        }
+        fn decode_account(
+            &self,
+            _data: &[u8],
+        ) -> Result<Option<DecodedAccountFields>, SolanaDecodeError> {
+            Ok(None)
+        }
+        fn event_types(&self) -> Vec<String> {
+            vec![]
+        }
+        fn instruction_types(&self) -> Vec<String> {
+            vec![]
+        }
+        fn account_types(&self) -> Vec<String> {
+            vec![]
+        }
+    }
+
+    fn make_instruction_record(program_id: [u8; 32]) -> SolanaInstructionRecord {
+        SolanaInstructionRecord {
+            slot: 200,
+            block_time: Some(1_700_000_000),
+            transaction_signature: [0xBB; 64],
+            program_id,
+            data: vec![3, 100, 0, 0, 0, 0, 0, 0, 0],
+            accounts: vec![[10u8; 32], [20u8; 32], [30u8; 32]],
+            instruction_index: 1,
+            inner_instruction_index: None,
+        }
+    }
+
+    #[test]
+    fn test_decode_known_instruction() {
+        let program_id = [1u8; 32];
+        let mut args = HashMap::new();
+        args.insert("amount".to_string(), DecodedValue::Uint64(100));
+
+        let mut named_accounts = HashMap::new();
+        named_accounts.insert("source".to_string(), [10u8; 32]);
+        named_accounts.insert("destination".to_string(), [20u8; 32]);
+
+        let decoder = MockDecoder {
+            id: program_id,
+            result: Ok(Some(DecodedInstructionFields {
+                instruction_name: "Transfer".to_string(),
+                args,
+                named_accounts,
+            })),
+        };
+
+        let router = SolanaInstructionDecoder::new(vec![Arc::new(decoder)]);
+        let record = make_instruction_record(program_id);
+        let results = router.decode_instruction_batch(&[record], "spl_token");
+
+        assert_eq!(results.len(), 1);
+        let event = &results[0];
+        assert_eq!(event.block_number, 200);
+        assert_eq!(event.event_name, "Transfer");
+        assert_eq!(event.event_signature, "Transfer");
+        // Args are merged in
+        assert_eq!(
+            event.params.get("amount"),
+            Some(&DecodedValue::Uint64(100))
+        );
+        // Named accounts are merged in as ChainAddress
+        assert_eq!(
+            event.params.get("source"),
+            Some(&DecodedValue::ChainAddress(ChainAddress::Solana(
+                [10u8; 32]
+            )))
+        );
+        assert_eq!(
+            event.params.get("destination"),
+            Some(&DecodedValue::ChainAddress(ChainAddress::Solana(
+                [20u8; 32]
+            )))
+        );
+    }
+
+    #[test]
+    fn test_named_accounts_as_chain_address() {
+        let program_id = [1u8; 32];
+        let pubkey = [42u8; 32];
+        let mut named_accounts = HashMap::new();
+        named_accounts.insert("authority".to_string(), pubkey);
+
+        let decoder = MockDecoder {
+            id: program_id,
+            result: Ok(Some(DecodedInstructionFields {
+                instruction_name: "MintTo".to_string(),
+                args: HashMap::new(),
+                named_accounts,
+            })),
+        };
+
+        let router = SolanaInstructionDecoder::new(vec![Arc::new(decoder)]);
+        let record = make_instruction_record(program_id);
+        let results = router.decode_instruction_batch(&[record], "test");
+
+        assert_eq!(results.len(), 1);
+        let val = results[0].params.get("authority").unwrap();
+        match val {
+            DecodedValue::ChainAddress(ChainAddress::Solana(bytes)) => {
+                assert_eq!(*bytes, pubkey);
+            }
+            other => panic!("expected ChainAddress::Solana, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_unknown_program_skipped() {
+        let decoder = MockDecoder {
+            id: [1u8; 32],
+            result: Ok(Some(DecodedInstructionFields {
+                instruction_name: "Transfer".to_string(),
+                args: HashMap::new(),
+                named_accounts: HashMap::new(),
+            })),
+        };
+
+        let router = SolanaInstructionDecoder::new(vec![Arc::new(decoder)]);
+        // Use a different program_id that has no decoder
+        let record = make_instruction_record([99u8; 32]);
+        let results = router.decode_instruction_batch(&[record], "test");
+
+        assert!(results.is_empty());
+    }
+}

--- a/src/solana/decoding/mod.rs
+++ b/src/solana/decoding/mod.rs
@@ -1,0 +1,9 @@
+pub mod traits;
+
+pub mod borsh_dynamic;
+pub mod idl;
+
+pub mod accounts;
+pub mod events;
+pub mod instructions;
+pub mod spl_token;

--- a/src/solana/decoding/spl_token.rs
+++ b/src/solana/decoding/spl_token.rs
@@ -1,0 +1,623 @@
+use std::collections::HashMap;
+
+use crate::types::chain::ChainAddress;
+use crate::types::decoded::DecodedValue;
+
+use super::traits::{
+    DecodedAccountFields, DecodedEventFields, DecodedInstructionFields, ProgramDecoder,
+    SolanaDecodeError,
+};
+
+/// SPL Token program ID: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
+const SPL_TOKEN_PROGRAM_ID: [u8; 32] = [
+    6, 221, 246, 225, 215, 101, 161, 147, 217, 203, 225, 70, 206, 235, 121, 172, 28, 180, 133,
+    237, 95, 91, 55, 145, 58, 140, 245, 133, 126, 255, 0, 169,
+];
+
+/// Hand-written `ProgramDecoder` for the SPL Token program.
+///
+/// SPL Token uses 1-byte instruction tags (not 8-byte Anchor discriminators)
+/// and fixed-layout account structures with `COption` (4-byte tag) for optional
+/// fields.
+pub struct SplTokenDecoder;
+
+impl SplTokenDecoder {
+    pub fn new() -> Self {
+        SplTokenDecoder
+    }
+}
+
+impl Default for SplTokenDecoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Read a little-endian u64 from a byte slice at the given offset.
+fn read_u64_le(data: &[u8], offset: usize) -> Result<u64, SolanaDecodeError> {
+    let end = offset + 8;
+    if data.len() < end {
+        return Err(SolanaDecodeError::UnexpectedEof {
+            needed: end,
+            available: data.len(),
+        });
+    }
+    let bytes: [u8; 8] = data[offset..end].try_into().unwrap();
+    Ok(u64::from_le_bytes(bytes))
+}
+
+/// Read a single byte at the given offset.
+fn read_u8(data: &[u8], offset: usize) -> Result<u8, SolanaDecodeError> {
+    if offset >= data.len() {
+        return Err(SolanaDecodeError::UnexpectedEof {
+            needed: offset + 1,
+            available: data.len(),
+        });
+    }
+    Ok(data[offset])
+}
+
+/// Read a 32-byte pubkey at the given offset.
+fn read_pubkey(data: &[u8], offset: usize) -> Result<[u8; 32], SolanaDecodeError> {
+    let end = offset + 32;
+    if data.len() < end {
+        return Err(SolanaDecodeError::UnexpectedEof {
+            needed: end,
+            available: data.len(),
+        });
+    }
+    let bytes: [u8; 32] = data[offset..end].try_into().unwrap();
+    Ok(bytes)
+}
+
+/// Read a COption<Pubkey> (4-byte LE tag + 32-byte pubkey).
+/// Returns DecodedValue::Null for None, DecodedValue::ChainAddress for Some.
+fn read_coption_pubkey(data: &[u8], offset: usize) -> Result<DecodedValue, SolanaDecodeError> {
+    let tag_end = offset + 4;
+    if data.len() < tag_end {
+        return Err(SolanaDecodeError::UnexpectedEof {
+            needed: tag_end,
+            available: data.len(),
+        });
+    }
+    let tag = u32::from_le_bytes(data[offset..tag_end].try_into().unwrap());
+    match tag {
+        0 => Ok(DecodedValue::Null),
+        1 => {
+            let pubkey = read_pubkey(data, tag_end)?;
+            Ok(DecodedValue::ChainAddress(ChainAddress::Solana(pubkey)))
+        }
+        _ => Err(SolanaDecodeError::InvalidEnumVariant(tag as usize)),
+    }
+}
+
+/// Read a COption<u64> (4-byte LE tag + 8-byte LE u64).
+/// Returns DecodedValue::Null for None, DecodedValue::Uint64 for Some.
+fn read_coption_u64(data: &[u8], offset: usize) -> Result<DecodedValue, SolanaDecodeError> {
+    let tag_end = offset + 4;
+    if data.len() < tag_end {
+        return Err(SolanaDecodeError::UnexpectedEof {
+            needed: tag_end,
+            available: data.len(),
+        });
+    }
+    let tag = u32::from_le_bytes(data[offset..tag_end].try_into().unwrap());
+    match tag {
+        0 => Ok(DecodedValue::Null),
+        1 => {
+            let value = read_u64_le(data, tag_end)?;
+            Ok(DecodedValue::Uint64(value))
+        }
+        _ => Err(SolanaDecodeError::InvalidEnumVariant(tag as usize)),
+    }
+}
+
+/// Extract named accounts from the accounts slice, returning only as many as
+/// names are provided. Extra accounts are silently ignored, and missing accounts
+/// leave the name out of the result.
+fn extract_named_accounts(
+    accounts: &[[u8; 32]],
+    names: &[&str],
+) -> HashMap<String, [u8; 32]> {
+    let mut map = HashMap::new();
+    for (i, name) in names.iter().enumerate() {
+        if let Some(pubkey) = accounts.get(i) {
+            map.insert(name.to_string(), *pubkey);
+        }
+    }
+    map
+}
+
+// ---------------------------------------------------------------------------
+// ProgramDecoder impl
+// ---------------------------------------------------------------------------
+
+impl ProgramDecoder for SplTokenDecoder {
+    fn program_id(&self) -> [u8; 32] {
+        SPL_TOKEN_PROGRAM_ID
+    }
+
+    fn program_name(&self) -> &str {
+        "spl_token"
+    }
+
+    /// SPL Token does not emit Anchor-style events.
+    fn decode_event(
+        &self,
+        _discriminator: &[u8],
+        _data: &[u8],
+    ) -> Result<Option<DecodedEventFields>, SolanaDecodeError> {
+        Ok(None)
+    }
+
+    fn decode_instruction(
+        &self,
+        data: &[u8],
+        accounts: &[[u8; 32]],
+    ) -> Result<Option<DecodedInstructionFields>, SolanaDecodeError> {
+        if data.is_empty() {
+            return Err(SolanaDecodeError::UnexpectedEof {
+                needed: 1,
+                available: 0,
+            });
+        }
+
+        let tag = data[0];
+        let payload = &data[1..];
+
+        match tag {
+            // Transfer
+            3 => {
+                let amount = read_u64_le(payload, 0)?;
+                let mut args = HashMap::new();
+                args.insert("amount".to_string(), DecodedValue::Uint64(amount));
+                let named_accounts =
+                    extract_named_accounts(accounts, &["source", "destination", "authority"]);
+                Ok(Some(DecodedInstructionFields {
+                    instruction_name: "Transfer".to_string(),
+                    args,
+                    named_accounts,
+                }))
+            }
+            // Approve
+            4 => {
+                let amount = read_u64_le(payload, 0)?;
+                let mut args = HashMap::new();
+                args.insert("amount".to_string(), DecodedValue::Uint64(amount));
+                let named_accounts =
+                    extract_named_accounts(accounts, &["source", "delegate", "owner"]);
+                Ok(Some(DecodedInstructionFields {
+                    instruction_name: "Approve".to_string(),
+                    args,
+                    named_accounts,
+                }))
+            }
+            // MintTo
+            7 => {
+                let amount = read_u64_le(payload, 0)?;
+                let mut args = HashMap::new();
+                args.insert("amount".to_string(), DecodedValue::Uint64(amount));
+                let named_accounts =
+                    extract_named_accounts(accounts, &["mint", "destination", "authority"]);
+                Ok(Some(DecodedInstructionFields {
+                    instruction_name: "MintTo".to_string(),
+                    args,
+                    named_accounts,
+                }))
+            }
+            // Burn
+            8 => {
+                let amount = read_u64_le(payload, 0)?;
+                let mut args = HashMap::new();
+                args.insert("amount".to_string(), DecodedValue::Uint64(amount));
+                let named_accounts =
+                    extract_named_accounts(accounts, &["account", "mint", "authority"]);
+                Ok(Some(DecodedInstructionFields {
+                    instruction_name: "Burn".to_string(),
+                    args,
+                    named_accounts,
+                }))
+            }
+            // TransferChecked
+            12 => {
+                let amount = read_u64_le(payload, 0)?;
+                let decimals = read_u8(payload, 8)?;
+                let mut args = HashMap::new();
+                args.insert("amount".to_string(), DecodedValue::Uint64(amount));
+                args.insert("decimals".to_string(), DecodedValue::Uint8(decimals));
+                let named_accounts = extract_named_accounts(
+                    accounts,
+                    &["source", "mint", "destination", "authority"],
+                );
+                Ok(Some(DecodedInstructionFields {
+                    instruction_name: "TransferChecked".to_string(),
+                    args,
+                    named_accounts,
+                }))
+            }
+            // ApproveChecked
+            13 => {
+                let amount = read_u64_le(payload, 0)?;
+                let decimals = read_u8(payload, 8)?;
+                let mut args = HashMap::new();
+                args.insert("amount".to_string(), DecodedValue::Uint64(amount));
+                args.insert("decimals".to_string(), DecodedValue::Uint8(decimals));
+                let named_accounts =
+                    extract_named_accounts(accounts, &["source", "mint", "delegate", "owner"]);
+                Ok(Some(DecodedInstructionFields {
+                    instruction_name: "ApproveChecked".to_string(),
+                    args,
+                    named_accounts,
+                }))
+            }
+            // Unknown instruction tag
+            _ => Ok(None),
+        }
+    }
+
+    fn decode_account(
+        &self,
+        data: &[u8],
+    ) -> Result<Option<DecodedAccountFields>, SolanaDecodeError> {
+        match data.len() {
+            82 => self.decode_mint_account(data),
+            165 => self.decode_token_account(data),
+            _ => Ok(None),
+        }
+    }
+
+    fn event_types(&self) -> Vec<String> {
+        vec![]
+    }
+
+    fn instruction_types(&self) -> Vec<String> {
+        vec![
+            "Transfer".to_string(),
+            "Approve".to_string(),
+            "MintTo".to_string(),
+            "Burn".to_string(),
+            "TransferChecked".to_string(),
+            "ApproveChecked".to_string(),
+        ]
+    }
+
+    fn account_types(&self) -> Vec<String> {
+        vec!["Mint".to_string(), "TokenAccount".to_string()]
+    }
+}
+
+impl SplTokenDecoder {
+    /// Decode a 82-byte Mint account.
+    ///
+    /// Layout:
+    ///   [0..36]  COption<Pubkey> mint_authority
+    ///   [36..44] u64 supply
+    ///   [44]     u8 decimals
+    ///   [45]     bool is_initialized
+    ///   [46..82] COption<Pubkey> freeze_authority
+    fn decode_mint_account(
+        &self,
+        data: &[u8],
+    ) -> Result<Option<DecodedAccountFields>, SolanaDecodeError> {
+        let mut fields = HashMap::new();
+
+        let mint_authority = read_coption_pubkey(data, 0)?;
+        fields.insert("mint_authority".to_string(), mint_authority);
+
+        let supply = read_u64_le(data, 36)?;
+        fields.insert("supply".to_string(), DecodedValue::Uint64(supply));
+
+        let decimals = read_u8(data, 44)?;
+        fields.insert("decimals".to_string(), DecodedValue::Uint8(decimals));
+
+        let is_initialized = read_u8(data, 45)? != 0;
+        fields.insert(
+            "is_initialized".to_string(),
+            DecodedValue::Bool(is_initialized),
+        );
+
+        let freeze_authority = read_coption_pubkey(data, 46)?;
+        fields.insert("freeze_authority".to_string(), freeze_authority);
+
+        Ok(Some(DecodedAccountFields {
+            account_type: "Mint".to_string(),
+            fields,
+        }))
+    }
+
+    /// Decode a 165-byte Token Account.
+    ///
+    /// Layout:
+    ///   [0..32]    Pubkey mint
+    ///   [32..64]   Pubkey owner
+    ///   [64..72]   u64 amount
+    ///   [72..108]  COption<Pubkey> delegate
+    ///   [108]      u8 state (0=Uninitialized, 1=Initialized, 2=Frozen)
+    ///   [109..121] COption<u64> is_native
+    ///   [121..129] u64 delegated_amount
+    ///   [129..165] COption<Pubkey> close_authority
+    fn decode_token_account(
+        &self,
+        data: &[u8],
+    ) -> Result<Option<DecodedAccountFields>, SolanaDecodeError> {
+        let mut fields = HashMap::new();
+
+        let mint = read_pubkey(data, 0)?;
+        fields.insert(
+            "mint".to_string(),
+            DecodedValue::ChainAddress(ChainAddress::Solana(mint)),
+        );
+
+        let owner = read_pubkey(data, 32)?;
+        fields.insert(
+            "owner".to_string(),
+            DecodedValue::ChainAddress(ChainAddress::Solana(owner)),
+        );
+
+        let amount = read_u64_le(data, 64)?;
+        fields.insert("amount".to_string(), DecodedValue::Uint64(amount));
+
+        let delegate = read_coption_pubkey(data, 72)?;
+        fields.insert("delegate".to_string(), delegate);
+
+        let state = read_u8(data, 108)?;
+        fields.insert("state".to_string(), DecodedValue::Uint8(state));
+
+        let is_native = read_coption_u64(data, 109)?;
+        fields.insert("is_native".to_string(), is_native);
+
+        let delegated_amount = read_u64_le(data, 121)?;
+        fields.insert(
+            "delegated_amount".to_string(),
+            DecodedValue::Uint64(delegated_amount),
+        );
+
+        let close_authority = read_coption_pubkey(data, 129)?;
+        fields.insert("close_authority".to_string(), close_authority);
+
+        Ok(Some(DecodedAccountFields {
+            account_type: "TokenAccount".to_string(),
+            fields,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_program_id_correct() {
+        let expected = bs58::decode("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA")
+            .into_vec()
+            .unwrap();
+        assert_eq!(expected.len(), 32);
+        let expected_bytes: [u8; 32] = expected.try_into().unwrap();
+        assert_eq!(SPL_TOKEN_PROGRAM_ID, expected_bytes);
+
+        let decoder = SplTokenDecoder::new();
+        assert_eq!(decoder.program_id(), SPL_TOKEN_PROGRAM_ID);
+    }
+
+    #[test]
+    fn test_decode_transfer() {
+        let decoder = SplTokenDecoder::new();
+
+        // tag=3, amount=1000u64 LE
+        let amount: u64 = 1000;
+        let mut data = vec![3u8];
+        data.extend_from_slice(&amount.to_le_bytes());
+
+        let accounts = vec![[10u8; 32], [20u8; 32], [30u8; 32]];
+
+        let result = decoder.decode_instruction(&data, &accounts).unwrap();
+        assert!(result.is_some());
+
+        let fields = result.unwrap();
+        assert_eq!(fields.instruction_name, "Transfer");
+        assert_eq!(
+            fields.args.get("amount"),
+            Some(&DecodedValue::Uint64(1000))
+        );
+        assert_eq!(fields.named_accounts.get("source"), Some(&[10u8; 32]));
+        assert_eq!(
+            fields.named_accounts.get("destination"),
+            Some(&[20u8; 32])
+        );
+        assert_eq!(fields.named_accounts.get("authority"), Some(&[30u8; 32]));
+    }
+
+    #[test]
+    fn test_decode_transfer_checked() {
+        let decoder = SplTokenDecoder::new();
+
+        // tag=12, amount=5000u64 LE, decimals=6u8
+        let amount: u64 = 5000;
+        let mut data = vec![12u8];
+        data.extend_from_slice(&amount.to_le_bytes());
+        data.push(6u8); // decimals
+
+        let accounts = vec![[11u8; 32], [22u8; 32], [33u8; 32], [44u8; 32]];
+
+        let result = decoder.decode_instruction(&data, &accounts).unwrap();
+        assert!(result.is_some());
+
+        let fields = result.unwrap();
+        assert_eq!(fields.instruction_name, "TransferChecked");
+        assert_eq!(
+            fields.args.get("amount"),
+            Some(&DecodedValue::Uint64(5000))
+        );
+        assert_eq!(fields.args.get("decimals"), Some(&DecodedValue::Uint8(6)));
+        assert_eq!(fields.named_accounts.get("source"), Some(&[11u8; 32]));
+        assert_eq!(fields.named_accounts.get("mint"), Some(&[22u8; 32]));
+        assert_eq!(
+            fields.named_accounts.get("destination"),
+            Some(&[33u8; 32])
+        );
+        assert_eq!(fields.named_accounts.get("authority"), Some(&[44u8; 32]));
+    }
+
+    #[test]
+    fn test_unknown_tag_returns_none() {
+        let decoder = SplTokenDecoder::new();
+        // tag=255, some payload
+        let data = vec![255u8, 0, 0, 0, 0, 0, 0, 0, 0];
+        let result = decoder.decode_instruction(&data, &[]).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_event_returns_none() {
+        let decoder = SplTokenDecoder::new();
+        let result = decoder.decode_event(&[1, 2, 3, 4, 5, 6, 7, 8], &[10, 20]).unwrap();
+        assert!(result.is_none());
+        assert!(decoder.event_types().is_empty());
+    }
+
+    #[test]
+    fn test_decode_mint_account() {
+        let decoder = SplTokenDecoder::new();
+
+        // Build a 82-byte Mint account
+        let mut data = vec![0u8; 82];
+
+        // mint_authority: COption<Pubkey> = Some([0xAA; 32])
+        // tag=1 (LE u32)
+        data[0..4].copy_from_slice(&1u32.to_le_bytes());
+        data[4..36].copy_from_slice(&[0xAA; 32]);
+
+        // supply: u64 = 1_000_000
+        let supply: u64 = 1_000_000;
+        data[36..44].copy_from_slice(&supply.to_le_bytes());
+
+        // decimals: u8 = 9
+        data[44] = 9;
+
+        // is_initialized: bool = true
+        data[45] = 1;
+
+        // freeze_authority: COption<Pubkey> = None
+        // tag=0 (LE u32), pubkey bytes are zero (don't matter)
+        data[46..50].copy_from_slice(&0u32.to_le_bytes());
+
+        let result = decoder.decode_account(&data).unwrap();
+        assert!(result.is_some());
+
+        let fields = result.unwrap();
+        assert_eq!(fields.account_type, "Mint");
+        assert_eq!(
+            fields.fields.get("supply"),
+            Some(&DecodedValue::Uint64(1_000_000))
+        );
+        assert_eq!(
+            fields.fields.get("decimals"),
+            Some(&DecodedValue::Uint8(9))
+        );
+        assert_eq!(
+            fields.fields.get("is_initialized"),
+            Some(&DecodedValue::Bool(true))
+        );
+        assert_eq!(
+            fields.fields.get("mint_authority"),
+            Some(&DecodedValue::ChainAddress(ChainAddress::Solana(
+                [0xAA; 32]
+            )))
+        );
+        assert_eq!(
+            fields.fields.get("freeze_authority"),
+            Some(&DecodedValue::Null)
+        );
+    }
+
+    #[test]
+    fn test_decode_token_account() {
+        let decoder = SplTokenDecoder::new();
+
+        // Build a 165-byte Token Account
+        let mut data = vec![0u8; 165];
+
+        // mint: Pubkey
+        data[0..32].copy_from_slice(&[0x11; 32]);
+
+        // owner: Pubkey
+        data[32..64].copy_from_slice(&[0x22; 32]);
+
+        // amount: u64 = 500
+        let amount: u64 = 500;
+        data[64..72].copy_from_slice(&amount.to_le_bytes());
+
+        // delegate: COption<Pubkey> = Some([0x33; 32])
+        data[72..76].copy_from_slice(&1u32.to_le_bytes());
+        data[76..108].copy_from_slice(&[0x33; 32]);
+
+        // state: u8 = 1 (Initialized)
+        data[108] = 1;
+
+        // is_native: COption<u64> = None
+        data[109..113].copy_from_slice(&0u32.to_le_bytes());
+
+        // delegated_amount: u64 = 100
+        let delegated: u64 = 100;
+        data[121..129].copy_from_slice(&delegated.to_le_bytes());
+
+        // close_authority: COption<Pubkey> = None
+        data[129..133].copy_from_slice(&0u32.to_le_bytes());
+
+        let result = decoder.decode_account(&data).unwrap();
+        assert!(result.is_some());
+
+        let fields = result.unwrap();
+        assert_eq!(fields.account_type, "TokenAccount");
+        assert_eq!(
+            fields.fields.get("mint"),
+            Some(&DecodedValue::ChainAddress(ChainAddress::Solana(
+                [0x11; 32]
+            )))
+        );
+        assert_eq!(
+            fields.fields.get("owner"),
+            Some(&DecodedValue::ChainAddress(ChainAddress::Solana(
+                [0x22; 32]
+            )))
+        );
+        assert_eq!(
+            fields.fields.get("amount"),
+            Some(&DecodedValue::Uint64(500))
+        );
+        assert_eq!(
+            fields.fields.get("delegate"),
+            Some(&DecodedValue::ChainAddress(ChainAddress::Solana(
+                [0x33; 32]
+            )))
+        );
+        assert_eq!(fields.fields.get("state"), Some(&DecodedValue::Uint8(1)));
+        assert_eq!(fields.fields.get("is_native"), Some(&DecodedValue::Null));
+        assert_eq!(
+            fields.fields.get("delegated_amount"),
+            Some(&DecodedValue::Uint64(100))
+        );
+        assert_eq!(
+            fields.fields.get("close_authority"),
+            Some(&DecodedValue::Null)
+        );
+    }
+
+    #[test]
+    fn test_unknown_account_size_returns_none() {
+        let decoder = SplTokenDecoder::new();
+
+        // Not 82 or 165 bytes
+        let data = vec![0u8; 50];
+        let result = decoder.decode_account(&data).unwrap();
+        assert!(result.is_none());
+
+        let data = vec![0u8; 200];
+        let result = decoder.decode_account(&data).unwrap();
+        assert!(result.is_none());
+    }
+}

--- a/src/solana/decoding/traits.rs
+++ b/src/solana/decoding/traits.rs
@@ -1,0 +1,86 @@
+use std::collections::HashMap;
+
+use crate::types::decoded::DecodedValue;
+
+/// Errors from Solana program decoding.
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum SolanaDecodeError {
+    #[error("Unexpected end of data: need {needed} bytes, have {available}")]
+    UnexpectedEof { needed: usize, available: usize },
+
+    #[error("Unknown defined type: {0}")]
+    UnknownType(String),
+
+    #[error("Invalid enum variant index: {0}")]
+    InvalidEnumVariant(usize),
+
+    #[error("IDL parse error: {0}")]
+    IdlParse(String),
+}
+
+/// Decoded event fields from a program decoder.
+#[derive(Debug, Clone)]
+pub struct DecodedEventFields {
+    pub event_name: String,
+    pub params: HashMap<String, DecodedValue>,
+}
+
+/// Decoded instruction fields from a program decoder.
+#[derive(Debug, Clone)]
+pub struct DecodedInstructionFields {
+    pub instruction_name: String,
+    pub args: HashMap<String, DecodedValue>,
+    /// Named account references from the IDL (e.g., "pool" → pubkey bytes).
+    pub named_accounts: HashMap<String, [u8; 32]>,
+}
+
+/// Decoded account state fields from a program decoder.
+#[derive(Debug, Clone)]
+pub struct DecodedAccountFields {
+    pub account_type: String,
+    pub fields: HashMap<String, DecodedValue>,
+}
+
+/// Trait for decoding a Solana program's events, instructions, and account state.
+///
+/// Implemented by `AnchorDecoder` (IDL-driven) and hand-written decoders for
+/// well-known programs like SPL Token.
+pub trait ProgramDecoder: Send + Sync {
+    /// Program ID this decoder handles.
+    fn program_id(&self) -> [u8; 32];
+
+    /// Human-readable name for logging.
+    fn program_name(&self) -> &str;
+
+    /// Decode an event from raw "Program data:" log entry.
+    /// Returns `None` if the discriminator doesn't match any known event.
+    fn decode_event(
+        &self,
+        discriminator: &[u8],
+        data: &[u8],
+    ) -> Result<Option<DecodedEventFields>, SolanaDecodeError>;
+
+    /// Decode instruction data + account keys.
+    /// Returns `None` if the discriminator doesn't match any known instruction.
+    fn decode_instruction(
+        &self,
+        data: &[u8],
+        accounts: &[[u8; 32]],
+    ) -> Result<Option<DecodedInstructionFields>, SolanaDecodeError>;
+
+    /// Decode account state from raw account data.
+    /// Returns `None` if the discriminator doesn't match any known account type.
+    fn decode_account(
+        &self,
+        data: &[u8],
+    ) -> Result<Option<DecodedAccountFields>, SolanaDecodeError>;
+
+    /// Event types this decoder can produce.
+    fn event_types(&self) -> Vec<String>;
+
+    /// Instruction types this decoder can produce.
+    fn instruction_types(&self) -> Vec<String>;
+
+    /// Account types this decoder can produce.
+    fn account_types(&self) -> Vec<String>;
+}

--- a/src/solana/discovery.rs
+++ b/src/solana/discovery.rs
@@ -440,6 +440,8 @@ mod tests {
             SolanaProgramConfig {
                 program_id: "whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc".to_string(),
                 idl_path: None,
+                idl_format: None,
+                decoder: None,
                 events: None,
                 accounts: None,
                 discovery: Some(vec![SolanaDiscoveryConfig {
@@ -461,6 +463,8 @@ mod tests {
             SolanaProgramConfig {
                 program_id: "11111111111111111111111111111111".to_string(),
                 idl_path: None,
+                idl_format: None,
+                decoder: None,
                 events: Some(vec![]),
                 accounts: None,
                 discovery: None,
@@ -779,6 +783,8 @@ mod tests {
             SolanaProgramConfig {
                 program_id: "22222222222222222222222222222222".to_string(),
                 idl_path: None,
+                idl_format: None,
+                decoder: None,
                 events: None,
                 accounts: None,
                 discovery: Some(vec![SolanaDiscoveryConfig {
@@ -866,6 +872,8 @@ mod tests {
             SolanaProgramConfig {
                 program_id: "11111111111111111111111111111111".to_string(),
                 idl_path: None,
+                idl_format: None,
+                decoder: None,
                 events: None,
                 accounts: None,
                 discovery: Some(vec![SolanaDiscoveryConfig {

--- a/src/solana/mod.rs
+++ b/src/solana/mod.rs
@@ -2,6 +2,8 @@ pub mod rpc;
 pub mod ws;
 
 #[cfg(feature = "solana")]
+pub mod decoding;
+#[cfg(feature = "solana")]
 pub mod discovery;
 #[cfg(feature = "solana")]
 pub mod raw_data;

--- a/src/solana/raw_data/catchup.rs
+++ b/src/solana/raw_data/catchup.rs
@@ -317,14 +317,19 @@ pub fn group_slots_into_ranges(slots: &BTreeSet<u64>, range_size: u64) -> Vec<Bl
 // Resume logic
 // ---------------------------------------------------------------------------
 
-/// Scan existing parquet files to find the highest slot already processed.
+/// Scan existing parquet files to find the highest fully-completed slot range.
 ///
-/// Looks at all three output directories (slots, events, instructions) and
-/// returns the maximum end-inclusive value from any file's range.
+/// A range is only counted if it has a corresponding entry in the
+/// `skipped_slots.json` index — parquet file existence alone is not
+/// sufficient because a crash between parquet writes and index update
+/// leaves an incomplete range that must be re-processed.
 pub fn find_resume_slot(chain_name: &str) -> Option<u64> {
+    let events_dir = raw_solana_events_dir(chain_name);
+    let skipped_index = crate::storage::skipped_slots::read_skipped_slots_index(&events_dir);
+
     let dirs = [
         raw_solana_slots_dir(chain_name),
-        raw_solana_events_dir(chain_name),
+        events_dir,
         raw_solana_instructions_dir(chain_name),
     ];
 
@@ -332,8 +337,12 @@ pub fn find_resume_slot(chain_name: &str) -> Option<u64> {
 
     for dir in &dirs {
         if let Ok(ranges) = crate::storage::paths::scan_parquet_ranges(dir) {
-            for (_start, end_inclusive, _path) in ranges {
-                max_slot = Some(max_slot.map_or(end_inclusive, |m: u64| m.max(end_inclusive)));
+            for (start, end_inclusive, _path) in ranges {
+                let rk = crate::storage::skipped_slots::range_key(start, end_inclusive);
+                if crate::storage::skipped_slots::is_range_complete(&skipped_index, &rk) {
+                    max_slot =
+                        Some(max_slot.map_or(end_inclusive, |m: u64| m.max(end_inclusive)));
+                }
             }
         }
     }

--- a/src/types/config/chain.rs
+++ b/src/types/config/chain.rs
@@ -157,6 +157,18 @@ pub fn resolve_chain_config(
     };
 
     #[cfg(feature = "solana")]
+    let solana_programs = {
+        let mut programs = solana_programs;
+        for (_name, config) in programs.iter_mut() {
+            if let Some(ref idl_path) = config.idl_path {
+                let resolved = base_dir.join(idl_path);
+                config.idl_path = Some(resolved.to_string_lossy().into_owned());
+            }
+        }
+        programs
+    };
+
+    #[cfg(feature = "solana")]
     let commitment = raw_config.commitment.unwrap_or_default();
 
     Ok(ChainConfig {

--- a/src/types/config/solana.rs
+++ b/src/types/config/solana.rs
@@ -32,6 +32,14 @@ pub struct SolanaProgramConfig {
     #[serde(default)]
     pub idl_path: Option<String>,
 
+    /// IDL format. Currently only "anchor" (default). Future: "shank".
+    #[serde(default)]
+    pub idl_format: Option<String>,
+
+    /// Built-in decoder name (e.g., "spl_token"). Takes precedence over idl_path.
+    #[serde(default)]
+    pub decoder: Option<String>,
+
     /// Events to decode and dispatch to handlers.
     #[serde(default)]
     pub events: Option<Vec<SolanaEventConfig>>,
@@ -221,6 +229,30 @@ mod tests {
         assert_eq!(triggers.len(), 1);
         assert_eq!(triggers[0].source, "whirlpool");
         assert_eq!(triggers[0].event, "Traded");
+    }
+
+    #[test]
+    fn solana_program_config_with_decoder_fields() {
+        let json = r#"{
+            "program_id": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+            "decoder": "spl_token"
+        }"#;
+        let cfg: SolanaProgramConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.decoder.as_deref(), Some("spl_token"));
+        assert!(cfg.idl_path.is_none());
+        assert!(cfg.idl_format.is_none());
+    }
+
+    #[test]
+    fn solana_program_config_with_idl_format() {
+        let json = r#"{
+            "program_id": "whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc",
+            "idl_path": "idls/whirlpool.json",
+            "idl_format": "anchor"
+        }"#;
+        let cfg: SolanaProgramConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.idl_format.as_deref(), Some("anchor"));
+        assert_eq!(cfg.idl_path.as_deref(), Some("idls/whirlpool.json"));
     }
 
     #[test]

--- a/src/types/decoded.rs
+++ b/src/types/decoded.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::types::chain::ChainAddress;
 
 /// A decoded value from an event parameter, eth_call result, or account-state field.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[allow(dead_code)]
 pub enum DecodedValue {
     Address([u8; 20]),
@@ -30,8 +30,12 @@ pub enum DecodedValue {
     UnnamedTuple(Vec<DecodedValue>),
     /// Array of values
     Array(Vec<DecodedValue>),
-    /// Chain-aware address/pubkey value. Kept last to preserve bincode enum ordinals.
+    /// Chain-aware address/pubkey value.
     ChainAddress(ChainAddress),
+    /// Floating-point value for Borsh f32/f64 fields.
+    Float(f64),
+    /// Null / absent value (e.g., Borsh `Option::None`).
+    Null,
 }
 
 #[allow(dead_code)]
@@ -154,6 +158,19 @@ impl DecodedValue {
         }
     }
 
+    /// Try to get as f64.
+    pub fn as_float(&self) -> Option<f64> {
+        match self {
+            DecodedValue::Float(f) => Some(*f),
+            _ => None,
+        }
+    }
+
+    /// Check if this is a Null value.
+    pub fn is_null(&self) -> bool {
+        matches!(self, DecodedValue::Null)
+    }
+
     /// Try to get as bool.
     pub fn as_bool(&self) -> Option<bool> {
         match self {
@@ -205,6 +222,7 @@ impl DecodedValue {
             DecodedValue::Int32(v) => Some(v.to_string()),
             DecodedValue::Uint8(v) => Some(v.to_string()),
             DecodedValue::Int8(v) => Some(v.to_string()),
+            DecodedValue::Float(v) => Some(v.to_string()),
             DecodedValue::String(s) => {
                 if U256::from_str(s.trim()).is_ok() || I256::from_str(s.trim()).is_ok() {
                     Some(s.trim().to_string())
@@ -241,5 +259,34 @@ mod tests {
         .unwrap();
 
         assert_eq!(&encoded[..4], &[18, 0, 0, 0]);
+    }
+
+    #[test]
+    fn test_bincode_float_and_null_ordinals() {
+        let float = bincode::serialize(&DecodedValue::Float(1.0)).unwrap();
+        assert_eq!(&float[..4], &[19, 0, 0, 0]);
+
+        let null = bincode::serialize(&DecodedValue::Null).unwrap();
+        assert_eq!(&null[..4], &[20, 0, 0, 0]);
+    }
+
+    #[test]
+    fn test_as_float() {
+        assert_eq!(DecodedValue::Float(3.14).as_float(), Some(3.14));
+        assert_eq!(DecodedValue::Uint64(42).as_float(), None);
+    }
+
+    #[test]
+    fn test_is_null() {
+        assert!(DecodedValue::Null.is_null());
+        assert!(!DecodedValue::Bool(false).is_null());
+    }
+
+    #[test]
+    fn test_float_to_numeric_string() {
+        assert_eq!(
+            DecodedValue::Float(42.5).to_numeric_string(),
+            Some("42.5".to_string())
+        );
     }
 }


### PR DESCRIPTION
## Summary

- **IDL parser** (`idl.rs`): Parses Anchor IDL JSON with version detection (pre-0.30 and 0.30+), computes discriminators, builds matcher maps. Handles composite instruction accounts, unnamed enum variants, and tuple-style struct definitions.
- **Dynamic Borsh deserializer** (`borsh_dynamic.rs`): Recursive runtime interpreter that walks IDL type trees and produces `DecodedValue`. Includes OOM protection on malformed vec lengths and strict Option tag validation.
- **ProgramDecoder trait** (`traits.rs`): Abstraction for decoding any Solana program — `AnchorDecoder` (IDL-driven) and `SplTokenDecoder` (hand-written) implement it.
- **SPL Token decoder** (`spl_token.rs`): Hand-written decoder for Transfer, TransferChecked, Approve, MintTo, Burn instructions and Mint/TokenAccount layouts.
- **Decoder routers** (`events.rs`, `instructions.rs`, `accounts.rs`): Dispatch raw records to the matching `ProgramDecoder` by program_id, producing `DecodedEvent` and `DecodedAccountState` for the transformation engine.
- **DecodedValue extensions**: Added `Float(f64)` and `Null` variants for Borsh f32/f64 and Option None.
- **Config extensions**: Added `idl_format` and `decoder` fields to `SolanaProgramConfig`, IDL path resolution at config parse time.
- **Resume fix**: `find_resume_slot` now cross-checks parquet ranges against `skipped_slots.json` to avoid permanently skipping incomplete ranges after a crash.

Runtime wiring (connecting decoders to the pipeline via channels) is deferred to phase 7.