### PR TITLE
fix: bound event call catchup memory with windowed JoinSet and trigger batching

### DIFF
--- a/src/decoding/catchup/eth_calls.rs
+++ b/src/decoding/catchup/eth_calls.rs
@@ -842,6 +842,8 @@ mod tests {
             decoding_concurrency: Some(1),
             factory_concurrency: None,
             event_call_concurrency: None,
+            event_call_window_size: None,
+            event_call_trigger_batch_size: None,
             live_mode: None,
             reorg_depth: None,
             compaction_interval_secs: None,

--- a/src/decoding/current/eth_calls/mod.rs
+++ b/src/decoding/current/eth_calls/mod.rs
@@ -277,6 +277,8 @@ mod tests {
             decoding_concurrency: None,
             factory_concurrency: None,
             event_call_concurrency: None,
+            event_call_window_size: None,
+            event_call_trigger_batch_size: None,
             live_mode: None,
             reorg_depth: None,
             compaction_interval_secs: None,

--- a/src/raw_data/historical/catchup/eth_calls.rs
+++ b/src/raw_data/historical/catchup/eth_calls.rs
@@ -21,9 +21,10 @@ use crate::raw_data::historical::eth_calls::{
     process_range, process_range_multicall, read_event_trigger_log_batches_from_parquet_async,
     scan_existing_parquet_files_async, AbortOnDropHandles, BlockInfo, BlockRange,
     EthCallCatchupState, EthCallCollectionError, EthCallContext, EventCallKey,
-    EventTriggeredCallConfig, FrequencyState, OnceCallConfig,
+    EventTriggeredCallConfig, ExistingLogRange, FrequencyState, OnceCallConfig,
 };
 use crate::raw_data::historical::factories::{get_factory_call_configs, FactoryAddressData};
+use crate::types::config::defaults;
 use crate::raw_data::historical::receipts::{
     build_event_trigger_matchers, extract_event_triggers_from_batches, EventTriggerData,
     EventTriggerMatcher,
@@ -963,280 +964,299 @@ pub async fn collect_eth_calls(
         // The I/O semaphore gates log reads and repair validation to avoid
         // exhausting file descriptors. The RPC semaphore gates network calls.
         // Contract index writes are deferred to after all ranges complete.
+        //
+        // Ranges are processed in windows to bound peak memory: only `window_size`
+        // tasks are alive in the JoinSet at any time. Each window is fully drained
+        // before the next one is spawned.
         let mut processed_event_ranges: Vec<(u64, u64)> = Vec::new();
+
+        // Pre-filter ranges (CPU-only checks, no I/O)
+        let eligible_ranges: Vec<(usize, &ExistingLogRange)> = log_ranges
+            .iter()
+            .enumerate()
+            .filter(|(_, log_range)| {
+                if let Some(scope) = repair_scope {
+                    if !scope.matches_range(log_range.start, log_range.end) {
+                        return false;
+                    }
+                }
+                !active_event_output_pairs_for_range(&catchup_event_call_configs, log_range.end)
+                    .is_empty()
+            })
+            .collect();
+
+        let window_size = raw_data_config
+            .event_call_window_size
+            .unwrap_or(event_call_concurrency * defaults::raw_data::EVENT_CALL_WINDOW_MULTIPLIER);
+        let trigger_batch_size = raw_data_config
+            .event_call_trigger_batch_size
+            .unwrap_or(defaults::raw_data::EVENT_CALL_TRIGGER_BATCH_SIZE);
+
         {
             let io_semaphore =
                 Arc::new(tokio::sync::Semaphore::new(event_call_concurrency * 2));
             let rpc_semaphore = Arc::new(tokio::sync::Semaphore::new(event_call_concurrency));
-            let mut join_set: tokio::task::JoinSet<
-                Result<Option<(u64, u64)>, EthCallCollectionError>,
-            > = tokio::task::JoinSet::new();
 
-            for (idx, log_range) in log_ranges.iter().enumerate() {
-                // Cheap pre-filters (CPU only, no I/O) stay outside spawn
-                if let Some(scope) = repair_scope {
-                    if !scope.matches_range(log_range.start, log_range.end) {
-                        continue;
-                    }
-                }
+            for window in eligible_ranges.chunks(window_size) {
+                let mut join_set: tokio::task::JoinSet<
+                    Result<Option<(u64, u64)>, EthCallCollectionError>,
+                > = tokio::task::JoinSet::new();
 
-                if active_event_output_pairs_for_range(&catchup_event_call_configs, log_range.end)
-                    .is_empty()
-                {
-                    continue;
-                }
+                for &(idx, log_range) in window {
+                    // Clone per-task data
+                    let io_semaphore = io_semaphore.clone();
+                    let rpc_semaphore = rpc_semaphore.clone();
+                    let event_matchers = event_matchers_arc.clone();
+                    let event_call_configs = event_call_configs_arc.clone();
+                    let factory_addresses = factory_addresses_arc.clone();
+                    let existing_files = existing_files_arc.clone();
+                    let contracts = contracts_arc.clone();
+                    let base_output_dir = base_output_dir_arc.clone();
+                    let s3_manifest = s3_manifest.clone();
+                    let s3_manifest_check = s3_manifest_arc.clone();
+                    let storage_manager: Option<Arc<StorageManager>> = storage_manager_arc.clone();
+                    let chain_name = chain_name_arc.clone();
+                    let client = client.clone();
+                    let decoder_tx = decoder_tx.clone();
+                    let factory_contract_indexes = factory_contract_indexes_arc.clone();
+                    let factory_collections = factory_collections_arc.clone();
+                    let log_range = log_range.clone();
 
-                // Clone per-task data
-                let io_semaphore = io_semaphore.clone();
-                let rpc_semaphore = rpc_semaphore.clone();
-                let event_matchers = event_matchers_arc.clone();
-                let event_call_configs = event_call_configs_arc.clone();
-                let factory_addresses = factory_addresses_arc.clone();
-                let existing_files = existing_files_arc.clone();
-                let contracts = contracts_arc.clone();
-                let base_output_dir = base_output_dir_arc.clone();
-                let s3_manifest = s3_manifest.clone();
-                let s3_manifest_check = s3_manifest_arc.clone();
-                let storage_manager: Option<Arc<StorageManager>> = storage_manager_arc.clone();
-                let chain_name = chain_name_arc.clone();
-                let client = client.clone();
-                let decoder_tx = decoder_tx.clone();
-                let factory_contract_indexes = factory_contract_indexes_arc.clone();
-                let factory_collections = factory_collections_arc.clone();
-                let log_range = log_range.clone();
+                    join_set.spawn(async move {
+                        let range_start = log_range.start;
+                        let inclusive_end = log_range.end - 1;
+                        let factory_range_key = range_key(range_start, inclusive_end);
+                        let ready_factory_sources_for_range: HashSet<String> = factory_collections
+                            .iter()
+                            .filter(|collection_name| {
+                                factory_contract_indexes
+                                    .get(*collection_name)
+                                    .is_some_and(|index| index.contains_key(&factory_range_key))
+                                    && factory_addresses.contains_key(*collection_name)
+                            })
+                            .cloned()
+                            .collect();
 
-                join_set.spawn(async move {
-                    let range_start = log_range.start;
-                    let inclusive_end = log_range.end - 1;
-                    let factory_range_key = range_key(range_start, inclusive_end);
-                    let ready_factory_sources_for_range: HashSet<String> = factory_collections
-                        .iter()
-                        .filter(|collection_name| {
-                            factory_contract_indexes
-                                .get(*collection_name)
-                                .is_some_and(|index| index.contains_key(&factory_range_key))
-                                && factory_addresses.contains_key(*collection_name)
-                        })
-                        .cloned()
-                        .collect();
+                        // === Skip check (non-repair only) ===
+                        if !repair {
+                            let event_expected_for_range =
+                                build_expected_factory_contracts_for_range(&contracts, log_range.end);
 
-                    // === Skip check (non-repair only) ===
-                    if !repair {
-                        let event_expected_for_range =
-                            build_expected_factory_contracts_for_range(&contracts, log_range.end);
-
-                        let mut all_exist = true;
-                        'outer: for configs in event_call_configs.values() {
-                            for config in configs {
-                                if let Some(sb) = config.start_block {
-                                    if log_range.end <= sb {
-                                        continue;
+                            let mut all_exist = true;
+                            'outer: for configs in event_call_configs.values() {
+                                for config in configs {
+                                    if let Some(sb) = config.start_block {
+                                        if log_range.end <= sb {
+                                            continue;
+                                        }
+                                    }
+                                    let expected_for_config = if config.is_factory {
+                                        event_expected_for_range.get(&config.contract_name).cloned()
+                                    } else {
+                                        None
+                                    };
+                                    if !event_output_exists_async(
+                                        base_output_dir.to_path_buf(),
+                                        config.contract_name.clone(),
+                                        config.function_name.clone(),
+                                        log_range.start,
+                                        log_range.end,
+                                        s3_manifest_check.clone(),
+                                        expected_for_config,
+                                    )
+                                    .await?
+                                    {
+                                        all_exist = false;
+                                        break 'outer;
                                     }
                                 }
-                                let expected_for_config = if config.is_factory {
-                                    event_expected_for_range.get(&config.contract_name).cloned()
-                                } else {
-                                    None
-                                };
-                                if !event_output_exists_async(
-                                    base_output_dir.to_path_buf(),
-                                    config.contract_name.clone(),
-                                    config.function_name.clone(),
-                                    log_range.start,
-                                    log_range.end,
-                                    s3_manifest_check.clone(),
-                                    expected_for_config,
+                            }
+
+                            if all_exist {
+                                tracing::debug!(
+                                    "Skipping event-triggered calls for blocks {}-{} (already exists)",
+                                    range_start,
+                                    inclusive_end
+                                );
+                                return Ok(None);
+                            }
+                        }
+
+                        // === I/O phase: acquire permit to limit concurrent file reads ===
+                        let _io_permit = io_semaphore.acquire_owned().await.unwrap();
+
+                        // Read projected parquet + extract triggers
+                        let batches = match read_event_trigger_log_batches_from_parquet_async(
+                            log_range.file_path.clone(),
+                        )
+                        .await
+                        {
+                            Ok(batches) => batches,
+                            Err(e) => {
+                                tracing::warn!(
+                                    "Failed to read projected logs from {}: {}",
+                                    log_range.file_path.display(),
+                                    e
+                                );
+                                return Ok(None);
+                            }
+                        };
+
+                        let log_count: usize = batches.iter().map(|b| b.num_rows()).sum();
+                        if log_count == 0 {
+                            return Ok(None);
+                        }
+
+                        tracing::info!(
+                            "Catchup: processing event-triggered calls for blocks {}-{} ({} logs)",
+                            range_start,
+                            inclusive_end,
+                            log_count
+                        );
+
+                        let triggers =
+                            extract_event_triggers_from_batches(&batches, event_matchers.as_ref());
+                        let (triggers, filtered_factory_triggers) =
+                            filter_ready_factory_event_triggers(
+                                triggers,
+                                &factory_addresses,
+                                &ready_factory_sources_for_range,
+                            );
+                        drop(batches);
+
+                        if filtered_factory_triggers > 0 {
+                            tracing::debug!(
+                                "Catchup: filtered {} factory event triggers for blocks {}-{} using pre-loaded factory addresses",
+                                filtered_factory_triggers,
+                                range_start,
+                                inclusive_end
+                            );
+                        }
+
+                        // Repair validation (repair only, after extraction)
+                        if repair {
+                            let needs_processing = repair_needs_event_recollection(
+                                &base_output_dir,
+                                &event_call_configs,
+                                &factory_addresses,
+                                &contracts,
+                                &triggers,
+                                range_start,
+                                inclusive_end,
+                            )
+                            .await?;
+
+                            if !needs_processing {
+                                tracing::debug!(
+                                    "Skipping event-triggered calls for blocks {}-{} (already verified)",
+                                    range_start,
+                                    inclusive_end
+                                );
+                                return Ok(None);
+                            }
+                        }
+
+                        // Release I/O permit before RPC phase
+                        drop(_io_permit);
+
+                        if !triggers.is_empty() {
+                            tracing::info!(
+                                "Extracted {} event triggers for blocks {}-{}",
+                                triggers.len(),
+                                range_start,
+                                inclusive_end
+                            );
+                        }
+
+                        // === Acquire permit for RPC phase ===
+                        let permit = rpc_semaphore.acquire_owned().await.unwrap();
+
+                        // RPC phase — hold permit to limit concurrent RPC work
+                        let (skipped, mut pending_writes) = {
+                            let _permit = permit; // dropped at end of this block
+
+                            let event_ctx = EthCallContext {
+                                client: &client,
+                                output_dir: &base_output_dir,
+                                existing_files: &existing_files,
+                                rpc_batch_size,
+                                repair,
+                                decoder_tx: &decoder_tx,
+                                chain_name: &chain_name,
+                                storage_manager: storage_manager.as_ref(),
+                                s3_manifest: &s3_manifest,
+                            };
+                            if let Some(multicall_addr) = multicall3_address {
+                                process_event_triggers_multicall(
+                                    triggers,
+                                    &event_call_configs,
+                                    &factory_addresses,
+                                    &event_ctx,
+                                    multicall_addr,
+                                    range_start,
+                                    inclusive_end,
+                                    &contracts,
+                                    true,
+                                    trigger_batch_size,
                                 )
                                 .await?
-                                {
-                                    all_exist = false;
-                                    break 'outer;
+                            } else {
+                                process_event_triggers(
+                                    triggers,
+                                    &event_call_configs,
+                                    &factory_addresses,
+                                    &event_ctx,
+                                    range_start,
+                                    inclusive_end,
+                                    &contracts,
+                                    true,
+                                    trigger_batch_size,
+                                )
+                                .await?
+                            }
+                        }; // permit released — next range's RPC can start immediately
+
+                        if !skipped.is_empty() {
+                            tracing::warn!(
+                                "Unexpected skipped factory triggers during catchup ({} triggers) — factory addresses should be pre-loaded",
+                                skipped.len()
+                            );
+                        }
+
+                        // Write phase — no permit held, runs concurrently with other ranges' RPC
+                        while let Some(result) = pending_writes.join_next().await {
+                            match result {
+                                Ok(Ok(())) => {}
+                                Ok(Err(e)) => return Err(e),
+                                Err(e) => {
+                                    return Err(EthCallCollectionError::JoinError(e.to_string()))
                                 }
                             }
                         }
 
-                        if all_exist {
-                            tracing::debug!(
-                                "Skipping event-triggered calls for blocks {}-{} (already exists)",
-                                range_start,
-                                inclusive_end
-                            );
-                            return Ok(None);
-                        }
-                    }
-
-                    // === I/O phase: acquire permit to limit concurrent file reads ===
-                    let _io_permit = io_semaphore.acquire_owned().await.unwrap();
-
-                    // Read projected parquet + extract triggers
-                    let batches = match read_event_trigger_log_batches_from_parquet_async(
-                        log_range.file_path.clone(),
-                    )
-                    .await
-                    {
-                        Ok(batches) => batches,
-                        Err(e) => {
-                            tracing::warn!(
-                                "Failed to read projected logs from {}: {}",
-                                log_range.file_path.display(),
-                                e
-                            );
-                            return Ok(None);
-                        }
-                    };
-
-                    let log_count: usize = batches.iter().map(|b| b.num_rows()).sum();
-                    if log_count == 0 {
-                        return Ok(None);
-                    }
-
-                    tracing::info!(
-                        "Catchup: processing event-triggered calls for blocks {}-{} ({} logs)",
-                        range_start,
-                        inclusive_end,
-                        log_count
-                    );
-
-                    let triggers =
-                        extract_event_triggers_from_batches(&batches, event_matchers.as_ref());
-                    let (triggers, filtered_factory_triggers) =
-                        filter_ready_factory_event_triggers(
-                            triggers,
-                            &factory_addresses,
-                            &ready_factory_sources_for_range,
-                        );
-                    drop(batches);
-
-                    if filtered_factory_triggers > 0 {
                         tracing::debug!(
-                            "Catchup: filtered {} factory event triggers for blocks {}-{} using pre-loaded factory addresses",
-                            filtered_factory_triggers,
+                            "Event-triggered calls catchup: processed range {}/{} (blocks {}-{})",
+                            idx + 1,
+                            total_log_ranges,
                             range_start,
                             inclusive_end
                         );
-                    }
 
-                    // Repair validation (repair only, after extraction)
-                    if repair {
-                        let needs_processing = repair_needs_event_recollection(
-                            &base_output_dir,
-                            &event_call_configs,
-                            &factory_addresses,
-                            &contracts,
-                            &triggers,
-                            range_start,
-                            inclusive_end,
-                        )
-                        .await?;
+                        Ok(Some((range_start, inclusive_end)))
+                    });
+                }
 
-                        if !needs_processing {
-                            tracing::debug!(
-                                "Skipping event-triggered calls for blocks {}-{} (already verified)",
-                                range_start,
-                                inclusive_end
-                            );
-                            return Ok(None);
+                // Drain current window before spawning next
+                while let Some(result) = join_set.join_next().await {
+                    match result {
+                        Ok(Ok(Some((start, end)))) => {
+                            processed_event_ranges.push((start, end));
                         }
-                    }
-
-                    // Release I/O permit before RPC phase
-                    drop(_io_permit);
-
-                    if !triggers.is_empty() {
-                        tracing::info!(
-                            "Extracted {} event triggers for blocks {}-{}",
-                            triggers.len(),
-                            range_start,
-                            inclusive_end
-                        );
-                    }
-
-                    // === Acquire permit for RPC phase ===
-                    let permit = rpc_semaphore.acquire_owned().await.unwrap();
-
-                    // RPC phase — hold permit to limit concurrent RPC work
-                    let (skipped, mut pending_writes) = {
-                        let _permit = permit; // dropped at end of this block
-
-                        let event_ctx = EthCallContext {
-                            client: &client,
-                            output_dir: &base_output_dir,
-                            existing_files: &existing_files,
-                            rpc_batch_size,
-                            repair,
-                            decoder_tx: &decoder_tx,
-                            chain_name: &chain_name,
-                            storage_manager: storage_manager.as_ref(),
-                            s3_manifest: &s3_manifest,
-                        };
-                        if let Some(multicall_addr) = multicall3_address {
-                            process_event_triggers_multicall(
-                                triggers,
-                                &event_call_configs,
-                                &factory_addresses,
-                                &event_ctx,
-                                multicall_addr,
-                                range_start,
-                                inclusive_end,
-                                &contracts,
-                                true,
-                            )
-                            .await?
-                        } else {
-                            process_event_triggers(
-                                triggers,
-                                &event_call_configs,
-                                &factory_addresses,
-                                &event_ctx,
-                                range_start,
-                                inclusive_end,
-                                &contracts,
-                                true,
-                            )
-                            .await?
+                        Ok(Ok(None)) => {}
+                        Ok(Err(e)) => return Err(e),
+                        Err(e) => {
+                            return Err(EthCallCollectionError::JoinError(e.to_string()));
                         }
-                    }; // permit released — next range's RPC can start immediately
-
-                    if !skipped.is_empty() {
-                        tracing::warn!(
-                            "Unexpected skipped factory triggers during catchup ({} triggers) — factory addresses should be pre-loaded",
-                            skipped.len()
-                        );
-                    }
-
-                    // Write phase — no permit held, runs concurrently with other ranges' RPC
-                    while let Some(result) = pending_writes.join_next().await {
-                        match result {
-                            Ok(Ok(())) => {}
-                            Ok(Err(e)) => return Err(e),
-                            Err(e) => {
-                                return Err(EthCallCollectionError::JoinError(e.to_string()))
-                            }
-                        }
-                    }
-
-                    tracing::debug!(
-                        "Event-triggered calls catchup: processed range {}/{} (blocks {}-{})",
-                        idx + 1,
-                        total_log_ranges,
-                        range_start,
-                        inclusive_end
-                    );
-
-                    Ok(Some((range_start, inclusive_end)))
-                });
-            }
-
-            // Collect results from all spawned tasks
-            while let Some(result) = join_set.join_next().await {
-                match result {
-                    Ok(Ok(Some((start, end)))) => {
-                        processed_event_ranges.push((start, end));
-                    }
-                    Ok(Ok(None)) => {}
-                    Ok(Err(e)) => return Err(e),
-                    Err(e) => {
-                        return Err(EthCallCollectionError::JoinError(e.to_string()));
                     }
                 }
             }

--- a/src/raw_data/historical/current/eth_calls/events.rs
+++ b/src/raw_data/historical/current/eth_calls/events.rs
@@ -71,6 +71,7 @@ pub(super) async fn handle_event_trigger_message(
                             inclusive_end,
                             &state.contracts,
                             false,
+                            0, // no trigger batching in live mode
                         )
                         .await?
                     } else {
@@ -83,6 +84,7 @@ pub(super) async fn handle_event_trigger_message(
                             inclusive_end,
                             &state.contracts,
                             false,
+                            0, // no trigger batching in live mode
                         )
                         .await?
                     };

--- a/src/raw_data/historical/current/eth_calls/factory.rs
+++ b/src/raw_data/historical/current/eth_calls/factory.rs
@@ -99,6 +99,7 @@ pub(super) async fn handle_factory_message(
                                     buf_range_end,
                                     &state.contracts,
                                     false,
+                                    0, // no trigger batching in live mode
                                 )
                                 .await?
                             } else {
@@ -111,6 +112,7 @@ pub(super) async fn handle_factory_message(
                                     buf_range_end,
                                     &state.contracts,
                                     false,
+                                    0, // no trigger batching in live mode
                                 )
                                 .await?
                             };

--- a/src/raw_data/historical/eth_calls/event_triggers.rs
+++ b/src/raw_data/historical/eth_calls/event_triggers.rs
@@ -47,11 +47,13 @@ pub struct SkippedFactoryTrigger {
 /// An event-triggered call matched with its config and encoded parameters,
 /// ready to be grouped by output key.
 pub(super) struct PreparedEventCall {
-    pub trigger: EventTriggerData,
-    pub config: EventTriggeredCallConfig,
+    pub block_number: u64,
+    pub block_timestamp: u64,
+    pub log_index: u32,
+    pub config: Arc<EventTriggeredCallConfig>,
     pub target_address: Address,
     pub decoded_values: Vec<DynSolValue>,
-    pub encoded_params: Vec<Vec<u8>>,
+    pub encoded_params: Arc<Vec<Vec<u8>>>,
 }
 
 /// A fully-built eth_call ready for RPC batch execution.
@@ -59,9 +61,11 @@ pub(super) struct PreparedEventCall {
 pub(super) struct PendingEventCall {
     pub request: TransactionRequest,
     pub block_id: BlockId,
-    pub trigger: EventTriggerData,
+    pub block_number: u64,
+    pub block_timestamp: u64,
+    pub log_index: u32,
     pub target_address: Address,
-    pub encoded_params: Vec<Vec<u8>>,
+    pub encoded_params: Arc<Vec<Vec<u8>>>,
 }
 
 /// Build event-triggered call configs from contracts configuration
@@ -594,6 +598,7 @@ pub(crate) async fn process_event_triggers(
     range_end: u64,
     contracts: &Contracts,
     skip_contract_index: bool,
+    trigger_batch_size: usize,
 ) -> Result<(Vec<SkippedFactoryTrigger>, PendingWrites), EthCallCollectionError> {
     let mut skipped_factory_triggers: Vec<SkippedFactoryTrigger> = Vec::new();
     let empty_writes = PendingWrites::new();
@@ -638,144 +643,159 @@ pub(crate) async fn process_event_triggers(
         return Ok((skipped_factory_triggers, empty_writes));
     }
 
-    // Group triggers by (source_name, event_signature) and then by (contract_name, function_name)
-    // to batch calls together
-    let mut calls_by_output: HashMap<(String, String), Vec<PreparedEventCall>> = HashMap::new();
-
-    for trigger in triggers {
-        let key = (trigger.source_name.clone(), trigger.event_signature);
-
-        if let Some(configs) = event_call_configs.get(&key) {
-            for config in configs {
-                // Skip if trigger block is before contract's start_block
-                if let Some(sb) = config.start_block {
-                    if trigger.block_number < sb {
-                        continue;
-                    }
-                }
-
-                // Determine target address
-                let target_address = if let Some(addr) = config.target_address {
-                    addr
-                } else {
-                    // Factory collection - use event emitter, but ONLY if it's a known factory address
-                    let emitter = Address::from(trigger.emitter_address);
-                    match factory_addresses.get(&config.contract_name) {
-                        Some(known_addresses) => {
-                            if !known_addresses.contains(&emitter) {
-                                // Emitter not in known addresses — could be not-yet-discovered.
-                                // Buffer for replay; factory RangeComplete will drop if
-                                // this is a legitimate miss.
-                                skipped_factory_triggers.push(SkippedFactoryTrigger {
-                                    trigger: trigger.clone(),
-                                });
-                                tracing::debug!(
-                                    "Buffering event trigger: emitter {:?} not yet in known addresses for {}",
-                                    emitter,
-                                    config.contract_name
-                                );
-                                continue;
-                            }
-                            emitter
-                        }
-                        None => {
-                            // No factory addresses known yet for this collection
-                            // Buffer the trigger for replay when addresses arrive
-                            skipped_factory_triggers.push(SkippedFactoryTrigger {
-                                trigger: trigger.clone(),
-                            });
-                            tracing::debug!(
-                                "Buffering event trigger for {}: no factory addresses loaded yet",
-                                config.contract_name
-                            );
-                            continue;
-                        }
-                    }
-                };
-
-                // Build parameters
-                let (params, encoded_params) =
-                    match build_event_call_params(&trigger, &config.params) {
-                        Ok(p) => p,
-                        Err(e) => {
-                            tracing::warn!(
-                                "Failed to build params for {}.{} from event: {}",
-                                config.contract_name,
-                                config.function_name,
-                                e
-                            );
-                            continue;
-                        }
-                    };
-
-                let output_key = (config.contract_name.clone(), config.function_name.clone());
-                calls_by_output
-                    .entry(output_key)
-                    .or_default()
-                    .push(PreparedEventCall {
-                        trigger: trigger.clone(),
-                        config: config.clone(),
-                        target_address,
-                        decoded_values: params,
-                        encoded_params,
-                    });
-            }
-        }
-    }
-
     // Track which (contract_name, function_name) pairs got results
     let mut written_pairs: HashSet<(String, String)> = HashSet::new();
 
-    // Phase 1: Submit ALL RPC calls across all groups in a single batch
-    // This maximizes RPC throughput vs. the old sequential-per-group approach.
+    // Accumulate results across trigger chunks. Each chunk builds PreparedEventCalls,
+    // submits RPC, and merges results here. Writing happens once after all chunks.
+    let mut group_results: HashMap<(String, String), (Vec<EventCallResult>, usize)> =
+        HashMap::new();
+
     struct TaggedCall {
         output_key: (String, String),
         pending: PendingEventCall,
         max_params: usize,
     }
 
-    let mut all_tagged: Vec<TaggedCall> = Vec::new();
-    for ((contract_name, function_name), calls) in &calls_by_output {
-        if calls.is_empty() {
+    // Determine chunk boundaries: 0 means "no chunking" (old behavior)
+    let chunk_size = if trigger_batch_size == 0 {
+        triggers.len()
+    } else {
+        trigger_batch_size
+    };
+
+    for trigger_chunk in triggers.chunks(chunk_size) {
+        // Group this chunk's triggers by (contract_name, function_name)
+        let mut calls_by_output: HashMap<(String, String), Vec<PreparedEventCall>> =
+            HashMap::new();
+
+        for trigger in trigger_chunk {
+            let key = (trigger.source_name.clone(), trigger.event_signature);
+
+            if let Some(configs) = event_call_configs.get(&key) {
+                for config in configs {
+                    // Skip if trigger block is before contract's start_block
+                    if let Some(sb) = config.start_block {
+                        if trigger.block_number < sb {
+                            continue;
+                        }
+                    }
+
+                    // Determine target address
+                    let target_address = if let Some(addr) = config.target_address {
+                        addr
+                    } else {
+                        // Factory collection - use event emitter, but ONLY if it's a known factory address
+                        let emitter = Address::from(trigger.emitter_address);
+                        match factory_addresses.get(&config.contract_name) {
+                            Some(known_addresses) => {
+                                if !known_addresses.contains(&emitter) {
+                                    skipped_factory_triggers.push(SkippedFactoryTrigger {
+                                        trigger: trigger.clone(),
+                                    });
+                                    tracing::debug!(
+                                        "Buffering event trigger: emitter {:?} not yet in known addresses for {}",
+                                        emitter,
+                                        config.contract_name
+                                    );
+                                    continue;
+                                }
+                                emitter
+                            }
+                            None => {
+                                skipped_factory_triggers.push(SkippedFactoryTrigger {
+                                    trigger: trigger.clone(),
+                                });
+                                tracing::debug!(
+                                    "Buffering event trigger for {}: no factory addresses loaded yet",
+                                    config.contract_name
+                                );
+                                continue;
+                            }
+                        }
+                    };
+
+                    // Build parameters
+                    let (params, encoded_params) =
+                        match build_event_call_params(trigger, &config.params) {
+                            Ok(p) => p,
+                            Err(e) => {
+                                tracing::warn!(
+                                    "Failed to build params for {}.{} from event: {}",
+                                    config.contract_name,
+                                    config.function_name,
+                                    e
+                                );
+                                continue;
+                            }
+                        };
+
+                    let output_key = (config.contract_name.clone(), config.function_name.clone());
+                    let config_arc = Arc::new(config.clone());
+                    calls_by_output
+                        .entry(output_key)
+                        .or_default()
+                        .push(PreparedEventCall {
+                            block_number: trigger.block_number,
+                            block_timestamp: trigger.block_timestamp,
+                            log_index: trigger.log_index,
+                            config: config_arc,
+                            target_address,
+                            decoded_values: params,
+                            encoded_params: Arc::new(encoded_params),
+                        });
+                }
+            }
+        }
+
+        // Build tagged calls for this chunk's RPC batch
+        let mut all_tagged: Vec<TaggedCall> = Vec::new();
+        for ((contract_name, function_name), calls) in &calls_by_output {
+            if calls.is_empty() {
+                continue;
+            }
+            written_pairs.insert((contract_name.clone(), function_name.clone()));
+
+            let max_params = calls
+                .iter()
+                .map(|c| c.encoded_params.len())
+                .max()
+                .unwrap_or(0);
+
+            for call in calls {
+                let calldata =
+                    encode_call_with_params(call.config.function_selector, &call.decoded_values);
+                let tx = TransactionRequest::default()
+                    .to(call.target_address)
+                    .input(calldata.into());
+                let block_id = BlockId::Number(BlockNumberOrTag::Number(call.block_number));
+                all_tagged.push(TaggedCall {
+                    output_key: (contract_name.clone(), function_name.clone()),
+                    pending: PendingEventCall {
+                        request: tx,
+                        block_id,
+                        block_number: call.block_number,
+                        block_timestamp: call.block_timestamp,
+                        log_index: call.log_index,
+                        target_address: call.target_address,
+                        encoded_params: call.encoded_params.clone(),
+                    },
+                    max_params,
+                });
+            }
+        }
+
+        if all_tagged.is_empty() {
             continue;
         }
-        written_pairs.insert((contract_name.clone(), function_name.clone()));
 
-        let max_params = calls
-            .iter()
-            .map(|c| c.encoded_params.len())
-            .max()
-            .unwrap_or(0);
-
-        for call in calls {
-            let calldata =
-                encode_call_with_params(call.config.function_selector, &call.decoded_values);
-            let tx = TransactionRequest::default()
-                .to(call.target_address)
-                .input(calldata.into());
-            let block_id = BlockId::Number(BlockNumberOrTag::Number(call.trigger.block_number));
-            all_tagged.push(TaggedCall {
-                output_key: (contract_name.clone(), function_name.clone()),
-                pending: PendingEventCall {
-                    request: tx,
-                    block_id,
-                    trigger: call.trigger.clone(),
-                    target_address: call.target_address,
-                    encoded_params: call.encoded_params.clone(),
-                },
-                max_params,
-            });
-        }
-    }
-
-    if !all_tagged.is_empty() {
         let batch_calls: Vec<(TransactionRequest, BlockId)> = all_tagged
             .iter()
             .map(|t| (t.pending.request.clone(), t.pending.block_id))
             .collect();
 
         tracing::info!(
-            "Submitting {} event-triggered eth_calls in single batch for blocks {}-{}",
+            "Submitting {} event-triggered eth_calls in batch for blocks {}-{}",
             batch_calls.len(),
             range_start,
             range_end
@@ -783,22 +803,18 @@ pub(crate) async fn process_event_triggers(
 
         let results = ctx.client.call_batch(batch_calls).await?;
 
-        // Distribute results back to groups
-        let mut group_results: HashMap<(String, String), (Vec<EventCallResult>, usize)> =
-            HashMap::new();
-
         for (i, result) in results.into_iter().enumerate() {
             let tagged = &all_tagged[i];
             let call = &tagged.pending;
 
             let event_result = match result {
                 Ok(bytes) => EventCallResult {
-                    block_number: call.trigger.block_number,
-                    block_timestamp: call.trigger.block_timestamp,
-                    log_index: call.trigger.log_index,
+                    block_number: call.block_number,
+                    block_timestamp: call.block_timestamp,
+                    log_index: call.log_index,
                     target_address: call.target_address.0 .0,
                     value_bytes: bytes.to_vec(),
-                    param_values: call.encoded_params.clone(),
+                    param_values: (*call.encoded_params).clone(),
                     is_reverted: false,
                     revert_reason: None,
                 },
@@ -808,17 +824,17 @@ pub(crate) async fn process_event_triggers(
                         "Event-triggered eth_call reverted for {}.{} at block {} (address {}): {}",
                         tagged.output_key.0,
                         tagged.output_key.1,
-                        call.trigger.block_number,
+                        call.block_number,
                         call.target_address,
                         reason
                     );
                     EventCallResult {
-                        block_number: call.trigger.block_number,
-                        block_timestamp: call.trigger.block_timestamp,
-                        log_index: call.trigger.log_index,
+                        block_number: call.block_number,
+                        block_timestamp: call.block_timestamp,
+                        log_index: call.log_index,
                         target_address: call.target_address.0 .0,
                         value_bytes: Vec::new(),
-                        param_values: call.encoded_params.clone(),
+                        param_values: (*call.encoded_params).clone(),
                         is_reverted: true,
                         revert_reason: Some(reason),
                     }
@@ -830,7 +846,9 @@ pub(crate) async fn process_event_triggers(
                 .or_insert_with(|| (Vec::new(), tagged.max_params));
             entry.0.push(event_result);
         }
+    } // end trigger chunk loop
 
+    if !group_results.is_empty() {
         // Phase 2: Write all groups concurrently
         let mut write_set: tokio::task::JoinSet<Result<(), EthCallCollectionError>> =
             tokio::task::JoinSet::new();
@@ -1030,6 +1048,7 @@ pub(crate) async fn process_event_triggers_multicall(
     range_end: u64,
     contracts: &Contracts,
     skip_contract_index: bool,
+    trigger_batch_size: usize,
 ) -> Result<(Vec<SkippedFactoryTrigger>, PendingWrites), EthCallCollectionError> {
     let mut skipped_factory_triggers: Vec<SkippedFactoryTrigger> = Vec::new();
     let empty_writes = PendingWrites::new();
@@ -1074,254 +1093,258 @@ pub(crate) async fn process_event_triggers_multicall(
         return Ok((skipped_factory_triggers, empty_writes));
     }
 
-    // Group triggers by (source_name, event_signature) and prepare call info
-    // Key: (contract_name, function_name)
-    let mut calls_by_output: HashMap<(String, String), Vec<PreparedEventCall>> = HashMap::new();
+    // Accumulate results across trigger chunks. Each chunk builds PreparedEventCalls,
+    // executes multicalls, and merges results here. Writing happens once after all chunks.
+    let mut group_results: HashMap<(String, String), Vec<EventCallResult>> = HashMap::new();
+    let mut written_pairs: HashSet<(String, String)> = HashSet::new();
 
-    for trigger in triggers {
-        let key = (trigger.source_name.clone(), trigger.event_signature);
+    // Determine chunk boundaries: 0 means "no chunking" (old behavior)
+    let chunk_size = if trigger_batch_size == 0 {
+        triggers.len()
+    } else {
+        trigger_batch_size
+    };
 
-        if let Some(configs) = event_call_configs.get(&key) {
-            for config in configs {
-                // Skip if trigger block is before contract's start_block
-                if let Some(sb) = config.start_block {
-                    if trigger.block_number < sb {
-                        continue;
+    for trigger_chunk in triggers.chunks(chunk_size) {
+        // Group this chunk's triggers by (contract_name, function_name)
+        let mut calls_by_output: HashMap<(String, String), Vec<PreparedEventCall>> =
+            HashMap::new();
+
+        for trigger in trigger_chunk {
+            let key = (trigger.source_name.clone(), trigger.event_signature);
+
+            if let Some(configs) = event_call_configs.get(&key) {
+                for config in configs {
+                    if let Some(sb) = config.start_block {
+                        if trigger.block_number < sb {
+                            continue;
+                        }
                     }
-                }
 
-                // Determine target address
-                let target_address = if let Some(addr) = config.target_address {
-                    addr
-                } else {
-                    // Factory collection - use event emitter, but ONLY if it's a known factory address
-                    let emitter = Address::from(trigger.emitter_address);
-                    match factory_addresses.get(&config.contract_name) {
-                        Some(known_addresses) => {
-                            if !known_addresses.contains(&emitter) {
-                                // Emitter not in known addresses — could be not-yet-discovered.
-                                // Buffer for replay; factory RangeComplete will drop if
-                                // this is a legitimate miss.
+                    let target_address = if let Some(addr) = config.target_address {
+                        addr
+                    } else {
+                        let emitter = Address::from(trigger.emitter_address);
+                        match factory_addresses.get(&config.contract_name) {
+                            Some(known_addresses) => {
+                                if !known_addresses.contains(&emitter) {
+                                    skipped_factory_triggers.push(SkippedFactoryTrigger {
+                                        trigger: trigger.clone(),
+                                    });
+                                    tracing::debug!(
+                                        "Buffering event trigger: emitter {:?} not yet in known addresses for {}",
+                                        emitter,
+                                        config.contract_name
+                                    );
+                                    continue;
+                                }
+                                emitter
+                            }
+                            None => {
                                 skipped_factory_triggers.push(SkippedFactoryTrigger {
                                     trigger: trigger.clone(),
                                 });
                                 tracing::debug!(
-                                    "Buffering event trigger: emitter {:?} not yet in known addresses for {}",
-                                    emitter,
+                                    "Buffering event trigger for {}: no factory addresses loaded yet",
                                     config.contract_name
                                 );
                                 continue;
                             }
-                            emitter
-                        }
-                        None => {
-                            // No factory addresses known yet for this collection
-                            // Buffer the trigger for replay when addresses arrive
-                            skipped_factory_triggers.push(SkippedFactoryTrigger {
-                                trigger: trigger.clone(),
-                            });
-                            tracing::debug!(
-                                "Buffering event trigger for {}: no factory addresses loaded yet",
-                                config.contract_name
-                            );
-                            continue;
-                        }
-                    }
-                };
-
-                // Build parameters
-                let (params, encoded_params) =
-                    match build_event_call_params(&trigger, &config.params) {
-                        Ok(p) => p,
-                        Err(e) => {
-                            tracing::warn!(
-                                "Failed to build params for {}.{} from event: {}",
-                                config.contract_name,
-                                config.function_name,
-                                e
-                            );
-                            continue;
                         }
                     };
 
-                let output_key = (config.contract_name.clone(), config.function_name.clone());
-                calls_by_output
-                    .entry(output_key)
-                    .or_default()
-                    .push(PreparedEventCall {
-                        trigger: trigger.clone(),
-                        config: config.clone(),
-                        target_address,
-                        decoded_values: params,
-                        encoded_params,
-                    });
-            }
-        }
-    }
+                    let (params, encoded_params) =
+                        match build_event_call_params(trigger, &config.params) {
+                            Ok(p) => p,
+                            Err(e) => {
+                                tracing::warn!(
+                                    "Failed to build params for {}.{} from event: {}",
+                                    config.contract_name,
+                                    config.function_name,
+                                    e
+                                );
+                                continue;
+                            }
+                        };
 
-    if calls_by_output.is_empty() {
-        return Ok((skipped_factory_triggers, empty_writes));
-    }
-
-    // Group all calls by block number for multicall batching
-    let mut calls_by_block: HashMap<u64, Vec<PreparedEventCall>> = HashMap::new();
-
-    for ((_contract_name, _function_name), calls) in calls_by_output {
-        for call in calls {
-            let block_number = call.trigger.block_number;
-            calls_by_block.entry(block_number).or_default().push(call);
-        }
-    }
-
-    // Build per-block multicalls with block info included in metadata
-    let mut sorted_blocks: Vec<u64> = calls_by_block.keys().copied().collect();
-    sorted_blocks.sort_unstable();
-
-    let mut block_multicalls: Vec<BlockMulticall<(EventCallMeta, u64, u64)>> = Vec::new();
-
-    for block_number in sorted_blocks {
-        if let Some(calls) = calls_by_block.get(&block_number) {
-            let mut slots: Vec<MulticallSlotGeneric<(EventCallMeta, u64, u64)>> = Vec::new();
-
-            for call_info in calls {
-                let calldata = encode_call_with_params(
-                    call_info.config.function_selector,
-                    &call_info.decoded_values,
-                );
-                slots.push(MulticallSlotGeneric {
-                    block_number,
-                    block_timestamp: call_info.trigger.block_timestamp,
-                    target_address: call_info.target_address,
-                    encoded_calldata: calldata,
-                    metadata: (
-                        EventCallMeta {
-                            contract_name: call_info.config.contract_name.clone(),
-                            function_name: call_info.config.function_name.clone(),
-                            target_address: call_info.target_address,
-                            log_index: call_info.trigger.log_index,
-                            param_values: call_info.encoded_params.clone(),
-                        },
-                        block_number,
-                        call_info.trigger.block_timestamp,
-                    ),
-                });
-            }
-
-            if !slots.is_empty() {
-                block_multicalls.push(BlockMulticall {
-                    block_number,
-                    block_id: BlockId::Number(BlockNumberOrTag::Number(block_number)),
-                    slots,
-                });
-            }
-        }
-    }
-
-    if block_multicalls.is_empty() {
-        return Ok((skipped_factory_triggers, empty_writes));
-    }
-
-    // Get min/max blocks for logging and file naming
-    let min_block = block_multicalls
-        .iter()
-        .map(|bm| bm.block_number)
-        .min()
-        .unwrap();
-    let max_block = block_multicalls
-        .iter()
-        .map(|bm| bm.block_number)
-        .max()
-        .unwrap();
-
-    // Split oversized multicalls to prevent RPC timeouts on blocks with many events.
-    // A single multicall with 50+ sub-calls can take seconds to execute on the node,
-    // causing timeouts and retries that tank throughput.
-    const MAX_SUBCALLS_PER_MULTICALL: usize = 25;
-    let total_subcalls: usize = block_multicalls.iter().map(|bm| bm.slots.len()).sum();
-    let max_subcalls = block_multicalls
-        .iter()
-        .map(|bm| bm.slots.len())
-        .max()
-        .unwrap_or(0);
-
-    let block_multicalls: Vec<BlockMulticall<(EventCallMeta, u64, u64)>> =
-        if max_subcalls > MAX_SUBCALLS_PER_MULTICALL {
-            let mut split = Vec::with_capacity(block_multicalls.len() * 2);
-            for bm in block_multicalls {
-                if bm.slots.len() <= MAX_SUBCALLS_PER_MULTICALL {
-                    split.push(bm);
-                } else {
-                    // Split into chunks, each becoming its own multicall at the same block
-                    for chunk in bm.slots.chunks(MAX_SUBCALLS_PER_MULTICALL) {
-                        split.push(BlockMulticall {
-                            block_number: bm.block_number,
-                            block_id: bm.block_id,
-                            slots: chunk.to_vec(),
+                    let output_key = (config.contract_name.clone(), config.function_name.clone());
+                    let config_arc = Arc::new(config.clone());
+                    calls_by_output
+                        .entry(output_key)
+                        .or_default()
+                        .push(PreparedEventCall {
+                            block_number: trigger.block_number,
+                            block_timestamp: trigger.block_timestamp,
+                            log_index: trigger.log_index,
+                            config: config_arc,
+                            target_address,
+                            decoded_values: params,
+                            encoded_params: Arc::new(encoded_params),
                         });
-                    }
                 }
             }
-            split
-        } else {
-            block_multicalls
-        };
-
-    tracing::info!(
-        "Executing {} multicalls ({} sub-calls, max {}/block) for event-triggered calls in blocks {}-{}",
-        block_multicalls.len(),
-        total_subcalls,
-        max_subcalls,
-        min_block,
-        max_block
-    );
-
-    // Execute all multicalls
-    let results = execute_multicalls_generic(
-        ctx.client,
-        multicall3_address,
-        block_multicalls,
-        ctx.chain_name,
-    )
-    .await?;
-
-    // Distribute results back to groups
-    let mut group_results: HashMap<(String, String), Vec<EventCallResult>> = HashMap::new();
-
-    for ((meta, block_number, block_timestamp), return_data, success) in results {
-        let key = (meta.contract_name.clone(), meta.function_name.clone());
-        let is_reverted = !success;
-        let revert_reason = if is_reverted {
-            Some(format!(
-                "Multicall3 reported failure for {}.{} at block {}",
-                meta.contract_name, meta.function_name, block_number
-            ))
-        } else {
-            None
-        };
-        if is_reverted {
-            tracing::warn!(
-                "Multicall event-triggered eth_call reverted for {}.{} at block {} (address {}, log_index {})",
-                meta.contract_name,
-                meta.function_name,
-                block_number,
-                meta.target_address,
-                meta.log_index
-            );
         }
-        group_results.entry(key).or_default().push(EventCallResult {
-            block_number,
-            block_timestamp,
-            log_index: meta.log_index,
-            target_address: meta.target_address.0 .0,
-            value_bytes: if is_reverted { Vec::new() } else { return_data },
-            param_values: meta.param_values,
-            is_reverted,
-            revert_reason,
-        });
-    }
 
-    // Track which (contract_name, function_name) pairs got results
-    let mut written_pairs: HashSet<(String, String)> = HashSet::new();
+        if calls_by_output.is_empty() {
+            continue;
+        }
+
+        // Track output pairs for this chunk
+        for key in calls_by_output.keys() {
+            written_pairs.insert(key.clone());
+        }
+
+        // Group all calls by block number for multicall batching
+        let mut calls_by_block: HashMap<u64, Vec<PreparedEventCall>> = HashMap::new();
+
+        for ((_contract_name, _function_name), calls) in calls_by_output {
+            for call in calls {
+                let block_number = call.block_number;
+                calls_by_block.entry(block_number).or_default().push(call);
+            }
+        }
+
+        // Build per-block multicalls with block info included in metadata
+        let mut sorted_blocks: Vec<u64> = calls_by_block.keys().copied().collect();
+        sorted_blocks.sort_unstable();
+
+        let mut block_multicalls: Vec<BlockMulticall<(EventCallMeta, u64, u64)>> = Vec::new();
+
+        for block_number in sorted_blocks {
+            if let Some(calls) = calls_by_block.get(&block_number) {
+                let mut slots: Vec<MulticallSlotGeneric<(EventCallMeta, u64, u64)>> = Vec::new();
+
+                for call_info in calls {
+                    let calldata = encode_call_with_params(
+                        call_info.config.function_selector,
+                        &call_info.decoded_values,
+                    );
+                    slots.push(MulticallSlotGeneric {
+                        block_number,
+                        block_timestamp: call_info.block_timestamp,
+                        target_address: call_info.target_address,
+                        encoded_calldata: calldata,
+                        metadata: (
+                            EventCallMeta {
+                                contract_name: call_info.config.contract_name.clone(),
+                                function_name: call_info.config.function_name.clone(),
+                                target_address: call_info.target_address,
+                                log_index: call_info.log_index,
+                                param_values: call_info.encoded_params.clone(),
+                            },
+                            block_number,
+                            call_info.block_timestamp,
+                        ),
+                    });
+                }
+
+                if !slots.is_empty() {
+                    block_multicalls.push(BlockMulticall {
+                        block_number,
+                        block_id: BlockId::Number(BlockNumberOrTag::Number(block_number)),
+                        slots,
+                    });
+                }
+            }
+        }
+
+        if block_multicalls.is_empty() {
+            continue;
+        }
+
+        // Split oversized multicalls to prevent RPC timeouts
+        const MAX_SUBCALLS_PER_MULTICALL: usize = 25;
+        let total_subcalls: usize = block_multicalls.iter().map(|bm| bm.slots.len()).sum();
+        let max_subcalls = block_multicalls
+            .iter()
+            .map(|bm| bm.slots.len())
+            .max()
+            .unwrap_or(0);
+
+        let min_block = block_multicalls
+            .iter()
+            .map(|bm| bm.block_number)
+            .min()
+            .unwrap();
+        let max_block = block_multicalls
+            .iter()
+            .map(|bm| bm.block_number)
+            .max()
+            .unwrap();
+
+        let block_multicalls: Vec<BlockMulticall<(EventCallMeta, u64, u64)>> =
+            if max_subcalls > MAX_SUBCALLS_PER_MULTICALL {
+                let mut split = Vec::with_capacity(block_multicalls.len() * 2);
+                for bm in block_multicalls {
+                    if bm.slots.len() <= MAX_SUBCALLS_PER_MULTICALL {
+                        split.push(bm);
+                    } else {
+                        for chunk in bm.slots.chunks(MAX_SUBCALLS_PER_MULTICALL) {
+                            split.push(BlockMulticall {
+                                block_number: bm.block_number,
+                                block_id: bm.block_id,
+                                slots: chunk.to_vec(),
+                            });
+                        }
+                    }
+                }
+                split
+            } else {
+                block_multicalls
+            };
+
+        tracing::info!(
+            "Executing {} multicalls ({} sub-calls, max {}/block) for event-triggered calls in blocks {}-{}",
+            block_multicalls.len(),
+            total_subcalls,
+            max_subcalls,
+            min_block,
+            max_block
+        );
+
+        // Execute multicalls for this chunk
+        let results = execute_multicalls_generic(
+            ctx.client,
+            multicall3_address,
+            block_multicalls,
+            ctx.chain_name,
+        )
+        .await?;
+
+        // Merge results into group_results
+        for ((meta, block_number, block_timestamp), return_data, success) in results {
+            let key = (meta.contract_name.clone(), meta.function_name.clone());
+            let is_reverted = !success;
+            let revert_reason = if is_reverted {
+                Some(format!(
+                    "Multicall3 reported failure for {}.{} at block {}",
+                    meta.contract_name, meta.function_name, block_number
+                ))
+            } else {
+                None
+            };
+            if is_reverted {
+                tracing::warn!(
+                    "Multicall event-triggered eth_call reverted for {}.{} at block {} (address {}, log_index {})",
+                    meta.contract_name,
+                    meta.function_name,
+                    block_number,
+                    meta.target_address,
+                    meta.log_index
+                );
+            }
+            group_results.entry(key).or_default().push(EventCallResult {
+                block_number,
+                block_timestamp,
+                log_index: meta.log_index,
+                target_address: meta.target_address.0 .0,
+                value_bytes: if is_reverted { Vec::new() } else { return_data },
+                param_values: (*meta.param_values).clone(),
+                is_reverted,
+                revert_reason,
+            });
+        }
+    } // end trigger chunk loop
 
     // Write parquet, upload S3, and send to decoder for all groups CONCURRENTLY.
     // Each group writes to a different file, so there's no conflict.
@@ -1332,8 +1355,6 @@ pub(crate) async fn process_event_triggers_multicall(
         if results.is_empty() {
             continue;
         }
-
-        written_pairs.insert((contract_name.clone(), function_name.clone()));
 
         results.sort_by_key(|r| (r.block_number, r.log_index, r.target_address));
 
@@ -1385,11 +1406,11 @@ pub(crate) async fn process_event_triggers_multicall(
                 .await?;
 
             tracing::info!(
-                "Wrote {} multicall event-triggered eth_call results to {} (event blocks {}-{})",
+                "Wrote {} multicall event-triggered eth_call results to {} (blocks {}-{})",
                 result_count,
                 output_path.display(),
-                min_block,
-                max_block,
+                range_start,
+                range_end,
             );
 
             if let Some(ref sm) = storage_manager {

--- a/src/raw_data/historical/eth_calls/multicall.rs
+++ b/src/raw_data/historical/eth_calls/multicall.rs
@@ -1,5 +1,6 @@
 //! Multicall3 infrastructure: types, calldata encoding/decoding, and generic executor.
 
+use std::sync::Arc;
 use std::time::Instant;
 
 use metrics::histogram;
@@ -60,7 +61,7 @@ pub(crate) struct EventCallMeta {
     pub(crate) function_name: String,
     pub(crate) target_address: Address,
     pub(crate) log_index: u32,
-    pub(crate) param_values: Vec<Vec<u8>>,
+    pub(crate) param_values: Arc<Vec<Vec<u8>>>,
 }
 
 /// Metadata for once calls.

--- a/src/types/config/defaults.rs
+++ b/src/types/config/defaults.rs
@@ -47,6 +47,12 @@ pub mod raw_data {
     /// Default number of concurrent tasks for factory collection catchup
     pub const FACTORY_CONCURRENCY: usize = 4;
 
+    /// Default event-call catchup window size (multiplied by event_call_concurrency at runtime)
+    pub const EVENT_CALL_WINDOW_MULTIPLIER: usize = 3;
+
+    /// Default maximum triggers per RPC batch within a single range
+    pub const EVENT_CALL_TRIGGER_BATCH_SIZE: usize = 50000;
+
     /// Default number of blocks to track for reorg detection
     pub const REORG_DEPTH: u64 = 128;
 
@@ -134,6 +140,8 @@ mod tests {
         assert_eq!(raw_data::REORG_DEPTH, 128);
         assert_eq!(raw_data::COMPACTION_INTERVAL_SECS, 10);
         assert_eq!(raw_data::TRANSFORM_RETRY_GRACE_PERIOD_SECS, 300);
+        assert_eq!(raw_data::EVENT_CALL_WINDOW_MULTIPLIER, 3);
+        assert_eq!(raw_data::EVENT_CALL_TRIGGER_BATCH_SIZE, 50000);
     }
 
     #[test]

--- a/src/types/config/raw_data.rs
+++ b/src/types/config/raw_data.rs
@@ -28,6 +28,14 @@ pub struct RawDataCollectionConfig {
     /// Higher values improve throughput during catchup but use more RPC bandwidth.
     /// Default: 4
     pub event_call_concurrency: Option<usize>,
+    /// Maximum number of event-call log-range tasks alive in the JoinSet at once.
+    /// Lower values reduce peak memory; higher values improve pipeline throughput.
+    /// Default: event_call_concurrency * 3
+    pub event_call_window_size: Option<usize>,
+    /// Maximum number of event triggers to process per RPC batch within a single range.
+    /// Lower values reduce peak memory; set to 0 to disable chunking (old behavior).
+    /// Default: 50000
+    pub event_call_trigger_batch_size: Option<usize>,
     /// Enable WebSocket live mode after catchup completes.
     /// Requires ws_url_env_var to be set in chain config.
     pub live_mode: Option<bool>,


### PR DESCRIPTION
## Summary

Event call catchup was OOM-killing at 60GB+ RAM + 64GB swap. Root cause: all ~3000+ log ranges were spawned into a single JoinSet simultaneously, and within each range, trigger data was cloned 3-4 times through the processing pipeline.

Three fixes:

- **Windowed JoinSet**: process ranges in windows of `event_call_window_size` (default: `concurrency * 3 = 24`) instead of spawning all at once. Bounds live tasks from thousands to ~24.
- **Trigger batching**: within each range, process triggers in chunks of `event_call_trigger_batch_size` (default: 50000) instead of one giant RPC batch. Bounds peak intermediate allocations (PreparedEventCall, TaggedCall, batch_calls) to chunk size.
- **Reduced cloning**: flatten `EventTriggerData` into scalar fields in `PreparedEventCall`/`PendingEventCall` (only block_number, block_timestamp, log_index are read downstream). Arc-wrap `encoded_params` and `EventTriggeredCallConfig` to share across triggers instead of cloning.

## New config knobs

```json
{
  "event_call_window_size": 24,
  "event_call_trigger_batch_size": 50000
}
```

**If OOM persists**: lower `event_call_window_size` to match `event_call_concurrency`, lower `event_call_trigger_batch_size` to 10000.  
**If too slow**: raise `event_call_window_size` to `concurrency * 5`, raise `event_call_trigger_batch_size` to 100000+.  
**Disable batching**: set `event_call_trigger_batch_size` to 0.