### PR TITLE
perf: intern decoded field names via Arc<str>

### DIFF
--- a/src/decoding/eth_calls/decode.rs
+++ b/src/decoding/eth_calls/decode.rs
@@ -1,5 +1,7 @@
 //! Value decoding: alloy DynSolType -> DecodedValue.
 
+use std::sync::Arc;
+
 use alloy::dyn_abi::{DynSolType, DynSolValue};
 
 use super::types::EthCallDecodingError;
@@ -84,7 +86,7 @@ fn convert_dyn_sol_value(
             let mut named_values = Vec::with_capacity(fields.len());
             for ((name, field_type), val) in fields.iter().zip(values.iter()) {
                 let decoded = convert_dyn_sol_value(val, field_type)?;
-                named_values.push((name.clone(), decoded));
+                named_values.push((Arc::from(name.as_str()), decoded));
             }
             return Ok(DecodedValue::NamedTuple(named_values));
         } else {

--- a/src/decoding/eth_calls/transform.rs
+++ b/src/decoding/eth_calls/transform.rs
@@ -1,6 +1,7 @@
 //! Transform helpers: build_result_map, convert_to_transform_call.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use super::types::{DecodedCallRecord, DecodedEventCallRecord};
 use crate::transformations::DecodedCall as TransformDecodedCall;
@@ -11,11 +12,11 @@ pub fn build_result_map(
     value: &DecodedValue,
     output_type: &EvmType,
     function_name: &str,
-) -> HashMap<String, DecodedValue> {
+) -> HashMap<Arc<str>, DecodedValue> {
     let mut result = HashMap::new();
     match output_type {
         EvmType::Named { name, .. } => {
-            result.insert(name.clone(), value.clone());
+            result.insert(Arc::from(name.as_str()), value.clone());
         }
         EvmType::NamedTuple(fields) => {
             if let DecodedValue::NamedTuple(named_values) = value {
@@ -25,7 +26,7 @@ pub fn build_result_map(
             }
         }
         _ => {
-            result.insert(function_name.to_string(), value.clone());
+            result.insert(Arc::from(function_name), value.clone());
         }
     }
     result
@@ -39,12 +40,12 @@ pub fn build_result_map_for_merge(
     value: &DecodedValue,
     output_type: &EvmType,
     function_name: &str,
-) -> HashMap<String, DecodedValue> {
+) -> HashMap<Arc<str>, DecodedValue> {
     let base = build_result_map(value, output_type, function_name);
     match output_type {
         EvmType::NamedTuple(_) => base
             .into_iter()
-            .map(|(k, v)| (format!("{}.{}", function_name, k), v))
+            .map(|(k, v)| (Arc::<str>::from(format!("{}.{}", function_name, k)), v))
             .collect(),
         _ => base,
     }
@@ -52,7 +53,7 @@ pub fn build_result_map_for_merge(
 
 /// Recursively flatten nested NamedTuples into dot-notation keys.
 fn insert_flattened(
-    result: &mut HashMap<String, DecodedValue>,
+    result: &mut HashMap<Arc<str>, DecodedValue>,
     prefix: &str,
     field_type: &EvmType,
     value: &DecodedValue,
@@ -69,7 +70,7 @@ fn insert_flattened(
             insert_flattened(result, prefix, inner, value);
         }
         _ => {
-            result.insert(prefix.to_string(), value.clone());
+            result.insert(Arc::from(prefix), value.clone());
         }
     }
 }

--- a/src/decoding/event_parsing.rs
+++ b/src/decoding/event_parsing.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use alloy::dyn_abi::DynSolType;
 use alloy::primitives::keccak256;
 use arrow::datatypes::DataType;
@@ -31,7 +33,7 @@ pub enum TupleFieldInfo {
 #[allow(dead_code)]
 pub struct FlattenedField {
     /// Full path name like "key.currency0", "deployer", or "poolKey.hash"
-    pub full_name: String,
+    pub full_name: Arc<str>,
     /// The leaf type for this field (FixedBytes(32) for indexed tuple hashes)
     pub leaf_type: DynSolType,
     /// Arrow data type for parquet writing
@@ -156,7 +158,7 @@ fn flatten_param_into(param: &EventParam, prefix: &str, output: &mut Vec<Flatten
     if param.indexed && param.tuple_fields.is_some() {
         if let Some(TupleFieldInfo::Tuple(_)) = &param.tuple_fields {
             output.push(FlattenedField {
-                full_name: format!("{}.hash", prefix),
+                full_name: Arc::from(format!("{}.hash", prefix)),
                 leaf_type: DynSolType::FixedBytes(32),
                 arrow_type: DataType::FixedSizeBinary(32),
                 from_indexed: true,
@@ -170,7 +172,7 @@ fn flatten_param_into(param: &EventParam, prefix: &str, output: &mut Vec<Flatten
         None | Some(TupleFieldInfo::Leaf) => {
             // Leaf field - add directly
             output.push(FlattenedField {
-                full_name: prefix.to_string(),
+                full_name: Arc::from(prefix),
                 leaf_type: param.param_type.clone(),
                 arrow_type: param_type_to_arrow(&param.param_type),
                 from_indexed: param.indexed,
@@ -552,9 +554,9 @@ mod tests {
 
         // Check flattened fields
         assert_eq!(parsed.flattened_fields.len(), 3);
-        assert_eq!(parsed.flattened_fields[0].full_name, "from");
-        assert_eq!(parsed.flattened_fields[1].full_name, "to");
-        assert_eq!(parsed.flattened_fields[2].full_name, "value");
+        assert_eq!(parsed.flattened_fields[0].full_name.as_ref(), "from");
+        assert_eq!(parsed.flattened_fields[1].full_name.as_ref(), "to");
+        assert_eq!(parsed.flattened_fields[2].full_name.as_ref(), "value");
     }
 
     #[test]
@@ -624,18 +626,18 @@ mod tests {
 
         // Check flattened fields
         assert_eq!(parsed.flattened_fields.len(), 9);
-        assert_eq!(parsed.flattened_fields[0].full_name, "key.currency0");
-        assert_eq!(parsed.flattened_fields[1].full_name, "key.currency1");
-        assert_eq!(parsed.flattened_fields[2].full_name, "key.fee");
-        assert_eq!(parsed.flattened_fields[3].full_name, "key.tickSpacing");
-        assert_eq!(parsed.flattened_fields[4].full_name, "key.hooks");
-        assert_eq!(parsed.flattened_fields[5].full_name, "params.tickLower");
-        assert_eq!(parsed.flattened_fields[6].full_name, "params.tickUpper");
+        assert_eq!(parsed.flattened_fields[0].full_name.as_ref(), "key.currency0");
+        assert_eq!(parsed.flattened_fields[1].full_name.as_ref(), "key.currency1");
+        assert_eq!(parsed.flattened_fields[2].full_name.as_ref(), "key.fee");
+        assert_eq!(parsed.flattened_fields[3].full_name.as_ref(), "key.tickSpacing");
+        assert_eq!(parsed.flattened_fields[4].full_name.as_ref(), "key.hooks");
+        assert_eq!(parsed.flattened_fields[5].full_name.as_ref(), "params.tickLower");
+        assert_eq!(parsed.flattened_fields[6].full_name.as_ref(), "params.tickUpper");
         assert_eq!(
-            parsed.flattened_fields[7].full_name,
+            parsed.flattened_fields[7].full_name.as_ref(),
             "params.liquidityDelta"
         );
-        assert_eq!(parsed.flattened_fields[8].full_name, "params.salt");
+        assert_eq!(parsed.flattened_fields[8].full_name.as_ref(), "params.salt");
     }
 
     #[test]
@@ -656,14 +658,14 @@ mod tests {
 
         // Check flattened fields - indexed tuple should be a hash
         assert_eq!(parsed.flattened_fields.len(), 3);
-        assert_eq!(parsed.flattened_fields[0].full_name, "sender");
+        assert_eq!(parsed.flattened_fields[0].full_name.as_ref(), "sender");
         assert!(!parsed.flattened_fields[0]._isindexed_tuple_hash);
 
-        assert_eq!(parsed.flattened_fields[1].full_name, "poolKey.hash");
+        assert_eq!(parsed.flattened_fields[1].full_name.as_ref(), "poolKey.hash");
         assert!(parsed.flattened_fields[1]._isindexed_tuple_hash);
         assert!(parsed.flattened_fields[1].from_indexed);
 
-        assert_eq!(parsed.flattened_fields[2].full_name, "poolId");
+        assert_eq!(parsed.flattened_fields[2].full_name.as_ref(), "poolId");
     }
 
     #[test]
@@ -680,9 +682,9 @@ mod tests {
 
         // Check flattened fields
         assert_eq!(parsed.flattened_fields.len(), 3);
-        assert_eq!(parsed.flattened_fields[0].full_name, "key.a");
-        assert_eq!(parsed.flattened_fields[1].full_name, "key.b");
-        assert_eq!(parsed.flattened_fields[2].full_name, "deployer");
+        assert_eq!(parsed.flattened_fields[0].full_name.as_ref(), "key.a");
+        assert_eq!(parsed.flattened_fields[1].full_name.as_ref(), "key.b");
+        assert_eq!(parsed.flattened_fields[2].full_name.as_ref(), "deployer");
     }
 
     #[test]
@@ -702,22 +704,22 @@ mod tests {
         // Check flattened fields
         // sender, poolKey.hash, poolId, params.zeroForOne, params.amountSpecified, params.sqrtPriceLimitX96, amount0, amount1, hookData
         assert_eq!(parsed.flattened_fields.len(), 9);
-        assert_eq!(parsed.flattened_fields[0].full_name, "sender");
-        assert_eq!(parsed.flattened_fields[1].full_name, "poolKey.hash");
+        assert_eq!(parsed.flattened_fields[0].full_name.as_ref(), "sender");
+        assert_eq!(parsed.flattened_fields[1].full_name.as_ref(), "poolKey.hash");
         assert!(parsed.flattened_fields[1]._isindexed_tuple_hash);
-        assert_eq!(parsed.flattened_fields[2].full_name, "poolId");
-        assert_eq!(parsed.flattened_fields[3].full_name, "params.zeroForOne");
+        assert_eq!(parsed.flattened_fields[2].full_name.as_ref(), "poolId");
+        assert_eq!(parsed.flattened_fields[3].full_name.as_ref(), "params.zeroForOne");
         assert_eq!(
-            parsed.flattened_fields[4].full_name,
+            parsed.flattened_fields[4].full_name.as_ref(),
             "params.amountSpecified"
         );
         assert_eq!(
-            parsed.flattened_fields[5].full_name,
+            parsed.flattened_fields[5].full_name.as_ref(),
             "params.sqrtPriceLimitX96"
         );
-        assert_eq!(parsed.flattened_fields[6].full_name, "amount0");
-        assert_eq!(parsed.flattened_fields[7].full_name, "amount1");
-        assert_eq!(parsed.flattened_fields[8].full_name, "hookData");
+        assert_eq!(parsed.flattened_fields[6].full_name.as_ref(), "amount0");
+        assert_eq!(parsed.flattened_fields[7].full_name.as_ref(), "amount1");
+        assert_eq!(parsed.flattened_fields[8].full_name.as_ref(), "hookData");
     }
 
     #[test]
@@ -728,13 +730,13 @@ mod tests {
 
         assert_eq!(parsed.name, "Swap");
         assert_eq!(parsed.flattened_fields.len(), 8);
-        assert_eq!(parsed.flattened_fields[0].full_name, "id");
-        assert_eq!(parsed.flattened_fields[1].full_name, "sender");
-        assert_eq!(parsed.flattened_fields[2].full_name, "amount0");
-        assert_eq!(parsed.flattened_fields[3].full_name, "amount1");
-        assert_eq!(parsed.flattened_fields[4].full_name, "sqrtPriceX96");
-        assert_eq!(parsed.flattened_fields[5].full_name, "liquidity");
-        assert_eq!(parsed.flattened_fields[6].full_name, "tick");
-        assert_eq!(parsed.flattened_fields[7].full_name, "fee");
+        assert_eq!(parsed.flattened_fields[0].full_name.as_ref(), "id");
+        assert_eq!(parsed.flattened_fields[1].full_name.as_ref(), "sender");
+        assert_eq!(parsed.flattened_fields[2].full_name.as_ref(), "amount0");
+        assert_eq!(parsed.flattened_fields[3].full_name.as_ref(), "amount1");
+        assert_eq!(parsed.flattened_fields[4].full_name.as_ref(), "sqrtPriceX96");
+        assert_eq!(parsed.flattened_fields[5].full_name.as_ref(), "liquidity");
+        assert_eq!(parsed.flattened_fields[6].full_name.as_ref(), "tick");
+        assert_eq!(parsed.flattened_fields[7].full_name.as_ref(), "fee");
     }
 }

--- a/src/decoding/logs.rs
+++ b/src/decoding/logs.rs
@@ -687,13 +687,13 @@ fn flatten_single_value(
             if let DynSolType::Tuple(types) = &param.param_type {
                 for ((field_name, field_info), field_type) in field_infos.iter().zip(types.iter()) {
                     // Find the matching value
-                    let field_value = match named_values.iter().find(|(n, _)| n == field_name) {
+                    let field_value = match named_values.iter().find(|(n, _)| &**n == field_name) {
                         Some((_, v)) => v.clone(),
                         None => {
                             let expected_fields: Vec<String> =
                                 field_infos.iter().map(|(n, _)| n.clone()).collect();
                             let actual_fields: Vec<String> =
-                                named_values.iter().map(|(n, _)| n.clone()).collect();
+                                named_values.iter().map(|(n, _)| n.to_string()).collect();
                             return FlattenResult::MissingField {
                                 field_name: field_name.clone(),
                                 expected_fields,
@@ -776,7 +776,7 @@ fn convert_dyn_sol_value_with_tuple_info(
             for ((field_name, field_info), val) in field_infos.iter().zip(values.iter()) {
                 let decoded =
                     convert_dyn_sol_value_with_tuple_info(val, &Some(field_info.clone()))?;
-                named_values.push((field_name.clone(), decoded));
+                named_values.push((Arc::from(field_name.as_str()), decoded));
             }
             Ok(DecodedValue::NamedTuple(named_values))
         }
@@ -823,7 +823,7 @@ fn convert_dyn_sol_value(value: &DynSolValue) -> Result<DecodedValue, LogDecodin
                 .enumerate()
                 .map(|(i, v)| {
                     let decoded = convert_dyn_sol_value(v)?;
-                    Ok((format!("field_{}", i), decoded))
+                    Ok((Arc::<str>::from(format!("field_{}", i)), decoded))
                 })
                 .collect::<Result<Vec<_>, LogDecodingError>>()?;
             Ok(DecodedValue::NamedTuple(named))
@@ -853,7 +853,7 @@ fn write_decoded_logs_to_parquet(
     // Add fields from flattened_fields
     for flattened in &event.flattened_fields {
         fields.push(Field::new(
-            &flattened.full_name,
+            &*flattened.full_name,
             flattened.arrow_type.clone(),
             true,
         ));

--- a/src/transformations/context.rs
+++ b/src/transformations/context.rs
@@ -57,7 +57,7 @@ macro_rules! impl_field_extractor {
 #[allow(dead_code)]
 pub trait FieldExtractor {
     /// Returns the underlying field values map.
-    fn field_values(&self) -> &HashMap<String, DecodedValue>;
+    fn field_values(&self) -> &HashMap<Arc<str>, DecodedValue>;
 
     /// Returns contextual information for error messages (e.g., event name, block number).
     fn context_info(&self) -> String;
@@ -153,7 +153,7 @@ pub struct DecodedEvent {
     pub event_signature: String,
     /// Decoded parameter values keyed by field name.
     /// Uses flattened field names like "key.currency0" for nested tuples.
-    pub params: HashMap<String, DecodedValue>,
+    pub params: HashMap<Arc<str>, DecodedValue>,
 }
 
 #[allow(dead_code)]
@@ -172,7 +172,7 @@ impl DecodedEvent {
 }
 
 impl FieldExtractor for DecodedEvent {
-    fn field_values(&self) -> &HashMap<String, DecodedValue> {
+    fn field_values(&self) -> &HashMap<Arc<str>, DecodedValue> {
         &self.params
     }
 
@@ -200,7 +200,7 @@ pub struct DecodedCall {
     /// Decoded return value(s) keyed by field name.
     /// For single return values, the key is the function name or "result".
     /// For tuples, uses field names from the output type.
-    pub result: HashMap<String, DecodedValue>,
+    pub result: HashMap<Arc<str>, DecodedValue>,
     /// Whether this call reverted during execution
     pub is_reverted: bool,
     /// If the call reverted, the reason string
@@ -223,7 +223,7 @@ impl DecodedCall {
 }
 
 impl FieldExtractor for DecodedCall {
-    fn field_values(&self) -> &HashMap<String, DecodedValue> {
+    fn field_values(&self) -> &HashMap<Arc<str>, DecodedValue> {
         &self.result
     }
 
@@ -742,7 +742,7 @@ fn encode_calldata(
 mod tests {
     use super::*;
 
-    fn make_test_event(params: HashMap<String, DecodedValue>) -> DecodedEvent {
+    fn make_test_event(params: HashMap<Arc<str>, DecodedValue>) -> DecodedEvent {
         DecodedEvent {
             block_number: 100,
             block_timestamp: 1234567890,
@@ -756,7 +756,7 @@ mod tests {
         }
     }
 
-    fn make_test_call(result: HashMap<String, DecodedValue>) -> DecodedCall {
+    fn make_test_call(result: HashMap<Arc<str>, DecodedValue>) -> DecodedCall {
         DecodedCall {
             block_number: 100,
             block_timestamp: 1234567890,
@@ -773,7 +773,7 @@ mod tests {
     #[test]
     fn test_field_extractor_extract_address() {
         let mut params = HashMap::new();
-        params.insert("from".to_string(), DecodedValue::Address([42u8; 20]));
+        params.insert(Arc::from("from"), DecodedValue::Address([42u8; 20]));
         let event = make_test_event(params);
 
         let addr = event.extract_address("from").unwrap();
@@ -783,7 +783,7 @@ mod tests {
     #[test]
     fn test_field_extractor_extract_address_wrong_type() {
         let mut params = HashMap::new();
-        params.insert("from".to_string(), DecodedValue::Uint256(U256::from(100)));
+        params.insert(Arc::from("from"), DecodedValue::Uint256(U256::from(100)));
         let event = make_test_event(params);
 
         let result = event.extract_address("from");
@@ -796,7 +796,7 @@ mod tests {
     #[test]
     fn test_field_extractor_extract_uint256() {
         let mut params = HashMap::new();
-        params.insert("value".to_string(), DecodedValue::Uint256(U256::from(1000)));
+        params.insert(Arc::from("value"), DecodedValue::Uint256(U256::from(1000)));
         let event = make_test_event(params);
 
         let value = event.extract_uint256("value").unwrap();
@@ -806,7 +806,7 @@ mod tests {
     #[test]
     fn test_field_extractor_extract_bool() {
         let mut result = HashMap::new();
-        result.insert("isToken0".to_string(), DecodedValue::Bool(true));
+        result.insert(Arc::from("isToken0"), DecodedValue::Bool(true));
         let call = make_test_call(result);
 
         let is_token0 = call.extract_bool("isToken0").unwrap();
@@ -828,20 +828,20 @@ mod tests {
     fn test_field_extractor_u64_flexible() {
         // Test with native u64
         let mut params = HashMap::new();
-        params.insert("timestamp".to_string(), DecodedValue::Uint64(1234567890));
+        params.insert(Arc::from("timestamp"), DecodedValue::Uint64(1234567890));
         let event = make_test_event(params);
         assert_eq!(event.extract_u64_flexible("timestamp").unwrap(), 1234567890);
 
         // Test with i64 (common in some encodings)
         let mut params = HashMap::new();
-        params.insert("timestamp".to_string(), DecodedValue::Int64(1234567890));
+        params.insert(Arc::from("timestamp"), DecodedValue::Int64(1234567890));
         let event = make_test_event(params);
         assert_eq!(event.extract_u64_flexible("timestamp").unwrap(), 1234567890);
 
         // Test with string
         let mut params = HashMap::new();
         params.insert(
-            "timestamp".to_string(),
+            Arc::from("timestamp"),
             DecodedValue::String("1234567890".to_string()),
         );
         let event = make_test_event(params);
@@ -852,20 +852,20 @@ mod tests {
     fn test_field_extractor_i32_flexible() {
         // Test with native i32
         let mut params = HashMap::new();
-        params.insert("tick".to_string(), DecodedValue::Int32(-12345));
+        params.insert(Arc::from("tick"), DecodedValue::Int32(-12345));
         let event = make_test_event(params);
         assert_eq!(event.extract_i32_flexible("tick").unwrap(), -12345);
 
         // Test with u32 (common for positive ticks)
         let mut params = HashMap::new();
-        params.insert("tick".to_string(), DecodedValue::Uint32(12345));
+        params.insert(Arc::from("tick"), DecodedValue::Uint32(12345));
         let event = make_test_event(params);
         assert_eq!(event.extract_i32_flexible("tick").unwrap(), 12345);
 
         // Test with string
         let mut params = HashMap::new();
         params.insert(
-            "tick".to_string(),
+            Arc::from("tick"),
             DecodedValue::String("-12345".to_string()),
         );
         let event = make_test_event(params);
@@ -876,19 +876,19 @@ mod tests {
     fn test_field_extractor_u32_flexible() {
         // Test with native u32
         let mut params = HashMap::new();
-        params.insert("fee".to_string(), DecodedValue::Uint32(3000));
+        params.insert(Arc::from("fee"), DecodedValue::Uint32(3000));
         let event = make_test_event(params);
         assert_eq!(event.extract_u32_flexible("fee").unwrap(), 3000);
 
         // Test with i32 (common in some encodings)
         let mut params = HashMap::new();
-        params.insert("fee".to_string(), DecodedValue::Int32(3000));
+        params.insert(Arc::from("fee"), DecodedValue::Int32(3000));
         let event = make_test_event(params);
         assert_eq!(event.extract_u32_flexible("fee").unwrap(), 3000);
 
         // Test with string
         let mut params = HashMap::new();
-        params.insert("fee".to_string(), DecodedValue::String("3000".to_string()));
+        params.insert(Arc::from("fee"), DecodedValue::String("3000".to_string()));
         let event = make_test_event(params);
         assert_eq!(event.extract_u32_flexible("fee").unwrap(), 3000);
     }
@@ -918,10 +918,10 @@ mod tests {
     fn test_decoded_call_implements_field_extractor() {
         let mut result = HashMap::new();
         result.insert(
-            "poolKey.currency0".to_string(),
+            Arc::from("poolKey.currency0"),
             DecodedValue::Address([10u8; 20]),
         );
-        result.insert("poolKey.fee".to_string(), DecodedValue::Uint32(3000));
+        result.insert(Arc::from("poolKey.fee"), DecodedValue::Uint32(3000));
         let call = make_test_call(result);
 
         // Use FieldExtractor methods

--- a/src/transformations/event/metrics/v4_hook_extract.rs
+++ b/src/transformations/event/metrics/v4_hook_extract.rs
@@ -251,9 +251,9 @@ mod tests {
         amount1: i128,
     ) -> DecodedEvent {
         let mut params = HashMap::new();
-        params.insert("poolId".to_string(), DecodedValue::Bytes32(pool_id));
-        params.insert("amount0".to_string(), DecodedValue::Int128(amount0));
-        params.insert("amount1".to_string(), DecodedValue::Int128(amount1));
+        params.insert(Arc::from("poolId"), DecodedValue::Bytes32(pool_id));
+        params.insert(Arc::from("amount0"), DecodedValue::Int128(amount0));
+        params.insert(Arc::from("amount1"), DecodedValue::Int128(amount1));
         DecodedEvent {
             block_number,
             block_timestamp: 1000,
@@ -285,10 +285,10 @@ mod tests {
     ) -> DecodedCall {
         let mut result = HashMap::new();
         result.insert(
-            "sqrtPriceX96".to_string(),
+            Arc::from("sqrtPriceX96"),
             DecodedValue::Uint256(sqrt_price_x96),
         );
-        result.insert("tick".to_string(), DecodedValue::Int32(tick));
+        result.insert(Arc::from("tick"), DecodedValue::Int32(tick));
         DecodedCall {
             block_number,
             block_timestamp: 1000,
@@ -415,23 +415,23 @@ mod tests {
 
         let mut params = HashMap::new();
         params.insert(
-            "key.currency0".to_string(),
+            Arc::from("key.currency0"),
             DecodedValue::Address(currency0),
         );
         params.insert(
-            "key.currency1".to_string(),
+            Arc::from("key.currency1"),
             DecodedValue::Address(currency1),
         );
-        params.insert("key.fee".to_string(), DecodedValue::Uint32(fee));
+        params.insert(Arc::from("key.fee"), DecodedValue::Uint32(fee));
         params.insert(
-            "key.tickSpacing".to_string(),
+            Arc::from("key.tickSpacing"),
             DecodedValue::Int32(tick_spacing),
         );
-        params.insert("key.hooks".to_string(), DecodedValue::Address(hooks));
-        params.insert("params.tickLower".to_string(), DecodedValue::Int32(-100));
-        params.insert("params.tickUpper".to_string(), DecodedValue::Int32(100));
+        params.insert(Arc::from("key.hooks"), DecodedValue::Address(hooks));
+        params.insert(Arc::from("params.tickLower"), DecodedValue::Int32(-100));
+        params.insert(Arc::from("params.tickUpper"), DecodedValue::Int32(100));
         params.insert(
-            "params.liquidityDelta".to_string(),
+            Arc::from("params.liquidityDelta"),
             DecodedValue::Int256(I256::try_from(500_000i64).unwrap()),
         );
 
@@ -477,11 +477,11 @@ mod tests {
         let pool_id = [3u8; 32];
 
         let mut params = HashMap::new();
-        params.insert("id".to_string(), DecodedValue::Bytes32(pool_id));
-        params.insert("tickLower".to_string(), DecodedValue::Int32(-200));
-        params.insert("tickUpper".to_string(), DecodedValue::Int32(200));
+        params.insert(Arc::from("id"), DecodedValue::Bytes32(pool_id));
+        params.insert(Arc::from("tickLower"), DecodedValue::Int32(-200));
+        params.insert(Arc::from("tickUpper"), DecodedValue::Int32(200));
         params.insert(
-            "liquidityDelta".to_string(),
+            Arc::from("liquidityDelta"),
             DecodedValue::Int256(I256::try_from(-250_000i64).unwrap()),
         );
 

--- a/src/transformations/event/v4/metrics.rs
+++ b/src/transformations/event/v4/metrics.rs
@@ -865,16 +865,17 @@ mod tests {
         tick: i32,
         total_proceeds: u64,
         total_tokens_sold: u64,
-    ) -> std::collections::HashMap<String, crate::types::decoded::DecodedValue> {
+    ) -> std::collections::HashMap<std::sync::Arc<str>, crate::types::decoded::DecodedValue> {
         use crate::types::decoded::DecodedValue;
+        use std::sync::Arc;
         let mut params = std::collections::HashMap::new();
-        params.insert("currentTick".to_string(), DecodedValue::Int32(tick));
+        params.insert(Arc::from("currentTick"), DecodedValue::Int32(tick));
         params.insert(
-            "totalProceeds".to_string(),
+            Arc::from("totalProceeds"),
             DecodedValue::Uint256(U256::from(total_proceeds)),
         );
         params.insert(
-            "totalTokensSold".to_string(),
+            Arc::from("totalTokensSold"),
             DecodedValue::Uint256(U256::from(total_tokens_sold)),
         );
         params

--- a/src/transformations/historical.rs
+++ b/src/transformations/historical.rs
@@ -4,7 +4,7 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::RwLock;
+use std::sync::{Arc, RwLock};
 
 use arrow::array::{
     Array, BinaryArray, BooleanArray, FixedSizeBinaryArray, Int16Array, Int32Array, Int64Array,
@@ -474,7 +474,7 @@ fn batch_to_events(
 
         for (col_idx, field) in &param_columns {
             if let Some(value) = extract_value_from_batch(&batch, *col_idx, row)? {
-                params.insert(field.name().clone(), value);
+                params.insert(Arc::from(field.name().as_str()), value);
             }
         }
 
@@ -539,10 +539,10 @@ fn batch_to_calls(
         for (col_idx, field) in &result_columns {
             if let Some(value) = extract_value_from_batch(&batch, *col_idx, row)? {
                 // Map generic "decoded_value" column to the function name for handler access
-                let key = if field.name() == "decoded_value" {
-                    function_name.to_string()
+                let key: Arc<str> = if field.name() == "decoded_value" {
+                    Arc::from(function_name)
                 } else {
-                    field.name().clone()
+                    Arc::from(field.name().as_str())
                 };
                 result.insert(key, value);
             }
@@ -743,7 +743,7 @@ fn extract_struct_value(
     for (col_idx, field) in fields.iter().enumerate() {
         let col = struct_arr.column(col_idx);
         let val = extract_value_from_array(col.as_ref(), row)?;
-        values.push((field.name().clone(), val));
+        values.push((Arc::from(field.name().as_str()), val));
     }
 
     if is_unnamed {

--- a/src/transformations/retry.rs
+++ b/src/transformations/retry.rs
@@ -1115,7 +1115,7 @@ mod tests {
             source_name: "Pool".to_string(),
             function_name: "slot0".to_string(),
             trigger_log_index: None,
-            result: HashMap::from([("result".to_string(), DecodedValue::Uint64(1))]),
+            result: HashMap::from([(Arc::from("result"), DecodedValue::Uint64(1))]),
             is_reverted: false,
             revert_reason: None,
         }];

--- a/src/types/decoded.rs
+++ b/src/types/decoded.rs
@@ -1,4 +1,5 @@
 use std::str::FromStr;
+use std::sync::Arc;
 
 use alloy::primitives::{I256, U256};
 use serde::{Deserialize, Serialize};
@@ -23,7 +24,7 @@ pub enum DecodedValue {
     Bytes(Vec<u8>),
     String(String),
     /// Named tuple of (field_name, field_value) pairs
-    NamedTuple(Vec<(String, DecodedValue)>),
+    NamedTuple(Vec<(Arc<str>, DecodedValue)>),
     /// Unnamed tuple of values (no field names)
     UnnamedTuple(Vec<DecodedValue>),
     /// Array of values
@@ -161,7 +162,7 @@ impl DecodedValue {
     pub fn get_field(&self, name: &str) -> Option<&DecodedValue> {
         match self {
             DecodedValue::NamedTuple(fields) => {
-                fields.iter().find(|(n, _)| n == name).map(|(_, v)| v)
+                fields.iter().find(|(n, _)| &**n == name).map(|(_, v)| v)
             }
             _ => None,
         }


### PR DESCRIPTION
## Summary

- Changes decoded field name strings from `String` to `Arc<str>` in `DecodedEvent.params` keys, `DecodedCall.result` keys, and `DecodedValue::NamedTuple` field names
- `FlattenedField.full_name` (created once per event type during parsing) becomes `Arc<str>`, so all downstream `params.insert(flattened.full_name.clone(), ...)` are pointer copies instead of string allocations
- Eliminates ~90MB of duplicate field name strings per active 10K-block range — field names like "amount0", "sender", "sqrtPriceX96" were previously allocated fresh for every event instance

## Files changed

- `decoded.rs` — `NamedTuple(Vec<(Arc<str>, DecodedValue)>)`
- `context.rs` — `DecodedEvent.params`, `DecodedCall.result`, `FieldExtractor::field_values()` return type
- `event_parsing.rs` — `FlattenedField.full_name: Arc<str>`
- `logs.rs` — NamedTuple construction sites
- `eth_calls/decode.rs` — NamedTuple construction
- `eth_calls/transform.rs` — `build_result_map`, `build_result_map_for_merge`, `insert_flattened`
- `historical.rs` — parquet deserialization keys
- `retry.rs` — flows through existing clone sites
- 2 test files — key construction updated

Serde/bincode compatibility maintained — `Arc<str>` serializes identically to `String`.

Note: will conflict with `perf/arc-wrap-tx-addresses` on `context.rs` — straightforward merge resolution.