### PR TITLE
perf: optimize transformation catchup memory and concurrency

### DIFF
--- a/src/transformations/engine.rs
+++ b/src/transformations/engine.rs
@@ -614,52 +614,14 @@ impl TransformationEngine {
         )
         .set(total_todo as f64);
 
-        // 4. Build work items.
-        let (items, per_handler_submitted) = self
-            .build_catchup_work_items(
-                &handlers,
-                &available,
-                &self_completed,
-                &trigger_range_sets,
-                &tracker,
-            )
-            .await;
-
-        // Per-handler submission summary.
-        for ch in &handlers {
-            let count = per_handler_submitted
-                .get(ch.handler.name())
-                .copied()
-                .unwrap_or(0);
-            if count > 0 {
-                tracing::info!(
-                    "Handler {} catchup: submitting {} range(s)",
-                    ch.handler.handler_key(),
-                    count
-                );
-            }
-        }
-
-        if items.is_empty() {
-            tracing::info!("{} handler catchup: no work items to submit", kind_label);
-            return Ok(());
-        }
-
-        tracing::info!(
-            "{} catchup: executing {} work items across {} handlers",
-            kind_label,
-            items.len(),
-            per_handler_submitted.len()
-        );
-
-        // 5. Spawn background call-dep scanner.
+        // 4. Spawn background call-dep scanner.
         let (cancel_tx, scanner_handle) = self.spawn_call_dep_scanner(&handlers, &tracker).await;
 
-        // 6. Spawn progress reporter.
+        // 5. Spawn progress reporter.
         let progress_handle =
             Self::spawn_progress_reporter(tracker.clone(), kind_label, available.len(), &handlers);
 
-        // 7. Execute all items.
+        // 6. Execute work items in chunks to bound peak allocation.
         let loader = Arc::new(CatchupLoader {
             decoded_logs_dir: self.decoded_logs_dir.clone(),
             decoded_calls_dir: self.decoded_calls_dir.clone(),
@@ -671,25 +633,60 @@ impl TransformationEngine {
             chain_id: self.chain_id,
             db_pool: self.db_pool.clone(),
             finalizer: self.finalizer.clone(),
+            receipt_cache: tokio::sync::RwLock::new(HashMap::new()),
         });
 
         let scheduler = DagScheduler::new(tracker.clone(), self.handler_concurrency);
         let catchup_start = Instant::now();
-        let loader_ref = loader.clone();
-        let outcomes = scheduler
-            .execute(items, move |item| {
-                let loader = loader_ref.clone();
-                Box::pin(async move {
-                    match loader.run(item).await {
-                        Ok(()) => WorkItemRunResult::Succeeded,
-                        Err(TransformationError::TransientBlocked(msg)) => {
-                            WorkItemRunResult::Blocked(msg)
+        let chunk_size = self.handler_concurrency * 4;
+        let mut all_outcomes: Vec<WorkItemOutcome> = Vec::new();
+
+        loop {
+            let (items, per_handler_submitted) = self
+                .build_catchup_work_items(
+                    &handlers,
+                    &available,
+                    &trigger_range_sets,
+                    &tracker,
+                    chunk_size,
+                )
+                .await;
+
+            if items.is_empty() {
+                if all_outcomes.is_empty() {
+                    tracing::info!(
+                        "{} handler catchup: no work items to submit",
+                        kind_label
+                    );
+                }
+                break;
+            }
+
+            tracing::info!(
+                "{} catchup: executing chunk of {} work items across {} handlers",
+                kind_label,
+                items.len(),
+                per_handler_submitted.len()
+            );
+
+            let loader_ref = loader.clone();
+            let outcomes = scheduler
+                .execute(items, move |item| {
+                    let loader = loader_ref.clone();
+                    Box::pin(async move {
+                        match loader.run(item).await {
+                            Ok(()) => WorkItemRunResult::Succeeded,
+                            Err(TransformationError::TransientBlocked(msg)) => {
+                                WorkItemRunResult::Blocked(msg)
+                            }
+                            Err(e) => WorkItemRunResult::Failed(e.to_string()),
                         }
-                        Err(e) => WorkItemRunResult::Failed(e.to_string()),
-                    }
+                    })
                 })
-            })
-            .await;
+                .await;
+
+            all_outcomes.extend(outcomes);
+        }
 
         histogram!(
             "transformation_catchup_total_duration_seconds",
@@ -697,14 +694,14 @@ impl TransformationEngine {
         )
         .record(catchup_start.elapsed().as_secs_f64());
 
-        // 8. Cancel background tasks and process outcomes.
+        // 7. Cancel background tasks and process outcomes.
         let _ = cancel_tx.send(true);
         if let Some(handle) = scanner_handle {
             handle.abort();
         }
         progress_handle.abort();
 
-        Self::process_catchup_outcomes(outcomes, &handlers, kind_label, catchup_start)
+        Self::process_catchup_outcomes(all_outcomes, &handlers, kind_label, catchup_start)
     }
 
     // ─── Catchup Sub-steps ──────────────────────────────────────────
@@ -843,24 +840,32 @@ impl TransformationEngine {
         Ok(self_completed)
     }
 
-    /// Build all catchup work items upfront.
+    /// Build the next chunk of catchup work items.
+    ///
+    /// Skips ranges already completed or failed in the tracker. Stops after
+    /// `chunk_size` items to bound peak allocation. The tracker persists across
+    /// chunks, so dependency state from earlier chunks is naturally available.
     async fn build_catchup_work_items(
         &self,
         handlers: &[CatchupHandler],
         available: &[(u64, u64)],
-        self_completed: &HashMap<String, HashSet<u64>>,
         trigger_range_sets: &HashMap<String, HashSet<(u64, u64)>>,
         tracker: &Arc<CompletionTracker>,
+        chunk_size: usize,
     ) -> (Vec<WorkItem>, HashMap<String, usize>) {
         let mut items: Vec<WorkItem> = Vec::new();
         let mut per_handler_submitted: HashMap<String, usize> = HashMap::new();
 
         for ch in handlers {
             let name = ch.handler.name().to_string();
-            let completed = self_completed.get(&name).cloned().unwrap_or_default();
 
             for &(range_start, range_end) in available {
-                if completed.contains(&range_start) {
+                if items.len() >= chunk_size {
+                    return (items, per_handler_submitted);
+                }
+
+                // Skip if already completed in the tracker (DB-seeded + runtime).
+                if tracker.is_completed(&name, range_start).await {
                     continue;
                 }
 

--- a/src/transformations/historical.rs
+++ b/src/transformations/historical.rs
@@ -280,9 +280,10 @@ impl HistoricalDataReader {
     ) -> Result<Vec<DecodedEvent>, TransformationError> {
         let file = std::fs::File::open(file_path)?;
         let builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
+        let num_rows = builder.metadata().file_metadata().num_rows() as usize;
         let reader = builder.build()?;
 
-        let mut events = Vec::new();
+        let mut events = Vec::with_capacity(num_rows);
 
         for batch_result in reader {
             let batch = batch_result?;
@@ -303,9 +304,10 @@ impl HistoricalDataReader {
     ) -> Result<Vec<DecodedCall>, TransformationError> {
         let file = std::fs::File::open(file_path)?;
         let builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
+        let num_rows = builder.metadata().file_metadata().num_rows() as usize;
         let reader = builder.build()?;
 
-        let mut calls = Vec::new();
+        let mut calls = Vec::with_capacity(num_rows);
 
         for batch_result in reader {
             let batch = batch_result?;

--- a/src/transformations/scheduler/dag.rs
+++ b/src/transformations/scheduler/dag.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 use std::future::Future;
 use std::sync::Arc;
 
-use tokio::sync::{Mutex, Semaphore};
+use tokio::sync::{watch, Mutex, Semaphore};
 use tokio::task::{Id, JoinSet};
 
 use super::tracker::CompletionTracker;
@@ -80,12 +80,17 @@ pub(crate) enum WorkItemRunResult {
 
 /// Per-handler sequential execution state.
 ///
-/// Groups the capacity-1 FIFO semaphore and the blocked-range marker that
-/// together enforce one-at-a-time ascending-order execution for handlers
-/// with `sequential: true`.
+/// Uses a capacity-1 semaphore for mutual exclusion and a watch channel to
+/// enforce strict ascending range_start ordering. The watch tracks how many
+/// ranges have completed; each task knows its ordinal and waits its turn.
 struct HandlerSequentialState {
     semaphore: Arc<Semaphore>,
     blocked_range: Arc<Mutex<Option<u64>>>,
+    /// Sorted range_starts for this handler (ascending order).
+    sorted_ranges: Arc<Vec<u64>>,
+    /// Broadcasts the index of the next range allowed to execute.
+    /// Tasks wait until this equals their position in `sorted_ranges`.
+    next_index: watch::Sender<usize>,
 }
 
 /// Pure DAG scheduler — owns the [`CompletionTracker`] and a concurrency semaphore.
@@ -128,19 +133,32 @@ impl DagScheduler {
             return Vec::new();
         }
 
-        // Build per-handler sequential state (capacity-1 semaphore + blocked
-        // range marker) in a single pass. Tokio semaphores are FIFO, so items
-        // submitted in ascending range_start order acquire permits in order.
+        // Build per-handler sequential state. Collect and sort range_starts per
+        // handler to enable deterministic ordering via watch channel.
         let seq_state: Arc<HashMap<String, HandlerSequentialState>> = {
-            let mut m = HashMap::new();
+            let mut ranges_per_handler: HashMap<String, Vec<u64>> = HashMap::new();
             for item in &items {
                 if item.sequential {
-                    m.entry(item.handler_name.clone())
-                        .or_insert_with(|| HandlerSequentialState {
-                            semaphore: Arc::new(Semaphore::new(1)),
-                            blocked_range: Arc::new(Mutex::new(None)),
-                        });
+                    ranges_per_handler
+                        .entry(item.handler_name.clone())
+                        .or_default()
+                        .push(item.range_start);
                 }
+            }
+            let mut m = HashMap::new();
+            for (name, mut ranges) in ranges_per_handler {
+                ranges.sort_unstable();
+                ranges.dedup();
+                let (tx, _rx) = watch::channel(0usize);
+                m.insert(
+                    name,
+                    HandlerSequentialState {
+                        semaphore: Arc::new(Semaphore::new(1)),
+                        blocked_range: Arc::new(Mutex::new(None)),
+                        sorted_ranges: Arc::new(ranges),
+                        next_index: tx,
+                    },
+                );
             }
             Arc::new(m)
         };
@@ -198,11 +216,48 @@ impl DagScheduler {
                     }
                 }
 
-                // 2. Per-handler sequential gate (capacity-1 FIFO).
-                //    Acquired after dep-wait so parked sequential tasks don't
-                //    consume global permits. Dropped at end of scope, releasing
-                //    the next range in FIFO order.
+                // 2. Per-handler sequential gate.
+                //    Uses a watch channel to enforce strict ascending range_start
+                //    ordering, then acquires a capacity-1 semaphore for mutual
+                //    exclusion. The watch ensures tasks execute in range_start
+                //    order regardless of dep-wait wake ordering.
                 let handler_seq = seq_state.get(&name_for_task);
+                if let Some(state) = handler_seq {
+                    // Find our ordinal position in the sorted range list.
+                    let my_index = state
+                        .sorted_ranges
+                        .binary_search(&range_start)
+                        .unwrap_or(0);
+
+                    // Wait until it's our turn.
+                    let mut rx = state.next_index.subscribe();
+                    loop {
+                        if *rx.borrow() >= my_index {
+                            break;
+                        }
+                        if rx.changed().await.is_err() {
+                            break; // Sender dropped, proceed anyway.
+                        }
+                    }
+
+                    // Check for earlier blocked range.
+                    let blocking_range = *state.blocked_range.lock().await;
+                    if let Some(blocking_range) = blocking_range.filter(|r| *r < range_start) {
+                        let reason = format!(
+                            "waiting on earlier blocked range {} before processing {}",
+                            blocking_range, range_start
+                        );
+                        tracker.mark_blocked(&name_for_task, range_start).await;
+                        // Advance to next index so subsequent tasks don't hang.
+                        let _ = state.next_index.send(my_index + 1);
+                        return WorkItemOutcome {
+                            handler_name: name_for_task,
+                            range_start,
+                            range_end,
+                            status: OutcomeStatus::Blocked { reason },
+                        };
+                    }
+                }
                 let _seq_permit = match handler_seq {
                     Some(state) => Some(
                         state
@@ -215,23 +270,6 @@ impl DagScheduler {
                     None => None,
                 };
 
-                if let Some(state) = handler_seq {
-                    let blocking_range = *state.blocked_range.lock().await;
-                    if let Some(blocking_range) = blocking_range.filter(|r| *r < range_start) {
-                        let reason = format!(
-                            "waiting on earlier blocked range {} before processing {}",
-                            blocking_range, range_start
-                        );
-                        tracker.mark_blocked(&name_for_task, range_start).await;
-                        return WorkItemOutcome {
-                            handler_name: name_for_task,
-                            range_start,
-                            range_end,
-                            status: OutcomeStatus::Blocked { reason },
-                        };
-                    }
-                }
-
                 // 3. Acquire global permit AFTER waiting to avoid permit-deadlock.
                 let _permit = permits
                     .acquire_owned()
@@ -242,11 +280,13 @@ impl DagScheduler {
                 let result = runner(item).await;
 
                 // 5. Propagate result to tracker + return outcome.
-                match result {
+                //    Advance sequential next_index after each result so the
+                //    next range can proceed.
+                let outcome = match result {
                     WorkItemRunResult::Succeeded => {
                         tracker.mark_completed(&name_for_task, range_start).await;
                         WorkItemOutcome {
-                            handler_name: name_for_task,
+                            handler_name: name_for_task.clone(),
                             range_start,
                             range_end,
                             status: OutcomeStatus::Succeeded,
@@ -255,7 +295,7 @@ impl DagScheduler {
                     WorkItemRunResult::Failed(reason) => {
                         tracker.mark_failed(&name_for_task, range_start).await;
                         WorkItemOutcome {
-                            handler_name: name_for_task,
+                            handler_name: name_for_task.clone(),
                             range_start,
                             range_end,
                             status: OutcomeStatus::HandlerFailed { reason },
@@ -270,13 +310,22 @@ impl DagScheduler {
                         }
                         tracker.mark_blocked(&name_for_task, range_start).await;
                         WorkItemOutcome {
-                            handler_name: name_for_task,
+                            handler_name: name_for_task.clone(),
                             range_start,
                             range_end,
                             status: OutcomeStatus::Blocked { reason },
                         }
                     }
+                };
+
+                // Advance the sequential next_index for the next range.
+                if let Some(state) = seq_state.get(&name_for_task) {
+                    if let Ok(idx) = state.sorted_ranges.binary_search(&range_start) {
+                        let _ = state.next_index.send(idx + 1);
+                    }
                 }
+
+                outcome
             });
             identity.insert(handle.id(), (name, range_start, range_end));
         }

--- a/src/transformations/scheduler/loader.rs
+++ b/src/transformations/scheduler/loader.rs
@@ -138,6 +138,7 @@ fn read_receipt_addresses_sync(
 ) -> HashMap<[u8; 32], TransactionAddresses> {
     use arrow::array::{Array, FixedSizeBinaryArray};
     use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+    use parquet::arrow::ProjectionMask;
 
     let file_name = format!("receipts_{}-{}.parquet", range_start, range_end - 1);
     let file_path = raw_receipts_dir.join(&file_name);
@@ -172,7 +173,17 @@ fn read_receipt_addresses_sync(
         }
     };
 
-    let reader = match builder.build() {
+    let num_rows = builder.metadata().file_metadata().num_rows() as usize;
+    let arrow_schema = builder.schema().clone();
+
+    let needed = ["transaction_hash", "from_address", "to_address"];
+    let root_indices: Vec<usize> = needed
+        .iter()
+        .filter_map(|name| arrow_schema.index_of(name).ok())
+        .collect();
+
+    let mask = ProjectionMask::roots(builder.parquet_schema(), root_indices);
+    let reader = match builder.with_projection(mask).build() {
         Ok(r) => r,
         Err(e) => {
             tracing::warn!(
@@ -184,7 +195,7 @@ fn read_receipt_addresses_sync(
         }
     };
 
-    let mut addresses = HashMap::new();
+    let mut addresses = HashMap::with_capacity(num_rows);
 
     for batch_result in reader {
         let batch = match batch_result {
@@ -206,7 +217,7 @@ fn read_receipt_addresses_sync(
 
         let tx_hash_col = match batch.column_by_name("transaction_hash") {
             Some(col) => match col.as_any().downcast_ref::<FixedSizeBinaryArray>() {
-                Some(arr) => arr.clone(),
+                Some(arr) => arr,
                 None => continue,
             },
             None => continue,
@@ -214,7 +225,7 @@ fn read_receipt_addresses_sync(
 
         let from_col = match batch.column_by_name("from_address") {
             Some(col) => match col.as_any().downcast_ref::<FixedSizeBinaryArray>() {
-                Some(arr) => arr.clone(),
+                Some(arr) => arr,
                 None => continue,
             },
             None => continue,
@@ -222,7 +233,7 @@ fn read_receipt_addresses_sync(
 
         let to_col = batch
             .column_by_name("to_address")
-            .and_then(|col| col.as_any().downcast_ref::<FixedSizeBinaryArray>().cloned());
+            .and_then(|col| col.as_any().downcast_ref::<FixedSizeBinaryArray>());
 
         for row in 0..num_rows {
             let tx_hash: [u8; 32] = match tx_hash_col.value(row).try_into() {
@@ -235,7 +246,7 @@ fn read_receipt_addresses_sync(
                 Err(_) => continue,
             };
 
-            let to_address = to_col.as_ref().and_then(|col| {
+            let to_address = to_col.and_then(|col| {
                 if col.is_null(row) {
                     None
                 } else {
@@ -294,6 +305,11 @@ pub(crate) struct CatchupLoader {
     pub chain_id: u64,
     pub db_pool: Arc<DbPool>,
     pub finalizer: Arc<RangeFinalizer>,
+    /// Cache of receipt address maps keyed by (range_start, range_end).
+    /// Multiple event handlers processing the same range share one Arc'd HashMap.
+    pub receipt_cache: tokio::sync::RwLock<
+        HashMap<(u64, u64), Arc<HashMap<[u8; 32], TransactionAddresses>>>,
+    >,
 }
 
 impl CatchupLoader {
@@ -350,7 +366,8 @@ impl CatchupLoader {
 
         let tx_addresses = match payload.kind {
             HandlerKind::Event => {
-                Arc::new(read_receipt_addresses(&self.raw_receipts_dir, range_start, range_end).await)
+                self.get_or_load_receipt_addresses(range_start, range_end)
+                    .await
             }
             HandlerKind::Call => Arc::new(HashMap::new()),
         };
@@ -380,6 +397,35 @@ impl CatchupLoader {
     }
 
     // ─── Private helpers ─────────────────────────────────────────────────────
+
+    async fn get_or_load_receipt_addresses(
+        &self,
+        range_start: u64,
+        range_end: u64,
+    ) -> Arc<HashMap<[u8; 32], TransactionAddresses>> {
+        let key = (range_start, range_end);
+
+        // Fast path: read lock
+        {
+            let cache = self.receipt_cache.read().await;
+            if let Some(cached) = cache.get(&key) {
+                return cached.clone();
+            }
+        }
+
+        // Slow path: load and insert under write lock
+        let mut cache = self.receipt_cache.write().await;
+        // Double-check after acquiring write lock
+        if let Some(cached) = cache.get(&key) {
+            return cached.clone();
+        }
+
+        let addresses = Arc::new(
+            read_receipt_addresses(&self.raw_receipts_dir, range_start, range_end).await,
+        );
+        cache.insert(key, addresses.clone());
+        addresses
+    }
 
     async fn load_events(
         &self,

--- a/src/transformations/scheduler/tracker.rs
+++ b/src/transformations/scheduler/tracker.rs
@@ -1,23 +1,18 @@
-//! Completion tracking with notify-based wake-up for dependency waiters.
+//! Completion tracking with per-handler watch channels for dependency waiters.
 //!
 //! [`CompletionTracker`] is the synchronization primitive used by [`DagScheduler`]
-//! to gate each `(handler, range_start)` work item on its dependencies. Each
-//! waiter constructs a `Notify::notified()` future, checks shared state, and
-//! awaits the future if any dep is still pending. Every `mark_completed` /
-//! `mark_failed` call wakes all waiters so they can re-check. The ordering
-//! "construct notified() *before* probe" is load-bearing: tokio's Notified
-//! captures the notify_waiters call count at construction and honors any
-//! call that happens before first poll, so no wake can be lost between
-//! probe and `.await`.
+//! to gate each `(handler, range_start)` work item on its dependencies.
 //!
 //! # Wake mechanism
 //!
-//! [`tokio::sync::Notify`] with `notify_waiters` on every completion/failure.
-//! The codebase has no other `Notify` usage, but here it's the natural primitive:
-//! each waiter re-checks its predicate against shared state after being woken.
-//! Under heavy cascade-failure the wake-storm could become noisy; a per-handler
-//! `watch<HashSet<u64>>` would be an isolated drop-in swap if profiling shows
-//! contention.
+//! Per-handler `tokio::sync::watch<()>` channels notify only the waiters that
+//! depend on a specific handler, avoiding the O(total_waiters) wake-storm that
+//! a single global `Notify` would cause. A separate global `Notify` is used for
+//! call-dep file registration events (infrequent, from the background scanner).
+//!
+//! Waiters subscribe to their dep handlers' watch channels before probing state.
+//! `watch::Receiver::changed()` is cancellation-safe and captures any send that
+//! occurs between subscription and `.await`, preserving the race-free invariant.
 //!
 //! # Lock ordering
 //!
@@ -27,11 +22,14 @@
 //! simultaneously. `advance_contiguous_watermark` reads `state` then writes
 //! `contiguous` — safe ordering. `call_dep_ranges` is independent.
 //!
+//! `handler_watches` uses `std::sync::RwLock` for synchronous access (never held
+//! across `.await`).
+//!
 //! [`DagScheduler`]: super::dag::DagScheduler
 
 use std::collections::{HashMap, HashSet};
 
-use tokio::sync::{Notify, RwLock};
+use tokio::sync::{watch, Notify, RwLock};
 
 /// Per-handler completed/failed/blocked range state, grouped under one lock.
 struct HandlerRangeState {
@@ -71,7 +69,12 @@ pub(crate) struct CompletionTracker {
     /// Matched by range_start only (log and call-dep files may have different range sizes).
     /// Updated by the background `CallDepScanner`.
     call_dep_ranges: RwLock<HashMap<(String, String), HashSet<u64>>>,
-    notify: Notify,
+    /// Per-handler watch channels. Sends on completion/failure/block wake only
+    /// the waiters that depend on that specific handler. Lazily populated via
+    /// `get_or_create_watch`. Uses `std::sync::RwLock` (never held across await).
+    handler_watches: std::sync::RwLock<HashMap<String, watch::Sender<()>>>,
+    /// Global notify for call-dep file registration (background scanner).
+    global_notify: Notify,
     /// Sorted list of all available range_starts (immutable after construction).
     available_starts: Vec<u64>,
 }
@@ -113,7 +116,8 @@ impl CompletionTracker {
                 positions: HashMap::new(),
             }),
             call_dep_ranges: RwLock::new(HashMap::new()),
-            notify: Notify::new(),
+            handler_watches: std::sync::RwLock::new(HashMap::new()),
+            global_notify: Notify::new(),
             available_starts: Vec::new(),
         }
     }
@@ -138,9 +142,49 @@ impl CompletionTracker {
                 positions: HashMap::new(),
             }),
             call_dep_ranges: RwLock::new(HashMap::new()),
-            notify: Notify::new(),
+            handler_watches: std::sync::RwLock::new(HashMap::new()),
+            global_notify: Notify::new(),
             available_starts: starts,
         }
+    }
+
+    // ─── Per-handler watch helpers ─────────────────────────────────────
+
+    /// Send a notification on the handler's watch channel.
+    /// Lazily creates the channel if it doesn't exist.
+    fn notify_handler(&self, handler_name: &str) {
+        // Fast path: read lock
+        {
+            let watches = self.handler_watches.read().unwrap();
+            if let Some(tx) = watches.get(handler_name) {
+                let _ = tx.send(());
+                return;
+            }
+        }
+        // Slow path: create and send
+        let mut watches = self.handler_watches.write().unwrap();
+        let tx = watches
+            .entry(handler_name.to_string())
+            .or_insert_with(|| watch::channel(()).0);
+        let _ = tx.send(());
+    }
+
+    /// Subscribe to a handler's watch channel. Returns `None` if the handler
+    /// has no watch yet (caller should fall back to global_notify).
+    fn subscribe_handler(&self, handler_name: &str) -> watch::Receiver<()> {
+        // Fast path: read lock
+        {
+            let watches = self.handler_watches.read().unwrap();
+            if let Some(tx) = watches.get(handler_name) {
+                return tx.subscribe();
+            }
+        }
+        // Slow path: create watch and subscribe
+        let mut watches = self.handler_watches.write().unwrap();
+        let tx = watches
+            .entry(handler_name.to_string())
+            .or_insert_with(|| watch::channel(()).0);
+        tx.subscribe()
     }
 
     /// Pre-populate completed ranges for a handler. Intended for startup
@@ -168,7 +212,7 @@ impl CompletionTracker {
         if !self.available_starts.is_empty() {
             self.recompute_contiguous_watermark(handler_name).await;
         }
-        self.notify.notify_waiters();
+        self.notify_handler(handler_name);
     }
 
     /// Snapshot check: are all `deps` completed for `range_start`?
@@ -228,11 +272,13 @@ impl CompletionTracker {
         deps: &[String],
         range_start: u64,
     ) -> Result<(), DepWaitError> {
+        // Subscribe to each dep handler's watch channel before the first probe.
+        // `watch::Receiver::changed()` captures any send after subscription,
+        // preserving the same race-free invariant as the old `notified()` pattern.
+        let mut receivers: Vec<watch::Receiver<()>> =
+            deps.iter().map(|d| self.subscribe_handler(d)).collect();
+
         loop {
-            // MUST be created before probing: the stored notify_waiters_calls
-            // counter is the mechanism that catches a mark that fires after
-            // our probe read but before we park on notified.
-            let notified = self.notify.notified();
             match self.probe(deps, range_start).await {
                 DepState::Ready => return Ok(()),
                 DepState::DepFailed { dep_name } => {
@@ -247,7 +293,9 @@ impl CompletionTracker {
                         range_start,
                     })
                 }
-                DepState::Waiting => notified.await,
+                DepState::Waiting => {
+                    wait_any_changed(&mut receivers).await;
+                }
             }
         }
     }
@@ -276,7 +324,16 @@ impl CompletionTracker {
         if !self.available_starts.is_empty() {
             self.advance_contiguous_watermark(handler_name).await;
         }
-        self.notify.notify_waiters();
+        self.notify_handler(handler_name);
+    }
+
+    /// Check whether `(handler_name, range_start)` has been marked as completed.
+    pub(crate) async fn is_completed(&self, handler_name: &str, range_start: u64) -> bool {
+        let state = self.state.read().await;
+        state
+            .completed
+            .get(handler_name)
+            .is_some_and(|ranges| ranges.contains(&range_start))
     }
 
     /// Check whether `(handler_name, range_start)` has been marked as failed.
@@ -311,7 +368,7 @@ impl CompletionTracker {
                 }
             }
         }
-        self.notify.notify_waiters();
+        self.notify_handler(handler_name);
     }
 
     /// Mark `(handler_name, range_start)` as transiently blocked for this pass.
@@ -324,7 +381,7 @@ impl CompletionTracker {
                 .or_insert_with(HashSet::new)
                 .insert(range_start);
         }
-        self.notify.notify_waiters();
+        self.notify_handler(handler_name);
     }
 
     /// Clear a transient blocked mark before the next scheduler pass.
@@ -469,7 +526,7 @@ impl CompletionTracker {
         let grew = entry.len() > old_len;
         drop(call_deps);
         if grew {
-            self.notify.notify_waiters();
+            self.global_notify.notify_waiters();
         }
     }
 
@@ -556,8 +613,10 @@ impl CompletionTracker {
     /// Call-dep availability is matched by `range_start` only (not range_end)
     /// since log and call-dep parquet files may use different range sizes.
     ///
-    /// Same wake-safety invariant as [`wait_ready`]: `notified()` is constructed
-    /// before probing.
+    /// Subscribes to per-handler watch channels for handler deps and contiguous
+    /// deps before the first probe. `watch::Receiver::changed()` is
+    /// cancellation-safe and captures any send after subscription, preserving
+    /// the race-free invariant. Call-dep changes use the global `Notify`.
     pub(crate) async fn wait_ready_extended(
         &self,
         handler_deps: &[String],
@@ -565,8 +624,35 @@ impl CompletionTracker {
         call_dep_keys: &[(String, String)],
         range_start: u64,
     ) -> Result<(), DepWaitError> {
+        // Collect unique dep handler names from both handler and contiguous deps.
+        let mut unique_dep_names: Vec<&str> = Vec::new();
+        for dep in handler_deps {
+            if !unique_dep_names.contains(&dep.as_str()) {
+                unique_dep_names.push(dep);
+            }
+        }
+        for dep in contiguous_deps {
+            if !unique_dep_names.contains(&dep.as_str()) {
+                unique_dep_names.push(dep);
+            }
+        }
+
+        // Subscribe to each dep handler's watch channel once before any probing.
+        let mut receivers: Vec<watch::Receiver<()>> = unique_dep_names
+            .iter()
+            .map(|d| self.subscribe_handler(d))
+            .collect();
+
+        let has_call_deps = !call_dep_keys.is_empty();
+
         loop {
-            let notified = self.notify.notified();
+            // For call-dep changes, use global notify (created before probe).
+            let global_notified = if has_call_deps {
+                Some(self.global_notify.notified())
+            } else {
+                None
+            };
+
             match self
                 .probe_extended(handler_deps, contiguous_deps, call_dep_keys, range_start)
                 .await
@@ -584,7 +670,17 @@ impl CompletionTracker {
                         range_start,
                     })
                 }
-                DepState::Waiting => notified.await,
+                DepState::Waiting => match global_notified {
+                    Some(global) => {
+                        tokio::select! {
+                            _ = wait_any_changed(&mut receivers) => {},
+                            _ = global => {},
+                        }
+                    }
+                    None => {
+                        wait_any_changed(&mut receivers).await;
+                    }
+                },
             }
         }
     }
@@ -610,6 +706,29 @@ impl CompletionTracker {
         }
         result
     }
+}
+
+/// Wait until any of the given watch receivers reports a change.
+///
+/// Returns immediately if `receivers` is empty (no deps to wait on).
+/// Cancellation-safe: cancelled `changed()` futures do not lose events.
+async fn wait_any_changed(receivers: &mut [watch::Receiver<()>]) {
+    if receivers.is_empty() {
+        // No deps: yield once and return (avoids infinite pending).
+        tokio::task::yield_now().await;
+        return;
+    }
+    if receivers.len() == 1 {
+        // Fast path: single dep, no select overhead.
+        let _ = receivers[0].changed().await;
+        return;
+    }
+    // General case: wait for any receiver to report a change.
+    let futures: Vec<_> = receivers
+        .iter_mut()
+        .map(|rx| Box::pin(rx.changed()))
+        .collect();
+    let _ = futures::future::select_all(futures).await;
 }
 
 #[cfg(test)]

--- a/src/types/config/defaults.rs
+++ b/src/types/config/defaults.rs
@@ -113,7 +113,7 @@ pub mod db_pool {
     /// Must be at least as large as `transformations::HANDLER_CONCURRENCY` to
     /// avoid connection starvation during catchup, where each concurrent handler
     /// needs a DB connection for its transaction.
-    pub const MAX_SIZE: usize = 32;
+    pub const MAX_SIZE: usize = 40;
 }
 
 #[cfg(test)]
@@ -156,7 +156,7 @@ mod tests {
 
     #[test]
     fn test_db_pool_defaults() {
-        assert_eq!(db_pool::MAX_SIZE, 32);
+        assert_eq!(db_pool::MAX_SIZE, 40);
     }
 
     #[test]

--- a/src/types/config/transformations.rs
+++ b/src/types/config/transformations.rs
@@ -2,7 +2,7 @@
 
 use serde::Deserialize;
 
-use super::defaults::{database, db_pool, transformations as defaults};
+use super::defaults::{database, transformations as defaults};
 
 /// Configuration for the transformation system.
 ///
@@ -65,7 +65,7 @@ fn default_catchup_batch_size() -> usize {
 }
 
 fn default_db_pool_size() -> usize {
-    db_pool::MAX_SIZE
+    defaults::HANDLER_CONCURRENCY + 8
 }
 
 impl Default for TransformationConfig {


### PR DESCRIPTION
## Summary

- **Pre-allocate collections from parquet metadata**: `read_events_from_file`, `read_calls_from_file`, and `read_receipt_addresses_sync` now use `Vec::with_capacity` / `HashMap::with_capacity` sized from parquet file metadata, eliminating repeated re-allocations for large files.
- **Column projection for receipts**: Receipt parquet reading now projects only the 3 needed columns (`transaction_hash`, `from_address`, `to_address`), skipping all other columns in the file.
- **Receipt address cache**: `CatchupLoader` caches receipt address HashMaps per `(range_start, range_end)` behind an `Arc`. Multiple event handlers processing the same range share one copy instead of each independently reading and deserializing the same parquet file.
- **Per-handler watch channels**: Replaces the single `tokio::sync::Notify` broadcast in `CompletionTracker` with per-handler `tokio::sync::watch` channels. Completions now only wake tasks that depend on the specific handler that completed, instead of waking all waiting tasks. A global `Notify` is retained for call-dep registration events only.
- **Watch-based sequential ordering**: Sequential handler ordering now uses explicit watch-channel gating on sorted range indices, making ordering deterministic regardless of wake order.
- **Chunked work item generation**: `build_catchup_work_items` now generates items in chunks of `handler_concurrency * 4` instead of all at once, bounding peak allocation for large catchups. The `CompletionTracker` persists across chunks so dependency state carries over.
- **Remove Arrow column clones**: Receipt address reading now borrows `FixedSizeBinaryArray` columns by reference instead of cloning them per batch.
- **DB pool headroom**: Default `db_pool_size` is now `handler_concurrency + 8` (was equal), leaving connections available for finalizer, progress tracking, and other background DB work.