### PR TITLE
perf: arc-wrap tx_addresses to eliminate per-handler deep copies

### DIFF
--- a/src/transformations/context.rs
+++ b/src/transformations/context.rs
@@ -313,7 +313,7 @@ pub struct TransformationContext {
 
     // ===== Transaction Address Data =====
     /// Transaction hash -> from/to addresses from receipt data
-    tx_addresses: HashMap<[u8; 32], TransactionAddresses>,
+    tx_addresses: Arc<HashMap<[u8; 32], TransactionAddresses>>,
 
     // ===== Services =====
     /// Historical data reader for querying parquet files
@@ -336,7 +336,7 @@ impl TransformationContext {
         blockrange_end: u64,
         events: Arc<Vec<DecodedEvent>>,
         calls: Arc<Vec<DecodedCall>>,
-        tx_addresses: HashMap<[u8; 32], TransactionAddresses>,
+        tx_addresses: Arc<HashMap<[u8; 32], TransactionAddresses>>,
         historical: Arc<HistoricalDataReader>,
         rpc: Arc<UnifiedRpcClient>,
         contracts: Arc<Contracts>,

--- a/src/transformations/engine.rs
+++ b/src/transformations/engine.rs
@@ -1700,9 +1700,10 @@ impl TransformationEngine {
         }
 
         // Build HandlerTasks and use executor
-        let tx_addresses = self
-            .read_receipt_addresses(msg.range_start, msg.range_end)
-            .await;
+        let tx_addresses = Arc::new(
+            self.read_receipt_addresses(msg.range_start, msg.range_end)
+                .await,
+        );
         let tasks: Vec<HandlerTask> = ready_handlers
             .into_iter()
             .map(|(handler, calls)| HandlerTask {
@@ -2193,9 +2194,10 @@ impl TransformationEngine {
             // Build HandlerTasks and use executor
             let mut tasks = Vec::new();
             for (_handler_key, event_data, handler) in ready_events {
-                let tx_addresses = self
-                    .read_receipt_addresses(event_data.range_start, event_data.range_end)
-                    .await;
+                let tx_addresses = Arc::new(
+                    self.read_receipt_addresses(event_data.range_start, event_data.range_end)
+                        .await,
+                );
                 tasks.push(HandlerTask {
                     handler,
                     events: Arc::new(event_data.events),
@@ -2474,7 +2476,7 @@ impl TransformationEngine {
         call_triggers: &[(String, String)],
         events: Arc<Vec<DecodedEvent>>,
         calls: Arc<Vec<DecodedCall>>,
-        tx_addresses: HashMap<[u8; 32], TransactionAddresses>,
+        tx_addresses: Arc<HashMap<[u8; 32], TransactionAddresses>>,
         range_start: u64,
         range_end: u64,
         snapshot_chain: Option<String>,
@@ -2587,7 +2589,7 @@ impl TransformationEngine {
             .into_iter()
             .collect();
 
-        let tx_addresses = self.read_receipt_addresses(range_start, range_end).await;
+        let tx_addresses = Arc::new(self.read_receipt_addresses(range_start, range_end).await);
         let events = Arc::new(events);
         let calls = Arc::new(calls);
 

--- a/src/transformations/event/metrics/v4_hook_extract.rs
+++ b/src/transformations/event/metrics/v4_hook_extract.rs
@@ -232,7 +232,7 @@ mod tests {
             200,
             Arc::new(events),
             Arc::new(calls),
-            HashMap::new(),
+            Arc::new(HashMap::new()),
             historical,
             rpc,
             Arc::new(HashMap::new()),

--- a/src/transformations/event/v3/create.rs
+++ b/src/transformations/event/v3/create.rs
@@ -411,7 +411,7 @@ mod tests {
             200,
             Arc::new(Vec::new()),
             Arc::new(Vec::new()),
-            HashMap::new(),
+            Arc::new(HashMap::new()),
             historical,
             rpc,
             Arc::new(HashMap::new()),

--- a/src/transformations/event/v3/metrics.rs
+++ b/src/transformations/event/v3/metrics.rs
@@ -754,7 +754,7 @@ mod tests {
             200,
             Arc::new(Vec::new()),
             Arc::new(Vec::new()),
-            HashMap::new(),
+            Arc::new(HashMap::new()),
             historical,
             rpc,
             Arc::new(HashMap::new()),

--- a/src/transformations/event/v4/metrics.rs
+++ b/src/transformations/event/v4/metrics.rs
@@ -1240,7 +1240,7 @@ mod tests {
             range_end,
             Arc::new(Vec::new()),
             Arc::new(Vec::new()),
-            StdHashMap::new(),
+            Arc::new(StdHashMap::new()),
             historical,
             rpc,
             Arc::new(StdHashMap::new()),

--- a/src/transformations/executor.rs
+++ b/src/transformations/executor.rs
@@ -44,7 +44,7 @@ pub(crate) struct HandlerTask {
     pub handler: Arc<dyn TransformationHandler>,
     pub events: Arc<Vec<DecodedEvent>>,
     pub calls: Arc<Vec<DecodedCall>>,
-    pub tx_addresses: HashMap<[u8; 32], TransactionAddresses>,
+    pub tx_addresses: Arc<HashMap<[u8; 32], TransactionAddresses>>,
 }
 
 /// Opaque payload carried inside a process-range [`WorkItem`].
@@ -58,7 +58,7 @@ pub(crate) struct ProcessRangePayload {
     pub handler: Arc<dyn TransformationHandler>,
     pub events: Arc<Vec<DecodedEvent>>,
     pub calls: Arc<Vec<DecodedCall>>,
-    pub tx_addresses: HashMap<[u8; 32], TransactionAddresses>,
+    pub tx_addresses: Arc<HashMap<[u8; 32], TransactionAddresses>>,
     /// `Some(chain_name)` → snapshot-capture mode (live); `None` → direct (historical).
     pub snapshot_chain: Option<String>,
 }
@@ -181,7 +181,7 @@ pub(crate) async fn run_handler_task(
     handler: Arc<dyn TransformationHandler>,
     events: Arc<Vec<DecodedEvent>>,
     calls: Arc<Vec<DecodedCall>>,
-    tx_addresses: HashMap<[u8; 32], TransactionAddresses>,
+    tx_addresses: Arc<HashMap<[u8; 32], TransactionAddresses>>,
     chain_name: String,
     chain_id: u64,
     range_start: u64,

--- a/src/transformations/retry.rs
+++ b/src/transformations/retry.rs
@@ -59,7 +59,7 @@ struct RetryPayload {
     handler: Arc<dyn super::traits::TransformationHandler>,
     handler_events: Arc<Vec<DecodedEvent>>,
     handler_calls: Arc<Vec<DecodedCall>>,
-    tx_addresses: HashMap<[u8; 32], TransactionAddresses>,
+    tx_addresses: Arc<HashMap<[u8; 32], TransactionAddresses>>,
 }
 
 pub(crate) fn resolve_retry_missing_handlers(
@@ -392,7 +392,7 @@ impl RetryProcessor {
     ) -> Result<HashSet<String>, TransformationError> {
         let range_start = block_number;
         let range_end = block_number + 1;
-        let tx_addresses = read_live_receipt_addresses(&self.chain_name, block_number)?;
+        let tx_addresses = Arc::new(read_live_receipt_addresses(&self.chain_name, block_number)?);
         let events = Arc::new(events);
         let calls = Arc::new(calls);
 
@@ -506,7 +506,7 @@ impl RetryProcessor {
             // tx_addresses for event handlers; empty for call handlers.
             let item_tx_addresses = match rh.kind {
                 HandlerKind::Event => tx_addresses.clone(),
-                HandlerKind::Call => HashMap::new(),
+                HandlerKind::Call => Arc::new(HashMap::new()),
             };
 
             // dep_names are handler names (not keys). The tracker already has

--- a/src/transformations/scheduler/loader.rs
+++ b/src/transformations/scheduler/loader.rs
@@ -350,9 +350,9 @@ impl CatchupLoader {
 
         let tx_addresses = match payload.kind {
             HandlerKind::Event => {
-                read_receipt_addresses(&self.raw_receipts_dir, range_start, range_end).await
+                Arc::new(read_receipt_addresses(&self.raw_receipts_dir, range_start, range_end).await)
             }
-            HandlerKind::Call => HashMap::new(),
+            HandlerKind::Call => Arc::new(HashMap::new()),
         };
 
         run_handler_task(


### PR DESCRIPTION
## Summary

- Wraps `tx_addresses: HashMap<[u8; 32], TransactionAddresses>` in `Arc` across `HandlerTask`, `ProcessRangePayload`, `RetryPayload`, and `TransformationContext`
- The map is never mutated after construction — only read via `.get()` — but was previously deep-cloned for every handler task sharing a block range
- With 5-10 handlers per range and ~750K entries per 10K-block range on Base chain, this eliminates 500MB-1GB of redundant HashMap copies during historical catchup

## Files changed

- `executor.rs` — struct type changes + `run_handler_task` param
- `engine.rs` — `Arc::new()` wrapping at 3 construction sites + `build_process_range_items` param
- `retry.rs` — `RetryPayload` type + construction wrapping
- `context.rs` — `TransformationContext` field + constructor param
- `scheduler/loader.rs` — catchup loader wrapping
- 4 test files — `HashMap::new()` → `Arc::new(HashMap::new())`

Note: will conflict with `perf/intern-decoded-field-names` on `context.rs` — straightforward merge resolution.