### PR TITLE
feat: per-chain from_block/to_block block range overrides

### DIFF
--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -8,6 +8,8 @@ Doppler Indexer is a high-performance Ethereum blockchain indexer written in Rus
 
 Operating modes: Full (historical + live), Decode-Only (`--decode-only`), Live-Only (`--live-only`), Catch-Up-Only (`--catch-up-only`), Transformation-Only (`--transformation-only`). The `--transformation-handlers` flag filters which handlers run (comma-separated names) and works with any mode.
 
+Per-chain block range overrides (`from_block`/`to_block`) limit all phases to a specific block range. Set via config JSON per chain or CLI (`--from-block [chain:]block`, `--to-block [chain:]block`). When `to_block` is set, live mode is suppressed. Priority: per-chain CLI > global CLI > config JSON.
+
 ### Subsystems
 
 | Subsystem | Description |

--- a/src/live/collector.rs
+++ b/src/live/collector.rs
@@ -1662,6 +1662,8 @@ mod tests {
             rpc_url_env_var: "RPC_URL".to_string(),
             ws_url_env_var: None,
             start_block: None,
+            from_block: None,
+            to_block: None,
             contracts: HashMap::new(),
             block_receipts_method: None,
             factory_collections: HashMap::new(),

--- a/src/live/eth_calls.rs
+++ b/src/live/eth_calls.rs
@@ -835,6 +835,8 @@ mod tests {
             rpc_url_env_var: "RPC_URL".to_string(),
             ws_url_env_var: None,
             start_block: None,
+            from_block: None,
+            to_block: None,
             contracts: HashMap::new(),
             block_receipts_method: None,
             factory_collections: HashMap::new(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,68 +107,68 @@ fn collect_flag_values(args: &[String], flag: &str) -> anyhow::Result<Vec<String
     Ok(values)
 }
 
-fn parse_optional_u64_flag(args: &[String], flag: &str) -> anyhow::Result<Option<u64>> {
-    let mut value = None;
-    let mut idx = 0usize;
-
-    while idx < args.len() {
-        let arg = &args[idx];
-        if arg == flag {
-            let Some(next) = args.get(idx + 1) else {
-                anyhow::bail!("Missing value for {}", flag);
-            };
-            if next.starts_with("--") {
-                anyhow::bail!("Missing value for {}", flag);
-            }
-            value = Some(
-                next.parse::<u64>()
-                    .with_context(|| format!("Invalid numeric value '{}' for {}", next, flag))?,
-            );
-            idx += 2;
-            continue;
-        }
-
-        let prefix = format!("{}=", flag);
-        if let Some(raw) = arg.strip_prefix(&prefix) {
-            value = Some(
-                raw.parse::<u64>()
-                    .with_context(|| format!("Invalid numeric value '{}' for {}", raw, flag))?,
-            );
-        }
-
-        idx += 1;
-    }
-
-    Ok(value)
+/// Parsed per-chain and global block overrides from CLI.
+struct BlockOverrides {
+    global_from: Option<u64>,
+    global_to: Option<u64>,
+    per_chain_from: HashMap<String, u64>,
+    per_chain_to: HashMap<String, u64>,
 }
 
-fn build_repair_scope(args: &[String]) -> anyhow::Result<Option<RepairScope>> {
-    let from_block = parse_optional_u64_flag(args, "--from-block")?;
-    let to_block = parse_optional_u64_flag(args, "--to-block")?;
-    let sources = collect_flag_values(args, "--source")?;
-    let functions = collect_flag_values(args, "--function")?;
+fn parse_block_overrides(args: &[String]) -> anyhow::Result<BlockOverrides> {
+    let from_values = collect_flag_values(args, "--from-block")?;
+    let to_values = collect_flag_values(args, "--to-block")?;
 
-    if let (Some(from_block), Some(to_block)) = (from_block, to_block) {
+    let mut global_from: Option<u64> = None;
+    let mut per_chain_from: HashMap<String, u64> = HashMap::new();
+
+    for val in &from_values {
+        if let Some((chain, block_str)) = val.split_once(':') {
+            let block = block_str.parse::<u64>().with_context(|| {
+                format!("Invalid numeric value '{}' for --from-block (chain '{}')", block_str, chain)
+            })?;
+            per_chain_from.insert(chain.to_string(), block);
+        } else {
+            let block = val.parse::<u64>().with_context(|| {
+                format!("Invalid numeric value '{}' for --from-block", val)
+            })?;
+            global_from = Some(block);
+        }
+    }
+
+    let mut global_to: Option<u64> = None;
+    let mut per_chain_to: HashMap<String, u64> = HashMap::new();
+
+    for val in &to_values {
+        if let Some((chain, block_str)) = val.split_once(':') {
+            let block = block_str.parse::<u64>().with_context(|| {
+                format!("Invalid numeric value '{}' for --to-block (chain '{}')", block_str, chain)
+            })?;
+            per_chain_to.insert(chain.to_string(), block);
+        } else {
+            let block = val.parse::<u64>().with_context(|| {
+                format!("Invalid numeric value '{}' for --to-block", val)
+            })?;
+            global_to = Some(block);
+        }
+    }
+
+    // Validate global from <= to when both set
+    if let (Some(from), Some(to)) = (global_from, global_to) {
         anyhow::ensure!(
-            from_block <= to_block,
+            from <= to,
             "--from-block ({}) cannot be greater than --to-block ({})",
-            from_block,
-            to_block
+            from,
+            to
         );
     }
 
-    let scope = RepairScope {
-        from_block,
-        to_block,
-        sources: (!sources.is_empty()).then(|| sources.into_iter().collect()),
-        functions: (!functions.is_empty()).then(|| functions.into_iter().collect()),
-    };
-
-    if scope.is_unscoped() {
-        Ok(None)
-    } else {
-        Ok(Some(scope))
-    }
+    Ok(BlockOverrides {
+        global_from,
+        global_to,
+        per_chain_from,
+        per_chain_to,
+    })
 }
 
 fn live_pipeline_expectations(
@@ -201,7 +201,9 @@ async fn main() -> anyhow::Result<()> {
     let repair_flag = args.iter().any(|a| a == "--repair");
     let transformation_only = args.iter().any(|a| a == "--transformation-only");
     let repair = repair_flag || repair_only;
-    let repair_scope = build_repair_scope(&args)?;
+    let block_overrides = parse_block_overrides(&args)?;
+    let parsed_sources = collect_flag_values(&args, "--source")?;
+    let parsed_functions = collect_flag_values(&args, "--function")?;
 
     let transformation_handlers: Option<HashSet<String>> = {
         let values = collect_flag_values(&args, "--transformation-handlers")?;
@@ -248,10 +250,10 @@ async fn main() -> anyhow::Result<()> {
     if transformation_only && repair_flag {
         anyhow::bail!("Cannot use --transformation-only and --repair together");
     }
-    if repair_scope.is_some() && !repair {
-        anyhow::bail!(
-            "--from-block/--to-block/--source/--function require --repair or --repair-only"
-        );
+    let has_source_or_function = args.iter().any(|a| a == "--source" || a.starts_with("--source="))
+        || args.iter().any(|a| a == "--function" || a.starts_with("--function="));
+    if has_source_or_function && !repair {
+        anyhow::bail!("--source/--function require --repair or --repair-only");
     }
 
     let chains_filter: Option<Vec<String>> = args
@@ -290,6 +292,37 @@ async fn main() -> anyhow::Result<()> {
             filter
         );
     }
+
+    // Merge CLI block range overrides into chain configs
+    for chain in &mut config.chains {
+        // Priority: per-chain CLI > global CLI > config JSON
+        chain.from_block = block_overrides
+            .per_chain_from
+            .get(&chain.name)
+            .copied()
+            .or(block_overrides.global_from)
+            .or(chain.from_block);
+        chain.to_block = block_overrides
+            .per_chain_to
+            .get(&chain.name)
+            .copied()
+            .or(block_overrides.global_to)
+            .or(chain.to_block);
+    }
+
+    // Validate per-chain from <= to after merging
+    for chain in &config.chains {
+        if let (Some(from), Some(to)) = (chain.from_block, chain.to_block) {
+            anyhow::ensure!(
+                from <= to,
+                "from_block ({}) cannot be greater than to_block ({}) for chain '{}'",
+                from,
+                to,
+                chain.name
+            );
+        }
+    }
+
     if !decode_only {
         let require_ws = !catch_up_only && !repair_only && !transformation_only;
         load_required_env_vars(&config, require_ws)?;
@@ -458,8 +491,15 @@ async fn main() -> anyhow::Result<()> {
             "Repair mode enabled: rebuilding once indexes from parquet, auditing raw-vs-decoded once schema drift, and repairing legacy factory-once sidecars"
         );
     }
-    if let Some(scope) = &repair_scope {
-        tracing::info!("Repair scope: {:?}", scope);
+    for chain in &config.chains {
+        if chain.from_block.is_some() || chain.to_block.is_some() {
+            tracing::info!(
+                "Chain {} block range override: from={:?}, to={:?}",
+                chain.name,
+                chain.from_block,
+                chain.to_block
+            );
+        }
     }
 
     tracing::info!("Loaded config with {} chain(s)", config.chains.len());
@@ -535,8 +575,26 @@ async fn main() -> anyhow::Result<()> {
         let storage_manager = storage_manager.clone();
         let shared_db_pool = shared_db_pool.clone();
         let chain = chain.clone();
-        let repair_scope = repair_scope.clone();
         let transformation_handlers = transformation_handlers.clone();
+
+        // Build per-chain repair scope from the chain's merged block overrides
+        let repair_scope = if repair {
+            let scope = RepairScope {
+                from_block: chain.from_block,
+                to_block: chain.to_block,
+                sources: (!parsed_sources.is_empty())
+                    .then(|| parsed_sources.iter().cloned().collect()),
+                functions: (!parsed_functions.is_empty())
+                    .then(|| parsed_functions.iter().cloned().collect()),
+            };
+            if scope.is_unscoped() {
+                None
+            } else {
+                Some(scope)
+            }
+        } else {
+            None
+        };
 
         // Look up shared rate limiter for this chain's group
         let shared_rate_limiter = chain
@@ -864,6 +922,8 @@ async fn transformation_only_chain(
             handler_concurrency: tc.handler_concurrency,
             expect_log_completion: false,
             expect_eth_call_completion: false,
+            from_block: chain.from_block,
+            to_block: chain.to_block,
         },
         None, // No live progress tracker
     )
@@ -1035,6 +1095,8 @@ async fn process_chain_live_only(
                 handler_concurrency: tc.handler_concurrency,
                 expect_log_completion: runtime.features.has_events,
                 expect_eth_call_completion: runtime.features.has_calls,
+                from_block: chain.from_block,
+                to_block: chain.to_block,
             },
             runtime.progress_tracker.clone(),
         )
@@ -1735,7 +1797,17 @@ async fn process_chain(
         None
     };
 
-    let live_mode_enabled = !catch_up_only && should_enable_live_mode(config, &runtime.chain);
+    let live_mode_enabled = !catch_up_only
+        && runtime.chain.to_block.is_none()
+        && should_enable_live_mode(config, &runtime.chain);
+
+    if runtime.chain.to_block.is_some() && !catch_up_only {
+        tracing::info!(
+            "Live mode suppressed for chain {}: to_block={} is set",
+            runtime.chain.name,
+            runtime.chain.to_block.unwrap()
+        );
+    }
 
     // Clone for live mode transition (before originals are moved)
     let log_decoder_tx_for_live = if live_mode_enabled && has_events {
@@ -1876,6 +1948,8 @@ async fn process_chain(
                 handler_concurrency: tc.handler_concurrency,
                 expect_log_completion: has_events,
                 expect_eth_call_completion: has_calls,
+                from_block: pipeline.runtime.chain.from_block,
+                to_block: pipeline.runtime.chain.to_block,
             },
             pipeline.runtime.progress_tracker.clone(),
         )

--- a/src/raw_data/historical/catchup/blocks.rs
+++ b/src/raw_data/historical/catchup/blocks.rs
@@ -53,9 +53,10 @@ pub async fn collect_blocks(
     tokio::fs::create_dir_all(&output_dir).await?;
 
     let range_size = raw_data_config.parquet_block_range.unwrap_or(1000) as u64;
-    let start_block = chain.start_block.map(|u| u.to::<u64>()).unwrap_or(0);
+    let start_block = chain.effective_start_block();
 
-    let chain_head = client.get_block_number().await?;
+    let raw_chain_head = client.get_block_number().await?;
+    let chain_head = chain.effective_upper_bound(raw_chain_head);
 
     tracing::info!(
         "Chain {} head at block {}, starting collection from block {}",

--- a/src/raw_data/historical/catchup/eth_calls.rs
+++ b/src/raw_data/historical/catchup/eth_calls.rs
@@ -486,6 +486,10 @@ pub async fn collect_eth_calls(
         let block_ranges =
             get_existing_block_ranges_async(chain.name.clone(), s3_manifest.as_ref().cloned())
                 .await;
+        let block_ranges: Vec<_> = block_ranges
+            .into_iter()
+            .filter(|br| chain.range_in_scope(br.start, br.end))
+            .collect();
         tracing::info!(
             "eth_calls catchup: checking {} block ranges (regular={}, once={})",
             block_ranges.len(),
@@ -816,6 +820,10 @@ pub async fn collect_eth_calls(
             let block_ranges =
                 get_existing_block_ranges_async(chain.name.clone(), s3_manifest.as_ref().cloned())
                     .await;
+            let block_ranges: Vec<_> = block_ranges
+                .into_iter()
+                .filter(|br| chain.range_in_scope(br.start, br.end))
+                .collect();
             let total_factory_ranges = block_ranges.len();
             let mut factory_once_catchup_count = 0;
 
@@ -938,6 +946,10 @@ pub async fn collect_eth_calls(
 
         let log_ranges =
             get_existing_log_ranges_async(chain.name.clone(), s3_manifest.as_ref().cloned()).await;
+        let log_ranges: Vec<_> = log_ranges
+            .into_iter()
+            .filter(|lr| chain.range_in_scope(lr.start, lr.end))
+            .collect();
         let total_log_ranges = log_ranges.len();
         let event_call_concurrency = raw_data_config.event_call_concurrency.unwrap_or(4);
         let scoped_log_range_count = log_ranges

--- a/src/raw_data/historical/catchup/receipts.rs
+++ b/src/raw_data/historical/catchup/receipts.rs
@@ -116,6 +116,10 @@ pub async fn collect_receipts(
     // =========================================================================
     let block_ranges =
         get_existing_block_ranges_async(chain.name.clone(), s3_manifest.as_ref().cloned()).await;
+    let block_ranges: Vec<_> = block_ranges
+        .into_iter()
+        .filter(|br| chain.range_in_scope(br.start, br.end))
+        .collect();
     let mut catchup_count = 0;
 
     // Check existing logs files

--- a/src/raw_data/historical/current/eth_calls/range_processor.rs
+++ b/src/raw_data/historical/current/eth_calls/range_processor.rs
@@ -415,6 +415,8 @@ mod tests {
             rpc_url_env_var: "RPC_URL".to_string(),
             ws_url_env_var: None,
             start_block: None,
+            from_block: None,
+            to_block: None,
             contracts: HashMap::new(),
             block_receipts_method: None,
             factory_collections: HashMap::new(),

--- a/src/transformations/engine.rs
+++ b/src/transformations/engine.rs
@@ -116,6 +116,10 @@ pub struct TransformationEngineConfig {
     pub handler_concurrency: usize,
     pub expect_log_completion: bool,
     pub expect_eth_call_completion: bool,
+    /// Optional lower bound (inclusive) for catchup block range filtering.
+    pub from_block: Option<u64>,
+    /// Optional upper bound (inclusive) for catchup block range filtering.
+    pub to_block: Option<u64>,
 }
 
 /// A handler paired with the decoded calls it needs to process.
@@ -178,6 +182,10 @@ pub struct TransformationEngine {
     live_state: Mutex<LiveProcessingState>,
     /// Live mode progress tracker for marking block completion.
     progress_tracker: Option<Arc<Mutex<LiveProgressTracker>>>,
+    /// Optional lower bound (inclusive) for catchup block range filtering.
+    from_block: Option<u64>,
+    /// Optional upper bound (inclusive) for catchup block range filtering.
+    to_block: Option<u64>,
 }
 
 impl TransformationEngine {
@@ -254,6 +262,8 @@ impl TransformationEngine {
             retry_processor,
             live_state: Mutex::new(LiveProcessingState::default()),
             progress_tracker,
+            from_block: config.from_block,
+            to_block: config.to_block,
         })
     }
 
@@ -371,6 +381,27 @@ impl TransformationEngine {
         })
         .await
         .map_err(|e| TransformationError::IoError(std::io::Error::other(e.to_string())))?
+    }
+
+    /// Check whether a range `[range_start, range_end_exclusive)` overlaps the
+    /// configured `from_block..=to_block` window.  Returns `false` for empty
+    /// ranges or ranges entirely outside the window.
+    fn range_in_scope(&self, range_start: u64, range_end_exclusive: u64) -> bool {
+        if range_end_exclusive <= range_start {
+            return false;
+        }
+        let end_inclusive = range_end_exclusive - 1;
+        if let Some(from) = self.from_block {
+            if end_inclusive < from {
+                return false;
+            }
+        }
+        if let Some(to) = self.to_block {
+            if range_start > to {
+                return false;
+            }
+        }
+        true
     }
 
     #[allow(dead_code)]
@@ -561,6 +592,21 @@ impl TransformationEngine {
         };
 
         let mut available = self.scan_available_ranges(base_dir).await?;
+
+        if self.from_block.is_some() || self.to_block.is_some() {
+            let before = available.len();
+            available.retain(|(start, end)| self.range_in_scope(*start, *end));
+            if available.len() < before {
+                tracing::info!(
+                    "{} handler catchup: filtered {} to {} ranges by block range override (from={:?}, to={:?})",
+                    kind_label,
+                    before,
+                    available.len(),
+                    self.from_block,
+                    self.to_block
+                );
+            }
+        }
 
         if available.is_empty() {
             tracing::info!(

--- a/src/types/config/chain.rs
+++ b/src/types/config/chain.rs
@@ -95,6 +95,14 @@ pub struct ChainConfigRaw {
     /// Environment variable name for WebSocket URL (for live mode).
     pub ws_url_env_var: Option<String>,
     pub start_block: Option<U256>,
+    /// Operational override: start processing from this block instead of `start_block`.
+    /// Set via config JSON or `--from-block chain:block` CLI flag.
+    #[serde(default)]
+    pub from_block: Option<u64>,
+    /// Operational override: stop processing at this block (inclusive).
+    /// Suppresses live mode when set. Set via config JSON or `--to-block chain:block` CLI flag.
+    #[serde(default)]
+    pub to_block: Option<u64>,
     pub contracts: InlineOrPath<Contracts>,
     pub block_receipts_method: Option<BlockReceiptsMethod>,
     #[serde(default)]
@@ -112,11 +120,53 @@ pub struct ChainConfig {
     /// Environment variable name for WebSocket URL (for live mode).
     pub ws_url_env_var: Option<String>,
     pub start_block: Option<U256>,
+    /// Operational override: start processing from this block instead of `start_block`.
+    pub from_block: Option<u64>,
+    /// Operational override: stop processing at this block (inclusive).
+    /// Suppresses live mode when set.
+    pub to_block: Option<u64>,
     pub contracts: Contracts,
     pub block_receipts_method: Option<BlockReceiptsMethod>,
     pub factory_collections: FactoryCollections,
     /// RPC client configuration (rate limiting, concurrency).
     pub rpc: RpcConfig,
+}
+
+impl ChainConfig {
+    /// Effective start block: `from_block` overrides `start_block` when set.
+    pub fn effective_start_block(&self) -> u64 {
+        self.from_block
+            .or(self.start_block.map(|u| u.to::<u64>()))
+            .unwrap_or(0)
+    }
+
+    /// Effective upper bound: clamp `chain_head` down to `to_block` when set.
+    pub fn effective_upper_bound(&self, chain_head: u64) -> u64 {
+        match self.to_block {
+            Some(cap) => cap.min(chain_head),
+            None => chain_head,
+        }
+    }
+
+    /// Check if a half-open range `[range_start, range_end)` overlaps
+    /// the active scope `[from_block, to_block]`.
+    pub fn range_in_scope(&self, range_start: u64, range_end_exclusive: u64) -> bool {
+        if range_end_exclusive <= range_start {
+            return false;
+        }
+        let end_inclusive = range_end_exclusive - 1;
+        if let Some(from) = self.from_block {
+            if end_inclusive < from {
+                return false;
+            }
+        }
+        if let Some(to) = self.to_block {
+            if range_start > to {
+                return false;
+            }
+        }
+        true
+    }
 }
 
 pub fn resolve_chain_config(
@@ -145,6 +195,8 @@ pub fn resolve_chain_config(
         rpc_url_env_var: raw_config.rpc_url_env_var,
         ws_url_env_var: raw_config.ws_url_env_var,
         start_block: raw_config.start_block,
+        from_block: raw_config.from_block,
+        to_block: raw_config.to_block,
         contracts,
         block_receipts_method: raw_config.block_receipts_method,
         factory_collections,
@@ -199,6 +251,8 @@ mod tests {
             rpc_url_env_var: "RPC_URL".to_string(),
             ws_url_env_var: None,
             start_block: None,
+            from_block: None,
+            to_block: None,
             contracts: InlineOrPath::Path("nonexistent/contracts.json".to_string()),
             block_receipts_method: None,
             factory_collections: None,
@@ -216,6 +270,8 @@ mod tests {
             rpc_url_env_var: "RPC_URL".to_string(),
             ws_url_env_var: None,
             start_block: None,
+            from_block: None,
+            to_block: None,
             contracts: InlineOrPath::Inline(Contracts::new()),
             block_receipts_method: Some(BlockReceiptsMethod::EthGetBlockReceipts),
             factory_collections: None,
@@ -274,5 +330,79 @@ mod tests {
         let rpc: RpcConfig = serde_json::from_str(json).unwrap();
         assert_eq!(rpc.http2, None);
         assert!(!rpc.http2_enabled());
+    }
+
+    fn make_chain_config(from_block: Option<u64>, to_block: Option<u64>) -> ChainConfig {
+        ChainConfig {
+            name: "test".to_string(),
+            chain_id: 1,
+            rpc_url_env_var: "RPC_URL".to_string(),
+            ws_url_env_var: None,
+            start_block: Some(U256::from(1000)),
+            from_block,
+            to_block,
+            contracts: Contracts::new(),
+            block_receipts_method: None,
+            factory_collections: FactoryCollections::new(),
+            rpc: RpcConfig::default(),
+        }
+    }
+
+    #[test]
+    fn test_effective_start_block_uses_from_block_when_set() {
+        let config = make_chain_config(Some(500), None);
+        assert_eq!(config.effective_start_block(), 500);
+    }
+
+    #[test]
+    fn test_effective_start_block_falls_back_to_start_block() {
+        let config = make_chain_config(None, None);
+        assert_eq!(config.effective_start_block(), 1000);
+    }
+
+    #[test]
+    fn test_effective_upper_bound_clamps_to_to_block() {
+        let config = make_chain_config(None, Some(5000));
+        assert_eq!(config.effective_upper_bound(10000), 5000);
+        assert_eq!(config.effective_upper_bound(3000), 3000);
+    }
+
+    #[test]
+    fn test_effective_upper_bound_no_cap() {
+        let config = make_chain_config(None, None);
+        assert_eq!(config.effective_upper_bound(10000), 10000);
+    }
+
+    #[test]
+    fn test_range_in_scope_both_bounds() {
+        let config = make_chain_config(Some(200), Some(299));
+        assert!(config.range_in_scope(100, 201));  // overlaps at 200
+        assert!(config.range_in_scope(299, 300));  // overlaps at 299
+        assert!(config.range_in_scope(250, 260));  // fully inside
+        assert!(!config.range_in_scope(100, 200)); // ends before from_block
+        assert!(!config.range_in_scope(300, 400)); // starts after to_block
+    }
+
+    #[test]
+    fn test_range_in_scope_no_bounds() {
+        let config = make_chain_config(None, None);
+        assert!(config.range_in_scope(0, 1000));
+        assert!(config.range_in_scope(999999, 1000000));
+    }
+
+    #[test]
+    fn test_range_in_scope_only_from() {
+        let config = make_chain_config(Some(500), None);
+        assert!(!config.range_in_scope(0, 500));
+        assert!(config.range_in_scope(0, 501));
+        assert!(config.range_in_scope(500, 1000));
+    }
+
+    #[test]
+    fn test_range_in_scope_only_to() {
+        let config = make_chain_config(None, Some(999));
+        assert!(config.range_in_scope(0, 1000));
+        assert!(config.range_in_scope(999, 1000));
+        assert!(!config.range_in_scope(1000, 2000));
     }
 }


### PR DESCRIPTION
## Summary

- Add `from_block` and `to_block` fields to `ChainConfig` that limit **all pipeline phases** (block collection, receipt/log/eth_call catchup, decoding, transformation catchup) to a specific block range
- Suppress live mode when `to_block` is set
- Support per-chain config JSON (`"from_block": 1000, "to_block": 5000`) and CLI overrides (`--from-block base:1000 --to-block base:5000`)
- Priority: per-chain CLI > global CLI > config JSON
- Decouple `--from-block`/`--to-block` from `--repair` flag (only `--source`/`--function` still require `--repair`)

## Key changes

- **`src/types/config/chain.rs`**: New fields + helper methods (`effective_start_block`, `effective_upper_bound`, `range_in_scope`) with 8 unit tests
- **`src/main.rs`**: New `parse_block_overrides` for `--from-block [chain:]block` syntax, per-chain merge logic, per-chain `RepairScope` construction, live mode suppression
- **`src/raw_data/historical/catchup/blocks.rs`**: Uses `effective_start_block()` and `effective_upper_bound()` to clamp collection range
- **`src/raw_data/historical/catchup/receipts.rs`**: Filters block ranges by `range_in_scope()`
- **`src/raw_data/historical/catchup/eth_calls.rs`**: Filters at 3 locations (regular, factory, event-triggered)
- **`src/transformations/engine.rs`**: Filters catchup ranges after `scan_available_ranges()`