### PR TITLE
fix: Solana repair data integrity and stale file cleanup

### DIFF
--- a/docs/solana/roadmap.md
+++ b/docs/solana/roadmap.md
@@ -14,9 +14,9 @@ Rather than abstracting everything behind traits, we use a **parallel implementa
 
 ## Branch Status
 
-This branch combines groundwork from data types and trait/runtime phases. Not a runnable Solana pipeline yet.
+Phases 1-7 are complete. The Solana historical pipeline is wired end-to-end: `chain_type: solana` in config activates signature-driven backfill, raw data collection, event/instruction decoding (via IDL or built-in decoders), and dispatches to the transformation engine when handlers exist. Live mode (Phase 8) is stubbed.
 
-Implemented:
+Implemented (Phases 1-2, from earlier work):
 - `src/types/chain.rs` with `ChainAddress`, `TxId`, `LogPosition`, and `ChainType`
 - `ChainConfig.chain_type` with a backward-compatible default of `evm`
 - `TransformationHandler::chain_type()` defaulting to `ChainType::Evm`
@@ -31,14 +31,37 @@ Implemented:
 - `serde-big-array` support for serializing `[u8; 64]` in `TxId::Solana`
 - UTF-8-safe RPC error truncation
 
-Not yet implemented:
-- Generalized `DecodedEvent` / `DecodedCall`
-- `ChainServices` wiring in `TransformationContext` (only a placeholder enum exists)
-- Solana config types such as `programs`, `idl_path`, or account-read config
-- `main.rs` chain-type dispatch or a real Solana pipeline
-- Solana RPC, raw-data, decoding, and live modules under `src/solana/`
+Implemented (Phases 3-6):
+- Solana config types: `SolanaProgramConfig`, `SolanaEventConfig`, `SolanaAccountReadConfig`, `SolanaDiscoveryConfig`, `SolanaCommitment`
+- `SolanaRpcClient` with rate limiting, retry, batch operations
+- `SolanaWsClient` with auto-reconnection and gap detection
+- Raw data collection: slot/block fetching, event/instruction extraction, signature-driven backfill
+- Address discovery: `DiscoveryManager` with bootstrap, event-driven discovery, persistence
+- `ProgramDecoder` trait with `AnchorDecoder` (IDL-driven) and `SplTokenDecoder` (built-in)
+- IDL parser supporting pre-0.30 and 0.30+ Anchor formats
+- Dynamic Borsh deserializer for IDL type trees
+- Event, instruction, and account decoder routers producing `DecodedEvent`/`DecodedAccountState`
 
-Practical implication: `chain_type: solana` is parsed and used for handler filtering, but it does not yet activate Solana collection, decoding, or live processing.
+Implemented (Phase 7):
+- `RangeCompleteKind::Instructions` for independent instruction completion signaling
+- `SolanaChainFeatures` detection from program config
+- `SolanaChainRuntime` with RPC client, decoder construction, program ID mapping
+- Decoder task functions (`decode_solana_events`, `decode_solana_instructions`) as async channel loops
+- `process_solana_chain()` historical pipeline entry point
+- `decode_only_solana_chain()` for re-decoding existing parquet
+- `main.rs` chain-type dispatch routing Solana chains to the new pipeline
+- `build_registry_for_solana_chain()` with source and chain-type filtering
+- Decoded Solana storage paths (`decoded_solana_events_dir`, `decoded_solana_instructions_dir`)
+- Solana RPC method variants in metrics
+
+Not yet implemented (Phase 8 — Live Mode):
+- Live slot collector via WebSocket subscription
+- Solana reorg detection via parent-slot chain verification
+- Live account reader (event-triggered account state fetches)
+- Live storage types and bincode persistence
+- `TransformationEngine` integration for Solana (requires making the EVM RPC client optional)
+
+Practical implication: `chain_type: solana` activates the full historical pipeline (backfill, decode, write parquet). Transformation handlers can be registered by implementing `TransformationHandler` with `chain_type() -> ChainType::Solana`. Live mode logs a warning and is skipped.
 
 ---
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -489,7 +489,7 @@ async fn main() -> anyhow::Result<()> {
                         );
                         Ok(())
                     } else if decode_only {
-                        solana::pipeline::decode_only_solana_chain(&config, &chain).await
+                        solana::pipeline::decode_only_solana_chain(&config, &chain, repair_scope).await
                     } else {
                         solana::pipeline::process_solana_chain(
                             &config,

--- a/src/main.rs
+++ b/src/main.rs
@@ -472,23 +472,72 @@ async fn main() -> anyhow::Result<()> {
         let repair_scope = repair_scope.clone();
 
         chain_tasks.spawn(async move {
-            let result = if live_only {
-                process_chain_live_only(&config, &chain, shared_db_pool).await
-            } else if repair_only {
-                repair_only_chain(&config, &chain, storage_manager, repair_scope).await
-            } else if decode_only {
-                decode_only_chain(&config, &chain, repair, repair_scope).await
-            } else {
-                process_chain(
-                    &config,
-                    &chain,
-                    storage_manager,
-                    catch_up_only,
-                    repair,
-                    repair_scope,
-                    shared_db_pool,
-                )
-                .await
+            let result = {
+                // Dispatch by chain type: Solana chains use a separate pipeline
+                #[cfg(feature = "solana")]
+                if chain.chain_type == types::chain::ChainType::Solana {
+                    if live_only {
+                        tracing::warn!(
+                            chain = chain.name.as_str(),
+                            "Live-only mode not yet supported for Solana chains"
+                        );
+                        Ok(())
+                    } else if repair_only {
+                        tracing::warn!(
+                            chain = chain.name.as_str(),
+                            "Repair mode not yet supported for Solana chains"
+                        );
+                        Ok(())
+                    } else if decode_only {
+                        solana::pipeline::decode_only_solana_chain(&config, &chain).await
+                    } else {
+                        solana::pipeline::process_solana_chain(
+                            &config,
+                            &chain,
+                            catch_up_only,
+                            shared_db_pool,
+                        )
+                        .await
+                    }
+                } else if live_only {
+                    process_chain_live_only(&config, &chain, shared_db_pool).await
+                } else if repair_only {
+                    repair_only_chain(&config, &chain, storage_manager, repair_scope).await
+                } else if decode_only {
+                    decode_only_chain(&config, &chain, repair, repair_scope).await
+                } else {
+                    process_chain(
+                        &config,
+                        &chain,
+                        storage_manager,
+                        catch_up_only,
+                        repair,
+                        repair_scope,
+                        shared_db_pool,
+                    )
+                    .await
+                }
+
+                // Without solana feature, all chains use the EVM pipeline
+                #[cfg(not(feature = "solana"))]
+                if live_only {
+                    process_chain_live_only(&config, &chain, shared_db_pool).await
+                } else if repair_only {
+                    repair_only_chain(&config, &chain, storage_manager, repair_scope).await
+                } else if decode_only {
+                    decode_only_chain(&config, &chain, repair, repair_scope).await
+                } else {
+                    process_chain(
+                        &config,
+                        &chain,
+                        storage_manager,
+                        catch_up_only,
+                        repair,
+                        repair_scope,
+                        shared_db_pool,
+                    )
+                    .await
+                }
             };
             (chain_name, result)
         });

--- a/src/main.rs
+++ b/src/main.rs
@@ -799,6 +799,7 @@ async fn process_chain_live_only(
                 expect_log_completion: runtime.features.has_events,
                 expect_eth_call_completion: runtime.features.has_calls,
                 expect_account_state_completion: false,
+                expect_instruction_completion: false,
             },
             runtime.progress_tracker.clone(),
         )
@@ -1644,6 +1645,7 @@ async fn process_chain(
                 expect_log_completion: has_events,
                 expect_eth_call_completion: has_calls,
                 expect_account_state_completion: false,
+                expect_instruction_completion: false,
             },
             pipeline.runtime.progress_tracker.clone(),
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -495,6 +495,8 @@ async fn main() -> anyhow::Result<()> {
                             &config,
                             &chain,
                             catch_up_only,
+                            repair,
+                            repair_scope,
                             shared_db_pool,
                         )
                         .await

--- a/src/metrics/rpc.rs
+++ b/src/metrics/rpc.rs
@@ -25,6 +25,21 @@ pub enum RpcMethod {
     GetLogsBatch,
     EthCallBatch,
     GetBlockReceiptsConcurrent,
+    // Solana RPC methods
+    #[cfg(feature = "solana")]
+    SolanaGetSlot,
+    #[cfg(feature = "solana")]
+    SolanaGetBlock,
+    #[cfg(feature = "solana")]
+    SolanaGetTransaction,
+    #[cfg(feature = "solana")]
+    SolanaGetSignaturesForAddress,
+    #[cfg(feature = "solana")]
+    SolanaGetAccountInfo,
+    #[cfg(feature = "solana")]
+    SolanaGetMultipleAccounts,
+    #[cfg(feature = "solana")]
+    SolanaGetProgramAccounts,
 }
 
 impl RpcMethod {
@@ -44,6 +59,20 @@ impl RpcMethod {
             Self::GetLogsBatch => "eth_getLogs_batch",
             Self::EthCallBatch => "eth_call_batch",
             Self::GetBlockReceiptsConcurrent => "eth_getBlockReceipts_concurrent",
+            #[cfg(feature = "solana")]
+            Self::SolanaGetSlot => "solana_getSlot",
+            #[cfg(feature = "solana")]
+            Self::SolanaGetBlock => "solana_getBlock",
+            #[cfg(feature = "solana")]
+            Self::SolanaGetTransaction => "solana_getTransaction",
+            #[cfg(feature = "solana")]
+            Self::SolanaGetSignaturesForAddress => "solana_getSignaturesForAddress",
+            #[cfg(feature = "solana")]
+            Self::SolanaGetAccountInfo => "solana_getAccountInfo",
+            #[cfg(feature = "solana")]
+            Self::SolanaGetMultipleAccounts => "solana_getMultipleAccounts",
+            #[cfg(feature = "solana")]
+            Self::SolanaGetProgramAccounts => "solana_getProgramAccounts",
         }
     }
 }

--- a/src/solana/decoding/decoded_parquet.rs
+++ b/src/solana/decoding/decoded_parquet.rs
@@ -1,0 +1,378 @@
+//! Arrow schema and parquet writing for decoded Solana events and instructions.
+//!
+//! Decoded events use a fixed structural schema with parameters serialized as
+//! JSON, rather than the per-event-type flattened schema used by the EVM
+//! decoder.  This keeps the writer generic across all program/event types.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+
+use arrow::array::{
+    ArrayRef, FixedSizeBinaryArray, FixedSizeBinaryBuilder, StringArray, UInt16Array, UInt64Array,
+};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+
+use crate::transformations::context::DecodedEvent;
+use crate::types::chain::{ChainAddress, LogPosition, TxId};
+use crate::types::decoded::DecodedValue;
+
+/// Build the Arrow schema for decoded Solana event parquet files.
+///
+/// Schema:
+/// - slot: UInt64
+/// - block_timestamp: UInt64
+/// - transaction_signature: FixedSizeBinary(64)
+/// - program_id: FixedSizeBinary(32)
+/// - instruction_index: UInt16
+/// - inner_instruction_index: UInt16 (nullable)
+/// - source_name: Utf8
+/// - event_name: Utf8
+/// - params: Utf8 (JSON-serialized)
+pub fn build_decoded_event_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("slot", DataType::UInt64, false),
+        Field::new("block_timestamp", DataType::UInt64, false),
+        Field::new(
+            "transaction_signature",
+            DataType::FixedSizeBinary(64),
+            false,
+        ),
+        Field::new("program_id", DataType::FixedSizeBinary(32), false),
+        Field::new("instruction_index", DataType::UInt16, false),
+        Field::new("inner_instruction_index", DataType::UInt16, true),
+        Field::new("source_name", DataType::Utf8, false),
+        Field::new("event_name", DataType::Utf8, false),
+        Field::new("params", DataType::Utf8, false),
+    ]))
+}
+
+/// Extract the Solana transaction signature bytes from a [`TxId`].
+fn tx_signature_bytes(tx_id: &TxId) -> [u8; 64] {
+    match tx_id {
+        TxId::Solana(sig) => *sig,
+        TxId::Evm(_) => [0u8; 64],
+    }
+}
+
+/// Extract the Solana program ID bytes from a [`ChainAddress`].
+fn program_id_bytes(addr: &ChainAddress) -> [u8; 32] {
+    match addr {
+        ChainAddress::Solana(pubkey) => *pubkey,
+        ChainAddress::Evm(_) => [0u8; 32],
+    }
+}
+
+/// Extract instruction_index and inner_instruction_index from a [`LogPosition`].
+fn instruction_indices(pos: &LogPosition) -> (u16, Option<u16>) {
+    match pos {
+        LogPosition::Solana {
+            instruction_index,
+            inner_instruction_index,
+        } => (*instruction_index, *inner_instruction_index),
+        LogPosition::Evm { .. } => (0, None),
+    }
+}
+
+/// Serialize params to JSON string.
+fn params_to_json(params: &HashMap<String, DecodedValue>) -> String {
+    serde_json::to_string(params).unwrap_or_else(|_| "{}".to_string())
+}
+
+/// Write decoded events to a parquet file.
+///
+/// Uses the fixed structural schema from [`build_decoded_event_schema`].
+pub fn write_decoded_events_to_parquet(
+    events: &[DecodedEvent],
+    schema: &Arc<Schema>,
+    output_path: &Path,
+) -> Result<(), std::io::Error> {
+    let mut arrays: Vec<ArrayRef> = Vec::new();
+
+    // slot (block_number)
+    let arr: UInt64Array = events.iter().map(|e| Some(e.block_number)).collect();
+    arrays.push(Arc::new(arr));
+
+    // block_timestamp
+    let arr: UInt64Array = events.iter().map(|e| Some(e.block_timestamp)).collect();
+    arrays.push(Arc::new(arr));
+
+    // transaction_signature (FixedSizeBinary(64))
+    if events.is_empty() {
+        arrays.push(Arc::new(FixedSizeBinaryBuilder::new(64).finish()));
+    } else {
+        let arr = FixedSizeBinaryArray::try_from_iter(
+            events
+                .iter()
+                .map(|e| tx_signature_bytes(&e.transaction_id))
+                .map(|sig| sig.to_vec()),
+        )
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        arrays.push(Arc::new(arr));
+    }
+
+    // program_id (FixedSizeBinary(32))
+    if events.is_empty() {
+        arrays.push(Arc::new(FixedSizeBinaryBuilder::new(32).finish()));
+    } else {
+        let arr = FixedSizeBinaryArray::try_from_iter(
+            events
+                .iter()
+                .map(|e| program_id_bytes(&e.contract_address))
+                .map(|pid| pid.to_vec()),
+        )
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        arrays.push(Arc::new(arr));
+    }
+
+    // instruction_index
+    let arr: UInt16Array = events
+        .iter()
+        .map(|e| {
+            let (ix, _) = instruction_indices(&e.position);
+            Some(ix)
+        })
+        .collect();
+    arrays.push(Arc::new(arr));
+
+    // inner_instruction_index (nullable)
+    let arr: UInt16Array = events
+        .iter()
+        .map(|e| {
+            let (_, inner) = instruction_indices(&e.position);
+            inner
+        })
+        .collect();
+    arrays.push(Arc::new(arr));
+
+    // source_name
+    let arr: StringArray = events.iter().map(|e| Some(e.source_name.as_str())).collect();
+    arrays.push(Arc::new(arr));
+
+    // event_name
+    let arr: StringArray = events.iter().map(|e| Some(e.event_name.as_str())).collect();
+    arrays.push(Arc::new(arr));
+
+    // params (JSON)
+    let arr: StringArray = events
+        .iter()
+        .map(|e| Some(params_to_json(&e.params)))
+        .collect();
+    arrays.push(Arc::new(arr));
+
+    let batch = RecordBatch::try_new(schema.clone(), arrays)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+    crate::storage::atomic_write_parquet_fast(&batch, output_path)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::chain::{ChainAddress, LogPosition, TxId};
+    use crate::types::decoded::DecodedValue;
+    use std::collections::HashMap;
+    use tempfile::TempDir;
+
+    fn make_decoded_event(
+        slot: u64,
+        source: &str,
+        event: &str,
+        program_id: [u8; 32],
+        tx_sig: [u8; 64],
+        ix: u16,
+        inner: Option<u16>,
+    ) -> DecodedEvent {
+        let mut params = HashMap::new();
+        params.insert("amount".to_string(), DecodedValue::Uint64(42));
+        params.insert("name".to_string(), DecodedValue::String("test".to_string()));
+
+        DecodedEvent {
+            block_number: slot,
+            block_timestamp: 1_700_000_000,
+            transaction_id: TxId::Solana(tx_sig),
+            position: LogPosition::Solana {
+                instruction_index: ix,
+                inner_instruction_index: inner,
+            },
+            contract_address: ChainAddress::Solana(program_id),
+            source_name: source.to_string(),
+            event_name: event.to_string(),
+            event_signature: format!("{}:{}", source, event),
+            params,
+        }
+    }
+
+    fn read_parquet_row_count(path: &Path) -> usize {
+        use parquet::file::reader::{FileReader, SerializedFileReader};
+        let file = std::fs::File::open(path).unwrap();
+        let reader = SerializedFileReader::new(file).unwrap();
+        reader.metadata().file_metadata().num_rows() as usize
+    }
+
+    #[test]
+    fn test_decoded_event_schema_field_count() {
+        let schema = build_decoded_event_schema();
+        assert_eq!(schema.fields().len(), 9);
+    }
+
+    #[test]
+    fn test_decoded_event_schema_field_names() {
+        let schema = build_decoded_event_schema();
+        let names: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
+        assert_eq!(
+            names,
+            vec![
+                "slot",
+                "block_timestamp",
+                "transaction_signature",
+                "program_id",
+                "instruction_index",
+                "inner_instruction_index",
+                "source_name",
+                "event_name",
+                "params",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_write_decoded_events_roundtrip() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("decoded.parquet");
+        let schema = build_decoded_event_schema();
+
+        let events = vec![
+            make_decoded_event(100, "spl_token", "Transfer", [0xAA; 32], [0xBB; 64], 0, None),
+            make_decoded_event(
+                100,
+                "spl_token",
+                "Transfer",
+                [0xAA; 32],
+                [0xCC; 64],
+                1,
+                Some(2),
+            ),
+        ];
+
+        write_decoded_events_to_parquet(&events, &schema, &path).unwrap();
+
+        assert!(path.exists());
+        assert_eq!(read_parquet_row_count(&path), 2);
+    }
+
+    #[test]
+    fn test_write_decoded_events_empty() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("decoded_empty.parquet");
+        let schema = build_decoded_event_schema();
+
+        write_decoded_events_to_parquet(&[], &schema, &path).unwrap();
+
+        assert!(path.exists());
+        assert_eq!(read_parquet_row_count(&path), 0);
+    }
+
+    #[test]
+    fn test_params_json_serialization() {
+        let mut params = HashMap::new();
+        params.insert("amount".to_string(), DecodedValue::Uint64(42));
+        params.insert("flag".to_string(), DecodedValue::Bool(true));
+
+        let json = params_to_json(&params);
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        // Verify it parses back to valid JSON with expected keys
+        assert!(parsed.is_object());
+        let obj = parsed.as_object().unwrap();
+        assert!(obj.contains_key("amount"));
+        assert!(obj.contains_key("flag"));
+    }
+
+    #[test]
+    fn test_write_decoded_events_roundtrip_reads_back() {
+        use arrow::array::Array;
+        use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("decoded_read.parquet");
+        let schema = build_decoded_event_schema();
+
+        let events = vec![make_decoded_event(
+            200,
+            "whirlpool",
+            "Swap",
+            [0x11; 32],
+            [0x22; 64],
+            3,
+            Some(1),
+        )];
+
+        write_decoded_events_to_parquet(&events, &schema, &path).unwrap();
+
+        // Read back and verify
+        let file = std::fs::File::open(&path).unwrap();
+        let builder = ParquetRecordBatchReaderBuilder::try_new(file).unwrap();
+        let mut reader = builder.build().unwrap();
+        let batch = reader.next().unwrap().unwrap();
+
+        assert_eq!(batch.num_rows(), 1);
+
+        // Verify slot
+        let slot_arr = batch
+            .column_by_name("slot")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .unwrap();
+        assert_eq!(slot_arr.value(0), 200);
+
+        // Verify source_name
+        let source_arr = batch
+            .column_by_name("source_name")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(source_arr.value(0), "whirlpool");
+
+        // Verify event_name
+        let event_arr = batch
+            .column_by_name("event_name")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(event_arr.value(0), "Swap");
+
+        // Verify instruction_index
+        let ix_arr = batch
+            .column_by_name("instruction_index")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<UInt16Array>()
+            .unwrap();
+        assert_eq!(ix_arr.value(0), 3);
+
+        // Verify inner_instruction_index (nullable)
+        let inner_arr = batch
+            .column_by_name("inner_instruction_index")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<UInt16Array>()
+            .unwrap();
+        assert!(!inner_arr.is_null(0));
+        assert_eq!(inner_arr.value(0), 1);
+
+        // Verify params is valid JSON
+        let params_arr = batch
+            .column_by_name("params")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(params_arr.value(0)).unwrap();
+        assert!(parsed.is_object());
+    }
+}

--- a/src/solana/decoding/mod.rs
+++ b/src/solana/decoding/mod.rs
@@ -4,6 +4,7 @@ pub mod borsh_dynamic;
 pub mod idl;
 
 pub mod accounts;
+pub mod decoded_parquet;
 pub mod events;
 pub mod instructions;
 pub mod spl_token;

--- a/src/solana/decoding/mod.rs
+++ b/src/solana/decoding/mod.rs
@@ -7,3 +7,4 @@ pub mod accounts;
 pub mod events;
 pub mod instructions;
 pub mod spl_token;
+pub mod tasks;

--- a/src/solana/decoding/tasks.rs
+++ b/src/solana/decoding/tasks.rs
@@ -38,10 +38,12 @@ use super::instructions::SolanaInstructionDecoder;
 /// Scans `base_dir/{source}/{event_name}/` for any file named `range_file`
 /// where `(source, event_name)` is NOT in `written_groups`.
 ///
-/// When `skip_sources` is `Some`, source directories whose name appears in
-/// the set are skipped — they belong to programs the decoder did not
-/// process in this run. All other directories are scanned, including old
-/// names left behind by source renames.
+/// When `only_sources` is `Some`, the scan is restricted to those source
+/// directories. Directories with unknown names (including old names from
+/// source renames) are left untouched because we cannot distinguish an old
+/// name for an in-scope program from one for an out-of-scope program
+/// without reading parquet content. Source renames are cleaned up by
+/// running unscoped `--decode-only --repair`.
 ///
 /// **Callers must not invoke this when a function filter is active**, since
 /// the written set would be incomplete *within* each source and cleanup
@@ -50,7 +52,7 @@ fn cleanup_stale_decoded_parquet(
     base_dir: &Path,
     written_groups: &HashMap<(String, String), Vec<DecodedEvent>>,
     range_file: &str,
-    skip_sources: Option<&HashSet<String>>,
+    only_sources: Option<&HashSet<String>>,
 ) {
     let written: HashSet<(&str, &str)> = written_groups
         .keys()
@@ -70,11 +72,11 @@ fn cleanup_stale_decoded_parquet(
             continue;
         };
 
-        // Skip sources that are known to belong to programs NOT processed
-        // in this run. Unknown directories (e.g. old names from a source
-        // rename) are still scanned so their stale files are cleaned up.
-        if let Some(skip) = skip_sources {
-            if skip.contains(source_name.as_str()) {
+        // When source-scoped, only scan directories whose name matches an
+        // in-scope source. We leave unknown directories alone to avoid
+        // accidentally deleting data for renamed out-of-scope programs.
+        if let Some(sources) = only_sources {
+            if !sources.contains(source_name.as_str()) {
                 continue;
             }
         }
@@ -132,9 +134,9 @@ fn cleanup_stale_decoded_parquet(
 /// `(source_name, event_name)` so each group gets its own parquet file and
 /// the transformation engine receives one [`DecodedEventsMessage`] per handler
 /// trigger.
-/// When `skip_sources` is `Some`, stale cleanup skips those source
-/// directories (they belong to programs not processed in this run) but
-/// still scans unknown directories such as old names from source renames.
+/// When `only_sources` is `Some`, stale cleanup is restricted to those
+/// source directories. Unknown directories (e.g. old names from a source
+/// rename) are left alone; use unscoped repair to clean those up.
 /// When a `function_filter` is active, cleanup is skipped entirely because
 /// the decoded output is incomplete within each source.
 pub async fn decode_solana_events(
@@ -145,7 +147,7 @@ pub async fn decode_solana_events(
     complete_tx: Option<Sender<RangeCompleteMessage>>,
     chain_name: String,
     function_filter: Option<Arc<HashSet<String>>>,
-    skip_sources: Option<Arc<HashSet<String>>>,
+    only_sources: Option<Arc<HashSet<String>>>,
 ) {
     let schema = build_decoded_event_schema();
     let base_dir = decoded_solana_events_dir(&chain_name);
@@ -234,15 +236,14 @@ pub async fn decode_solana_events(
 
                 // Remove stale decoded parquet for this range. Function
                 // filtering makes the output incomplete per-source, so
-                // cleanup must be skipped. Source scoping skips known
-                // out-of-scope directories but still scans unknown ones
-                // (e.g. old names from source renames).
+                // cleanup must be skipped. Source scoping restricts the
+                // scan to in-scope sources only.
                 if function_filter.is_none() {
                     cleanup_stale_decoded_parquet(
                         &base_dir,
                         &by_trigger,
                         &range_file,
-                        skip_sources.as_deref(),
+                        only_sources.as_deref(),
                     );
                 }
 
@@ -311,7 +312,7 @@ pub async fn decode_solana_instructions(
     complete_tx: Option<Sender<RangeCompleteMessage>>,
     chain_name: String,
     function_filter: Option<Arc<HashSet<String>>>,
-    skip_sources: Option<Arc<HashSet<String>>>,
+    only_sources: Option<Arc<HashSet<String>>>,
 ) {
     let schema = build_decoded_event_schema();
     let base_dir = decoded_solana_instructions_dir(&chain_name);
@@ -404,7 +405,7 @@ pub async fn decode_solana_instructions(
                         &base_dir,
                         &by_trigger,
                         &range_file,
-                        skip_sources.as_deref(),
+                        only_sources.as_deref(),
                     );
                 }
 

--- a/src/solana/decoding/tasks.rs
+++ b/src/solana/decoding/tasks.rs
@@ -3,6 +3,9 @@
 //! These functions receive raw events/instructions on a channel, decode them
 //! using [`SolanaEventDecoder`] / [`SolanaInstructionDecoder`], and forward
 //! decoded results to the transformation engine.
+//!
+//! Decoded events are also always written to parquet on disk so that output
+//! is persisted regardless of whether the transformation channel is present.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -10,10 +13,12 @@ use std::sync::Arc;
 use tokio::sync::mpsc::{Receiver, Sender};
 
 use crate::decoding::DecoderMessage;
+use crate::storage::paths::{decoded_solana_events_dir, decoded_solana_instructions_dir};
 use crate::transformations::engine::{
     DecodedEventsMessage, RangeCompleteKind, RangeCompleteMessage,
 };
 
+use super::decoded_parquet::{build_decoded_event_schema, write_decoded_events_to_parquet};
 use super::events::SolanaEventDecoder;
 use super::instructions::SolanaInstructionDecoder;
 
@@ -22,20 +27,25 @@ use super::instructions::SolanaInstructionDecoder;
 // ---------------------------------------------------------------------------
 
 /// Async task that receives [`DecoderMessage::SolanaEventsReady`], decodes
-/// events via the routing layer, and forwards results to the transformation
-/// engine.
+/// events via the routing layer, writes decoded parquet to disk, and
+/// optionally forwards results to the transformation engine.
 ///
 /// Events are grouped by `program_id` before decoding (since each program has
 /// a different decoder). Decoded events are then regrouped by
-/// `(source_name, event_name)` so the transformation engine receives one
-/// [`DecodedEventsMessage`] per handler trigger.
+/// `(source_name, event_name)` so each group gets its own parquet file and
+/// the transformation engine receives one [`DecodedEventsMessage`] per handler
+/// trigger.
 pub async fn decode_solana_events(
     decoder: Arc<SolanaEventDecoder>,
     program_names: Arc<HashMap<[u8; 32], String>>,
     mut decoder_rx: Receiver<DecoderMessage>,
     transform_tx: Option<Sender<DecodedEventsMessage>>,
     complete_tx: Option<Sender<RangeCompleteMessage>>,
+    chain_name: String,
 ) {
+    let schema = build_decoded_event_schema();
+    let base_dir = decoded_solana_events_dir(&chain_name);
+
     while let Some(msg) = decoder_rx.recv().await {
         match msg {
             #[cfg(feature = "solana")]
@@ -73,6 +83,41 @@ pub async fn decode_solana_events(
                     for event in decoded {
                         let key = (event.source_name.clone(), event.event_name.clone());
                         by_trigger.entry(key).or_default().push(event);
+                    }
+                }
+
+                // Write decoded parquet per (source_name, event_name) group
+                let range_end_inclusive = if range_end > 0 { range_end - 1 } else { 0 };
+                for ((source_name, event_name), events) in &by_trigger {
+                    if events.is_empty() {
+                        continue;
+                    }
+                    let output_dir = base_dir.join(source_name).join(event_name);
+                    if let Err(e) = std::fs::create_dir_all(&output_dir) {
+                        tracing::error!(
+                            path = %output_dir.display(),
+                            error = %e,
+                            "Failed to create decoded events output directory"
+                        );
+                        continue;
+                    }
+                    let file_name = format!("{}-{}.parquet", range_start, range_end_inclusive);
+                    let output_path = output_dir.join(&file_name);
+
+                    if let Err(e) = write_decoded_events_to_parquet(events, &schema, &output_path) {
+                        tracing::error!(
+                            path = %output_path.display(),
+                            error = %e,
+                            "Failed to write decoded events parquet"
+                        );
+                    } else {
+                        tracing::debug!(
+                            source = source_name.as_str(),
+                            event = event_name.as_str(),
+                            count = events.len(),
+                            path = %output_path.display(),
+                            "Wrote decoded events parquet"
+                        );
                     }
                 }
 
@@ -128,8 +173,8 @@ pub async fn decode_solana_events(
 // ---------------------------------------------------------------------------
 
 /// Async task that receives [`DecoderMessage::SolanaInstructionsReady`],
-/// decodes instructions via the routing layer, and forwards results to the
-/// transformation engine.
+/// decodes instructions via the routing layer, writes decoded parquet to disk,
+/// and optionally forwards results to the transformation engine.
 ///
 /// Instructions are decoded into [`DecodedEvent`]s (instruction args + named
 /// accounts merged into params) and sent as [`DecodedEventsMessage`]s.
@@ -139,7 +184,11 @@ pub async fn decode_solana_instructions(
     mut decoder_rx: Receiver<DecoderMessage>,
     transform_tx: Option<Sender<DecodedEventsMessage>>,
     complete_tx: Option<Sender<RangeCompleteMessage>>,
+    chain_name: String,
 ) {
+    let schema = build_decoded_event_schema();
+    let base_dir = decoded_solana_instructions_dir(&chain_name);
+
     while let Some(msg) = decoder_rx.recv().await {
         match msg {
             #[cfg(feature = "solana")]
@@ -178,6 +227,41 @@ pub async fn decode_solana_instructions(
                     for event in decoded {
                         let key = (event.source_name.clone(), event.event_name.clone());
                         by_trigger.entry(key).or_default().push(event);
+                    }
+                }
+
+                // Write decoded parquet per (source_name, instruction_name) group
+                let range_end_inclusive = if range_end > 0 { range_end - 1 } else { 0 };
+                for ((source_name, event_name), events) in &by_trigger {
+                    if events.is_empty() {
+                        continue;
+                    }
+                    let output_dir = base_dir.join(source_name).join(event_name);
+                    if let Err(e) = std::fs::create_dir_all(&output_dir) {
+                        tracing::error!(
+                            path = %output_dir.display(),
+                            error = %e,
+                            "Failed to create decoded instructions output directory"
+                        );
+                        continue;
+                    }
+                    let file_name = format!("{}-{}.parquet", range_start, range_end_inclusive);
+                    let output_path = output_dir.join(&file_name);
+
+                    if let Err(e) = write_decoded_events_to_parquet(events, &schema, &output_path) {
+                        tracing::error!(
+                            path = %output_path.display(),
+                            error = %e,
+                            "Failed to write decoded instructions parquet"
+                        );
+                    } else {
+                        tracing::debug!(
+                            source = source_name.as_str(),
+                            instruction = event_name.as_str(),
+                            count = events.len(),
+                            path = %output_path.display(),
+                            "Wrote decoded instructions parquet"
+                        );
                     }
                 }
 
@@ -333,12 +417,18 @@ mod tests {
         let (transform_tx, mut transform_rx) = tokio::sync::mpsc::channel(10);
         let (complete_tx, mut complete_rx) = tokio::sync::mpsc::channel(10);
 
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let chain_name = format!("test-{}", tmp_dir.path().file_name().unwrap().to_str().unwrap());
+
+        // Create the expected output directory under a temp-like data dir
+        // We need the test to write to a real dir so use the chain_name approach
         let handle = tokio::spawn(decode_solana_events(
             decoder,
             program_names,
             decoder_rx,
             Some(transform_tx),
             Some(complete_tx),
+            chain_name,
         ));
 
         // Send an event batch
@@ -404,6 +494,7 @@ mod tests {
             decoder_rx,
             Some(transform_tx),
             Some(complete_tx),
+            "test-solana-instr".to_string(),
         ));
 
         decoder_tx
@@ -440,6 +531,7 @@ mod tests {
             decoder_rx,
             None,
             None,
+            "test-close".to_string(),
         ));
 
         // Drop sender to close channel
@@ -478,6 +570,7 @@ mod tests {
             decoder_rx,
             Some(transform_tx),
             Some(complete_tx),
+            "test-unknown".to_string(),
         ));
 
         // Send batch with one known and one unknown program event

--- a/src/solana/decoding/tasks.rs
+++ b/src/solana/decoding/tasks.rs
@@ -38,14 +38,18 @@ use super::instructions::SolanaInstructionDecoder;
 /// Scans `base_dir/{source}/{event_name}/` for any file named `range_file`
 /// where `(source, event_name)` is NOT in `written_groups`.
 ///
-/// **Only safe when `written_groups` represents the complete decoded output
-/// for the range.** Callers must skip this when source or function filters
-/// are active, since the written set would be an incomplete subset and
-/// cleanup would delete files for out-of-scope groups.
+/// When `only_sources` is `Some`, the scan is limited to those source
+/// directories — other sources are left untouched because the decoder did
+/// not receive their data and cannot judge staleness.
+///
+/// **Callers must not invoke this when a function filter is active**, since
+/// the written set would be incomplete *within* each source and cleanup
+/// would delete files for out-of-scope event/instruction names.
 fn cleanup_stale_decoded_parquet(
     base_dir: &Path,
     written_groups: &HashMap<(String, String), Vec<DecodedEvent>>,
     range_file: &str,
+    only_sources: Option<&HashSet<String>>,
 ) {
     let written: HashSet<(&str, &str)> = written_groups
         .keys()
@@ -64,6 +68,14 @@ fn cleanup_stale_decoded_parquet(
         let Some(source_name) = source_entry.file_name().to_str().map(String::from) else {
             continue;
         };
+
+        // When source-scoped, skip sources outside the scope — we have no
+        // data for them and cannot determine staleness.
+        if let Some(sources) = only_sources {
+            if !sources.contains(source_name.as_str()) {
+                continue;
+            }
+        }
 
         let Ok(event_dirs) = std::fs::read_dir(&source_path) else {
             continue;
@@ -118,9 +130,10 @@ fn cleanup_stale_decoded_parquet(
 /// `(source_name, event_name)` so each group gets its own parquet file and
 /// the transformation engine receives one [`DecodedEventsMessage`] per handler
 /// trigger.
-/// When `scoped_repair` is true, stale decoded parquet cleanup is skipped
-/// because the decoder only sees a filtered subset of the range and cannot
-/// determine which other files are genuinely stale vs. out-of-scope.
+/// When `source_scope` is `Some`, stale cleanup is limited to those sources
+/// (the decoder only received data for them). When a `function_filter` is
+/// active, cleanup is skipped entirely because the decoded output is
+/// incomplete within each source.
 pub async fn decode_solana_events(
     decoder: Arc<SolanaEventDecoder>,
     program_names: Arc<HashMap<[u8; 32], String>>,
@@ -129,7 +142,7 @@ pub async fn decode_solana_events(
     complete_tx: Option<Sender<RangeCompleteMessage>>,
     chain_name: String,
     function_filter: Option<Arc<HashSet<String>>>,
-    scoped_repair: bool,
+    source_scope: Option<Arc<HashSet<String>>>,
 ) {
     let schema = build_decoded_event_schema();
     let base_dir = decoded_solana_events_dir(&chain_name);
@@ -216,10 +229,17 @@ pub async fn decode_solana_events(
                     }
                 }
 
-                // Remove stale decoded parquet for this range — only when the
-                // decoder has the complete picture (no source or function filters).
-                if !scoped_repair {
-                    cleanup_stale_decoded_parquet(&base_dir, &by_trigger, &range_file);
+                // Remove stale decoded parquet for this range. Function
+                // filtering makes the output incomplete per-source, so
+                // cleanup must be skipped. Source scoping is safe — cleanup
+                // is limited to the scoped sources where we have full data.
+                if function_filter.is_none() {
+                    cleanup_stale_decoded_parquet(
+                        &base_dir,
+                        &by_trigger,
+                        &range_file,
+                        source_scope.as_deref(),
+                    );
                 }
 
                 // Send one message per (source_name, event_name) group
@@ -287,7 +307,7 @@ pub async fn decode_solana_instructions(
     complete_tx: Option<Sender<RangeCompleteMessage>>,
     chain_name: String,
     function_filter: Option<Arc<HashSet<String>>>,
-    scoped_repair: bool,
+    source_scope: Option<Arc<HashSet<String>>>,
 ) {
     let schema = build_decoded_event_schema();
     let base_dir = decoded_solana_instructions_dir(&chain_name);
@@ -374,9 +394,14 @@ pub async fn decode_solana_instructions(
                     }
                 }
 
-                // Remove stale decoded parquet for this range — only when unscoped
-                if !scoped_repair {
-                    cleanup_stale_decoded_parquet(&base_dir, &by_trigger, &range_file);
+                // Remove stale decoded parquet — see decode_solana_events
+                if function_filter.is_none() {
+                    cleanup_stale_decoded_parquet(
+                        &base_dir,
+                        &by_trigger,
+                        &range_file,
+                        source_scope.as_deref(),
+                    );
                 }
 
                 // Send one message per (source_name, instruction_name) group
@@ -544,7 +569,7 @@ mod tests {
             Some(complete_tx),
             chain_name,
             None,
-            false,
+            None,
         ));
 
         // Send an event batch
@@ -612,7 +637,7 @@ mod tests {
             Some(complete_tx),
             "test-solana-instr".to_string(),
             None,
-            false,
+            None,
         ));
 
         decoder_tx
@@ -651,7 +676,7 @@ mod tests {
             None,
             "test-close".to_string(),
             None,
-            false,
+            None,
         ));
 
         // Drop sender to close channel
@@ -692,7 +717,7 @@ mod tests {
             Some(complete_tx),
             "test-unknown".to_string(),
             None,
-            false,
+            None,
         ));
 
         // Send batch with one known and one unknown program event

--- a/src/solana/decoding/tasks.rs
+++ b/src/solana/decoding/tasks.rs
@@ -38,9 +38,10 @@ use super::instructions::SolanaInstructionDecoder;
 /// Scans `base_dir/{source}/{event_name}/` for any file named `range_file`
 /// where `(source, event_name)` is NOT in `written_groups`.
 ///
-/// When `only_sources` is `Some`, the scan is limited to those source
-/// directories — other sources are left untouched because the decoder did
-/// not receive their data and cannot judge staleness.
+/// When `skip_sources` is `Some`, source directories whose name appears in
+/// the set are skipped — they belong to programs the decoder did not
+/// process in this run. All other directories are scanned, including old
+/// names left behind by source renames.
 ///
 /// **Callers must not invoke this when a function filter is active**, since
 /// the written set would be incomplete *within* each source and cleanup
@@ -49,7 +50,7 @@ fn cleanup_stale_decoded_parquet(
     base_dir: &Path,
     written_groups: &HashMap<(String, String), Vec<DecodedEvent>>,
     range_file: &str,
-    only_sources: Option<&HashSet<String>>,
+    skip_sources: Option<&HashSet<String>>,
 ) {
     let written: HashSet<(&str, &str)> = written_groups
         .keys()
@@ -69,10 +70,11 @@ fn cleanup_stale_decoded_parquet(
             continue;
         };
 
-        // When source-scoped, skip sources outside the scope — we have no
-        // data for them and cannot determine staleness.
-        if let Some(sources) = only_sources {
-            if !sources.contains(source_name.as_str()) {
+        // Skip sources that are known to belong to programs NOT processed
+        // in this run. Unknown directories (e.g. old names from a source
+        // rename) are still scanned so their stale files are cleaned up.
+        if let Some(skip) = skip_sources {
+            if skip.contains(source_name.as_str()) {
                 continue;
             }
         }
@@ -130,10 +132,11 @@ fn cleanup_stale_decoded_parquet(
 /// `(source_name, event_name)` so each group gets its own parquet file and
 /// the transformation engine receives one [`DecodedEventsMessage`] per handler
 /// trigger.
-/// When `source_scope` is `Some`, stale cleanup is limited to those sources
-/// (the decoder only received data for them). When a `function_filter` is
-/// active, cleanup is skipped entirely because the decoded output is
-/// incomplete within each source.
+/// When `skip_sources` is `Some`, stale cleanup skips those source
+/// directories (they belong to programs not processed in this run) but
+/// still scans unknown directories such as old names from source renames.
+/// When a `function_filter` is active, cleanup is skipped entirely because
+/// the decoded output is incomplete within each source.
 pub async fn decode_solana_events(
     decoder: Arc<SolanaEventDecoder>,
     program_names: Arc<HashMap<[u8; 32], String>>,
@@ -142,7 +145,7 @@ pub async fn decode_solana_events(
     complete_tx: Option<Sender<RangeCompleteMessage>>,
     chain_name: String,
     function_filter: Option<Arc<HashSet<String>>>,
-    source_scope: Option<Arc<HashSet<String>>>,
+    skip_sources: Option<Arc<HashSet<String>>>,
 ) {
     let schema = build_decoded_event_schema();
     let base_dir = decoded_solana_events_dir(&chain_name);
@@ -231,14 +234,15 @@ pub async fn decode_solana_events(
 
                 // Remove stale decoded parquet for this range. Function
                 // filtering makes the output incomplete per-source, so
-                // cleanup must be skipped. Source scoping is safe — cleanup
-                // is limited to the scoped sources where we have full data.
+                // cleanup must be skipped. Source scoping skips known
+                // out-of-scope directories but still scans unknown ones
+                // (e.g. old names from source renames).
                 if function_filter.is_none() {
                     cleanup_stale_decoded_parquet(
                         &base_dir,
                         &by_trigger,
                         &range_file,
-                        source_scope.as_deref(),
+                        skip_sources.as_deref(),
                     );
                 }
 
@@ -307,7 +311,7 @@ pub async fn decode_solana_instructions(
     complete_tx: Option<Sender<RangeCompleteMessage>>,
     chain_name: String,
     function_filter: Option<Arc<HashSet<String>>>,
-    source_scope: Option<Arc<HashSet<String>>>,
+    skip_sources: Option<Arc<HashSet<String>>>,
 ) {
     let schema = build_decoded_event_schema();
     let base_dir = decoded_solana_instructions_dir(&chain_name);
@@ -400,7 +404,7 @@ pub async fn decode_solana_instructions(
                         &base_dir,
                         &by_trigger,
                         &range_file,
-                        source_scope.as_deref(),
+                        skip_sources.as_deref(),
                     );
                 }
 

--- a/src/solana/decoding/tasks.rs
+++ b/src/solana/decoding/tasks.rs
@@ -1,0 +1,508 @@
+//! Async task wrappers for Solana decoders.
+//!
+//! These functions receive raw events/instructions on a channel, decode them
+//! using [`SolanaEventDecoder`] / [`SolanaInstructionDecoder`], and forward
+//! decoded results to the transformation engine.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::sync::mpsc::{Receiver, Sender};
+
+use crate::decoding::DecoderMessage;
+use crate::transformations::engine::{
+    DecodedEventsMessage, RangeCompleteKind, RangeCompleteMessage,
+};
+
+use super::events::SolanaEventDecoder;
+use super::instructions::SolanaInstructionDecoder;
+
+// ---------------------------------------------------------------------------
+// Event decoder task
+// ---------------------------------------------------------------------------
+
+/// Async task that receives [`DecoderMessage::SolanaEventsReady`], decodes
+/// events via the routing layer, and forwards results to the transformation
+/// engine.
+///
+/// Events are grouped by `program_id` before decoding (since each program has
+/// a different decoder). Decoded events are then regrouped by
+/// `(source_name, event_name)` so the transformation engine receives one
+/// [`DecodedEventsMessage`] per handler trigger.
+pub async fn decode_solana_events(
+    decoder: Arc<SolanaEventDecoder>,
+    program_names: Arc<HashMap<[u8; 32], String>>,
+    mut decoder_rx: Receiver<DecoderMessage>,
+    transform_tx: Option<Sender<DecodedEventsMessage>>,
+    complete_tx: Option<Sender<RangeCompleteMessage>>,
+) {
+    while let Some(msg) = decoder_rx.recv().await {
+        match msg {
+            #[cfg(feature = "solana")]
+            DecoderMessage::SolanaEventsReady {
+                range_start,
+                range_end,
+                events,
+                live_mode: _,
+            } => {
+                // Group raw events by program_id
+                let mut by_program: HashMap<[u8; 32], Vec<_>> = HashMap::new();
+                for event in events {
+                    by_program
+                        .entry(event.program_id)
+                        .or_default()
+                        .push(event);
+                }
+
+                // Decode per-program, then regroup by (source_name, event_name)
+                let mut by_trigger: HashMap<(String, String), Vec<_>> = HashMap::new();
+
+                for (program_id, program_events) in &by_program {
+                    let source_name = match program_names.get(program_id) {
+                        Some(name) => name.as_str(),
+                        None => {
+                            tracing::debug!(
+                                program_id = hex::encode(program_id),
+                                "No source name for program, skipping"
+                            );
+                            continue;
+                        }
+                    };
+
+                    let decoded = decoder.decode_event_batch(program_events, source_name);
+                    for event in decoded {
+                        let key = (event.source_name.clone(), event.event_name.clone());
+                        by_trigger.entry(key).or_default().push(event);
+                    }
+                }
+
+                // Send one message per (source_name, event_name) group
+                if let Some(ref tx) = transform_tx {
+                    for ((source_name, event_name), events) in by_trigger {
+                        if events.is_empty() {
+                            continue;
+                        }
+                        if tx
+                            .send(DecodedEventsMessage {
+                                range_start,
+                                range_end,
+                                source_name,
+                                event_name,
+                                events,
+                            })
+                            .await
+                            .is_err()
+                        {
+                            tracing::debug!("Transform events channel closed");
+                            return;
+                        }
+                    }
+                }
+
+                // Signal event decoding complete for this range
+                if let Some(ref tx) = complete_tx {
+                    if tx
+                        .send(RangeCompleteMessage {
+                            range_start,
+                            range_end,
+                            kind: RangeCompleteKind::Logs,
+                        })
+                        .await
+                        .is_err()
+                    {
+                        tracing::debug!("Transform complete channel closed");
+                        return;
+                    }
+                }
+            }
+            DecoderMessage::AllComplete => break,
+            _ => {} // Ignore EVM-specific messages
+        }
+    }
+
+    tracing::info!("Solana event decoder task finished");
+}
+
+// ---------------------------------------------------------------------------
+// Instruction decoder task
+// ---------------------------------------------------------------------------
+
+/// Async task that receives [`DecoderMessage::SolanaInstructionsReady`],
+/// decodes instructions via the routing layer, and forwards results to the
+/// transformation engine.
+///
+/// Instructions are decoded into [`DecodedEvent`]s (instruction args + named
+/// accounts merged into params) and sent as [`DecodedEventsMessage`]s.
+pub async fn decode_solana_instructions(
+    decoder: Arc<SolanaInstructionDecoder>,
+    program_names: Arc<HashMap<[u8; 32], String>>,
+    mut decoder_rx: Receiver<DecoderMessage>,
+    transform_tx: Option<Sender<DecodedEventsMessage>>,
+    complete_tx: Option<Sender<RangeCompleteMessage>>,
+) {
+    while let Some(msg) = decoder_rx.recv().await {
+        match msg {
+            #[cfg(feature = "solana")]
+            DecoderMessage::SolanaInstructionsReady {
+                range_start,
+                range_end,
+                instructions,
+                live_mode: _,
+            } => {
+                // Group raw instructions by program_id
+                let mut by_program: HashMap<[u8; 32], Vec<_>> = HashMap::new();
+                for instr in instructions {
+                    by_program
+                        .entry(instr.program_id)
+                        .or_default()
+                        .push(instr);
+                }
+
+                // Decode per-program, then regroup by (source_name, event_name)
+                let mut by_trigger: HashMap<(String, String), Vec<_>> = HashMap::new();
+
+                for (program_id, program_instrs) in &by_program {
+                    let source_name = match program_names.get(program_id) {
+                        Some(name) => name.as_str(),
+                        None => {
+                            tracing::debug!(
+                                program_id = hex::encode(program_id),
+                                "No source name for program, skipping"
+                            );
+                            continue;
+                        }
+                    };
+
+                    let decoded =
+                        decoder.decode_instruction_batch(program_instrs, source_name);
+                    for event in decoded {
+                        let key = (event.source_name.clone(), event.event_name.clone());
+                        by_trigger.entry(key).or_default().push(event);
+                    }
+                }
+
+                // Send one message per (source_name, instruction_name) group
+                if let Some(ref tx) = transform_tx {
+                    for ((source_name, event_name), events) in by_trigger {
+                        if events.is_empty() {
+                            continue;
+                        }
+                        if tx
+                            .send(DecodedEventsMessage {
+                                range_start,
+                                range_end,
+                                source_name,
+                                event_name,
+                                events,
+                            })
+                            .await
+                            .is_err()
+                        {
+                            tracing::debug!("Transform events channel closed");
+                            return;
+                        }
+                    }
+                }
+
+                // Signal instruction decoding complete for this range
+                if let Some(ref tx) = complete_tx {
+                    if tx
+                        .send(RangeCompleteMessage {
+                            range_start,
+                            range_end,
+                            kind: RangeCompleteKind::Instructions,
+                        })
+                        .await
+                        .is_err()
+                    {
+                        tracing::debug!("Transform complete channel closed");
+                        return;
+                    }
+                }
+            }
+            DecoderMessage::AllComplete => break,
+            _ => {} // Ignore EVM-specific messages
+        }
+    }
+
+    tracing::info!("Solana instruction decoder task finished");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::solana::decoding::traits::{
+        DecodedAccountFields, DecodedEventFields, DecodedInstructionFields, ProgramDecoder,
+        SolanaDecodeError,
+    };
+    use crate::solana::raw_data::types::{SolanaEventRecord, SolanaInstructionRecord};
+    use crate::types::decoded::DecodedValue;
+
+    struct MockDecoder {
+        id: [u8; 32],
+        event_result: Option<DecodedEventFields>,
+        instruction_result: Option<DecodedInstructionFields>,
+    }
+
+    impl ProgramDecoder for MockDecoder {
+        fn program_id(&self) -> [u8; 32] {
+            self.id
+        }
+        fn program_name(&self) -> &str {
+            "mock"
+        }
+        fn decode_event(
+            &self,
+            _discriminator: &[u8],
+            _data: &[u8],
+        ) -> Result<Option<DecodedEventFields>, SolanaDecodeError> {
+            Ok(self.event_result.clone())
+        }
+        fn decode_instruction(
+            &self,
+            _data: &[u8],
+            _accounts: &[[u8; 32]],
+        ) -> Result<Option<DecodedInstructionFields>, SolanaDecodeError> {
+            Ok(self.instruction_result.clone())
+        }
+        fn decode_account(
+            &self,
+            _data: &[u8],
+        ) -> Result<Option<DecodedAccountFields>, SolanaDecodeError> {
+            Ok(None)
+        }
+        fn event_types(&self) -> Vec<String> {
+            vec![]
+        }
+        fn instruction_types(&self) -> Vec<String> {
+            vec![]
+        }
+        fn account_types(&self) -> Vec<String> {
+            vec![]
+        }
+    }
+
+    fn make_event_record(program_id: [u8; 32]) -> SolanaEventRecord {
+        SolanaEventRecord {
+            slot: 100,
+            block_time: Some(1_700_000_000),
+            transaction_signature: [0xAA; 64],
+            program_id,
+            event_discriminator: [1, 2, 3, 4, 5, 6, 7, 8],
+            event_data: vec![10, 20, 30],
+            log_index: 0,
+            instruction_index: 0,
+            inner_instruction_index: None,
+        }
+    }
+
+    fn make_instruction_record(program_id: [u8; 32]) -> SolanaInstructionRecord {
+        SolanaInstructionRecord {
+            slot: 200,
+            block_time: Some(1_700_000_000),
+            transaction_signature: [0xBB; 64],
+            program_id,
+            data: vec![1, 2, 3],
+            accounts: vec![[10u8; 32]],
+            instruction_index: 0,
+            inner_instruction_index: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn event_decoder_task_sends_grouped_messages() {
+        let program_id = [1u8; 32];
+
+        let mut params = HashMap::new();
+        params.insert("amount".to_string(), DecodedValue::Uint64(42));
+
+        let decoder = Arc::new(SolanaEventDecoder::new(vec![Arc::new(MockDecoder {
+            id: program_id,
+            event_result: Some(DecodedEventFields {
+                event_name: "Transfer".to_string(),
+                params,
+            }),
+            instruction_result: None,
+        })]));
+
+        let mut names = HashMap::new();
+        names.insert(program_id, "spl_token".to_string());
+        let program_names = Arc::new(names);
+
+        let (decoder_tx, decoder_rx) = tokio::sync::mpsc::channel(10);
+        let (transform_tx, mut transform_rx) = tokio::sync::mpsc::channel(10);
+        let (complete_tx, mut complete_rx) = tokio::sync::mpsc::channel(10);
+
+        let handle = tokio::spawn(decode_solana_events(
+            decoder,
+            program_names,
+            decoder_rx,
+            Some(transform_tx),
+            Some(complete_tx),
+        ));
+
+        // Send an event batch
+        decoder_tx
+            .send(DecoderMessage::SolanaEventsReady {
+                range_start: 0,
+                range_end: 1000,
+                events: vec![make_event_record(program_id)],
+                live_mode: false,
+            })
+            .await
+            .unwrap();
+
+        // Should receive a decoded events message
+        let msg = transform_rx.recv().await.unwrap();
+        assert_eq!(msg.source_name, "spl_token");
+        assert_eq!(msg.event_name, "Transfer");
+        assert_eq!(msg.events.len(), 1);
+        assert_eq!(msg.range_start, 0);
+        assert_eq!(msg.range_end, 1000);
+
+        // Should receive a completion message
+        let complete = complete_rx.recv().await.unwrap();
+        assert_eq!(complete.range_start, 0);
+        assert_eq!(complete.range_end, 1000);
+        assert_eq!(complete.kind, RangeCompleteKind::Logs);
+
+        // Send AllComplete to stop
+        decoder_tx.send(DecoderMessage::AllComplete).await.unwrap();
+        handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn instruction_decoder_task_sends_instruction_complete() {
+        let program_id = [2u8; 32];
+
+        let mut args = HashMap::new();
+        args.insert("amount".to_string(), DecodedValue::Uint64(100));
+
+        let decoder = Arc::new(SolanaInstructionDecoder::new(vec![Arc::new(
+            MockDecoder {
+                id: program_id,
+                event_result: None,
+                instruction_result: Some(DecodedInstructionFields {
+                    instruction_name: "Transfer".to_string(),
+                    args,
+                    named_accounts: HashMap::new(),
+                }),
+            },
+        )]));
+
+        let mut names = HashMap::new();
+        names.insert(program_id, "spl_token".to_string());
+        let program_names = Arc::new(names);
+
+        let (decoder_tx, decoder_rx) = tokio::sync::mpsc::channel(10);
+        let (transform_tx, mut transform_rx) = tokio::sync::mpsc::channel(10);
+        let (complete_tx, mut complete_rx) = tokio::sync::mpsc::channel(10);
+
+        let handle = tokio::spawn(decode_solana_instructions(
+            decoder,
+            program_names,
+            decoder_rx,
+            Some(transform_tx),
+            Some(complete_tx),
+        ));
+
+        decoder_tx
+            .send(DecoderMessage::SolanaInstructionsReady {
+                range_start: 1000,
+                range_end: 2000,
+                instructions: vec![make_instruction_record(program_id)],
+                live_mode: false,
+            })
+            .await
+            .unwrap();
+
+        let msg = transform_rx.recv().await.unwrap();
+        assert_eq!(msg.source_name, "spl_token");
+        assert_eq!(msg.event_name, "Transfer");
+        assert_eq!(msg.events.len(), 1);
+
+        let complete = complete_rx.recv().await.unwrap();
+        assert_eq!(complete.kind, RangeCompleteKind::Instructions);
+
+        decoder_tx.send(DecoderMessage::AllComplete).await.unwrap();
+        handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn decoder_task_exits_on_channel_close() {
+        let decoder = Arc::new(SolanaEventDecoder::new(vec![]));
+        let program_names = Arc::new(HashMap::new());
+
+        let (decoder_tx, decoder_rx) = tokio::sync::mpsc::channel(10);
+        let handle = tokio::spawn(decode_solana_events(
+            decoder,
+            program_names,
+            decoder_rx,
+            None,
+            None,
+        ));
+
+        // Drop sender to close channel
+        drop(decoder_tx);
+        handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn unknown_program_events_skipped() {
+        let known_id = [1u8; 32];
+        let unknown_id = [99u8; 32];
+
+        let mut params = HashMap::new();
+        params.insert("x".to_string(), DecodedValue::Uint64(1));
+
+        let decoder = Arc::new(SolanaEventDecoder::new(vec![Arc::new(MockDecoder {
+            id: known_id,
+            event_result: Some(DecodedEventFields {
+                event_name: "Evt".to_string(),
+                params,
+            }),
+            instruction_result: None,
+        })]));
+
+        let mut names = HashMap::new();
+        names.insert(known_id, "prog".to_string());
+        let program_names = Arc::new(names);
+
+        let (decoder_tx, decoder_rx) = tokio::sync::mpsc::channel(10);
+        let (transform_tx, mut transform_rx) = tokio::sync::mpsc::channel(10);
+        let (complete_tx, mut complete_rx) = tokio::sync::mpsc::channel(10);
+
+        let handle = tokio::spawn(decode_solana_events(
+            decoder,
+            program_names,
+            decoder_rx,
+            Some(transform_tx),
+            Some(complete_tx),
+        ));
+
+        // Send batch with one known and one unknown program event
+        decoder_tx
+            .send(DecoderMessage::SolanaEventsReady {
+                range_start: 0,
+                range_end: 1000,
+                events: vec![
+                    make_event_record(known_id),
+                    make_event_record(unknown_id),
+                ],
+                live_mode: false,
+            })
+            .await
+            .unwrap();
+
+        // Only the known program event should appear
+        let msg = transform_rx.recv().await.unwrap();
+        assert_eq!(msg.events.len(), 1);
+        assert_eq!(msg.source_name, "prog");
+
+        // Completion still sent
+        let _complete = complete_rx.recv().await.unwrap();
+
+        decoder_tx.send(DecoderMessage::AllComplete).await.unwrap();
+        handle.await.unwrap();
+    }
+}

--- a/src/solana/decoding/tasks.rs
+++ b/src/solana/decoding/tasks.rs
@@ -37,6 +37,11 @@ use super::instructions::SolanaInstructionDecoder;
 ///
 /// Scans `base_dir/{source}/{event_name}/` for any file named `range_file`
 /// where `(source, event_name)` is NOT in `written_groups`.
+///
+/// **Only safe when `written_groups` represents the complete decoded output
+/// for the range.** Callers must skip this when source or function filters
+/// are active, since the written set would be an incomplete subset and
+/// cleanup would delete files for out-of-scope groups.
 fn cleanup_stale_decoded_parquet(
     base_dir: &Path,
     written_groups: &HashMap<(String, String), Vec<DecodedEvent>>,
@@ -113,6 +118,9 @@ fn cleanup_stale_decoded_parquet(
 /// `(source_name, event_name)` so each group gets its own parquet file and
 /// the transformation engine receives one [`DecodedEventsMessage`] per handler
 /// trigger.
+/// When `scoped_repair` is true, stale decoded parquet cleanup is skipped
+/// because the decoder only sees a filtered subset of the range and cannot
+/// determine which other files are genuinely stale vs. out-of-scope.
 pub async fn decode_solana_events(
     decoder: Arc<SolanaEventDecoder>,
     program_names: Arc<HashMap<[u8; 32], String>>,
@@ -121,6 +129,7 @@ pub async fn decode_solana_events(
     complete_tx: Option<Sender<RangeCompleteMessage>>,
     chain_name: String,
     function_filter: Option<Arc<HashSet<String>>>,
+    scoped_repair: bool,
 ) {
     let schema = build_decoded_event_schema();
     let base_dir = decoded_solana_events_dir(&chain_name);
@@ -207,10 +216,11 @@ pub async fn decode_solana_events(
                     }
                 }
 
-                // Remove stale decoded parquet for this range: any
-                // (source, event_name) directory that has the range file
-                // but was NOT in this batch's by_trigger output.
-                cleanup_stale_decoded_parquet(&base_dir, &by_trigger, &range_file);
+                // Remove stale decoded parquet for this range — only when the
+                // decoder has the complete picture (no source or function filters).
+                if !scoped_repair {
+                    cleanup_stale_decoded_parquet(&base_dir, &by_trigger, &range_file);
+                }
 
                 // Send one message per (source_name, event_name) group
                 if let Some(ref tx) = transform_tx {
@@ -277,6 +287,7 @@ pub async fn decode_solana_instructions(
     complete_tx: Option<Sender<RangeCompleteMessage>>,
     chain_name: String,
     function_filter: Option<Arc<HashSet<String>>>,
+    scoped_repair: bool,
 ) {
     let schema = build_decoded_event_schema();
     let base_dir = decoded_solana_instructions_dir(&chain_name);
@@ -363,8 +374,10 @@ pub async fn decode_solana_instructions(
                     }
                 }
 
-                // Remove stale decoded parquet for this range
-                cleanup_stale_decoded_parquet(&base_dir, &by_trigger, &range_file);
+                // Remove stale decoded parquet for this range — only when unscoped
+                if !scoped_repair {
+                    cleanup_stale_decoded_parquet(&base_dir, &by_trigger, &range_file);
+                }
 
                 // Send one message per (source_name, instruction_name) group
                 if let Some(ref tx) = transform_tx {
@@ -531,6 +544,7 @@ mod tests {
             Some(complete_tx),
             chain_name,
             None,
+            false,
         ));
 
         // Send an event batch
@@ -598,6 +612,7 @@ mod tests {
             Some(complete_tx),
             "test-solana-instr".to_string(),
             None,
+            false,
         ));
 
         decoder_tx
@@ -636,6 +651,7 @@ mod tests {
             None,
             "test-close".to_string(),
             None,
+            false,
         ));
 
         // Drop sender to close channel
@@ -676,6 +692,7 @@ mod tests {
             Some(complete_tx),
             "test-unknown".to_string(),
             None,
+            false,
         ));
 
         // Send batch with one known and one unknown program event

--- a/src/solana/decoding/tasks.rs
+++ b/src/solana/decoding/tasks.rs
@@ -7,7 +7,7 @@
 //! Decoded events are also always written to parquet on disk so that output
 //! is persisted regardless of whether the transformation channel is present.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use tokio::sync::mpsc::{Receiver, Sender};
@@ -42,6 +42,7 @@ pub async fn decode_solana_events(
     transform_tx: Option<Sender<DecodedEventsMessage>>,
     complete_tx: Option<Sender<RangeCompleteMessage>>,
     chain_name: String,
+    function_filter: Option<Arc<HashSet<String>>>,
 ) {
     let schema = build_decoded_event_schema();
     let base_dir = decoded_solana_events_dir(&chain_name);
@@ -84,6 +85,12 @@ pub async fn decode_solana_events(
                         let key = (event.source_name.clone(), event.event_name.clone());
                         by_trigger.entry(key).or_default().push(event);
                     }
+                }
+
+                // Apply function filter: drop groups whose event_name
+                // doesn't match --function scope
+                if let Some(ref filter) = function_filter {
+                    by_trigger.retain(|(_, event_name), _| filter.contains(event_name.as_str()));
                 }
 
                 // Write decoded parquet per (source_name, event_name) group
@@ -185,6 +192,7 @@ pub async fn decode_solana_instructions(
     transform_tx: Option<Sender<DecodedEventsMessage>>,
     complete_tx: Option<Sender<RangeCompleteMessage>>,
     chain_name: String,
+    function_filter: Option<Arc<HashSet<String>>>,
 ) {
     let schema = build_decoded_event_schema();
     let base_dir = decoded_solana_instructions_dir(&chain_name);
@@ -228,6 +236,11 @@ pub async fn decode_solana_instructions(
                         let key = (event.source_name.clone(), event.event_name.clone());
                         by_trigger.entry(key).or_default().push(event);
                     }
+                }
+
+                // Apply function filter
+                if let Some(ref filter) = function_filter {
+                    by_trigger.retain(|(_, event_name), _| filter.contains(event_name.as_str()));
                 }
 
                 // Write decoded parquet per (source_name, instruction_name) group
@@ -429,6 +442,7 @@ mod tests {
             Some(transform_tx),
             Some(complete_tx),
             chain_name,
+            None,
         ));
 
         // Send an event batch
@@ -495,6 +509,7 @@ mod tests {
             Some(transform_tx),
             Some(complete_tx),
             "test-solana-instr".to_string(),
+            None,
         ));
 
         decoder_tx
@@ -532,6 +547,7 @@ mod tests {
             None,
             None,
             "test-close".to_string(),
+            None,
         ));
 
         // Drop sender to close channel
@@ -571,6 +587,7 @@ mod tests {
             Some(transform_tx),
             Some(complete_tx),
             "test-unknown".to_string(),
+            None,
         ));
 
         // Send batch with one known and one unknown program event

--- a/src/solana/decoding/tasks.rs
+++ b/src/solana/decoding/tasks.rs
@@ -8,9 +8,12 @@
 //! is persisted regardless of whether the transformation channel is present.
 
 use std::collections::{HashMap, HashSet};
+use std::path::Path;
 use std::sync::Arc;
 
 use tokio::sync::mpsc::{Receiver, Sender};
+
+use crate::transformations::context::DecodedEvent;
 
 use crate::decoding::DecoderMessage;
 use crate::storage::paths::{decoded_solana_events_dir, decoded_solana_instructions_dir};
@@ -21,6 +24,81 @@ use crate::transformations::engine::{
 use super::decoded_parquet::{build_decoded_event_schema, write_decoded_events_to_parquet};
 use super::events::SolanaEventDecoder;
 use super::instructions::SolanaInstructionDecoder;
+
+// ---------------------------------------------------------------------------
+// Stale decoded parquet cleanup
+// ---------------------------------------------------------------------------
+
+/// Remove decoded parquet files for a range that no longer appear in the
+/// current decoded output. This handles IDL/decoder changes that rename or
+/// remove event/instruction types: after re-decoding, the old
+/// `{source}/{old_event_name}/{range}.parquet` file would otherwise remain
+/// on disk as stale output.
+///
+/// Scans `base_dir/{source}/{event_name}/` for any file named `range_file`
+/// where `(source, event_name)` is NOT in `written_groups`.
+fn cleanup_stale_decoded_parquet(
+    base_dir: &Path,
+    written_groups: &HashMap<(String, String), Vec<DecodedEvent>>,
+    range_file: &str,
+) {
+    let written: HashSet<(&str, &str)> = written_groups
+        .keys()
+        .map(|(s, e)| (s.as_str(), e.as_str()))
+        .collect();
+
+    let Ok(source_dirs) = std::fs::read_dir(base_dir) else {
+        return;
+    };
+
+    for source_entry in source_dirs.flatten() {
+        let source_path = source_entry.path();
+        if !source_path.is_dir() {
+            continue;
+        }
+        let Some(source_name) = source_entry.file_name().to_str().map(String::from) else {
+            continue;
+        };
+
+        let Ok(event_dirs) = std::fs::read_dir(&source_path) else {
+            continue;
+        };
+
+        for event_entry in event_dirs.flatten() {
+            let event_path = event_entry.path();
+            if !event_path.is_dir() {
+                continue;
+            }
+            let Some(event_name) = event_entry.file_name().to_str().map(String::from) else {
+                continue;
+            };
+
+            // If this (source, event_name) was written in this batch, skip
+            if written.contains(&(source_name.as_str(), event_name.as_str())) {
+                continue;
+            }
+
+            // Check if the stale range file exists and delete it
+            let stale_path = event_path.join(range_file);
+            if stale_path.exists() {
+                if let Err(e) = std::fs::remove_file(&stale_path) {
+                    tracing::warn!(
+                        path = %stale_path.display(),
+                        error = %e,
+                        "Failed to remove stale decoded parquet"
+                    );
+                } else {
+                    tracing::debug!(
+                        source = source_name.as_str(),
+                        event = event_name.as_str(),
+                        path = %stale_path.display(),
+                        "Removed stale decoded parquet"
+                    );
+                }
+            }
+        }
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Event decoder task
@@ -95,6 +173,8 @@ pub async fn decode_solana_events(
 
                 // Write decoded parquet per (source_name, event_name) group
                 let range_end_inclusive = if range_end > 0 { range_end - 1 } else { 0 };
+                let range_file = format!("{}-{}.parquet", range_start, range_end_inclusive);
+
                 for ((source_name, event_name), events) in &by_trigger {
                     if events.is_empty() {
                         continue;
@@ -108,8 +188,7 @@ pub async fn decode_solana_events(
                         );
                         continue;
                     }
-                    let file_name = format!("{}-{}.parquet", range_start, range_end_inclusive);
-                    let output_path = output_dir.join(&file_name);
+                    let output_path = output_dir.join(&range_file);
 
                     if let Err(e) = write_decoded_events_to_parquet(events, &schema, &output_path) {
                         tracing::error!(
@@ -127,6 +206,11 @@ pub async fn decode_solana_events(
                         );
                     }
                 }
+
+                // Remove stale decoded parquet for this range: any
+                // (source, event_name) directory that has the range file
+                // but was NOT in this batch's by_trigger output.
+                cleanup_stale_decoded_parquet(&base_dir, &by_trigger, &range_file);
 
                 // Send one message per (source_name, event_name) group
                 if let Some(ref tx) = transform_tx {
@@ -245,6 +329,8 @@ pub async fn decode_solana_instructions(
 
                 // Write decoded parquet per (source_name, instruction_name) group
                 let range_end_inclusive = if range_end > 0 { range_end - 1 } else { 0 };
+                let range_file = format!("{}-{}.parquet", range_start, range_end_inclusive);
+
                 for ((source_name, event_name), events) in &by_trigger {
                     if events.is_empty() {
                         continue;
@@ -258,8 +344,7 @@ pub async fn decode_solana_instructions(
                         );
                         continue;
                     }
-                    let file_name = format!("{}-{}.parquet", range_start, range_end_inclusive);
-                    let output_path = output_dir.join(&file_name);
+                    let output_path = output_dir.join(&range_file);
 
                     if let Err(e) = write_decoded_events_to_parquet(events, &schema, &output_path) {
                         tracing::error!(
@@ -277,6 +362,9 @@ pub async fn decode_solana_instructions(
                         );
                     }
                 }
+
+                // Remove stale decoded parquet for this range
+                cleanup_stale_decoded_parquet(&base_dir, &by_trigger, &range_file);
 
                 // Send one message per (source_name, instruction_name) group
                 if let Some(ref tx) = transform_tx {

--- a/src/solana/mod.rs
+++ b/src/solana/mod.rs
@@ -6,4 +6,6 @@ pub mod decoding;
 #[cfg(feature = "solana")]
 pub mod discovery;
 #[cfg(feature = "solana")]
+pub mod pipeline;
+#[cfg(feature = "solana")]
 pub mod raw_data;

--- a/src/solana/pipeline.rs
+++ b/src/solana/pipeline.rs
@@ -20,12 +20,17 @@ use crate::solana::decoding::spl_token::SplTokenDecoder;
 use crate::solana::decoding::tasks::{decode_solana_events, decode_solana_instructions};
 use crate::solana::decoding::traits::ProgramDecoder;
 use crate::solana::raw_data::catchup::signature_driven_backfill;
+use crate::solana::raw_data::parquet::{read_events_from_parquet, read_instructions_from_parquet};
 use crate::solana::rpc::SolanaRpcClient;
+use crate::storage::paths::{
+    raw_solana_events_dir, raw_solana_instructions_dir, scan_parquet_ranges,
+};
 use crate::transformations::registry::{build_registry_for_solana_chain, TransformationRegistry};
 use crate::types::config::chain::ChainConfig;
 use crate::types::config::defaults;
 use crate::types::config::indexer::IndexerConfig;
 use crate::types::config::solana::SolanaPrograms;
+use crate::types::shared::repair::RepairScope;
 
 // ---------------------------------------------------------------------------
 // Feature detection
@@ -324,9 +329,19 @@ pub async fn process_solana_chain(
     config: &IndexerConfig,
     chain: &ChainConfig,
     catch_up_only: bool,
+    repair: bool,
+    repair_scope: Option<RepairScope>,
     shared_db_pool: Option<Arc<DbPool>>,
 ) -> anyhow::Result<()> {
     tracing::info!(chain = chain.name.as_str(), "Starting Solana pipeline");
+
+    if repair || repair_scope.is_some() {
+        tracing::warn!(
+            chain = chain.name.as_str(),
+            "Solana repair mode is not yet implemented — running normal backfill instead. \
+             Repair scope will be ignored."
+        );
+    }
 
     let runtime = SolanaChainRuntime::build(config, chain, shared_db_pool).await?;
 
@@ -413,9 +428,11 @@ pub async fn process_solana_chain(
         let program_names = runtime.program_names.clone();
         let tx = transform_events_tx.clone();
         let complete = transform_complete_tx.clone();
+        let chain_name = runtime.chain.name.clone();
 
         tasks.spawn(async move {
-            decode_solana_events(event_decoder, program_names, event_rx, tx, complete).await;
+            decode_solana_events(event_decoder, program_names, event_rx, tx, complete, chain_name)
+                .await;
             Ok(())
         });
     }
@@ -429,9 +446,18 @@ pub async fn process_solana_chain(
         let program_names = runtime.program_names.clone();
         let tx = transform_events_tx.clone();
         let complete = transform_complete_tx.clone();
+        let chain_name = runtime.chain.name.clone();
 
         tasks.spawn(async move {
-            decode_solana_instructions(instr_decoder, program_names, instr_rx, tx, complete).await;
+            decode_solana_instructions(
+                instr_decoder,
+                program_names,
+                instr_rx,
+                tx,
+                complete,
+                chain_name,
+            )
+            .await;
             Ok(())
         });
     }
@@ -510,15 +536,18 @@ pub async fn decode_only_solana_chain(
         let event_decoder = Arc::new(SolanaEventDecoder::new(decoders.clone()));
         let (tx, rx) = mpsc::channel::<DecoderMessage>(channel_capacity);
         let names = program_names.clone();
+        let chain_name = chain.name.clone();
 
         tasks.spawn(async move {
-            decode_solana_events(event_decoder, names, rx, None, None).await;
+            decode_solana_events(event_decoder, names, rx, None, None, chain_name).await;
             Ok(())
         });
 
-        // TODO: Read raw event parquet files and send as SolanaEventsReady messages.
-        // For now, close the channel immediately since parquet reading is not wired.
-        drop(tx);
+        // Spawn reader task to feed raw event parquet files into the decoder channel
+        let event_chain_name = chain.name.clone();
+        tasks.spawn(async move {
+            feed_raw_events_to_decoder(&event_chain_name, tx).await
+        });
     }
 
     // Instruction decoding
@@ -526,14 +555,18 @@ pub async fn decode_only_solana_chain(
         let instr_decoder = Arc::new(SolanaInstructionDecoder::new(decoders.clone()));
         let (tx, rx) = mpsc::channel::<DecoderMessage>(channel_capacity);
         let names = program_names.clone();
+        let chain_name = chain.name.clone();
 
         tasks.spawn(async move {
-            decode_solana_instructions(instr_decoder, names, rx, None, None).await;
+            decode_solana_instructions(instr_decoder, names, rx, None, None, chain_name).await;
             Ok(())
         });
 
-        // TODO: Read raw instruction parquet files and send as SolanaInstructionsReady.
-        drop(tx);
+        // Spawn reader task to feed raw instruction parquet files into the decoder channel
+        let instr_chain_name = chain.name.clone();
+        tasks.spawn(async move {
+            feed_raw_instructions_to_decoder(&instr_chain_name, tx).await
+        });
     }
 
     while let Some(result) = tasks.join_next().await {
@@ -545,6 +578,145 @@ pub async fn decode_only_solana_chain(
         "Solana decode-only processing complete"
     );
 
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Raw parquet file readers for decode-only mode
+// ---------------------------------------------------------------------------
+
+/// Read raw event parquet files from disk and send them as
+/// [`DecoderMessage::SolanaEventsReady`] on the provided channel.
+///
+/// After all files are sent, sends [`DecoderMessage::AllComplete`] and drops
+/// the sender.
+async fn feed_raw_events_to_decoder(
+    chain_name: &str,
+    tx: mpsc::Sender<DecoderMessage>,
+) -> anyhow::Result<()> {
+    let events_dir = raw_solana_events_dir(chain_name);
+
+    let ranges = match scan_parquet_ranges(&events_dir) {
+        Ok(r) => r,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            tracing::info!(
+                chain = chain_name,
+                "No raw events directory found, skipping event decode"
+            );
+            let _ = tx.send(DecoderMessage::AllComplete).await;
+            return Ok(());
+        }
+        Err(e) => return Err(e.into()),
+    };
+
+    tracing::info!(
+        chain = chain_name,
+        files = ranges.len(),
+        "Reading raw event parquet files for decode-only mode"
+    );
+
+    for (start, end_inclusive, path) in &ranges {
+        let events = tokio::task::spawn_blocking({
+            let path = path.clone();
+            move || read_events_from_parquet(&path)
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("join error reading events: {}", e))?
+        .map_err(|e| anyhow::anyhow!("error reading event parquet {}: {}", path.display(), e))?;
+
+        if events.is_empty() {
+            continue;
+        }
+
+        // range_end is exclusive in DecoderMessage convention
+        let range_end = end_inclusive + 1;
+
+        if tx
+            .send(DecoderMessage::SolanaEventsReady {
+                range_start: *start,
+                range_end,
+                events,
+                live_mode: false,
+            })
+            .await
+            .is_err()
+        {
+            tracing::debug!("Event decoder channel closed early");
+            return Ok(());
+        }
+    }
+
+    let _ = tx.send(DecoderMessage::AllComplete).await;
+    Ok(())
+}
+
+/// Read raw instruction parquet files from disk and send them as
+/// [`DecoderMessage::SolanaInstructionsReady`] on the provided channel.
+///
+/// After all files are sent, sends [`DecoderMessage::AllComplete`] and drops
+/// the sender.
+async fn feed_raw_instructions_to_decoder(
+    chain_name: &str,
+    tx: mpsc::Sender<DecoderMessage>,
+) -> anyhow::Result<()> {
+    let instructions_dir = raw_solana_instructions_dir(chain_name);
+
+    let ranges = match scan_parquet_ranges(&instructions_dir) {
+        Ok(r) => r,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            tracing::info!(
+                chain = chain_name,
+                "No raw instructions directory found, skipping instruction decode"
+            );
+            let _ = tx.send(DecoderMessage::AllComplete).await;
+            return Ok(());
+        }
+        Err(e) => return Err(e.into()),
+    };
+
+    tracing::info!(
+        chain = chain_name,
+        files = ranges.len(),
+        "Reading raw instruction parquet files for decode-only mode"
+    );
+
+    for (start, end_inclusive, path) in &ranges {
+        let instructions = tokio::task::spawn_blocking({
+            let path = path.clone();
+            move || read_instructions_from_parquet(&path)
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("join error reading instructions: {}", e))?
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "error reading instruction parquet {}: {}",
+                path.display(),
+                e
+            )
+        })?;
+
+        if instructions.is_empty() {
+            continue;
+        }
+
+        let range_end = end_inclusive + 1;
+
+        if tx
+            .send(DecoderMessage::SolanaInstructionsReady {
+                range_start: *start,
+                range_end,
+                instructions,
+                live_mode: false,
+            })
+            .await
+            .is_err()
+        {
+            tracing::debug!("Instruction decoder channel closed early");
+            return Ok(());
+        }
+    }
+
+    let _ = tx.send(DecoderMessage::AllComplete).await;
     Ok(())
 }
 

--- a/src/solana/pipeline.rs
+++ b/src/solana/pipeline.rs
@@ -521,6 +521,15 @@ pub async fn decode_only_solana_chain(
         "Decode-only mode for Solana chain"
     );
 
+    if let Some(scope) = &repair_scope {
+        if scope.functions.is_some() {
+            tracing::warn!(
+                chain = chain.name.as_str(),
+                "Decode-only mode does not support --function filtering; all event/instruction types will be re-decoded"
+            );
+        }
+    }
+
     let chain_arc = Arc::new(chain.clone());
     let decoders = build_decoders(&chain_arc)?;
     let program_names = Arc::new(build_program_names(&chain_arc)?);
@@ -547,8 +556,15 @@ pub async fn decode_only_solana_chain(
         // Spawn reader task to feed raw event parquet files into the decoder channel
         let event_chain_name = chain.name.clone();
         let event_scope = repair_scope.clone();
+        let event_program_names = program_names.clone();
         tasks.spawn(async move {
-            feed_raw_events_to_decoder(&event_chain_name, tx, event_scope.as_ref()).await
+            feed_raw_events_to_decoder(
+                &event_chain_name,
+                tx,
+                event_scope.as_ref(),
+                event_program_names.as_ref(),
+            )
+            .await
         });
     }
 
@@ -567,8 +583,15 @@ pub async fn decode_only_solana_chain(
         // Spawn reader task to feed raw instruction parquet files into the decoder channel
         let instr_chain_name = chain.name.clone();
         let instr_scope = repair_scope.clone();
+        let instr_program_names = program_names.clone();
         tasks.spawn(async move {
-            feed_raw_instructions_to_decoder(&instr_chain_name, tx, instr_scope.as_ref()).await
+            feed_raw_instructions_to_decoder(
+                &instr_chain_name,
+                tx,
+                instr_scope.as_ref(),
+                instr_program_names.as_ref(),
+            )
+            .await
         });
     }
 
@@ -597,6 +620,7 @@ async fn feed_raw_events_to_decoder(
     chain_name: &str,
     tx: mpsc::Sender<DecoderMessage>,
     repair_scope: Option<&RepairScope>,
+    program_names: &HashMap<[u8; 32], String>,
 ) -> anyhow::Result<()> {
     let events_dir = raw_solana_events_dir(chain_name);
 
@@ -637,6 +661,24 @@ async fn feed_raw_events_to_decoder(
         .map_err(|e| anyhow::anyhow!("join error reading events: {}", e))?
         .map_err(|e| anyhow::anyhow!("error reading event parquet {}: {}", path.display(), e))?;
 
+        // Filter by source (program name) when repair scope specifies sources
+        let events = if let Some(scope) = repair_scope {
+            if let Some(ref sources) = scope.sources {
+                events
+                    .into_iter()
+                    .filter(|e| {
+                        program_names
+                            .get(&e.program_id)
+                            .is_some_and(|name| sources.contains(name.as_str()))
+                    })
+                    .collect()
+            } else {
+                events
+            }
+        } else {
+            events
+        };
+
         if events.is_empty() {
             continue;
         }
@@ -669,6 +711,7 @@ async fn feed_raw_instructions_to_decoder(
     chain_name: &str,
     tx: mpsc::Sender<DecoderMessage>,
     repair_scope: Option<&RepairScope>,
+    program_names: &HashMap<[u8; 32], String>,
 ) -> anyhow::Result<()> {
     let instructions_dir = raw_solana_instructions_dir(chain_name);
 
@@ -714,6 +757,24 @@ async fn feed_raw_instructions_to_decoder(
                 e
             )
         })?;
+
+        // Filter by source (program name) when repair scope specifies sources
+        let instructions = if let Some(scope) = repair_scope {
+            if let Some(ref sources) = scope.sources {
+                instructions
+                    .into_iter()
+                    .filter(|i| {
+                        program_names
+                            .get(&i.program_id)
+                            .is_some_and(|name| sources.contains(name.as_str()))
+                    })
+                    .collect()
+            } else {
+                instructions
+            }
+        } else {
+            instructions
+        };
 
         if instructions.is_empty() {
             continue;

--- a/src/solana/pipeline.rs
+++ b/src/solana/pipeline.rs
@@ -399,6 +399,13 @@ pub async fn process_solana_chain(
         None
     };
 
+    // Scoped repair: source or function filters narrow the decoded output,
+    // so stale-file cleanup must be skipped (the decoder only sees a subset).
+    let scoped_repair = repair
+        && repair_scope
+            .as_ref()
+            .is_some_and(|s| s.sources.is_some() || s.functions.is_some());
+
     // Backfill task
     {
         let chain_name = runtime.chain.name.clone();
@@ -440,8 +447,9 @@ pub async fn process_solana_chain(
         let chain_name = runtime.chain.name.clone();
         let ff = function_filter.clone();
 
+        let sr = scoped_repair;
         tasks.spawn(async move {
-            decode_solana_events(event_decoder, program_names, event_rx, tx, complete, chain_name, ff)
+            decode_solana_events(event_decoder, program_names, event_rx, tx, complete, chain_name, ff, sr)
                 .await;
             Ok(())
         });
@@ -458,6 +466,7 @@ pub async fn process_solana_chain(
         let complete = transform_complete_tx.clone();
         let chain_name = runtime.chain.name.clone();
         let ff = function_filter.clone();
+        let sr = scoped_repair;
 
         tasks.spawn(async move {
             decode_solana_instructions(
@@ -468,6 +477,7 @@ pub async fn process_solana_chain(
                 complete,
                 chain_name,
                 ff,
+                sr,
             )
             .await;
             Ok(())
@@ -549,6 +559,11 @@ pub async fn decode_only_solana_chain(
         .and_then(|s| s.functions.as_ref())
         .map(|f| Arc::new(f.clone()));
 
+    // Scoped decode-only: source or function filters narrow the output
+    let scoped = repair_scope
+        .as_ref()
+        .is_some_and(|s| s.sources.is_some() || s.functions.is_some());
+
     let mut tasks: JoinSet<anyhow::Result<()>> = JoinSet::new();
 
     // Event decoding
@@ -560,7 +575,7 @@ pub async fn decode_only_solana_chain(
         let ff = function_filter.clone();
 
         tasks.spawn(async move {
-            decode_solana_events(event_decoder, names, rx, None, None, chain_name, ff).await;
+            decode_solana_events(event_decoder, names, rx, None, None, chain_name, ff, scoped).await;
             Ok(())
         });
 
@@ -588,7 +603,7 @@ pub async fn decode_only_solana_chain(
         let ff = function_filter.clone();
 
         tasks.spawn(async move {
-            decode_solana_instructions(instr_decoder, names, rx, None, None, chain_name, ff).await;
+            decode_solana_instructions(instr_decoder, names, rx, None, None, chain_name, ff, scoped).await;
             Ok(())
         });
 

--- a/src/solana/pipeline.rs
+++ b/src/solana/pipeline.rs
@@ -399,12 +399,10 @@ pub async fn process_solana_chain(
         None
     };
 
-    // Scoped repair: source or function filters narrow the decoded output,
-    // so stale-file cleanup must be skipped (the decoder only sees a subset).
-    let scoped_repair = repair
-        && repair_scope
-            .as_ref()
-            .is_some_and(|s| s.sources.is_some() || s.functions.is_some());
+    // During any repair, the decoder only receives freshly re-collected slots
+    // (not the full aligned range), so stale-file cleanup must be skipped —
+    // the decoder's output is never the authoritative full contents of a range.
+    let scoped_repair = repair;
 
     // Backfill task
     {
@@ -559,10 +557,9 @@ pub async fn decode_only_solana_chain(
         .and_then(|s| s.functions.as_ref())
         .map(|f| Arc::new(f.clone()));
 
-    // Scoped decode-only: source or function filters narrow the output
-    let scoped = repair_scope
-        .as_ref()
-        .is_some_and(|s| s.sources.is_some() || s.functions.is_some());
+    // Any repair scope makes the decode partial (range, source, or function
+    // filters all reduce what the decoder sees), so stale cleanup is unsafe.
+    let scoped = repair_scope.is_some();
 
     let mut tasks: JoinSet<anyhow::Result<()>> = JoinSet::new();
 

--- a/src/solana/pipeline.rs
+++ b/src/solana/pipeline.rs
@@ -551,17 +551,16 @@ pub async fn decode_only_solana_chain(
         .and_then(|s| s.functions.as_ref())
         .map(|f| Arc::new(f.clone()));
 
-    // Build the set of source names to SKIP during stale cleanup: current
-    // source names for programs NOT in the repair scope. Unknown directories
-    // on disk (e.g. old names from a source rename) are NOT in this set, so
-    // they will still be scanned and cleaned up.
-    let skip_sources: Option<Arc<HashSet<String>>> = repair_scope
+    // When source-scoped, restrict stale cleanup to the in-scope source
+    // directories. Unknown directories (including old names from source
+    // renames) are left untouched — we cannot distinguish an old name for
+    // an in-scope program from one for an out-of-scope program without
+    // reading parquet content. Source renames are cleaned up by running
+    // unscoped --decode-only --repair.
+    let only_sources: Option<Arc<HashSet<String>>> = repair_scope
         .as_ref()
         .and_then(|s| s.sources.as_ref())
-        .map(|scoped| {
-            let all_names: HashSet<String> = program_names.values().cloned().collect();
-            Arc::new(all_names.difference(scoped).cloned().collect())
-        });
+        .map(|s| Arc::new(s.clone()));
 
     let mut tasks: JoinSet<anyhow::Result<()>> = JoinSet::new();
 
@@ -572,7 +571,7 @@ pub async fn decode_only_solana_chain(
         let names = program_names.clone();
         let chain_name = chain.name.clone();
         let ff = function_filter.clone();
-        let ss = skip_sources.clone();
+        let ss = only_sources.clone();
 
         tasks.spawn(async move {
             decode_solana_events(event_decoder, names, rx, None, None, chain_name, ff, ss).await;
@@ -601,7 +600,7 @@ pub async fn decode_only_solana_chain(
         let names = program_names.clone();
         let chain_name = chain.name.clone();
         let ff = function_filter.clone();
-        let ss = skip_sources.clone();
+        let ss = only_sources.clone();
 
         tasks.spawn(async move {
             decode_solana_instructions(instr_decoder, names, rx, None, None, chain_name, ff, ss).await;

--- a/src/solana/pipeline.rs
+++ b/src/solana/pipeline.rs
@@ -1,0 +1,738 @@
+//! Solana pipeline orchestration.
+//!
+//! Wires together raw data collection, decoding, and transformation for Solana
+//! chains. Parallel to the EVM pipeline functions in `main.rs`.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use anyhow::Context;
+use tokio::sync::{mpsc, Mutex};
+use tokio::task::JoinSet;
+
+use crate::db::DbPool;
+use crate::decoding::DecoderMessage;
+use crate::live::LiveProgressTracker;
+use crate::solana::decoding::events::SolanaEventDecoder;
+use crate::solana::decoding::idl::AnchorDecoder;
+use crate::solana::decoding::instructions::SolanaInstructionDecoder;
+use crate::solana::decoding::spl_token::SplTokenDecoder;
+use crate::solana::decoding::tasks::{decode_solana_events, decode_solana_instructions};
+use crate::solana::decoding::traits::ProgramDecoder;
+use crate::solana::raw_data::catchup::signature_driven_backfill;
+use crate::solana::rpc::SolanaRpcClient;
+use crate::transformations::registry::{build_registry_for_solana_chain, TransformationRegistry};
+use crate::types::config::chain::ChainConfig;
+use crate::types::config::defaults;
+use crate::types::config::indexer::IndexerConfig;
+use crate::types::config::solana::SolanaPrograms;
+
+// ---------------------------------------------------------------------------
+// Feature detection
+// ---------------------------------------------------------------------------
+
+/// Feature flags derived from a Solana chain's program configuration.
+#[derive(Debug, Clone)]
+pub struct SolanaChainFeatures {
+    pub has_events: bool,
+    pub has_instructions: bool,
+    pub has_discovery: bool,
+    pub has_account_reads: bool,
+}
+
+impl SolanaChainFeatures {
+    pub fn detect(programs: &SolanaPrograms) -> Self {
+        let mut has_events = false;
+        let mut has_instructions = false;
+        let mut has_discovery = false;
+        let mut has_account_reads = false;
+
+        for program in programs.values() {
+            // Events: program has an IDL, explicit event config, or a built-in decoder
+            if program.idl_path.is_some()
+                || program.decoder.is_some()
+                || program.events.as_ref().is_some_and(|e| !e.is_empty())
+            {
+                has_events = true;
+            }
+
+            // Instructions: program has an IDL or built-in decoder
+            if program.idl_path.is_some() || program.decoder.is_some() {
+                has_instructions = true;
+            }
+
+            if program.discovery.as_ref().is_some_and(|d| !d.is_empty()) {
+                has_discovery = true;
+            }
+
+            if program.accounts.as_ref().is_some_and(|a| !a.is_empty()) {
+                has_account_reads = true;
+            }
+        }
+
+        Self {
+            has_events,
+            has_instructions,
+            has_discovery,
+            has_account_reads,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Runtime
+// ---------------------------------------------------------------------------
+
+/// Runtime infrastructure for a Solana chain.
+///
+/// Parallel to the EVM [`ChainRuntime`](crate::runtime::ChainRuntime) with
+/// Solana-specific fields.
+pub struct SolanaChainRuntime {
+    pub rpc_client: Arc<SolanaRpcClient>,
+    pub chain: Arc<ChainConfig>,
+    pub db_pool: Option<Arc<DbPool>>,
+    pub registry: Arc<TransformationRegistry>,
+    pub decoders: Vec<Arc<dyn ProgramDecoder>>,
+    pub configured_programs: HashSet<[u8; 32]>,
+    pub program_names: Arc<HashMap<[u8; 32], String>>,
+    pub features: SolanaChainFeatures,
+    pub transformations_enabled: bool,
+    pub progress_tracker: Option<Arc<Mutex<LiveProgressTracker>>>,
+}
+
+impl SolanaChainRuntime {
+    pub async fn build(
+        config: &IndexerConfig,
+        chain: &ChainConfig,
+        shared_db_pool: Option<Arc<DbPool>>,
+    ) -> anyhow::Result<Self> {
+        let chain = Arc::new(chain.clone());
+
+        // Build RPC client
+        let rpc_url = std::env::var(&chain.rpc_url_env_var).with_context(|| {
+            format!("env var {} not set for Solana RPC", chain.rpc_url_env_var)
+        })?;
+        let rpc_client = Arc::new(SolanaRpcClient::new(
+            &rpc_url,
+            chain.commitment,
+            None,
+            None,
+        )?);
+
+        // Detect features
+        let features = SolanaChainFeatures::detect(&chain.solana_programs);
+
+        // Build decoders
+        let decoders = build_decoders(&chain)?;
+
+        // Build program_id -> name mapping and configured program set
+        let program_names = Arc::new(build_program_names(&chain)?);
+        let configured_programs = build_configured_programs(&chain)?;
+
+        // Build registry
+        let registry = Arc::new(build_registry_for_solana_chain(
+            chain.chain_id,
+            &chain.solana_programs,
+        ));
+
+        // Transformations enabled if registry has handlers AND db config present
+        let transformations_enabled =
+            registry.handler_count() > 0 && config.transformations.is_some();
+
+        // Setup database if transformations enabled
+        let db_pool = if transformations_enabled {
+            if let Some(pool) = shared_db_pool {
+                Some(pool)
+            } else {
+                let tc = config.transformations.as_ref().unwrap();
+                let database_url = std::env::var(&tc.database_url_env_var).with_context(|| {
+                    format!(
+                        "env var {} not set for transformations",
+                        tc.database_url_env_var
+                    )
+                })?;
+
+                let pool = DbPool::new(&database_url, tc.db_pool_size)
+                    .await
+                    .context("failed to create database pool")?;
+                pool.run_migrations()
+                    .await
+                    .context("failed to run database migrations")?;
+                pool.run_handler_migrations(&registry)
+                    .await
+                    .context("failed to run handler migrations")?;
+
+                tracing::info!("Solana database pool initialized and migrations complete");
+                Some(Arc::new(pool))
+            }
+        } else {
+            None
+        };
+
+        // Create progress tracker
+        let progress_tracker = if transformations_enabled {
+            let tracker = Arc::new(Mutex::new(LiveProgressTracker::new(
+                chain.chain_id as i64,
+                db_pool.clone(),
+                chain.name.clone(),
+            )));
+            {
+                let mut t = tracker.lock().await;
+                for handler in registry.all_handlers() {
+                    t.register_handler(&handler.handler_key());
+                }
+            }
+            Some(tracker)
+        } else {
+            None
+        };
+
+        tracing::info!(
+            chain = chain.name.as_str(),
+            has_events = features.has_events,
+            has_instructions = features.has_instructions,
+            has_discovery = features.has_discovery,
+            has_account_reads = features.has_account_reads,
+            transformations_enabled,
+            programs = chain.solana_programs.len(),
+            decoders = decoders.len(),
+            handlers = registry.handler_count(),
+            "Solana chain runtime built"
+        );
+
+        Ok(Self {
+            rpc_client,
+            chain,
+            db_pool,
+            registry,
+            decoders,
+            configured_programs,
+            program_names,
+            features,
+            transformations_enabled,
+            progress_tracker,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Decoder construction
+// ---------------------------------------------------------------------------
+
+/// Build [`ProgramDecoder`] instances from the chain's Solana program configs.
+fn build_decoders(chain: &ChainConfig) -> anyhow::Result<Vec<Arc<dyn ProgramDecoder>>> {
+    let mut decoders: Vec<Arc<dyn ProgramDecoder>> = Vec::new();
+
+    for (name, program) in &chain.solana_programs {
+        let program_id_bytes = parse_program_id(&program.program_id)
+            .with_context(|| format!("invalid program_id for '{}'", name))?;
+
+        // Built-in decoder takes precedence
+        if let Some(ref decoder_name) = program.decoder {
+            match decoder_name.as_str() {
+                "spl_token" => {
+                    tracing::info!(program = name.as_str(), "Using built-in SPL Token decoder");
+                    decoders.push(Arc::new(SplTokenDecoder::new()));
+                }
+                other => {
+                    tracing::warn!(
+                        program = name.as_str(),
+                        decoder = other,
+                        "Unknown built-in decoder, skipping"
+                    );
+                }
+            }
+            continue;
+        }
+
+        // IDL-based decoder
+        if let Some(ref idl_path) = program.idl_path {
+            let idl_json = std::fs::read_to_string(idl_path)
+                .with_context(|| format!("failed to read IDL for '{}' at {}", name, idl_path))?;
+
+            let anchor = AnchorDecoder::new(program_id_bytes, name.clone(), &idl_json)
+                .map_err(|e| anyhow::anyhow!("failed to parse IDL for '{}': {}", name, e))?;
+
+            tracing::info!(
+                program = name.as_str(),
+                idl_path,
+                events = anchor.event_types().len(),
+                instructions = anchor.instruction_types().len(),
+                accounts = anchor.account_types().len(),
+                "Loaded Anchor IDL decoder"
+            );
+            decoders.push(Arc::new(anchor));
+            continue;
+        }
+
+        tracing::warn!(
+            program = name.as_str(),
+            "No decoder or IDL configured, program events/instructions will not be decoded"
+        );
+    }
+
+    Ok(decoders)
+}
+
+/// Build `program_id bytes -> config key name` mapping.
+fn build_program_names(chain: &ChainConfig) -> anyhow::Result<HashMap<[u8; 32], String>> {
+    let mut names = HashMap::new();
+    for (name, program) in &chain.solana_programs {
+        let bytes = parse_program_id(&program.program_id)
+            .with_context(|| format!("invalid program_id for '{}'", name))?;
+        names.insert(bytes, name.clone());
+    }
+    Ok(names)
+}
+
+/// Build the set of configured program IDs (as bytes) for raw data filtering.
+fn build_configured_programs(chain: &ChainConfig) -> anyhow::Result<HashSet<[u8; 32]>> {
+    let mut programs = HashSet::new();
+    for (name, program) in &chain.solana_programs {
+        let bytes = parse_program_id(&program.program_id)
+            .with_context(|| format!("invalid program_id for '{}'", name))?;
+        programs.insert(bytes);
+    }
+    Ok(programs)
+}
+
+/// Decode a base58 program ID string into 32 bytes.
+fn parse_program_id(program_id: &str) -> anyhow::Result<[u8; 32]> {
+    let decoded = bs58::decode(program_id)
+        .into_vec()
+        .map_err(|e| anyhow::anyhow!("invalid base58: {}", e))?;
+    let bytes: [u8; 32] = decoded
+        .try_into()
+        .map_err(|v: Vec<u8>| anyhow::anyhow!("expected 32 bytes, got {}", v.len()))?;
+    Ok(bytes)
+}
+
+// ---------------------------------------------------------------------------
+// Historical pipeline
+// ---------------------------------------------------------------------------
+
+/// Run the Solana historical pipeline for a chain.
+///
+/// 1. Build runtime (RPC client, decoders, registry)
+/// 2. Create channels between collection → decoding → transformation
+/// 3. Spawn signature-driven backfill
+/// 4. Spawn decoder tasks
+/// 5. (Future) Spawn transformation engine when handlers exist
+/// 6. Wait for completion
+/// 7. Stub live mode
+pub async fn process_solana_chain(
+    config: &IndexerConfig,
+    chain: &ChainConfig,
+    catch_up_only: bool,
+    shared_db_pool: Option<Arc<DbPool>>,
+) -> anyhow::Result<()> {
+    tracing::info!(chain = chain.name.as_str(), "Starting Solana pipeline");
+
+    let runtime = SolanaChainRuntime::build(config, chain, shared_db_pool).await?;
+
+    let channel_capacity = config
+        .raw_data_collection
+        .channel_capacity
+        .unwrap_or(defaults::raw_data::CHANNEL_CAPACITY);
+    let range_size = config
+        .raw_data_collection
+        .parquet_block_range
+        .unwrap_or(1000) as u64;
+
+    // --- Create channels ---
+
+    // Decoder input channels (raw data → decoders)
+    let (event_decoder_tx, event_decoder_rx) = if runtime.features.has_events {
+        let (tx, rx) = mpsc::channel::<DecoderMessage>(channel_capacity);
+        (Some(tx), Some(rx))
+    } else {
+        (None, None)
+    };
+
+    let (instr_decoder_tx, instr_decoder_rx) = if runtime.features.has_instructions {
+        let (tx, rx) = mpsc::channel::<DecoderMessage>(channel_capacity);
+        (Some(tx), Some(rx))
+    } else {
+        (None, None)
+    };
+
+    // Transformation channels (decoders → engine)
+    // Currently unused since no Solana handlers exist yet, but wired up
+    // so the decoder tasks have somewhere to send when handlers are added.
+    let (transform_events_tx, _transform_events_rx) = if runtime.transformations_enabled {
+        let (tx, rx) = mpsc::channel(channel_capacity);
+        (Some(tx), Some(rx))
+    } else {
+        (None, None)
+    };
+
+    let (transform_complete_tx, _transform_complete_rx) = if runtime.transformations_enabled {
+        let (tx, rx) = mpsc::channel(channel_capacity);
+        (Some(tx), Some(rx))
+    } else {
+        (None, None)
+    };
+
+    // --- Spawn tasks ---
+
+    let mut tasks: JoinSet<anyhow::Result<()>> = JoinSet::new();
+
+    // Backfill task
+    {
+        let chain_name = runtime.chain.name.clone();
+        let rpc_client = runtime.rpc_client.clone();
+        let programs = runtime.chain.solana_programs.clone();
+        let configured_programs = runtime.configured_programs.clone();
+        let event_tx = event_decoder_tx.clone();
+        let instr_tx = instr_decoder_tx.clone();
+
+        tasks.spawn(async move {
+            let result = signature_driven_backfill(
+                &chain_name,
+                &rpc_client,
+                &programs,
+                range_size,
+                &configured_programs,
+                event_tx.as_ref(),
+                instr_tx.as_ref(),
+            )
+            .await;
+
+            // Drop our senders to signal downstream that backfill is done.
+            // The decoder tasks will see channel close after all senders are dropped.
+            drop(event_tx);
+            drop(instr_tx);
+
+            result.map_err(|e| anyhow::anyhow!("Solana backfill failed: {}", e))
+        });
+    }
+
+    // Event decoder task
+    if let Some(event_rx) = event_decoder_rx {
+        let event_decoder = Arc::new(SolanaEventDecoder::new(runtime.decoders.clone()));
+        let program_names = runtime.program_names.clone();
+        let tx = transform_events_tx.clone();
+        let complete = transform_complete_tx.clone();
+
+        tasks.spawn(async move {
+            decode_solana_events(event_decoder, program_names, event_rx, tx, complete).await;
+            Ok(())
+        });
+    }
+
+    // Drop the original event_decoder_tx so only the backfill task's clone remains
+    drop(event_decoder_tx);
+
+    // Instruction decoder task
+    if let Some(instr_rx) = instr_decoder_rx {
+        let instr_decoder = Arc::new(SolanaInstructionDecoder::new(runtime.decoders.clone()));
+        let program_names = runtime.program_names.clone();
+        let tx = transform_events_tx.clone();
+        let complete = transform_complete_tx.clone();
+
+        tasks.spawn(async move {
+            decode_solana_instructions(instr_decoder, program_names, instr_rx, tx, complete).await;
+            Ok(())
+        });
+    }
+
+    // Drop remaining transform senders so channels close when decoder tasks finish
+    drop(transform_events_tx);
+    drop(transform_complete_tx);
+
+    // Drop the original instr_decoder_tx so only the backfill task's clone remains
+    drop(instr_decoder_tx);
+
+    // TODO: Spawn TransformationEngine when Solana handlers exist.
+    // Currently `transformations_enabled` is always false (no handlers registered).
+    // When handlers are added, the engine will need to accept a Solana RPC client
+    // (or make the EVM client optional). Wire _transform_events_rx and
+    // _transform_complete_rx into engine.run() at that point.
+
+    // --- Wait for all tasks ---
+
+    while let Some(result) = tasks.join_next().await {
+        result.context("Solana pipeline task panicked")??;
+    }
+
+    tracing::info!(chain = chain.name.as_str(), "Solana historical pipeline complete");
+
+    // --- Live mode stub ---
+
+    if !catch_up_only {
+        let live_mode = config
+            .raw_data_collection
+            .live_mode
+            .unwrap_or(false);
+        if live_mode {
+            tracing::warn!(
+                chain = chain.name.as_str(),
+                "Solana live mode not yet implemented — skipping. \
+                 Live collector, reorg detection, and account reader are Phase 8."
+            );
+        }
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Decode-only pipeline
+// ---------------------------------------------------------------------------
+
+/// Re-decode existing raw parquet files without collection or transformation.
+///
+/// Reads raw event and instruction parquet from disk, runs them through the
+/// configured decoders, and writes decoded parquet output. Useful for
+/// re-processing after IDL updates.
+pub async fn decode_only_solana_chain(
+    config: &IndexerConfig,
+    chain: &ChainConfig,
+) -> anyhow::Result<()> {
+    tracing::info!(
+        chain = chain.name.as_str(),
+        "Decode-only mode for Solana chain"
+    );
+
+    let chain_arc = Arc::new(chain.clone());
+    let decoders = build_decoders(&chain_arc)?;
+    let program_names = Arc::new(build_program_names(&chain_arc)?);
+
+    let channel_capacity = config
+        .raw_data_collection
+        .channel_capacity
+        .unwrap_or(defaults::raw_data::CHANNEL_CAPACITY);
+
+    let mut tasks: JoinSet<anyhow::Result<()>> = JoinSet::new();
+
+    // Event decoding
+    if !decoders.is_empty() {
+        let event_decoder = Arc::new(SolanaEventDecoder::new(decoders.clone()));
+        let (tx, rx) = mpsc::channel::<DecoderMessage>(channel_capacity);
+        let names = program_names.clone();
+
+        tasks.spawn(async move {
+            decode_solana_events(event_decoder, names, rx, None, None).await;
+            Ok(())
+        });
+
+        // TODO: Read raw event parquet files and send as SolanaEventsReady messages.
+        // For now, close the channel immediately since parquet reading is not wired.
+        drop(tx);
+    }
+
+    // Instruction decoding
+    if !decoders.is_empty() {
+        let instr_decoder = Arc::new(SolanaInstructionDecoder::new(decoders.clone()));
+        let (tx, rx) = mpsc::channel::<DecoderMessage>(channel_capacity);
+        let names = program_names.clone();
+
+        tasks.spawn(async move {
+            decode_solana_instructions(instr_decoder, names, rx, None, None).await;
+            Ok(())
+        });
+
+        // TODO: Read raw instruction parquet files and send as SolanaInstructionsReady.
+        drop(tx);
+    }
+
+    while let Some(result) = tasks.join_next().await {
+        result.context("Solana decode-only task panicked")??;
+    }
+
+    tracing::info!(
+        chain = chain.name.as_str(),
+        "Solana decode-only processing complete"
+    );
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::config::solana::{
+        SolanaAccountReadConfig, SolanaDiscoveryConfig, SolanaEventConfig, SolanaProgramConfig,
+    };
+
+    fn make_programs(configs: Vec<(&str, SolanaProgramConfig)>) -> SolanaPrograms {
+        configs
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v))
+            .collect()
+    }
+
+    fn idl_program(program_id: &str) -> SolanaProgramConfig {
+        SolanaProgramConfig {
+            program_id: program_id.to_string(),
+            idl_path: Some("/tmp/test.json".to_string()),
+            idl_format: None,
+            decoder: None,
+            events: None,
+            accounts: None,
+            discovery: None,
+            start_slot: None,
+        }
+    }
+
+    fn builtin_program(program_id: &str, decoder: &str) -> SolanaProgramConfig {
+        SolanaProgramConfig {
+            program_id: program_id.to_string(),
+            idl_path: None,
+            idl_format: None,
+            decoder: Some(decoder.to_string()),
+            events: None,
+            accounts: None,
+            discovery: None,
+            start_slot: None,
+        }
+    }
+
+    fn bare_program(program_id: &str) -> SolanaProgramConfig {
+        SolanaProgramConfig {
+            program_id: program_id.to_string(),
+            idl_path: None,
+            idl_format: None,
+            decoder: None,
+            events: None,
+            accounts: None,
+            discovery: None,
+            start_slot: None,
+        }
+    }
+
+    #[test]
+    fn features_empty_programs() {
+        let features = SolanaChainFeatures::detect(&SolanaPrograms::new());
+        assert!(!features.has_events);
+        assert!(!features.has_instructions);
+        assert!(!features.has_discovery);
+        assert!(!features.has_account_reads);
+    }
+
+    #[test]
+    fn features_idl_program() {
+        let programs = make_programs(vec![("whirlpool", idl_program("11111111111111111111111111111111"))]);
+        let features = SolanaChainFeatures::detect(&programs);
+        assert!(features.has_events);
+        assert!(features.has_instructions);
+        assert!(!features.has_discovery);
+        assert!(!features.has_account_reads);
+    }
+
+    #[test]
+    fn features_builtin_decoder() {
+        let programs = make_programs(vec![("spl_token", builtin_program("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA", "spl_token"))]);
+        let features = SolanaChainFeatures::detect(&programs);
+        assert!(features.has_events);
+        assert!(features.has_instructions);
+    }
+
+    #[test]
+    fn features_bare_program_no_capabilities() {
+        let programs = make_programs(vec![("bare", bare_program("11111111111111111111111111111111"))]);
+        let features = SolanaChainFeatures::detect(&programs);
+        assert!(!features.has_events);
+        assert!(!features.has_instructions);
+    }
+
+    #[test]
+    fn features_explicit_events_only() {
+        let mut prog = bare_program("11111111111111111111111111111111");
+        prog.events = Some(vec![SolanaEventConfig {
+            name: "Transfer".to_string(),
+            discriminator: None,
+        }]);
+        let programs = make_programs(vec![("test", prog)]);
+        let features = SolanaChainFeatures::detect(&programs);
+        assert!(features.has_events);
+        assert!(!features.has_instructions);
+    }
+
+    #[test]
+    fn features_discovery_detected() {
+        let mut prog = idl_program("11111111111111111111111111111111");
+        prog.discovery = Some(vec![SolanaDiscoveryConfig {
+            event_name: "PoolCreated".to_string(),
+            address_field: "pool".to_string(),
+            account_type: Some("Pool".to_string()),
+        }]);
+        let programs = make_programs(vec![("test", prog)]);
+        let features = SolanaChainFeatures::detect(&programs);
+        assert!(features.has_discovery);
+    }
+
+    #[test]
+    fn features_account_reads_detected() {
+        let mut prog = idl_program("11111111111111111111111111111111");
+        prog.accounts = Some(vec![SolanaAccountReadConfig {
+            name: "pool_state".to_string(),
+            account_type: "Pool".to_string(),
+            frequency: crate::types::config::eth_call::Frequency::Once,
+        }]);
+        let programs = make_programs(vec![("test", prog)]);
+        let features = SolanaChainFeatures::detect(&programs);
+        assert!(features.has_account_reads);
+    }
+
+    #[test]
+    fn parse_program_id_valid() {
+        // 11111111111111111111111111111111 is the system program
+        let bytes = parse_program_id("11111111111111111111111111111111").unwrap();
+        assert_eq!(bytes, [0u8; 32]);
+    }
+
+    #[test]
+    fn parse_program_id_invalid() {
+        assert!(parse_program_id("not-a-valid-base58!!!").is_err());
+        assert!(parse_program_id("").is_err());
+    }
+
+    #[test]
+    fn build_program_names_and_configured() {
+        let mut programs = SolanaPrograms::new();
+        programs.insert(
+            "spl_token".to_string(),
+            builtin_program("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA", "spl_token"),
+        );
+
+        // Construct a minimal ChainConfig to test with
+        let chain = test_chain_config(programs);
+        let names = build_program_names(&chain).unwrap();
+        let configured = build_configured_programs(&chain).unwrap();
+
+        assert_eq!(names.len(), 1);
+        assert_eq!(configured.len(), 1);
+
+        // The name should map back to "spl_token"
+        let first_key = *configured.iter().next().unwrap();
+        assert_eq!(names.get(&first_key), Some(&"spl_token".to_string()));
+    }
+
+    /// Build a minimal ChainConfig for testing.
+    fn test_chain_config(programs: SolanaPrograms) -> ChainConfig {
+        use crate::types::chain::ChainType;
+        use crate::types::config::contract::{Contracts, FactoryCollections};
+        use crate::types::config::chain::RpcConfig;
+        use crate::types::config::solana::SolanaCommitment;
+
+        ChainConfig {
+            name: "test-solana".to_string(),
+            chain_id: 0,
+            chain_type: ChainType::Solana,
+            rpc_url_env_var: "SOLANA_RPC_URL".to_string(),
+            ws_url_env_var: None,
+            start_block: None,
+            contracts: Contracts::new(),
+            block_receipts_method: None,
+            factory_collections: FactoryCollections::new(),
+            rpc: RpcConfig::default(),
+            solana_programs: programs,
+            commitment: SolanaCommitment::default(),
+        }
+    }
+}

--- a/src/solana/pipeline.rs
+++ b/src/solana/pipeline.rs
@@ -703,10 +703,9 @@ async fn feed_raw_events_to_decoder(
             events
         };
 
-        if events.is_empty() {
-            continue;
-        }
-
+        // Always send the message — even when empty — so the decoder task
+        // runs stale cleanup for this range. Skipping empty ranges would
+        // leave old decoded parquet behind after an IDL rename/removal.
         if tx
             .send(DecoderMessage::SolanaEventsReady {
                 range_start: *start,
@@ -800,10 +799,7 @@ async fn feed_raw_instructions_to_decoder(
             instructions
         };
 
-        if instructions.is_empty() {
-            continue;
-        }
-
+        // Always send — see comment in feed_raw_events_to_decoder.
         if tx
             .send(DecoderMessage::SolanaInstructionsReady {
                 range_start: *start,

--- a/src/solana/pipeline.rs
+++ b/src/solana/pipeline.rs
@@ -399,10 +399,10 @@ pub async fn process_solana_chain(
         None
     };
 
-    // During any repair, the decoder only receives freshly re-collected slots
-    // (not the full aligned range), so stale-file cleanup must be skipped —
-    // the decoder's output is never the authoritative full contents of a range.
-    let scoped_repair = repair;
+    // The decoder receives fully merged data for each range (fresh + retained),
+    // so stale cleanup is safe unless a function filter is active — that makes
+    // the decoded output a partial subset of the range's decoded groups.
+    let scoped_repair = function_filter.is_some();
 
     // Backfill task
     {
@@ -557,9 +557,13 @@ pub async fn decode_only_solana_chain(
         .and_then(|s| s.functions.as_ref())
         .map(|f| Arc::new(f.clone()));
 
-    // Any repair scope makes the decode partial (range, source, or function
-    // filters all reduce what the decoder sees), so stale cleanup is unsafe.
-    let scoped = repair_scope.is_some();
+    // Range-only scoping still sends complete file contents to the decoder (the
+    // feeder skips entire files, not individual records), so stale cleanup is
+    // safe. Only source or function filters make the decoder's output a partial
+    // subset where cleanup would incorrectly delete out-of-scope files.
+    let scoped = repair_scope.as_ref().is_some_and(|s| {
+        s.sources.is_some() || s.functions.is_some()
+    });
 
     let mut tasks: JoinSet<anyhow::Result<()>> = JoinSet::new();
 

--- a/src/solana/pipeline.rs
+++ b/src/solana/pipeline.rs
@@ -551,13 +551,17 @@ pub async fn decode_only_solana_chain(
         .and_then(|s| s.functions.as_ref())
         .map(|f| Arc::new(f.clone()));
 
-    // Source scope for stale cleanup: in decode-only mode the feeders already
-    // filter raw records by source, so the decoder has a complete view for those
-    // sources. Pass the source set so cleanup is limited to them.
-    let source_scope: Option<Arc<HashSet<String>>> = repair_scope
+    // Build the set of source names to SKIP during stale cleanup: current
+    // source names for programs NOT in the repair scope. Unknown directories
+    // on disk (e.g. old names from a source rename) are NOT in this set, so
+    // they will still be scanned and cleaned up.
+    let skip_sources: Option<Arc<HashSet<String>>> = repair_scope
         .as_ref()
         .and_then(|s| s.sources.as_ref())
-        .map(|s| Arc::new(s.clone()));
+        .map(|scoped| {
+            let all_names: HashSet<String> = program_names.values().cloned().collect();
+            Arc::new(all_names.difference(scoped).cloned().collect())
+        });
 
     let mut tasks: JoinSet<anyhow::Result<()>> = JoinSet::new();
 
@@ -568,7 +572,7 @@ pub async fn decode_only_solana_chain(
         let names = program_names.clone();
         let chain_name = chain.name.clone();
         let ff = function_filter.clone();
-        let ss = source_scope.clone();
+        let ss = skip_sources.clone();
 
         tasks.spawn(async move {
             decode_solana_events(event_decoder, names, rx, None, None, chain_name, ff, ss).await;
@@ -597,7 +601,7 @@ pub async fn decode_only_solana_chain(
         let names = program_names.clone();
         let chain_name = chain.name.clone();
         let ff = function_filter.clone();
-        let ss = source_scope.clone();
+        let ss = skip_sources.clone();
 
         tasks.spawn(async move {
             decode_solana_instructions(instr_decoder, names, rx, None, None, chain_name, ff, ss).await;

--- a/src/solana/pipeline.rs
+++ b/src/solana/pipeline.rs
@@ -389,6 +389,16 @@ pub async fn process_solana_chain(
 
     let mut tasks: JoinSet<anyhow::Result<()>> = JoinSet::new();
 
+    // Build function filter from repair scope before moving repair_scope
+    let function_filter = if repair {
+        repair_scope
+            .as_ref()
+            .and_then(|s| s.functions.as_ref())
+            .map(|f| Arc::new(f.clone()))
+    } else {
+        None
+    };
+
     // Backfill task
     {
         let chain_name = runtime.chain.name.clone();
@@ -428,9 +438,10 @@ pub async fn process_solana_chain(
         let tx = transform_events_tx.clone();
         let complete = transform_complete_tx.clone();
         let chain_name = runtime.chain.name.clone();
+        let ff = function_filter.clone();
 
         tasks.spawn(async move {
-            decode_solana_events(event_decoder, program_names, event_rx, tx, complete, chain_name)
+            decode_solana_events(event_decoder, program_names, event_rx, tx, complete, chain_name, ff)
                 .await;
             Ok(())
         });
@@ -446,6 +457,7 @@ pub async fn process_solana_chain(
         let tx = transform_events_tx.clone();
         let complete = transform_complete_tx.clone();
         let chain_name = runtime.chain.name.clone();
+        let ff = function_filter.clone();
 
         tasks.spawn(async move {
             decode_solana_instructions(
@@ -455,6 +467,7 @@ pub async fn process_solana_chain(
                 tx,
                 complete,
                 chain_name,
+                ff,
             )
             .await;
             Ok(())
@@ -521,15 +534,6 @@ pub async fn decode_only_solana_chain(
         "Decode-only mode for Solana chain"
     );
 
-    if let Some(scope) = &repair_scope {
-        if scope.functions.is_some() {
-            tracing::warn!(
-                chain = chain.name.as_str(),
-                "Decode-only mode does not support --function filtering; all event/instruction types will be re-decoded"
-            );
-        }
-    }
-
     let chain_arc = Arc::new(chain.clone());
     let decoders = build_decoders(&chain_arc)?;
     let program_names = Arc::new(build_program_names(&chain_arc)?);
@@ -539,6 +543,12 @@ pub async fn decode_only_solana_chain(
         .channel_capacity
         .unwrap_or(defaults::raw_data::CHANNEL_CAPACITY);
 
+    // Build function filter from repair scope
+    let function_filter = repair_scope
+        .as_ref()
+        .and_then(|s| s.functions.as_ref())
+        .map(|f| Arc::new(f.clone()));
+
     let mut tasks: JoinSet<anyhow::Result<()>> = JoinSet::new();
 
     // Event decoding
@@ -547,9 +557,10 @@ pub async fn decode_only_solana_chain(
         let (tx, rx) = mpsc::channel::<DecoderMessage>(channel_capacity);
         let names = program_names.clone();
         let chain_name = chain.name.clone();
+        let ff = function_filter.clone();
 
         tasks.spawn(async move {
-            decode_solana_events(event_decoder, names, rx, None, None, chain_name).await;
+            decode_solana_events(event_decoder, names, rx, None, None, chain_name, ff).await;
             Ok(())
         });
 
@@ -574,9 +585,10 @@ pub async fn decode_only_solana_chain(
         let (tx, rx) = mpsc::channel::<DecoderMessage>(channel_capacity);
         let names = program_names.clone();
         let chain_name = chain.name.clone();
+        let ff = function_filter.clone();
 
         tasks.spawn(async move {
-            decode_solana_instructions(instr_decoder, names, rx, None, None, chain_name).await;
+            decode_solana_instructions(instr_decoder, names, rx, None, None, chain_name, ff).await;
             Ok(())
         });
 

--- a/src/solana/pipeline.rs
+++ b/src/solana/pipeline.rs
@@ -513,9 +513,11 @@ pub async fn process_solana_chain(
 pub async fn decode_only_solana_chain(
     config: &IndexerConfig,
     chain: &ChainConfig,
+    repair_scope: Option<RepairScope>,
 ) -> anyhow::Result<()> {
     tracing::info!(
         chain = chain.name.as_str(),
+        ?repair_scope,
         "Decode-only mode for Solana chain"
     );
 
@@ -544,8 +546,9 @@ pub async fn decode_only_solana_chain(
 
         // Spawn reader task to feed raw event parquet files into the decoder channel
         let event_chain_name = chain.name.clone();
+        let event_scope = repair_scope.clone();
         tasks.spawn(async move {
-            feed_raw_events_to_decoder(&event_chain_name, tx).await
+            feed_raw_events_to_decoder(&event_chain_name, tx, event_scope.as_ref()).await
         });
     }
 
@@ -563,8 +566,9 @@ pub async fn decode_only_solana_chain(
 
         // Spawn reader task to feed raw instruction parquet files into the decoder channel
         let instr_chain_name = chain.name.clone();
+        let instr_scope = repair_scope.clone();
         tasks.spawn(async move {
-            feed_raw_instructions_to_decoder(&instr_chain_name, tx).await
+            feed_raw_instructions_to_decoder(&instr_chain_name, tx, instr_scope.as_ref()).await
         });
     }
 
@@ -592,6 +596,7 @@ pub async fn decode_only_solana_chain(
 async fn feed_raw_events_to_decoder(
     chain_name: &str,
     tx: mpsc::Sender<DecoderMessage>,
+    repair_scope: Option<&RepairScope>,
 ) -> anyhow::Result<()> {
     let events_dir = raw_solana_events_dir(chain_name);
 
@@ -615,6 +620,15 @@ async fn feed_raw_events_to_decoder(
     );
 
     for (start, end_inclusive, path) in &ranges {
+        let range_end = end_inclusive + 1;
+
+        // Skip ranges outside the repair scope
+        if let Some(scope) = repair_scope {
+            if !scope.matches_range(*start, range_end) {
+                continue;
+            }
+        }
+
         let events = tokio::task::spawn_blocking({
             let path = path.clone();
             move || read_events_from_parquet(&path)
@@ -626,9 +640,6 @@ async fn feed_raw_events_to_decoder(
         if events.is_empty() {
             continue;
         }
-
-        // range_end is exclusive in DecoderMessage convention
-        let range_end = end_inclusive + 1;
 
         if tx
             .send(DecoderMessage::SolanaEventsReady {
@@ -657,6 +668,7 @@ async fn feed_raw_events_to_decoder(
 async fn feed_raw_instructions_to_decoder(
     chain_name: &str,
     tx: mpsc::Sender<DecoderMessage>,
+    repair_scope: Option<&RepairScope>,
 ) -> anyhow::Result<()> {
     let instructions_dir = raw_solana_instructions_dir(chain_name);
 
@@ -680,6 +692,15 @@ async fn feed_raw_instructions_to_decoder(
     );
 
     for (start, end_inclusive, path) in &ranges {
+        let range_end = end_inclusive + 1;
+
+        // Skip ranges outside the repair scope
+        if let Some(scope) = repair_scope {
+            if !scope.matches_range(*start, range_end) {
+                continue;
+            }
+        }
+
         let instructions = tokio::task::spawn_blocking({
             let path = path.clone();
             move || read_instructions_from_parquet(&path)
@@ -697,8 +718,6 @@ async fn feed_raw_instructions_to_decoder(
         if instructions.is_empty() {
             continue;
         }
-
-        let range_end = end_inclusive + 1;
 
         if tx
             .send(DecoderMessage::SolanaInstructionsReady {

--- a/src/solana/pipeline.rs
+++ b/src/solana/pipeline.rs
@@ -399,11 +399,6 @@ pub async fn process_solana_chain(
         None
     };
 
-    // The decoder receives fully merged data for each range (fresh + retained),
-    // so stale cleanup is safe unless a function filter is active — that makes
-    // the decoded output a partial subset of the range's decoded groups.
-    let scoped_repair = function_filter.is_some();
-
     // Backfill task
     {
         let chain_name = runtime.chain.name.clone();
@@ -436,7 +431,8 @@ pub async fn process_solana_chain(
         });
     }
 
-    // Event decoder task
+    // Event decoder task — decoder receives fully merged data for each range
+    // (no source scope needed). Only function filtering makes output partial.
     if let Some(event_rx) = event_decoder_rx {
         let event_decoder = Arc::new(SolanaEventDecoder::new(runtime.decoders.clone()));
         let program_names = runtime.program_names.clone();
@@ -445,9 +441,8 @@ pub async fn process_solana_chain(
         let chain_name = runtime.chain.name.clone();
         let ff = function_filter.clone();
 
-        let sr = scoped_repair;
         tasks.spawn(async move {
-            decode_solana_events(event_decoder, program_names, event_rx, tx, complete, chain_name, ff, sr)
+            decode_solana_events(event_decoder, program_names, event_rx, tx, complete, chain_name, ff, None)
                 .await;
             Ok(())
         });
@@ -464,7 +459,6 @@ pub async fn process_solana_chain(
         let complete = transform_complete_tx.clone();
         let chain_name = runtime.chain.name.clone();
         let ff = function_filter.clone();
-        let sr = scoped_repair;
 
         tasks.spawn(async move {
             decode_solana_instructions(
@@ -475,7 +469,7 @@ pub async fn process_solana_chain(
                 complete,
                 chain_name,
                 ff,
-                sr,
+                None,
             )
             .await;
             Ok(())
@@ -557,13 +551,13 @@ pub async fn decode_only_solana_chain(
         .and_then(|s| s.functions.as_ref())
         .map(|f| Arc::new(f.clone()));
 
-    // Range-only scoping still sends complete file contents to the decoder (the
-    // feeder skips entire files, not individual records), so stale cleanup is
-    // safe. Only source or function filters make the decoder's output a partial
-    // subset where cleanup would incorrectly delete out-of-scope files.
-    let scoped = repair_scope.as_ref().is_some_and(|s| {
-        s.sources.is_some() || s.functions.is_some()
-    });
+    // Source scope for stale cleanup: in decode-only mode the feeders already
+    // filter raw records by source, so the decoder has a complete view for those
+    // sources. Pass the source set so cleanup is limited to them.
+    let source_scope: Option<Arc<HashSet<String>>> = repair_scope
+        .as_ref()
+        .and_then(|s| s.sources.as_ref())
+        .map(|s| Arc::new(s.clone()));
 
     let mut tasks: JoinSet<anyhow::Result<()>> = JoinSet::new();
 
@@ -574,9 +568,10 @@ pub async fn decode_only_solana_chain(
         let names = program_names.clone();
         let chain_name = chain.name.clone();
         let ff = function_filter.clone();
+        let ss = source_scope.clone();
 
         tasks.spawn(async move {
-            decode_solana_events(event_decoder, names, rx, None, None, chain_name, ff, scoped).await;
+            decode_solana_events(event_decoder, names, rx, None, None, chain_name, ff, ss).await;
             Ok(())
         });
 
@@ -602,9 +597,10 @@ pub async fn decode_only_solana_chain(
         let names = program_names.clone();
         let chain_name = chain.name.clone();
         let ff = function_filter.clone();
+        let ss = source_scope.clone();
 
         tasks.spawn(async move {
-            decode_solana_instructions(instr_decoder, names, rx, None, None, chain_name, ff, scoped).await;
+            decode_solana_instructions(instr_decoder, names, rx, None, None, chain_name, ff, ss).await;
             Ok(())
         });
 

--- a/src/solana/pipeline.rs
+++ b/src/solana/pipeline.rs
@@ -333,15 +333,12 @@ pub async fn process_solana_chain(
     repair_scope: Option<RepairScope>,
     shared_db_pool: Option<Arc<DbPool>>,
 ) -> anyhow::Result<()> {
-    tracing::info!(chain = chain.name.as_str(), "Starting Solana pipeline");
-
-    if repair || repair_scope.is_some() {
-        tracing::warn!(
-            chain = chain.name.as_str(),
-            "Solana repair mode is not yet implemented — running normal backfill instead. \
-             Repair scope will be ignored."
-        );
-    }
+    tracing::info!(
+        chain = chain.name.as_str(),
+        repair,
+        ?repair_scope,
+        "Starting Solana pipeline"
+    );
 
     let runtime = SolanaChainRuntime::build(config, chain, shared_db_pool).await?;
 
@@ -400,6 +397,7 @@ pub async fn process_solana_chain(
         let configured_programs = runtime.configured_programs.clone();
         let event_tx = event_decoder_tx.clone();
         let instr_tx = instr_decoder_tx.clone();
+        let backfill_repair_scope = if repair { repair_scope } else { None };
 
         tasks.spawn(async move {
             let result = signature_driven_backfill(
@@ -410,6 +408,7 @@ pub async fn process_solana_chain(
                 &configured_programs,
                 event_tx.as_ref(),
                 instr_tx.as_ref(),
+                backfill_repair_scope.as_ref(),
             )
             .await;
 

--- a/src/solana/raw_data/catchup.rs
+++ b/src/solana/raw_data/catchup.rs
@@ -142,7 +142,7 @@ pub async fn signature_driven_backfill(
     let slots_with_sigs =
         collect_all_signatures(rpc_client, active_programs, effective_start, end_slot).await?;
 
-    if slots_with_sigs.is_empty() {
+    if slots_with_sigs.is_empty() && !is_repair {
         tracing::info!(
             chain = chain_name,
             "No new signatures found, backfill complete"
@@ -150,27 +150,30 @@ pub async fn signature_driven_backfill(
         return Ok(());
     }
 
-    let total_slots = slots_with_sigs.len();
-    let min_slot = *slots_with_sigs.keys().next().unwrap();
-    let max_slot = *slots_with_sigs.keys().next_back().unwrap();
+    if !slots_with_sigs.is_empty() {
+        let total_slots = slots_with_sigs.len();
+        let min_slot = *slots_with_sigs.keys().next().unwrap();
+        let max_slot = *slots_with_sigs.keys().next_back().unwrap();
 
-    tracing::info!(
-        chain = chain_name,
-        total_slots,
-        min_slot,
-        max_slot,
-        "Discovered slots with relevant transactions"
-    );
+        tracing::info!(
+            chain = chain_name,
+            total_slots,
+            min_slot,
+            max_slot,
+            "Discovered slots with relevant transactions"
+        );
+    }
 
     // Group slots into aligned ranges
     let target_slots: BTreeSet<u64> = slots_with_sigs.keys().copied().collect();
+    let mut sig_ranges: HashSet<(u64, u64)> = HashSet::new();
     let ranges = group_slots_into_ranges(&target_slots, range_size);
 
     // Filter ranges: skip already-completed ranges (unless repair mode).
     // In repair mode, also apply repair_scope range bounds.
     let skipped_index = skipped_slots::read_skipped_slots_index(&events_dir);
 
-    let ranges_to_process: Vec<BlockRange> = ranges
+    let mut ranges_to_process: Vec<BlockRange> = ranges
         .into_iter()
         .filter(|range| {
             // In repair mode, skip the "already completed" check to force re-processing
@@ -186,9 +189,35 @@ pub async fn signature_driven_backfill(
                     return false;
                 }
             }
+            sig_ranges.insert((range.start, range.end));
             true
         })
         .collect();
+
+    // In repair mode, also include existing on-disk ranges that fall within
+    // the repair scope but were not discovered through signatures. This
+    // handles ranges that only contained removed programs: signature
+    // discovery misses them because the program is no longer configured.
+    if is_repair {
+        if let Ok(existing) = crate::storage::paths::scan_parquet_ranges(&events_dir) {
+            for (start, end_inclusive, _) in existing {
+                let range_end = end_inclusive + 1;
+                let range = BlockRange {
+                    start,
+                    end: range_end,
+                };
+                if sig_ranges.contains(&(start, range_end)) {
+                    continue;
+                }
+                if let Some(scope) = repair_scope {
+                    if !scope.matches_range(start, range_end) {
+                        continue;
+                    }
+                }
+                ranges_to_process.push(range);
+            }
+        }
+    }
 
     if ranges_to_process.is_empty() {
         tracing::info!(

--- a/src/solana/raw_data/catchup.rs
+++ b/src/solana/raw_data/catchup.rs
@@ -27,6 +27,7 @@ use crate::storage::paths::{
 };
 use crate::storage::skipped_slots;
 use crate::types::config::solana::SolanaPrograms;
+use crate::types::shared::repair::RepairScope;
 
 use super::slots::collect_slots_selective;
 use super::types::SolanaCollectionError;
@@ -55,11 +56,14 @@ pub async fn signature_driven_backfill(
     configured_programs: &HashSet<[u8; 32]>,
     event_decoder_tx: Option<&Sender<DecoderMessage>>,
     instr_decoder_tx: Option<&Sender<DecoderMessage>>,
+    repair_scope: Option<&RepairScope>,
 ) -> Result<(), SolanaCollectionError> {
     if programs.is_empty() {
         tracing::info!(chain = chain_name, "No Solana programs configured, nothing to backfill");
         return Ok(());
     }
+
+    let is_repair = repair_scope.is_some();
 
     // Create output directories
     let slots_dir = raw_solana_slots_dir(chain_name);
@@ -70,16 +74,6 @@ pub async fn signature_driven_backfill(
     std::fs::create_dir_all(&events_dir)?;
     std::fs::create_dir_all(&instructions_dir)?;
 
-    // Find resume point from existing data
-    let resume_slot = find_resume_slot(chain_name);
-    if let Some(slot) = resume_slot {
-        tracing::info!(
-            chain = chain_name,
-            resume_slot = slot,
-            "Resuming signature-driven backfill from existing data"
-        );
-    }
-
     // Determine global start_slot (minimum across all programs)
     let global_start = programs
         .values()
@@ -87,23 +81,41 @@ pub async fn signature_driven_backfill(
         .min()
         .unwrap_or(0);
 
-    // Effective start: if we have existing data, skip slots we already processed
-    let effective_start = match resume_slot {
-        Some(s) if s >= global_start => s + 1,
-        _ => global_start,
+    // In repair mode, from_block overrides resume and global start.
+    // In normal mode, resume from existing data.
+    let effective_start = if let Some(scope) = repair_scope {
+        scope.from_block.unwrap_or(global_start)
+    } else {
+        let resume_slot = find_resume_slot(chain_name);
+        if let Some(slot) = resume_slot {
+            tracing::info!(
+                chain = chain_name,
+                resume_slot = slot,
+                "Resuming signature-driven backfill from existing data"
+            );
+        }
+        match resume_slot {
+            Some(s) if s >= global_start => s + 1,
+            _ => global_start,
+        }
     };
+
+    // In repair mode, to_block bounds the signature scan.
+    let end_slot = repair_scope.and_then(|s| s.to_block);
 
     tracing::info!(
         chain = chain_name,
         global_start,
         effective_start,
+        ?end_slot,
+        is_repair,
         programs = programs.len(),
         "Starting signature-driven backfill"
     );
 
     // Collect all signatures for all programs, grouped by slot
     let slots_with_sigs =
-        collect_all_signatures(rpc_client, programs, effective_start).await?;
+        collect_all_signatures(rpc_client, programs, effective_start, end_slot).await?;
 
     if slots_with_sigs.is_empty() {
         tracing::info!(
@@ -129,15 +141,27 @@ pub async fn signature_driven_backfill(
     let target_slots: BTreeSet<u64> = slots_with_sigs.keys().copied().collect();
     let ranges = group_slots_into_ranges(&target_slots, range_size);
 
-    // Load skipped slots index for completeness check
+    // Filter ranges: skip already-completed ranges (unless repair mode).
+    // In repair mode, also apply repair_scope range bounds.
     let skipped_index = skipped_slots::read_skipped_slots_index(&events_dir);
 
-    // Filter out already-completed ranges
     let ranges_to_process: Vec<BlockRange> = ranges
         .into_iter()
         .filter(|range| {
-            let rk = skipped_slots::range_key(range.start, range.end_inclusive());
-            !skipped_slots::is_range_complete(&skipped_index, &rk)
+            // In repair mode, skip the "already completed" check to force re-processing
+            if !is_repair {
+                let rk = skipped_slots::range_key(range.start, range.end_inclusive());
+                if skipped_slots::is_range_complete(&skipped_index, &rk) {
+                    return false;
+                }
+            }
+            // Apply repair scope range bounds
+            if let Some(scope) = repair_scope {
+                if !scope.matches_range(range.start, range.end) {
+                    return false;
+                }
+            }
+            true
         })
         .collect();
 
@@ -152,6 +176,7 @@ pub async fn signature_driven_backfill(
     tracing::info!(
         chain = chain_name,
         ranges = ranges_to_process.len(),
+        is_repair,
         "Processing signature-discovered ranges"
     );
 
@@ -191,6 +216,7 @@ async fn collect_all_signatures(
     rpc_client: &SolanaRpcClient,
     programs: &SolanaPrograms,
     start_slot: u64,
+    end_slot: Option<u64>,
 ) -> Result<BTreeMap<u64, Vec<[u8; 64]>>, SolanaRpcError> {
     let mut all_slots: BTreeMap<u64, Vec<[u8; 64]>> = BTreeMap::new();
 
@@ -208,6 +234,7 @@ async fn collect_all_signatures(
             program = program_name.as_str(),
             pubkey = %pubkey,
             start_slot = effective_start,
+            ?end_slot,
             "Collecting signatures for program"
         );
 
@@ -232,6 +259,13 @@ async fn collect_all_signatures(
                 if sig_info.slot < effective_start {
                     reached_start = true;
                     break;
+                }
+
+                // Skip slots above the end bound (repair scoping)
+                if let Some(end) = end_slot {
+                    if sig_info.slot > end {
+                        continue;
+                    }
                 }
 
                 // Parse the signature string

--- a/src/solana/raw_data/catchup.rs
+++ b/src/solana/raw_data/catchup.rs
@@ -232,6 +232,15 @@ pub async fn signature_driven_backfill(
         configured_programs.clone()
     };
 
+    // When source-scoped, pass the scoped program IDs to the merge logic so
+    // only records for repaired programs are replaced; other programs' records
+    // in the same slot are preserved.
+    let repair_program_ids = if is_repair && repair_scope.is_some_and(|s| s.sources.is_some()) {
+        Some(&active_configured_programs)
+    } else {
+        None
+    };
+
     for range in &ranges_to_process {
         collect_slots_selective(
             chain_name,
@@ -242,6 +251,7 @@ pub async fn signature_driven_backfill(
             event_decoder_tx,
             instr_decoder_tx,
             merge_slots,
+            repair_program_ids,
         )
         .await?;
     }

--- a/src/solana/raw_data/catchup.rs
+++ b/src/solana/raw_data/catchup.rs
@@ -213,13 +213,32 @@ pub async fn signature_driven_backfill(
         None
     };
 
+    // When repair scopes to specific sources, also scope the program IDs
+    // used for event/instruction extraction so unrelated programs in the
+    // same slot are not re-extracted.
+    let active_configured_programs = if let Some(scope) = repair_scope {
+        if scope.sources.is_some() {
+            active_programs
+                .values()
+                .filter_map(|p| {
+                    let bytes = p.program_id.parse::<solana_sdk::pubkey::Pubkey>().ok()?;
+                    Some(bytes.to_bytes())
+                })
+                .collect()
+        } else {
+            configured_programs.clone()
+        }
+    } else {
+        configured_programs.clone()
+    };
+
     for range in &ranges_to_process {
         collect_slots_selective(
             chain_name,
             rpc_client,
             range,
             &target_slots,
-            configured_programs,
+            &active_configured_programs,
             event_decoder_tx,
             instr_decoder_tx,
             merge_slots,

--- a/src/solana/raw_data/catchup.rs
+++ b/src/solana/raw_data/catchup.rs
@@ -113,9 +113,34 @@ pub async fn signature_driven_backfill(
         "Starting signature-driven backfill"
     );
 
-    // Collect all signatures for all programs, grouped by slot
+    // Filter programs by repair scope sources (if specified)
+    let scoped_programs: SolanaPrograms;
+    let active_programs = if let Some(scope) = repair_scope {
+        if let Some(ref sources) = scope.sources {
+            scoped_programs = programs
+                .iter()
+                .filter(|(name, _)| sources.contains(name.as_str()))
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect();
+            if scoped_programs.is_empty() {
+                tracing::info!(
+                    chain = chain_name,
+                    ?sources,
+                    "No configured programs match repair source filter"
+                );
+                return Ok(());
+            }
+            &scoped_programs
+        } else {
+            programs
+        }
+    } else {
+        programs
+    };
+
+    // Collect all signatures for active programs, grouped by slot
     let slots_with_sigs =
-        collect_all_signatures(rpc_client, programs, effective_start, end_slot).await?;
+        collect_all_signatures(rpc_client, active_programs, effective_start, end_slot).await?;
 
     if slots_with_sigs.is_empty() {
         tracing::info!(
@@ -180,6 +205,14 @@ pub async fn signature_driven_backfill(
         "Processing signature-discovered ranges"
     );
 
+    // During repair, pass the target slots so collect_slots_selective can
+    // merge fresh data with existing records instead of overwriting.
+    let merge_slots = if is_repair {
+        Some(&target_slots)
+    } else {
+        None
+    };
+
     for range in &ranges_to_process {
         collect_slots_selective(
             chain_name,
@@ -189,6 +222,7 @@ pub async fn signature_driven_backfill(
             configured_programs,
             event_decoder_tx,
             instr_decoder_tx,
+            merge_slots,
         )
         .await?;
     }

--- a/src/solana/raw_data/parquet.rs
+++ b/src/solana/raw_data/parquet.rs
@@ -431,6 +431,123 @@ pub fn read_events_from_parquet(path: &Path) -> Result<Vec<SolanaEventRecord>, S
     Ok(records)
 }
 
+/// Read `SolanaSlotRecord`s from a parquet file.
+pub fn read_slots_from_parquet(path: &Path) -> Result<Vec<SolanaSlotRecord>, SolanaCollectionError> {
+    let file = std::fs::File::open(path)?;
+    let builder = ParquetRecordBatchReaderBuilder::try_new(file)
+        .map_err(|e| SolanaCollectionError::ParquetWrite(e.to_string()))?;
+    let reader = builder
+        .build()
+        .map_err(|e| SolanaCollectionError::ParquetWrite(e.to_string()))?;
+
+    let mut records = Vec::new();
+
+    for batch_result in reader {
+        let batch = batch_result?;
+        let num_rows = batch.num_rows();
+
+        let slot_arr = batch
+            .column_by_name("slot")
+            .expect("missing slot column")
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .expect("slot is not UInt64");
+
+        let block_time_arr = batch
+            .column_by_name("block_time")
+            .expect("missing block_time column")
+            .as_any()
+            .downcast_ref::<arrow::array::Int64Array>()
+            .expect("block_time is not Int64");
+
+        let block_height_arr = batch
+            .column_by_name("block_height")
+            .expect("missing block_height column")
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .expect("block_height is not UInt64");
+
+        let parent_slot_arr = batch
+            .column_by_name("parent_slot")
+            .expect("missing parent_slot column")
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .expect("parent_slot is not UInt64");
+
+        let blockhash_arr = batch
+            .column_by_name("blockhash")
+            .expect("missing blockhash column")
+            .as_any()
+            .downcast_ref::<FixedSizeBinaryArray>()
+            .expect("blockhash is not FixedSizeBinary");
+
+        let prev_blockhash_arr = batch
+            .column_by_name("previous_blockhash")
+            .expect("missing previous_blockhash column")
+            .as_any()
+            .downcast_ref::<FixedSizeBinaryArray>()
+            .expect("previous_blockhash is not FixedSizeBinary");
+
+        let tx_count_arr = batch
+            .column_by_name("transaction_count")
+            .expect("missing transaction_count column")
+            .as_any()
+            .downcast_ref::<UInt32Array>()
+            .expect("transaction_count is not UInt32");
+
+        let tx_sigs_col = batch
+            .column_by_name("transaction_signatures")
+            .expect("missing transaction_signatures column");
+        let tx_sigs_list = tx_sigs_col.as_list::<i32>();
+
+        for i in 0..num_rows {
+            let mut blockhash = [0u8; 32];
+            blockhash.copy_from_slice(blockhash_arr.value(i));
+
+            let mut previous_blockhash = [0u8; 32];
+            previous_blockhash.copy_from_slice(prev_blockhash_arr.value(i));
+
+            // Extract transaction_signatures list
+            let mut transaction_signatures: Vec<[u8; 64]> = Vec::new();
+            if !tx_sigs_list.is_null(i) {
+                let sig_values = tx_sigs_list.value(i);
+                let fsb = sig_values
+                    .as_any()
+                    .downcast_ref::<FixedSizeBinaryArray>()
+                    .expect("transaction_signatures list items are not FixedSizeBinary(64)");
+                for j in 0..fsb.len() {
+                    if !fsb.is_null(j) {
+                        let mut sig = [0u8; 64];
+                        sig.copy_from_slice(fsb.value(j));
+                        transaction_signatures.push(sig);
+                    }
+                }
+            }
+
+            records.push(SolanaSlotRecord {
+                slot: slot_arr.value(i),
+                block_time: if block_time_arr.is_null(i) {
+                    None
+                } else {
+                    Some(block_time_arr.value(i))
+                },
+                block_height: if block_height_arr.is_null(i) {
+                    None
+                } else {
+                    Some(block_height_arr.value(i))
+                },
+                parent_slot: parent_slot_arr.value(i),
+                blockhash,
+                previous_blockhash,
+                transaction_count: tx_count_arr.value(i),
+                transaction_signatures,
+            });
+        }
+    }
+
+    Ok(records)
+}
+
 /// Read `SolanaInstructionRecord`s from a parquet file.
 pub fn read_instructions_from_parquet(
     path: &Path,
@@ -950,6 +1067,57 @@ mod tests {
 
         write_instructions_to_parquet(&[], &schema, &path).unwrap();
         let read_back = read_instructions_from_parquet(&path).unwrap();
+
+        assert!(read_back.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // Slot reader tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_read_slots_roundtrip() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("slots_rt.parquet");
+        let schema = build_slot_schema();
+        let original = sample_slot_records();
+
+        write_slots_to_parquet(&original, &schema, &path).unwrap();
+        let read_back = read_slots_from_parquet(&path).unwrap();
+
+        assert_eq!(read_back.len(), 2);
+
+        // First record
+        assert_eq!(read_back[0].slot, original[0].slot);
+        assert_eq!(read_back[0].block_time, original[0].block_time);
+        assert_eq!(read_back[0].block_height, original[0].block_height);
+        assert_eq!(read_back[0].parent_slot, original[0].parent_slot);
+        assert_eq!(read_back[0].blockhash, original[0].blockhash);
+        assert_eq!(read_back[0].previous_blockhash, original[0].previous_blockhash);
+        assert_eq!(read_back[0].transaction_count, original[0].transaction_count);
+        assert_eq!(read_back[0].transaction_signatures.len(), 2);
+        assert_eq!(read_back[0].transaction_signatures[0], original[0].transaction_signatures[0]);
+        assert_eq!(read_back[0].transaction_signatures[1], original[0].transaction_signatures[1]);
+
+        // Second record (optional fields are None, empty signatures)
+        assert_eq!(read_back[1].slot, original[1].slot);
+        assert!(read_back[1].block_time.is_none());
+        assert!(read_back[1].block_height.is_none());
+        assert_eq!(read_back[1].parent_slot, original[1].parent_slot);
+        assert_eq!(read_back[1].blockhash, original[1].blockhash);
+        assert_eq!(read_back[1].previous_blockhash, original[1].previous_blockhash);
+        assert_eq!(read_back[1].transaction_count, 0);
+        assert!(read_back[1].transaction_signatures.is_empty());
+    }
+
+    #[test]
+    fn test_read_slots_empty() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("slots_empty_rt.parquet");
+        let schema = build_slot_schema();
+
+        write_slots_to_parquet(&[], &schema, &path).unwrap();
+        let read_back = read_slots_from_parquet(&path).unwrap();
 
         assert!(read_back.is_empty());
     }

--- a/src/solana/raw_data/parquet.rs
+++ b/src/solana/raw_data/parquet.rs
@@ -1,14 +1,15 @@
-//! Arrow schemas and parquet writing for Solana raw data records.
+//! Arrow schemas and parquet writing/reading for Solana raw data records.
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use arrow::array::{
-    ArrayRef, BinaryArray, FixedSizeBinaryArray, FixedSizeBinaryBuilder, ListBuilder, UInt16Array,
-    UInt32Array, UInt64Array,
+    Array, ArrayRef, AsArray, BinaryArray, FixedSizeBinaryArray, FixedSizeBinaryBuilder,
+    ListBuilder, UInt16Array, UInt32Array, UInt64Array,
 };
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 
 use super::types::{
     SolanaCollectionError, SolanaEventRecord, SolanaInstructionRecord, SolanaSlotRecord,
@@ -311,6 +312,243 @@ pub async fn write_instructions_to_parquet_async(
     })
     .await
     .map_err(|e| SolanaCollectionError::JoinError(e.to_string()))?
+}
+
+// ---------------------------------------------------------------------------
+// Parquet readers
+// ---------------------------------------------------------------------------
+
+/// Read `SolanaEventRecord`s from a parquet file.
+pub fn read_events_from_parquet(path: &Path) -> Result<Vec<SolanaEventRecord>, SolanaCollectionError> {
+    let file = std::fs::File::open(path)?;
+    let builder = ParquetRecordBatchReaderBuilder::try_new(file)
+        .map_err(|e| SolanaCollectionError::ParquetWrite(e.to_string()))?;
+    let reader = builder
+        .build()
+        .map_err(|e| SolanaCollectionError::ParquetWrite(e.to_string()))?;
+
+    let mut records = Vec::new();
+
+    for batch_result in reader {
+        let batch = batch_result?;
+        let num_rows = batch.num_rows();
+
+        let slot_arr = batch
+            .column_by_name("slot")
+            .expect("missing slot column")
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .expect("slot is not UInt64");
+
+        let block_time_arr = batch
+            .column_by_name("block_time")
+            .expect("missing block_time column")
+            .as_any()
+            .downcast_ref::<arrow::array::Int64Array>()
+            .expect("block_time is not Int64");
+
+        let tx_sig_arr = batch
+            .column_by_name("transaction_signature")
+            .expect("missing transaction_signature column")
+            .as_any()
+            .downcast_ref::<FixedSizeBinaryArray>()
+            .expect("transaction_signature is not FixedSizeBinary");
+
+        let program_id_arr = batch
+            .column_by_name("program_id")
+            .expect("missing program_id column")
+            .as_any()
+            .downcast_ref::<FixedSizeBinaryArray>()
+            .expect("program_id is not FixedSizeBinary");
+
+        let discriminator_arr = batch
+            .column_by_name("event_discriminator")
+            .expect("missing event_discriminator column")
+            .as_any()
+            .downcast_ref::<FixedSizeBinaryArray>()
+            .expect("event_discriminator is not FixedSizeBinary");
+
+        let data_arr = batch
+            .column_by_name("event_data")
+            .expect("missing event_data column")
+            .as_any()
+            .downcast_ref::<BinaryArray>()
+            .expect("event_data is not Binary");
+
+        let log_index_arr = batch
+            .column_by_name("log_index")
+            .expect("missing log_index column")
+            .as_any()
+            .downcast_ref::<UInt32Array>()
+            .expect("log_index is not UInt32");
+
+        let ix_arr = batch
+            .column_by_name("instruction_index")
+            .expect("missing instruction_index column")
+            .as_any()
+            .downcast_ref::<UInt16Array>()
+            .expect("instruction_index is not UInt16");
+
+        let inner_ix_arr = batch
+            .column_by_name("inner_instruction_index")
+            .expect("missing inner_instruction_index column")
+            .as_any()
+            .downcast_ref::<UInt16Array>()
+            .expect("inner_instruction_index is not UInt16");
+
+        for i in 0..num_rows {
+            let mut tx_sig = [0u8; 64];
+            tx_sig.copy_from_slice(tx_sig_arr.value(i));
+
+            let mut program_id = [0u8; 32];
+            program_id.copy_from_slice(program_id_arr.value(i));
+
+            let mut discriminator = [0u8; 8];
+            discriminator.copy_from_slice(discriminator_arr.value(i));
+
+            records.push(SolanaEventRecord {
+                slot: slot_arr.value(i),
+                block_time: if block_time_arr.is_null(i) {
+                    None
+                } else {
+                    Some(block_time_arr.value(i))
+                },
+                transaction_signature: tx_sig,
+                program_id,
+                event_discriminator: discriminator,
+                event_data: data_arr.value(i).to_vec(),
+                log_index: log_index_arr.value(i),
+                instruction_index: ix_arr.value(i),
+                inner_instruction_index: if inner_ix_arr.is_null(i) {
+                    None
+                } else {
+                    Some(inner_ix_arr.value(i))
+                },
+            });
+        }
+    }
+
+    Ok(records)
+}
+
+/// Read `SolanaInstructionRecord`s from a parquet file.
+pub fn read_instructions_from_parquet(
+    path: &Path,
+) -> Result<Vec<SolanaInstructionRecord>, SolanaCollectionError> {
+    let file = std::fs::File::open(path)?;
+    let builder = ParquetRecordBatchReaderBuilder::try_new(file)
+        .map_err(|e| SolanaCollectionError::ParquetWrite(e.to_string()))?;
+    let reader = builder
+        .build()
+        .map_err(|e| SolanaCollectionError::ParquetWrite(e.to_string()))?;
+
+    let mut records = Vec::new();
+
+    for batch_result in reader {
+        let batch = batch_result?;
+        let num_rows = batch.num_rows();
+
+        let slot_arr = batch
+            .column_by_name("slot")
+            .expect("missing slot column")
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .expect("slot is not UInt64");
+
+        let block_time_arr = batch
+            .column_by_name("block_time")
+            .expect("missing block_time column")
+            .as_any()
+            .downcast_ref::<arrow::array::Int64Array>()
+            .expect("block_time is not Int64");
+
+        let tx_sig_arr = batch
+            .column_by_name("transaction_signature")
+            .expect("missing transaction_signature column")
+            .as_any()
+            .downcast_ref::<FixedSizeBinaryArray>()
+            .expect("transaction_signature is not FixedSizeBinary");
+
+        let program_id_arr = batch
+            .column_by_name("program_id")
+            .expect("missing program_id column")
+            .as_any()
+            .downcast_ref::<FixedSizeBinaryArray>()
+            .expect("program_id is not FixedSizeBinary");
+
+        let data_arr = batch
+            .column_by_name("data")
+            .expect("missing data column")
+            .as_any()
+            .downcast_ref::<BinaryArray>()
+            .expect("data is not Binary");
+
+        let accounts_col = batch
+            .column_by_name("accounts")
+            .expect("missing accounts column");
+        let accounts_list = accounts_col
+            .as_list::<i32>();
+
+        let ix_arr = batch
+            .column_by_name("instruction_index")
+            .expect("missing instruction_index column")
+            .as_any()
+            .downcast_ref::<UInt16Array>()
+            .expect("instruction_index is not UInt16");
+
+        let inner_ix_arr = batch
+            .column_by_name("inner_instruction_index")
+            .expect("missing inner_instruction_index column")
+            .as_any()
+            .downcast_ref::<UInt16Array>()
+            .expect("inner_instruction_index is not UInt16");
+
+        for i in 0..num_rows {
+            let mut tx_sig = [0u8; 64];
+            tx_sig.copy_from_slice(tx_sig_arr.value(i));
+
+            let mut program_id = [0u8; 32];
+            program_id.copy_from_slice(program_id_arr.value(i));
+
+            // Extract accounts list
+            let mut accounts: Vec<[u8; 32]> = Vec::new();
+            if !accounts_list.is_null(i) {
+                let account_values = accounts_list.value(i);
+                let fsb = account_values
+                    .as_any()
+                    .downcast_ref::<FixedSizeBinaryArray>()
+                    .expect("account list items are not FixedSizeBinary(32)");
+                for j in 0..fsb.len() {
+                    if !fsb.is_null(j) {
+                        let mut acc = [0u8; 32];
+                        acc.copy_from_slice(fsb.value(j));
+                        accounts.push(acc);
+                    }
+                }
+            }
+
+            records.push(SolanaInstructionRecord {
+                slot: slot_arr.value(i),
+                block_time: if block_time_arr.is_null(i) {
+                    None
+                } else {
+                    Some(block_time_arr.value(i))
+                },
+                transaction_signature: tx_sig,
+                program_id,
+                data: data_arr.value(i).to_vec(),
+                accounts,
+                instruction_index: ix_arr.value(i),
+                inner_instruction_index: if inner_ix_arr.is_null(i) {
+                    None
+                } else {
+                    Some(inner_ix_arr.value(i))
+                },
+            });
+        }
+    }
+
+    Ok(records)
 }
 
 // ---------------------------------------------------------------------------
@@ -617,5 +855,102 @@ mod tests {
 
         assert!(path.exists());
         assert_eq!(read_parquet_row_count(&path), 2);
+    }
+
+    // -----------------------------------------------------------------------
+    // Event reader tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_read_events_roundtrip() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("events_rt.parquet");
+        let schema = build_event_schema();
+        let original = sample_event_records();
+
+        write_events_to_parquet(&original, &schema, &path).unwrap();
+        let read_back = read_events_from_parquet(&path).unwrap();
+
+        assert_eq!(read_back.len(), 2);
+        assert_eq!(read_back[0].slot, original[0].slot);
+        assert_eq!(read_back[0].block_time, original[0].block_time);
+        assert_eq!(
+            read_back[0].transaction_signature,
+            original[0].transaction_signature
+        );
+        assert_eq!(read_back[0].program_id, original[0].program_id);
+        assert_eq!(
+            read_back[0].event_discriminator,
+            original[0].event_discriminator
+        );
+        assert_eq!(read_back[0].event_data, original[0].event_data);
+        assert_eq!(read_back[0].log_index, original[0].log_index);
+        assert_eq!(read_back[0].instruction_index, original[0].instruction_index);
+        assert_eq!(
+            read_back[0].inner_instruction_index,
+            original[0].inner_instruction_index
+        );
+
+        // Second record has inner_instruction_index = Some(3)
+        assert_eq!(read_back[1].inner_instruction_index, Some(3));
+    }
+
+    #[test]
+    fn test_read_events_empty() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("events_empty_rt.parquet");
+        let schema = build_event_schema();
+
+        write_events_to_parquet(&[], &schema, &path).unwrap();
+        let read_back = read_events_from_parquet(&path).unwrap();
+
+        assert!(read_back.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // Instruction reader tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_read_instructions_roundtrip() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("instructions_rt.parquet");
+        let schema = build_instruction_schema();
+        let original = sample_instruction_records();
+
+        write_instructions_to_parquet(&original, &schema, &path).unwrap();
+        let read_back = read_instructions_from_parquet(&path).unwrap();
+
+        assert_eq!(read_back.len(), 2);
+        assert_eq!(read_back[0].slot, original[0].slot);
+        assert_eq!(read_back[0].block_time, original[0].block_time);
+        assert_eq!(
+            read_back[0].transaction_signature,
+            original[0].transaction_signature
+        );
+        assert_eq!(read_back[0].program_id, original[0].program_id);
+        assert_eq!(read_back[0].data, original[0].data);
+        assert_eq!(read_back[0].accounts.len(), 2);
+        assert_eq!(read_back[0].accounts[0], original[0].accounts[0]);
+        assert_eq!(read_back[0].accounts[1], original[0].accounts[1]);
+        assert_eq!(read_back[0].instruction_index, original[0].instruction_index);
+        assert!(read_back[0].inner_instruction_index.is_none());
+
+        // Second record
+        assert_eq!(read_back[1].inner_instruction_index, Some(0));
+        assert!(read_back[1].accounts.is_empty());
+        assert!(read_back[1].data.is_empty());
+    }
+
+    #[test]
+    fn test_read_instructions_empty() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("instructions_empty_rt.parquet");
+        let schema = build_instruction_schema();
+
+        write_instructions_to_parquet(&[], &schema, &path).unwrap();
+        let read_back = read_instructions_from_parquet(&path).unwrap();
+
+        assert!(read_back.is_empty());
     }
 }

--- a/src/solana/raw_data/slots.rs
+++ b/src/solana/raw_data/slots.rs
@@ -355,6 +355,7 @@ pub async fn collect_slots_selective(
     event_decoder_tx: Option<&Sender<DecoderMessage>>,
     instr_decoder_tx: Option<&Sender<DecoderMessage>>,
     repair_slots: Option<&BTreeSet<u64>>,
+    repair_program_ids: Option<&HashSet<[u8; 32]>>,
 ) -> Result<(), SolanaCollectionError> {
     let slots_dir = raw_solana_slots_dir(chain_name);
     let events_dir = raw_solana_events_dir(chain_name);
@@ -400,13 +401,26 @@ pub async fn collect_slots_selective(
 
     // In repair mode, merge fresh data with existing records from the parquet
     // file so that non-repaired slots in the same aligned range are preserved.
+    // When repair_program_ids is set (source-scoped repair), only drop records
+    // that match both the repaired slot AND the repaired program; records from
+    // other programs in the same slot are retained.
     if let Some(repaired) = repair_slots {
+        let is_being_repaired = |slot: u64, program_id: &[u8; 32]| -> bool {
+            if !repaired.contains(&slot) {
+                return false;
+            }
+            match repair_program_ids {
+                Some(programs) => programs.contains(program_id),
+                None => true, // unscoped repair: all programs in repaired slots
+            }
+        };
+
         let events_path = events_dir.join(range.file_name("events"));
         if events_path.exists() {
             if let Ok(existing) = read_events_from_parquet(&events_path) {
                 let retained: Vec<_> = existing
                     .into_iter()
-                    .filter(|r| !repaired.contains(&r.slot))
+                    .filter(|r| !is_being_repaired(r.slot, &r.program_id))
                     .collect();
                 all_events.extend(retained);
             }
@@ -418,7 +432,7 @@ pub async fn collect_slots_selective(
             if let Ok(existing) = read_instructions_from_parquet(&instr_path) {
                 let retained: Vec<_> = existing
                     .into_iter()
-                    .filter(|r| !repaired.contains(&r.slot))
+                    .filter(|r| !is_being_repaired(r.slot, &r.program_id))
                     .collect();
                 all_instructions.extend(retained);
             }

--- a/src/solana/raw_data/slots.rs
+++ b/src/solana/raw_data/slots.rs
@@ -399,26 +399,14 @@ pub async fn collect_slots_selective(
         }
     }
 
-    // Clone fresh records before the merge so we can send only these to decoders.
-    // Retained records from other programs/slots are preserved in parquet but
-    // should not trigger re-decoding (which would overwrite decoded output for
-    // sources outside the repair scope).
-    let decoder_events = if repair_slots.is_some() {
-        Some(all_events.clone())
-    } else {
-        None
-    };
-    let decoder_instructions = if repair_slots.is_some() {
-        Some(all_instructions.clone())
-    } else {
-        None
-    };
-
     // In repair mode, merge fresh data with existing records from the parquet
     // file so that non-repaired slots in the same aligned range are preserved.
     // When repair_program_ids is set (source-scoped repair), only drop records
     // that match both the repaired slot AND the repaired program; records from
     // other programs in the same slot are retained.
+    //
+    // The merged result is sent to decoders (not just the fresh subset) so that
+    // decoded parquet output is complete for the full aligned range.
     if let Some(repaired) = repair_slots {
         let is_being_repaired = |slot: u64, program_id: &[u8; 32]| -> bool {
             if !repaired.contains(&slot) {
@@ -432,25 +420,23 @@ pub async fn collect_slots_selective(
 
         let events_path = events_dir.join(range.file_name("events"));
         if events_path.exists() {
-            if let Ok(existing) = read_events_from_parquet(&events_path) {
-                let retained: Vec<_> = existing
-                    .into_iter()
-                    .filter(|r| !is_being_repaired(r.slot, &r.program_id))
-                    .collect();
-                all_events.extend(retained);
-            }
+            let existing = read_events_from_parquet(&events_path)?;
+            let retained: Vec<_> = existing
+                .into_iter()
+                .filter(|r| !is_being_repaired(r.slot, &r.program_id))
+                .collect();
+            all_events.extend(retained);
         }
         all_events.sort_by_key(|r| (r.slot, r.log_index));
 
         let instr_path = instructions_dir.join(range.file_name("instructions"));
         if instr_path.exists() {
-            if let Ok(existing) = read_instructions_from_parquet(&instr_path) {
-                let retained: Vec<_> = existing
-                    .into_iter()
-                    .filter(|r| !is_being_repaired(r.slot, &r.program_id))
-                    .collect();
-                all_instructions.extend(retained);
-            }
+            let existing = read_instructions_from_parquet(&instr_path)?;
+            let retained: Vec<_> = existing
+                .into_iter()
+                .filter(|r| !is_being_repaired(r.slot, &r.program_id))
+                .collect();
+            all_instructions.extend(retained);
         }
         all_instructions.sort_by_key(|r| (r.slot, r.instruction_index));
     }
@@ -460,11 +446,10 @@ pub async fn collect_slots_selective(
     if let Some(repaired) = repair_slots {
         let slot_path = slots_dir.join(range.file_name("slots"));
         if slot_path.exists() {
-            if let Ok(existing) = read_slots_from_parquet(&slot_path) {
-                for record in existing {
-                    if !repaired.contains(&record.slot) {
-                        slot_records.entry(record.slot).or_insert(record);
-                    }
+            let existing = read_slots_from_parquet(&slot_path)?;
+            for record in existing {
+                if !repaired.contains(&record.slot) {
+                    slot_records.entry(record.slot).or_insert(record);
                 }
             }
         }
@@ -506,16 +491,11 @@ pub async fn collect_slots_selective(
     }
     skipped_slots::write_skipped_slots_index(&events_dir, &skipped_index)?;
 
-    // During repair, send only the freshly extracted records (cloned before
-    // the merge) to decoders. During normal backfill, send all records.
-    let events_for_decoder = decoder_events.unwrap_or(all_events);
-    let instructions_for_decoder = decoder_instructions.unwrap_or(all_instructions);
-
     if let Some(tx) = event_decoder_tx {
         let msg = DecoderMessage::SolanaEventsReady {
             range_start: range.start,
             range_end: range.end,
-            events: events_for_decoder,
+            events: all_events,
             live_mode: false,
         };
         tx.send(msg)
@@ -529,7 +509,7 @@ pub async fn collect_slots_selective(
         let msg = DecoderMessage::SolanaInstructionsReady {
             range_start: range.start,
             range_end: range.end,
-            instructions: instructions_for_decoder,
+            instructions: all_instructions,
             live_mode: false,
         };
         tx.send(msg)

--- a/src/solana/raw_data/slots.rs
+++ b/src/solana/raw_data/slots.rs
@@ -399,6 +399,13 @@ pub async fn collect_slots_selective(
         }
     }
 
+    // Snapshot the fresh record counts before merging in retained records.
+    // Only fresh records should be sent downstream to decoders — retained
+    // records are preserved in parquet but were not re-collected and should
+    // not trigger re-decoding.
+    let fresh_event_count = all_events.len();
+    let fresh_instruction_count = all_instructions.len();
+
     // In repair mode, merge fresh data with existing records from the parquet
     // file so that non-repaired slots in the same aligned range are preserved.
     // When repair_program_ids is set (source-scoped repair), only drop records
@@ -491,12 +498,18 @@ pub async fn collect_slots_selective(
     }
     skipped_slots::write_skipped_slots_index(&events_dir, &skipped_index)?;
 
-    // Send downstream
+    // Send only the freshly extracted records downstream to decoders.
+    // Retained records from the merge are already decoded and should not
+    // be re-decoded (which would overwrite decoded parquet for sources
+    // outside the repair scope).
+    let decoder_events = all_events[..fresh_event_count].to_vec();
+    let decoder_instructions = all_instructions[..fresh_instruction_count].to_vec();
+
     if let Some(tx) = event_decoder_tx {
         let msg = DecoderMessage::SolanaEventsReady {
             range_start: range.start,
             range_end: range.end,
-            events: all_events,
+            events: decoder_events,
             live_mode: false,
         };
         tx.send(msg)
@@ -510,7 +523,7 @@ pub async fn collect_slots_selective(
         let msg = DecoderMessage::SolanaInstructionsReady {
             range_start: range.start,
             range_end: range.end,
-            instructions: all_instructions,
+            instructions: decoder_instructions,
             live_mode: false,
         };
         tx.send(msg)

--- a/src/solana/raw_data/slots.rs
+++ b/src/solana/raw_data/slots.rs
@@ -366,11 +366,18 @@ pub async fn collect_slots_selective(
         .copied()
         .collect();
 
-    if slots_to_fetch.is_empty() {
+    // In non-repair mode, skip ranges with nothing to fetch. In repair mode,
+    // proceed even with zero slots: the merge step may need to filter out
+    // records from programs no longer in the config.
+    if slots_to_fetch.is_empty() && repair_slots.is_none() {
         return Ok(());
     }
 
-    let block_results = rpc_client.get_blocks_batch(&slots_to_fetch).await?;
+    let block_results = if slots_to_fetch.is_empty() {
+        Vec::new()
+    } else {
+        rpc_client.get_blocks_batch(&slots_to_fetch).await?
+    };
 
     let mut slot_records: BTreeMap<u64, SolanaSlotRecord> = BTreeMap::new();
     let mut all_events = Vec::new();
@@ -450,15 +457,23 @@ pub async fn collect_slots_selective(
         }
     }
 
+    // During unscoped repair (repair_program_ids is None), drop records from
+    // programs no longer in the config. This cleans up raw data for removed
+    // sources whose ranges are revisited but yield no new signatures.
+    if repair_slots.is_some() && repair_program_ids.is_none() {
+        all_events.retain(|r| configured_programs.contains(&r.program_id));
+        all_instructions.retain(|r| configured_programs.contains(&r.program_id));
+    }
+
     // Write parquet files
     let slot_records_vec: Vec<_> = slot_records.into_values().collect();
 
     let slot_path = slots_dir.join(range.file_name("slots"));
     if !slot_records_vec.is_empty() {
         write_slots_to_parquet_async(slot_records_vec, slot_schema, slot_path).await?;
-    } else if repair_slots.is_some() && slot_path.exists() {
-        // All slots in the range resolved to empty/skipped after repair — remove
-        // the stale slot file so it stays consistent with events/instructions.
+    } else if slot_path.exists() {
+        // All slots in the range resolved to empty/skipped — remove the stale
+        // slot file so it stays consistent with events/instructions.
         std::fs::remove_file(&slot_path)?;
     }
 

--- a/src/solana/raw_data/slots.rs
+++ b/src/solana/raw_data/slots.rs
@@ -77,7 +77,6 @@ pub async fn collect_solana_raw_data(
         start_slot,
         end_slot,
         range_size,
-        &events_dir,
         &skipped_index,
     );
 
@@ -205,7 +204,6 @@ pub fn compute_slot_ranges_to_fetch(
     start: u64,
     end: u64,
     range_size: u64,
-    dir: &Path,
     skipped_index: &SkippedSlotsIndex,
 ) -> Vec<BlockRange> {
     if start >= end || range_size == 0 {
@@ -213,9 +211,6 @@ pub fn compute_slot_ranges_to_fetch(
     }
 
     let aligned_start = (start / range_size) * range_size;
-
-    // Scan existing parquet files for completed ranges
-    let existing_files = crate::storage::paths::scan_parquet_filenames(dir, "events_");
 
     let mut ranges = Vec::new();
     let mut current = aligned_start;
@@ -228,13 +223,13 @@ pub fn compute_slot_ranges_to_fetch(
 
         let rk = skipped_slots::range_key(range.start, range.end_inclusive());
 
-        // Skip if already complete (exists in skipped index, meaning we processed it)
+        // The skipped-slots sidecar is the authoritative completion marker — it
+        // is written after all parquet files for the range. A parquet file alone
+        // is not proof of completion (a crash between parquet write and sidecar
+        // update would leave a partial range).
         let already_complete = skipped_slots::is_range_complete(skipped_index, &rk);
 
-        // Also skip if parquet file already exists
-        let file_exists = existing_files.contains(&range.file_name("events"));
-
-        if !already_complete && !file_exists {
+        if !already_complete {
             ranges.push(range);
         }
 
@@ -458,9 +453,13 @@ pub async fn collect_slots_selective(
     // Write parquet files
     let slot_records_vec: Vec<_> = slot_records.into_values().collect();
 
+    let slot_path = slots_dir.join(range.file_name("slots"));
     if !slot_records_vec.is_empty() {
-        let slot_path = slots_dir.join(range.file_name("slots"));
         write_slots_to_parquet_async(slot_records_vec, slot_schema, slot_path).await?;
+    } else if repair_slots.is_some() && slot_path.exists() {
+        // All slots in the range resolved to empty/skipped after repair — remove
+        // the stale slot file so it stays consistent with events/instructions.
+        std::fs::remove_file(&slot_path)?;
     }
 
     let events_path = events_dir.join(range.file_name("events"));
@@ -542,9 +541,8 @@ mod tests {
     #[test]
     fn test_compute_slot_ranges_basic() {
         let empty_index = SkippedSlotsIndex::new();
-        let dir = tempfile::TempDir::new().unwrap();
 
-        let ranges = compute_slot_ranges_to_fetch(0, 3000, 1000, dir.path(), &empty_index);
+        let ranges = compute_slot_ranges_to_fetch(0, 3000, 1000, &empty_index);
 
         assert_eq!(ranges.len(), 3);
         assert_eq!(ranges[0].start, 0);
@@ -558,10 +556,9 @@ mod tests {
     #[test]
     fn test_compute_slot_ranges_alignment() {
         let empty_index = SkippedSlotsIndex::new();
-        let dir = tempfile::TempDir::new().unwrap();
 
         // start_slot=500 should align down to 0
-        let ranges = compute_slot_ranges_to_fetch(500, 2500, 1000, dir.path(), &empty_index);
+        let ranges = compute_slot_ranges_to_fetch(500, 2500, 1000, &empty_index);
 
         assert_eq!(ranges.len(), 3);
         assert_eq!(ranges[0].start, 0);
@@ -578,9 +575,7 @@ mod tests {
         // Mark range 1000-1999 as complete
         index.insert(skipped_slots::range_key(1000, 1999), vec![1050]);
 
-        let dir = tempfile::TempDir::new().unwrap();
-
-        let ranges = compute_slot_ranges_to_fetch(0, 3000, 1000, dir.path(), &index);
+        let ranges = compute_slot_ranges_to_fetch(0, 3000, 1000, &index);
 
         assert_eq!(ranges.len(), 2);
         assert_eq!(ranges[0].start, 0);
@@ -595,31 +590,27 @@ mod tests {
         index.insert(skipped_slots::range_key(0, 999), vec![]);
         index.insert(skipped_slots::range_key(1000, 1999), vec![]);
 
-        let dir = tempfile::TempDir::new().unwrap();
-
-        let ranges = compute_slot_ranges_to_fetch(0, 2000, 1000, dir.path(), &index);
+        let ranges = compute_slot_ranges_to_fetch(0, 2000, 1000, &index);
         assert!(ranges.is_empty());
     }
 
     #[test]
     fn test_compute_slot_ranges_empty_input() {
         let empty_index = SkippedSlotsIndex::new();
-        let dir = tempfile::TempDir::new().unwrap();
 
         // start >= end
-        let ranges = compute_slot_ranges_to_fetch(1000, 1000, 1000, dir.path(), &empty_index);
+        let ranges = compute_slot_ranges_to_fetch(1000, 1000, 1000, &empty_index);
         assert!(ranges.is_empty());
 
-        let ranges = compute_slot_ranges_to_fetch(2000, 1000, 1000, dir.path(), &empty_index);
+        let ranges = compute_slot_ranges_to_fetch(2000, 1000, 1000, &empty_index);
         assert!(ranges.is_empty());
     }
 
     #[test]
     fn test_compute_slot_ranges_zero_range_size() {
         let empty_index = SkippedSlotsIndex::new();
-        let dir = tempfile::TempDir::new().unwrap();
 
-        let ranges = compute_slot_ranges_to_fetch(0, 1000, 0, dir.path(), &empty_index);
+        let ranges = compute_slot_ranges_to_fetch(0, 1000, 0, &empty_index);
         assert!(ranges.is_empty());
     }
 

--- a/src/solana/raw_data/slots.rs
+++ b/src/solana/raw_data/slots.rs
@@ -26,7 +26,7 @@ use crate::storage::skipped_slots::{self, SkippedSlotsIndex};
 use super::extraction::extract_events_and_instructions;
 use super::parquet::{
     build_event_schema, build_instruction_schema, build_slot_schema, read_events_from_parquet,
-    read_instructions_from_parquet, write_events_to_parquet_async,
+    read_instructions_from_parquet, read_slots_from_parquet, write_events_to_parquet_async,
     write_instructions_to_parquet_async, write_slots_to_parquet_async,
 };
 use super::types::{SolanaCollectionError, SolanaSlotRecord};
@@ -426,6 +426,21 @@ pub async fn collect_slots_selective(
         all_instructions.sort_by_key(|r| (r.slot, r.instruction_index));
     }
 
+    // In repair mode, merge slot records with existing so non-repaired slots
+    // in the same aligned range are preserved.
+    if let Some(repaired) = repair_slots {
+        let slot_path = slots_dir.join(range.file_name("slots"));
+        if slot_path.exists() {
+            if let Ok(existing) = read_slots_from_parquet(&slot_path) {
+                for record in existing {
+                    if !repaired.contains(&record.slot) {
+                        slot_records.entry(record.slot).or_insert(record);
+                    }
+                }
+            }
+        }
+    }
+
     // Write parquet files
     let slot_records_vec: Vec<_> = slot_records.into_values().collect();
 
@@ -443,7 +458,23 @@ pub async fn collect_slots_selective(
     // Update skipped slots index
     let mut skipped_index = skipped_slots::read_skipped_slots_index(&events_dir);
     let rk = skipped_slots::range_key(range.start, range.end_inclusive());
-    skipped_index.insert(rk, skipped_slots_list);
+    if let Some(repaired) = repair_slots {
+        // Merge: keep existing skipped slots for non-repaired slots,
+        // add new skipped slots from repaired slots
+        let mut merged = skipped_index
+            .get(&rk)
+            .cloned()
+            .unwrap_or_default();
+        // Remove skipped entries for slots being repaired (they may no longer be skipped)
+        merged.retain(|s| !repaired.contains(s));
+        // Add newly discovered skipped slots
+        merged.extend(&skipped_slots_list);
+        merged.sort_unstable();
+        merged.dedup();
+        skipped_index.insert(rk, merged);
+    } else {
+        skipped_index.insert(rk, skipped_slots_list);
+    }
     skipped_slots::write_skipped_slots_index(&events_dir, &skipped_index)?;
 
     // Send downstream

--- a/src/solana/raw_data/slots.rs
+++ b/src/solana/raw_data/slots.rs
@@ -25,7 +25,8 @@ use crate::storage::skipped_slots::{self, SkippedSlotsIndex};
 
 use super::extraction::extract_events_and_instructions;
 use super::parquet::{
-    build_event_schema, build_instruction_schema, build_slot_schema, write_events_to_parquet_async,
+    build_event_schema, build_instruction_schema, build_slot_schema, read_events_from_parquet,
+    read_instructions_from_parquet, write_events_to_parquet_async,
     write_instructions_to_parquet_async, write_slots_to_parquet_async,
 };
 use super::types::{SolanaCollectionError, SolanaSlotRecord};
@@ -339,6 +340,11 @@ fn extract_block_signatures(block: &UiConfirmedBlock) -> Vec<[u8; 64]> {
 /// Similar to [`collect_solana_raw_data`] but only fetches the given slots
 /// instead of every slot in the range. Used by the signature-driven backfill
 /// which knows exactly which slots contain relevant transactions.
+///
+/// When `repair_slots` is `Some`, only those specific slots are re-fetched and
+/// the new data is **merged** with existing parquet records for the range.
+/// Records from the repaired slots are replaced; records from other slots in
+/// the range are preserved.
 #[allow(clippy::too_many_arguments)]
 pub async fn collect_slots_selective(
     chain_name: &str,
@@ -348,6 +354,7 @@ pub async fn collect_slots_selective(
     configured_programs: &HashSet<[u8; 32]>,
     event_decoder_tx: Option<&Sender<DecoderMessage>>,
     instr_decoder_tx: Option<&Sender<DecoderMessage>>,
+    repair_slots: Option<&BTreeSet<u64>>,
 ) -> Result<(), SolanaCollectionError> {
     let slots_dir = raw_solana_slots_dir(chain_name);
     let events_dir = raw_solana_events_dir(chain_name);
@@ -389,6 +396,34 @@ pub async fn collect_slots_selective(
                 all_instructions.extend(instructions);
             }
         }
+    }
+
+    // In repair mode, merge fresh data with existing records from the parquet
+    // file so that non-repaired slots in the same aligned range are preserved.
+    if let Some(repaired) = repair_slots {
+        let events_path = events_dir.join(range.file_name("events"));
+        if events_path.exists() {
+            if let Ok(existing) = read_events_from_parquet(&events_path) {
+                let retained: Vec<_> = existing
+                    .into_iter()
+                    .filter(|r| !repaired.contains(&r.slot))
+                    .collect();
+                all_events.extend(retained);
+            }
+        }
+        all_events.sort_by_key(|r| (r.slot, r.log_index));
+
+        let instr_path = instructions_dir.join(range.file_name("instructions"));
+        if instr_path.exists() {
+            if let Ok(existing) = read_instructions_from_parquet(&instr_path) {
+                let retained: Vec<_> = existing
+                    .into_iter()
+                    .filter(|r| !repaired.contains(&r.slot))
+                    .collect();
+                all_instructions.extend(retained);
+            }
+        }
+        all_instructions.sort_by_key(|r| (r.slot, r.instruction_index));
     }
 
     // Write parquet files

--- a/src/solana/raw_data/slots.rs
+++ b/src/solana/raw_data/slots.rs
@@ -399,12 +399,20 @@ pub async fn collect_slots_selective(
         }
     }
 
-    // Snapshot the fresh record counts before merging in retained records.
-    // Only fresh records should be sent downstream to decoders — retained
-    // records are preserved in parquet but were not re-collected and should
-    // not trigger re-decoding.
-    let fresh_event_count = all_events.len();
-    let fresh_instruction_count = all_instructions.len();
+    // Clone fresh records before the merge so we can send only these to decoders.
+    // Retained records from other programs/slots are preserved in parquet but
+    // should not trigger re-decoding (which would overwrite decoded output for
+    // sources outside the repair scope).
+    let decoder_events = if repair_slots.is_some() {
+        Some(all_events.clone())
+    } else {
+        None
+    };
+    let decoder_instructions = if repair_slots.is_some() {
+        Some(all_instructions.clone())
+    } else {
+        None
+    };
 
     // In repair mode, merge fresh data with existing records from the parquet
     // file so that non-repaired slots in the same aligned range are preserved.
@@ -498,18 +506,16 @@ pub async fn collect_slots_selective(
     }
     skipped_slots::write_skipped_slots_index(&events_dir, &skipped_index)?;
 
-    // Send only the freshly extracted records downstream to decoders.
-    // Retained records from the merge are already decoded and should not
-    // be re-decoded (which would overwrite decoded parquet for sources
-    // outside the repair scope).
-    let decoder_events = all_events[..fresh_event_count].to_vec();
-    let decoder_instructions = all_instructions[..fresh_instruction_count].to_vec();
+    // During repair, send only the freshly extracted records (cloned before
+    // the merge) to decoders. During normal backfill, send all records.
+    let events_for_decoder = decoder_events.unwrap_or(all_events);
+    let instructions_for_decoder = decoder_instructions.unwrap_or(all_instructions);
 
     if let Some(tx) = event_decoder_tx {
         let msg = DecoderMessage::SolanaEventsReady {
             range_start: range.start,
             range_end: range.end,
-            events: decoder_events,
+            events: events_for_decoder,
             live_mode: false,
         };
         tx.send(msg)
@@ -523,7 +529,7 @@ pub async fn collect_slots_selective(
         let msg = DecoderMessage::SolanaInstructionsReady {
             range_start: range.start,
             range_end: range.end,
-            instructions: decoder_instructions,
+            instructions: instructions_for_decoder,
             live_mode: false,
         };
         tx.send(msg)

--- a/src/storage/paths.rs
+++ b/src/storage/paths.rs
@@ -75,6 +75,18 @@ pub fn solana_discovery_dir(chain: &str) -> PathBuf {
     PathBuf::from(format!("data/{}/discovery", chain))
 }
 
+/// `data/{chain}/historical/decoded/events`
+#[cfg(feature = "solana")]
+pub fn decoded_solana_events_dir(chain: &str) -> PathBuf {
+    PathBuf::from(format!("data/{}/historical/decoded/events", chain))
+}
+
+/// `data/{chain}/historical/decoded/instructions`
+#[cfg(feature = "solana")]
+pub fn decoded_solana_instructions_dir(chain: &str) -> PathBuf {
+    PathBuf::from(format!("data/{}/historical/decoded/instructions", chain))
+}
+
 // ---------------------------------------------------------------------------
 // EVM decoded path builders
 // ---------------------------------------------------------------------------
@@ -352,6 +364,19 @@ mod tests {
         assert_eq!(
             decoded_eth_calls_dir("ethereum"),
             PathBuf::from("data/ethereum/historical/decoded/eth_calls")
+        );
+    }
+
+    #[cfg(feature = "solana")]
+    #[test]
+    fn solana_decoded_path_builders() {
+        assert_eq!(
+            decoded_solana_events_dir("solana-mainnet"),
+            PathBuf::from("data/solana-mainnet/historical/decoded/events")
+        );
+        assert_eq!(
+            decoded_solana_instructions_dir("solana-mainnet"),
+            PathBuf::from("data/solana-mainnet/historical/decoded/instructions")
         );
     }
 

--- a/src/transformations/engine.rs
+++ b/src/transformations/engine.rs
@@ -90,6 +90,7 @@ pub enum RangeCompleteKind {
     Logs,
     EthCalls,
     AccountStates,
+    Instructions,
 }
 
 /// Signal that a reorg occurred and orphaned blocks need cleanup.
@@ -127,6 +128,7 @@ pub struct TransformationEngineConfig {
     pub expect_log_completion: bool,
     pub expect_eth_call_completion: bool,
     pub expect_account_state_completion: bool,
+    pub expect_instruction_completion: bool,
 }
 
 /// A handler paired with the decoded calls it needs to process.
@@ -233,6 +235,7 @@ impl TransformationEngine {
             expect_log_completion: config.expect_log_completion,
             expect_eth_call_completion: config.expect_eth_call_completion,
             expect_account_state_completion: config.expect_account_state_completion,
+            expect_instruction_completion: config.expect_instruction_completion,
         });
 
         let retry_processor = RetryProcessor {

--- a/src/transformations/finalizer.rs
+++ b/src/transformations/finalizer.rs
@@ -28,6 +28,7 @@ pub(crate) struct RangeFinalizer {
     pub expect_log_completion: bool,
     pub expect_eth_call_completion: bool,
     pub expect_account_state_completion: bool,
+    pub expect_instruction_completion: bool,
 }
 
 impl RangeFinalizer {
@@ -121,6 +122,7 @@ impl RangeFinalizer {
                 self.expect_log_completion,
                 self.range_requires_eth_call_completion(range_key),
                 self.range_requires_account_state_completion(range_key),
+                self.range_requires_instruction_completion(range_key),
             )
         };
 
@@ -395,6 +397,11 @@ impl RangeFinalizer {
     /// Check if this range requires account-state completion before finalization.
     fn range_requires_account_state_completion(&self, range_key: (u64, u64)) -> bool {
         self.expect_account_state_completion && range_key.1.saturating_sub(range_key.0) == 1
+    }
+
+    /// Check if this range requires instruction completion before finalization.
+    fn range_requires_instruction_completion(&self, _range_key: (u64, u64)) -> bool {
+        self.expect_instruction_completion
     }
 
     // ─── Reorg Cleanup ─────────────────────────────────────────────────

--- a/src/transformations/live_state.rs
+++ b/src/transformations/live_state.rs
@@ -142,10 +142,11 @@ impl LiveProcessingState {
         expect_logs: bool,
         expect_eth_calls: bool,
         expect_account_states: bool,
+        expect_instructions: bool,
     ) -> (bool, Vec<TimedOutPendingHandler>) {
         let completion = self.completion.get(&range_key).copied().unwrap_or_default();
         let streams_ready =
-            completion.is_ready(expect_logs, expect_eth_calls, expect_account_states);
+            completion.is_ready(expect_logs, expect_eth_calls, expect_account_states, expect_instructions);
 
         // Check for timed-out pending events
         let timeout = Duration::from_secs(PENDING_EVENT_TIMEOUT_SECS);
@@ -233,7 +234,7 @@ impl LiveProcessingState {
         }
 
         let ready = !has_pending
-            && completion.is_ready(expect_logs, expect_eth_calls, expect_account_states);
+            && completion.is_ready(expect_logs, expect_eth_calls, expect_account_states, expect_instructions);
         (ready, timed_out.into_values().collect())
     }
 
@@ -282,6 +283,7 @@ pub(crate) struct RangeCompletionState {
     pub logs_complete: bool,
     pub eth_calls_complete: bool,
     pub account_states_complete: bool,
+    pub instructions_complete: bool,
 }
 
 impl RangeCompletionState {
@@ -290,6 +292,7 @@ impl RangeCompletionState {
             RangeCompleteKind::Logs => self.logs_complete = true,
             RangeCompleteKind::EthCalls => self.eth_calls_complete = true,
             RangeCompleteKind::AccountStates => self.account_states_complete = true,
+            RangeCompleteKind::Instructions => self.instructions_complete = true,
         }
     }
 
@@ -298,10 +301,12 @@ impl RangeCompletionState {
         expect_logs: bool,
         expect_eth_calls: bool,
         expect_account_states: bool,
+        expect_instructions: bool,
     ) -> bool {
         (!expect_logs || self.logs_complete)
             && (!expect_eth_calls || self.eth_calls_complete)
             && (!expect_account_states || self.account_states_complete)
+            && (!expect_instructions || self.instructions_complete)
     }
 
     pub fn is_ready(
@@ -309,8 +314,9 @@ impl RangeCompletionState {
         expect_logs: bool,
         expect_eth_calls: bool,
         expect_account_states: bool,
+        expect_instructions: bool,
     ) -> bool {
-        self.has_required_completions(expect_logs, expect_eth_calls, expect_account_states)
+        self.has_required_completions(expect_logs, expect_eth_calls, expect_account_states, expect_instructions)
     }
 }
 
@@ -322,30 +328,30 @@ mod tests {
     fn range_completion_requires_both_streams_when_calls_expected() {
         let mut state = RangeCompletionState::default();
         state.mark(RangeCompleteKind::Logs);
-        assert!(!state.is_ready(true, true, false));
+        assert!(!state.is_ready(true, true, false, false));
         state.mark(RangeCompleteKind::EthCalls);
-        assert!(state.is_ready(true, true, false));
+        assert!(state.is_ready(true, true, false, false));
     }
 
     #[test]
     fn range_completion_only_requires_logs_without_calls() {
         let mut state = RangeCompletionState::default();
         state.mark(RangeCompleteKind::Logs);
-        assert!(state.is_ready(true, false, false));
+        assert!(state.is_ready(true, false, false, false));
     }
 
     #[test]
     fn range_completion_can_finalize_call_only_ranges() {
         let mut state = RangeCompletionState::default();
         state.mark(RangeCompleteKind::EthCalls);
-        assert!(state.is_ready(false, true, false));
+        assert!(state.is_ready(false, true, false, false));
     }
 
     #[test]
     fn range_completion_can_require_account_states() {
         let mut state = RangeCompletionState::default();
         state.mark(RangeCompleteKind::AccountStates);
-        assert!(state.is_ready(false, false, true));
+        assert!(state.is_ready(false, false, true, false));
     }
 
     #[test]
@@ -354,8 +360,16 @@ mod tests {
         state.mark(RangeCompleteKind::Logs);
         state.mark(RangeCompleteKind::EthCalls);
 
-        assert!(state.has_required_completions(true, true, false));
-        assert!(!state.has_required_completions(true, true, true));
+        assert!(state.has_required_completions(true, true, false, false));
+        assert!(!state.has_required_completions(true, true, true, false));
+    }
+
+    #[test]
+    fn range_completion_can_require_instructions() {
+        let mut state = RangeCompletionState::default();
+        assert!(!state.is_ready(false, false, false, true));
+        state.mark(RangeCompleteKind::Instructions);
+        assert!(state.is_ready(false, false, false, true));
     }
 
     /// Helper: check whether a handler has remaining pending entries for a range.
@@ -610,7 +624,7 @@ mod tests {
             .or_default()
             .mark(RangeCompleteKind::Logs);
 
-        let (ready, timed_out) = state.check_finalization_readiness(range_key, true, true, false);
+        let (ready, timed_out) = state.check_finalization_readiness(range_key, true, true, false, false);
         assert!(!ready);
         assert!(
             timed_out.is_empty(),
@@ -622,7 +636,7 @@ mod tests {
             .entry(range_key)
             .or_default()
             .mark(RangeCompleteKind::EthCalls);
-        let (_, timed_out) = state.check_finalization_readiness(range_key, true, true, false);
+        let (_, timed_out) = state.check_finalization_readiness(range_key, true, true, false, false);
         assert_eq!(timed_out.len(), 1);
         assert_eq!(timed_out[0].handler_key, "handler_v1");
     }

--- a/src/transformations/registry.rs
+++ b/src/transformations/registry.rs
@@ -886,6 +886,34 @@ pub fn build_registry_for_chain(
     registry
 }
 
+/// Build a transformation registry for a Solana chain.
+///
+/// Sources are derived from `solana_programs` keys instead of EVM contracts.
+/// Handlers are filtered by `ChainType::Solana`.
+#[cfg(feature = "solana")]
+pub fn build_registry_for_solana_chain(
+    chain_id: u64,
+    solana_programs: &crate::types::config::solana::SolanaPrograms,
+) -> TransformationRegistry {
+    let available: HashSet<String> = solana_programs.keys().cloned().collect();
+    let mut registry =
+        TransformationRegistry::with_source_and_chain_filter(available, ChainType::Solana);
+
+    // Solana transformation handlers will be registered here as they're implemented.
+    // For now, the registry is empty but properly source-filtered and chain-type-filtered.
+
+    registry.validate_and_sort_handler_dependencies();
+
+    tracing::info!(
+        "Built Solana transformation registry with {} handlers ({} event triggers, {} account state triggers)",
+        registry.handler_count(),
+        registry.all_event_triggers().len(),
+        registry.all_account_state_triggers().len(),
+    );
+
+    registry
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

- **Prevent data loss in repair merges**: send fully merged records (not just fresh subset) to decoders so decoded parquet output is complete for each aligned range. Propagate read errors during merge instead of silently falling back to the fresh subset.
- **Stale decoded parquet cleanup**: restrict cleanup to in-scope source directories during source-scoped decode-only repairs; enable cleanup for range-only scoping where the decoder has complete data. Send empty batches from feeders so the decoder runs stale cleanup even for ranges with zero rows.
- **Removed program convergence**: scan existing on-disk ranges during repair (not just signature-discovered ranges) so ranges that only contained removed programs are revisited. Filter out unconfigured programs from raw parquet during unscoped repair.
- **Consistent slot parquet**: remove stale slot files when the range becomes empty, regardless of repair vs. non-repair mode.
- **Sidecar-only resume**: use the skipped-slots sidecar as the sole completion marker in `compute_slot_ranges_to_fetch`, so a crash between parquet write and sidecar update triggers reprocessing.