### PR TITLE
feat: Solana live mode pipeline (phase 8)

### DIFF
--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -200,6 +200,11 @@ migrations/
 - **depends_on**: [solana_rpc, configuration]
 - **doc**: `docs/features/solana_raw_data.md`
 
+### solana_live_mode
+- **description**: Solana live mode behind the `solana` feature flag. Real-time slot processing via WebSocket `slotSubscribe`. Reorg detection via parent-slot chain verification with commitment-aware depth (150/processed, 32/confirmed, 0/finalized). Bincode live storage, event-triggered account reads, and compaction to parquet. Parallels the EVM live mode architecture.
+- **entry_points**: `src/solana/live/collector.rs`, `src/solana/live/reorg.rs`, `src/solana/live/storage.rs`, `src/solana/pipeline.rs`
+- **depends_on**: [solana_raw_data, solana_rpc, live_mode]
+
 ---
 
 ## Project Structure

--- a/docs/features/transformations.md
+++ b/docs/features/transformations.md
@@ -133,6 +133,18 @@ The engine delegates to sub-components:
 - **RetryProcessor** (`retry.rs`): Re-processing failed live blocks from bincode storage
 - **LiveProcessingState** (`live_state.rs`): Pending event buffering for handlers with unmet call dependencies
 
+### Optional EVM Fields (Multi-Chain Support)
+
+The transformation engine, executor, retry processor, and catchup loader accept optional EVM-specific fields so non-EVM chains (e.g. Solana) can reuse the engine without requiring an EVM RPC client:
+
+| Field | Type | Behavior when `None` |
+|-------|------|---------------------|
+| `rpc_client` | `Option<Arc<UnifiedRpcClient>>` | Ad-hoc `eth_call` and `find_log_emitter` on `TransformationContext` return an error. Handlers that don't use EVM RPC are unaffected. |
+| `contracts` | `Option<Arc<Contracts>>` | Start-block filtering passes all events/calls through unfiltered. `TransformationContext` receives an empty `Contracts` map. Factory contract index checks use an empty map. |
+| `factory_collections` | `Option<Arc<FactoryCollections>>` | Event matcher building uses an empty map, producing no factory matchers. |
+
+EVM callers pass `Some(rpc_client)` and the engine derives `contracts`/`factory_collections` from `TransformationEngineConfig`. Solana callers pass `None` for `rpc_client` and empty collections for `contracts`/`factory_collections` in the config.
+
 ## Configuration
 
 Configure transformations in your `config.json`. Transformations are automatically enabled when:

--- a/docs/solana/analysis.md
+++ b/docs/solana/analysis.md
@@ -153,7 +153,7 @@ Read the tables below as target analysis plus branch notes, not a literal invent
 | `ReorgDetector` | At `confirmed` commitment, skip reorg detection (Solana has never reorged a confirmed block). Reject `processed` commitment in config validation |
 | `WsClient` | `eth_subscribe("newHeads")` → `slotSubscribe` or `blockSubscribe` |
 | `CompactionService` | Generic — works for any block-ranged data |
-| `LiveProgressTracker` | Generic — no changes needed |
+| `LiveProgressTracker` | Generic — uses `ProgressStatusStorage` trait; Solana sets `SolanaLiveStorage` backend via `set_status_storage()` |
 
 ---
 

--- a/docs/solana/roadmap.md
+++ b/docs/solana/roadmap.md
@@ -54,14 +54,20 @@ Implemented (Phase 7):
 - Decoded Solana storage paths (`decoded_solana_events_dir`, `decoded_solana_instructions_dir`)
 - Solana RPC method variants in metrics
 
-Not yet implemented (Phase 8 — Live Mode):
-- Live slot collector via WebSocket subscription
-- Solana reorg detection via parent-slot chain verification
-- Live account reader (event-triggered account state fetches)
-- Live storage types and bincode persistence
-- `TransformationEngine` integration for Solana (requires making the EVM RPC client optional)
+Implemented (Phase 8):
+- `SolanaLiveCollector` for real-time slot processing via WebSocket `slotSubscribe`
+- `SolanaReorgDetector` using parent-slot chain verification (commitment-aware depth)
+- `SolanaLiveAccountReader` for event-triggered account state fetches
+- `SolanaLiveStorage` with bincode persistence and JSON status tracking
+- `SolanaCompactionService` for bincode-to-parquet merging
+- `SolanaLiveCatchupService` for restart recovery of incomplete slots
+- Pipeline wiring in `process_solana_chain()` and `process_solana_chain_live_only()`
+- `main.rs` dispatch for Solana `--live-only` mode
 
-Practical implication: `chain_type: solana` activates the full historical pipeline (backfill, decode, write parquet). Transformation handlers can be registered by implementing `TransformationHandler` with `chain_type() -> ChainType::Solana`. Live mode logs a warning and is skipped.
+Also implemented:
+- `TransformationEngine` integration: RPC client and contracts made `Option` throughout the engine, executor, retry processor, and context. Solana pipelines pass `None` for EVM RPC. EVM-specific context methods (`eth_call`, `find_log_emitter`) return errors on non-EVM chains. Both historical and live Solana pipelines spawn the engine when handlers are registered.
+
+Practical implication: `chain_type: solana` activates the full historical pipeline (backfill, decode, write parquet) and live mode (slot subscription, real-time extraction/decoding, bincode storage, compaction). Transformation handlers can be registered by implementing `TransformationHandler` with `chain_type() -> ChainType::Solana`. TransformationEngine integration is pending — the engine currently requires an EVM RPC client.
 
 ---
 

--- a/src/live/bincode_io.rs
+++ b/src/live/bincode_io.rs
@@ -1,0 +1,222 @@
+//! Shared bincode I/O helpers for live mode storage.
+//!
+//! Used by both EVM `LiveStorage` and Solana `SolanaLiveStorage` to avoid
+//! duplicating atomic write, read, and deletion logic.
+
+use std::fs;
+use std::io::{BufReader, BufWriter, Write};
+use std::path::Path;
+
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum StorageError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Bincode error: {0}")]
+    Bincode(#[from] bincode::Error),
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("Block not found: {0}")]
+    NotFound(u64),
+}
+
+/// Atomically write to a file using a caller-supplied write function.
+///
+/// Uses write-to-temp, flush, rename pattern for atomicity.
+/// When `durable` is true, also calls `sync_all()` before rename for crash safety.
+/// Uses unique temp file names to avoid race conditions between concurrent writers.
+pub fn atomic_write_with<F>(path: &Path, durable: bool, write_fn: F) -> Result<(), StorageError>
+where
+    F: FnOnce(&mut BufWriter<fs::File>) -> Result<(), StorageError>,
+{
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let random_suffix: u32 = rand::random();
+    let temp_name = format!(
+        "{}.tmp.{}",
+        path.file_name().unwrap().to_string_lossy(),
+        random_suffix
+    );
+    let temp_path = path.with_file_name(temp_name);
+
+    let file = fs::File::create(&temp_path)?;
+    let mut writer = BufWriter::new(file);
+
+    let result = (|| -> Result<(), StorageError> {
+        write_fn(&mut writer)?;
+        writer.flush()?;
+        let file = writer.into_inner().map_err(std::io::Error::other)?;
+        if durable {
+            file.sync_all()?;
+        }
+        fs::rename(&temp_path, path)?;
+        Ok(())
+    })();
+
+    if let Err(e) = &result {
+        tracing::debug!(
+            "Cleaning up temp file after write error: {:?} ({})",
+            temp_path,
+            e
+        );
+        let _ = fs::remove_file(&temp_path);
+    }
+
+    result
+}
+
+/// Atomically write bincode-serialized data to a file without sync_all().
+///
+/// Data writes skip fsync because they are rebuildable — the status file
+/// is the crash-safety gatekeeper.
+pub fn write_bincode<T: Serialize + ?Sized>(path: &Path, data: &T) -> Result<(), StorageError> {
+    atomic_write_with(path, false, |writer| {
+        bincode::serialize_into(writer, data)?;
+        Ok(())
+    })
+}
+
+pub fn read_bincode<T: DeserializeOwned>(path: &Path) -> Result<T, StorageError> {
+    let file = fs::File::open(path)?;
+    let reader = BufReader::new(file);
+    let data = bincode::deserialize_from(reader)?;
+    Ok(data)
+}
+
+/// Map IO NotFound errors to StorageError::NotFound for bincode operations.
+pub fn map_not_found(err: StorageError, block_number: u64) -> StorageError {
+    match err {
+        StorageError::Io(ref io_err) if io_err.kind() == std::io::ErrorKind::NotFound => {
+            StorageError::NotFound(block_number)
+        }
+        other => other,
+    }
+}
+
+/// Map raw IO NotFound errors to StorageError::NotFound.
+pub fn map_io_not_found(err: std::io::Error, block_number: u64) -> StorageError {
+    if err.kind() == std::io::ErrorKind::NotFound {
+        StorageError::NotFound(block_number)
+    } else {
+        StorageError::Io(err)
+    }
+}
+
+/// Check if a file is a temp file (has `.tmp.{random}` suffix).
+pub fn is_temp_file(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .is_some_and(|name| name.contains(".tmp."))
+}
+
+/// Parse `.bin` / `.json` file stems as `u64` block/slot numbers.
+pub fn list_numbered_entries(dir: &Path) -> Result<Vec<u64>, StorageError> {
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut entries = Vec::new();
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if let Some(stem) = path.file_stem() {
+            if let Some(stem_str) = stem.to_str() {
+                if let Ok(number) = stem_str.parse::<u64>() {
+                    entries.push(number);
+                }
+            }
+        }
+    }
+    entries.sort_unstable();
+    Ok(entries)
+}
+
+/// TOCTOU-safe file deletion. Ignores NotFound errors since the file
+/// may have been deleted between check and remove (or never existed).
+pub fn safe_delete(path: &Path) -> Result<(), StorageError> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(StorageError::Io(e)),
+    }
+}
+
+/// TOCTOU-safe directory deletion. Ignores NotFound errors since the directory
+/// may have been deleted between check and remove (or never existed).
+pub fn safe_delete_dir_all(path: &Path) -> Result<(), StorageError> {
+    match fs::remove_dir_all(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(StorageError::Io(e)),
+    }
+}
+
+/// Generate path, write, read, and delete methods for a bincode storage entity.
+///
+/// Two forms:
+/// - `slice`: write takes `&[T]`, read returns `Vec<T>`
+/// - `ref`: write takes `&T`, read returns `T`
+#[macro_export]
+macro_rules! storage_entity {
+    // Slice variant: write_foo(number, &[T]), read_foo(number) -> Vec<T>
+    (slice $name:ident, $type:ty, $subdir:expr) => {
+        paste::paste! {
+            fn [<$name _path>](&self, number: u64) -> std::path::PathBuf {
+                self.base_dir.join(format!(concat!($subdir, "/{}.bin"), number))
+            }
+
+            pub fn [<write_ $name>](
+                &self,
+                number: u64,
+                data: &[$type],
+            ) -> Result<(), $crate::live::bincode_io::StorageError> {
+                $crate::live::bincode_io::write_bincode(&self.[<$name _path>](number), data)
+            }
+
+            pub fn [<read_ $name>](
+                &self,
+                number: u64,
+            ) -> Result<Vec<$type>, $crate::live::bincode_io::StorageError> {
+                $crate::live::bincode_io::read_bincode(&self.[<$name _path>](number))
+                    .map_err(|e| $crate::live::bincode_io::map_not_found(e, number))
+            }
+
+            pub fn [<delete_ $name>](&self, number: u64) -> Result<(), $crate::live::bincode_io::StorageError> {
+                $crate::live::bincode_io::safe_delete(&self.[<$name _path>](number))
+            }
+        }
+    };
+    // Ref variant: write_foo(number, &T), read_foo(number) -> T
+    (ref $name:ident, $type:ty, $subdir:expr) => {
+        paste::paste! {
+            fn [<$name _path>](&self, number: u64) -> std::path::PathBuf {
+                self.base_dir.join(format!(concat!($subdir, "/{}.bin"), number))
+            }
+
+            pub fn [<write_ $name>](
+                &self,
+                number: u64,
+                data: &$type,
+            ) -> Result<(), $crate::live::bincode_io::StorageError> {
+                $crate::live::bincode_io::write_bincode(&self.[<$name _path>](number), data)
+            }
+
+            pub fn [<read_ $name>](
+                &self,
+                number: u64,
+            ) -> Result<$type, $crate::live::bincode_io::StorageError> {
+                $crate::live::bincode_io::read_bincode(&self.[<$name _path>](number))
+                    .map_err(|e| $crate::live::bincode_io::map_not_found(e, number))
+            }
+
+            pub fn [<delete_ $name>](&self, number: u64) -> Result<(), $crate::live::bincode_io::StorageError> {
+                $crate::live::bincode_io::safe_delete(&self.[<$name _path>](number))
+            }
+        }
+    };
+}

--- a/src/live/catchup.rs
+++ b/src/live/catchup.rs
@@ -15,7 +15,8 @@ use alloy::primitives::{Address, B256};
 use tokio::sync::mpsc;
 use tokio_postgres::types::ToSql;
 
-use super::storage::{LiveStorage, StorageError};
+use super::bincode_io::StorageError;
+use super::storage::LiveStorage;
 use super::types::{LiveBlockStatus, LivePipelineExpectations};
 use crate::db::DbPool;
 use crate::decoding::{DecoderMessage, EthCallResult};

--- a/src/live/collector.rs
+++ b/src/live/collector.rs
@@ -17,11 +17,12 @@ use thiserror::Error;
 use tokio::sync::{mpsc, Mutex};
 use tokio_postgres::types::ToSql;
 
+use super::bincode_io::StorageError;
 use super::catchup::{CollectionResumeRequest, CollectionResumeStage, LiveCatchupService};
 use super::eth_calls::{CollectedEthCallBatch, LiveEthCallCollector};
 use super::progress::LiveProgressTracker;
 use super::reorg::{ReorgDetector, ReorgEvent};
-use super::storage::{LiveStorage, StorageError};
+use super::storage::LiveStorage;
 use super::types::{
     LiveBlock, LiveBlockStatus, LiveFactoryAddresses, LiveLog, LiveMessage, LiveModeConfig,
     LivePipelineExpectations, LiveReceipt,

--- a/src/live/compaction.rs
+++ b/src/live/compaction.rs
@@ -20,8 +20,9 @@ use arrow::record_batch::RecordBatch;
 use thiserror::Error;
 use tokio::sync::Mutex;
 
+use super::bincode_io::StorageError;
 use super::progress::LiveProgressTracker;
-use super::storage::{LiveStorage, StorageError};
+use super::storage::LiveStorage;
 use super::types::{LiveModeConfig, LivePipelineExpectations};
 use crate::db::DbPool;
 use crate::storage::StorageManager;

--- a/src/live/error.rs
+++ b/src/live/error.rs
@@ -5,7 +5,7 @@
 
 use thiserror::Error;
 
-use super::storage::StorageError;
+use super::bincode_io::StorageError;
 use crate::db::DbError;
 use crate::rpc::RpcError;
 

--- a/src/live/mod.rs
+++ b/src/live/mod.rs
@@ -7,6 +7,7 @@
 //! - Compaction to merge live blocks into parquet ranges
 //! - Catchup for incomplete blocks on restart
 
+pub(crate) mod bincode_io;
 mod catchup;
 mod collector;
 mod compaction;
@@ -17,11 +18,12 @@ mod reorg;
 mod storage;
 mod types;
 
+pub use bincode_io::StorageError;
 pub use collector::LiveCollector;
 pub use compaction::{CompactionService, TransformRetryRequest};
 pub use eth_calls::LiveEthCallCollector;
-pub use progress::LiveProgressTracker;
-pub use storage::{LiveStorage, StorageError};
+pub use progress::{LiveProgressTracker, ProgressStatusStorage};
+pub use storage::LiveStorage;
 #[allow(unused_imports)]
 pub use types::{
     LiveBlockStatus, LiveDbValue, LiveDecodedCall, LiveDecodedEventCall, LiveDecodedLog,

--- a/src/live/progress.rs
+++ b/src/live/progress.rs
@@ -287,6 +287,20 @@ impl LiveProgressTracker {
         self.handler_keys.difference(&completed).cloned().collect()
     }
 
+    /// Restore completed-handler progress from a persisted source.
+    ///
+    /// Called on startup to reseed the in-memory tracker from saved status
+    /// files so that compaction can recognize slots that finished transformation
+    /// before the last restart.
+    pub fn restore_completed(&mut self, block_number: u64, handlers: HashSet<String>) {
+        if !handlers.is_empty() {
+            self.completed
+                .entry(block_number)
+                .or_default()
+                .extend(handlers);
+        }
+    }
+
     /// Clear progress for a block (used after compaction).
     pub fn clear_block(&mut self, block_number: u64) {
         self.completed.remove(&block_number);

--- a/src/live/progress.rs
+++ b/src/live/progress.rs
@@ -1,6 +1,6 @@
 //! Per-block progress tracking for live mode.
 //!
-//! Tracks which handlers have completed processing for each block,
+//! Tracks which handlers have completed processing for each block/slot,
 //! enabling the compaction service to know when ranges are ready.
 
 use std::collections::{HashMap, HashSet};
@@ -8,11 +8,96 @@ use std::sync::Arc;
 
 use tokio_postgres::types::ToSql;
 
+use super::bincode_io::StorageError;
 use super::error::LiveError;
 use super::storage::LiveStorage;
 use crate::db::DbPool;
 
-/// Tracks per-block progress for all handlers.
+/// Abstracts status-file operations so the progress tracker and the
+/// transformation engine work with both EVM (`LiveBlockStatus`) and
+/// Solana (`LiveSlotStatus`) storage.
+///
+/// Only the shared handler-tracking fields are exposed — completed
+/// handlers, failed handlers, and the `transformed` flag — so callers
+/// never need to know which concrete status type is on disk.
+pub trait ProgressStatusStorage: Send + Sync {
+    /// Atomically insert a handler key into `completed_handlers` and,
+    /// when `all_complete` is true, set `transformed = true`.
+    fn update_handler_completion(
+        &self,
+        number: u64,
+        handler_key: &str,
+        all_complete: bool,
+    ) -> Result<(), StorageError>;
+
+    /// Set `transformed = true` (used when no handlers are registered).
+    fn mark_transformed(&self, number: u64) -> Result<(), StorageError>;
+
+    /// Read `(failed_handlers, completed_handlers)` from the status file.
+    ///
+    /// Returns `Err(StorageError::NotFound(_))` when the file is absent —
+    /// callers typically treat that as a pair of empty sets.
+    fn read_handler_sets(
+        &self,
+        number: u64,
+    ) -> Result<(HashSet<String>, HashSet<String>), StorageError>;
+
+    /// Atomically read-modify-write the handler-tracking fields of a
+    /// status file. The closure receives mutable references to
+    /// `completed_handlers`, `failed_handlers`, and `transformed`.
+    fn update_handler_sets_atomic(
+        &self,
+        number: u64,
+        update_fn: &mut dyn FnMut(&mut HashSet<String>, &mut HashSet<String>, &mut bool),
+    ) -> Result<(), StorageError>;
+}
+
+impl ProgressStatusStorage for LiveStorage {
+    fn update_handler_completion(
+        &self,
+        number: u64,
+        handler_key: &str,
+        all_complete: bool,
+    ) -> Result<(), StorageError> {
+        let hk = handler_key.to_string();
+        self.update_status_atomic(number, move |status| {
+            status.completed_handlers.insert(hk);
+            if all_complete {
+                status.transformed = true;
+            }
+        })
+    }
+
+    fn mark_transformed(&self, number: u64) -> Result<(), StorageError> {
+        self.update_status_atomic(number, |status| {
+            status.transformed = true;
+        })
+    }
+
+    fn read_handler_sets(
+        &self,
+        number: u64,
+    ) -> Result<(HashSet<String>, HashSet<String>), StorageError> {
+        let status = self.read_status(number)?;
+        Ok((status.failed_handlers, status.completed_handlers))
+    }
+
+    fn update_handler_sets_atomic(
+        &self,
+        number: u64,
+        update_fn: &mut dyn FnMut(&mut HashSet<String>, &mut HashSet<String>, &mut bool),
+    ) -> Result<(), StorageError> {
+        self.update_status_atomic(number, |status| {
+            update_fn(
+                &mut status.completed_handlers,
+                &mut status.failed_handlers,
+                &mut status.transformed,
+            );
+        })
+    }
+}
+
+/// Tracks per-block/slot progress for all handlers.
 pub struct LiveProgressTracker {
     chain_id: i64,
     /// Chain name for LiveStorage access.
@@ -23,18 +108,46 @@ pub struct LiveProgressTracker {
     handler_keys: HashSet<String>,
     /// Database pool for persistence (optional).
     db_pool: Option<Arc<DbPool>>,
+    /// Backend for status-file updates. Defaults to EVM `LiveStorage`;
+    /// Solana pipelines override this with `SolanaLiveStorage`.
+    /// Stored as `Arc` so the transformation engine can share the same
+    /// backend for its own status-file reads/writes.
+    status_storage: Arc<dyn ProgressStatusStorage>,
 }
 
 impl LiveProgressTracker {
     /// Create a new progress tracker.
+    ///
+    /// Defaults to EVM `LiveStorage` for status-file updates. Call
+    /// [`set_status_storage`] to override for Solana pipelines.
     pub fn new(chain_id: i64, db_pool: Option<Arc<DbPool>>, chain_name: String) -> Self {
+        let status_storage: Arc<dyn ProgressStatusStorage> =
+            Arc::new(LiveStorage::new(&chain_name));
         Self {
             chain_id,
             chain_name,
             completed: HashMap::new(),
             handler_keys: HashSet::new(),
             db_pool,
+            status_storage,
         }
+    }
+
+    /// Replace the status-file storage backend.
+    ///
+    /// Solana pipelines call this with a `SolanaLiveStorage` so that
+    /// handler completion, failure, and `transformed` flags are written
+    /// to `LiveSlotStatus` files instead of `LiveBlockStatus` files.
+    pub fn set_status_storage(&mut self, storage: Arc<dyn ProgressStatusStorage>) {
+        self.status_storage = storage;
+    }
+
+    /// Return the current status-file storage backend.
+    ///
+    /// Used by the transformation engine to share the same backend for
+    /// its own read/modify/write of status files.
+    pub fn status_storage(&self) -> Arc<dyn ProgressStatusStorage> {
+        self.status_storage.clone()
     }
 
     /// Register a handler key. Must be called before marking progress.
@@ -87,9 +200,8 @@ impl LiveProgressTracker {
                 .await?;
         }
 
-        // Persist handler completion to status file using atomic update
-        // to prevent race conditions when multiple handlers complete simultaneously
-        let storage = LiveStorage::new(&self.chain_name);
+        // Persist handler completion to status file using the configured
+        // storage backend (EVM LiveStorage or SolanaLiveStorage).
         let all_complete = self.is_block_complete(block_number);
         let handler_count = self.handler_keys.len();
         let pending = if all_complete {
@@ -99,15 +211,10 @@ impl LiveProgressTracker {
         } else {
             None
         };
-        let handler_key_owned = handler_key.to_string();
 
-        let update_result = storage.update_status_atomic(block_number, |status| {
-            status.completed_handlers.insert(handler_key_owned.clone());
-
-            if all_complete {
-                status.transformed = true;
-            }
-        });
+        let update_result =
+            self.status_storage
+                .update_handler_completion(block_number, handler_key, all_complete);
 
         match update_result {
             Ok(()) => {
@@ -154,18 +261,15 @@ impl LiveProgressTracker {
         }
     }
 
-    /// Mark a block as transformed when no handlers are registered.
+    /// Mark a block/slot as transformed when no handlers are registered.
     /// This should be called after all collection/decoding is done.
     pub fn mark_transformed_if_no_handlers(&self, block_number: u64) {
         if !self.handler_keys.is_empty() {
             return;
         }
 
-        let storage = LiveStorage::new(&self.chain_name);
-        if let Err(e) = storage.update_status_atomic(block_number, |status| {
-            status.transformed = true;
-        }) {
-            tracing::warn!("Failed to update block status (no handlers): {}", e);
+        if let Err(e) = self.status_storage.mark_transformed(block_number) {
+            tracing::warn!("Failed to update status (no handlers): {}", e);
         }
     }
 
@@ -240,7 +344,7 @@ impl LiveProgressTracker {
                             .extend(status.completed_handlers);
                     }
                 }
-                Err(super::storage::StorageError::NotFound(_)) => {
+                Err(super::bincode_io::StorageError::NotFound(_)) => {
                     // Status file doesn't exist, skip
                     continue;
                 }

--- a/src/live/storage.rs
+++ b/src/live/storage.rs
@@ -20,94 +20,19 @@
 //! ```
 
 use std::fs;
-use std::io::{BufReader, BufWriter, Write};
+use std::io::BufReader;
 use std::path::{Path, PathBuf};
 
-use serde::de::DeserializeOwned;
-use serde::Serialize;
-use thiserror::Error;
-
+use super::bincode_io::{
+    atomic_write_with, is_temp_file, list_numbered_entries, map_io_not_found, map_not_found,
+    read_bincode, safe_delete, safe_delete_dir_all, write_bincode, StorageError,
+};
 use super::types::{
     LiveBlock, LiveBlockStatus, LiveDecodedCall, LiveDecodedEventCall, LiveDecodedLog,
     LiveDecodedOnceCall, LiveEthCall, LiveFactoryAddresses, LiveLog, LiveReceipt,
     LiveUpsertSnapshot,
 };
-
-#[derive(Debug, Error)]
-pub enum StorageError {
-    #[error("IO error: {0}")]
-    Io(#[from] std::io::Error),
-    #[error("Bincode error: {0}")]
-    Bincode(#[from] bincode::Error),
-    #[error("JSON error: {0}")]
-    Json(#[from] serde_json::Error),
-    #[error("Block not found: {0}")]
-    NotFound(u64),
-}
-
-/// Generate path, write, read, and delete methods for a bincode storage entity.
-///
-/// Two forms:
-/// - `slice`: write takes `&[T]`, read returns `Vec<T>`
-/// - `ref`: write takes `&T`, read returns `T`
-macro_rules! storage_entity {
-    // Slice variant: write_foo(block_number, &[T]), read_foo(block_number) -> Vec<T>
-    (slice $name:ident, $type:ty, $subdir:expr) => {
-        paste::paste! {
-            fn [<$name _path>](&self, block_number: u64) -> PathBuf {
-                self.base_dir.join(format!(concat!($subdir, "/{}.bin"), block_number))
-            }
-
-            pub fn [<write_ $name>](
-                &self,
-                block_number: u64,
-                data: &[$type],
-            ) -> Result<(), StorageError> {
-                write_bincode(&self.[<$name _path>](block_number), data)
-            }
-
-            pub fn [<read_ $name>](
-                &self,
-                block_number: u64,
-            ) -> Result<Vec<$type>, StorageError> {
-                read_bincode(&self.[<$name _path>](block_number))
-                    .map_err(|e| map_not_found(e, block_number))
-            }
-
-            pub fn [<delete_ $name>](&self, block_number: u64) -> Result<(), StorageError> {
-                safe_delete(&self.[<$name _path>](block_number))
-            }
-        }
-    };
-    // Ref variant: write_foo(block_number, &T), read_foo(block_number) -> T
-    (ref $name:ident, $type:ty, $subdir:expr) => {
-        paste::paste! {
-            fn [<$name _path>](&self, block_number: u64) -> PathBuf {
-                self.base_dir.join(format!(concat!($subdir, "/{}.bin"), block_number))
-            }
-
-            pub fn [<write_ $name>](
-                &self,
-                block_number: u64,
-                data: &$type,
-            ) -> Result<(), StorageError> {
-                write_bincode(&self.[<$name _path>](block_number), data)
-            }
-
-            pub fn [<read_ $name>](
-                &self,
-                block_number: u64,
-            ) -> Result<$type, StorageError> {
-                read_bincode(&self.[<$name _path>](block_number))
-                    .map_err(|e| map_not_found(e, block_number))
-            }
-
-            pub fn [<delete_ $name>](&self, block_number: u64) -> Result<(), StorageError> {
-                safe_delete(&self.[<$name _path>](block_number))
-            }
-        }
-    };
-}
+use crate::storage_entity;
 
 /// Storage manager for live mode block data.
 #[derive(Debug, Clone)]
@@ -248,7 +173,7 @@ impl LiveStorage {
 
     /// List all block numbers in storage.
     pub fn list_blocks(&self) -> Result<Vec<u64>, StorageError> {
-        list_block_numbers(&self.base_dir.join("raw/blocks"))
+        list_numbered_entries(&self.base_dir.join("raw/blocks"))
     }
 
     // =========================================================================
@@ -277,7 +202,7 @@ impl LiveStorage {
 
     /// List all block numbers with factory address files.
     pub fn list_factory_blocks(&self) -> Result<Vec<u64>, StorageError> {
-        list_block_numbers(&self.base_dir.join("factories"))
+        list_numbered_entries(&self.base_dir.join("factories"))
     }
 
     // =========================================================================
@@ -736,141 +661,7 @@ impl LiveStorage {
     }
 }
 
-// =========================================================================
-// Helper functions
-// =========================================================================
-
-/// Atomically write to a file using a caller-supplied write function.
-///
-/// Uses write-to-temp, flush, rename pattern for atomicity.
-/// When `durable` is true, also calls `sync_all()` before rename for crash safety.
-/// Uses unique temp file names to avoid race conditions between concurrent writers.
-fn atomic_write_with<F>(path: &Path, durable: bool, write_fn: F) -> Result<(), StorageError>
-where
-    F: FnOnce(&mut BufWriter<fs::File>) -> Result<(), StorageError>,
-{
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
-    }
-
-    let random_suffix: u32 = rand::random();
-    let temp_name = format!(
-        "{}.tmp.{}",
-        path.file_name().unwrap().to_string_lossy(),
-        random_suffix
-    );
-    let temp_path = path.with_file_name(temp_name);
-
-    let file = fs::File::create(&temp_path)?;
-    let mut writer = BufWriter::new(file);
-
-    let result = (|| -> Result<(), StorageError> {
-        write_fn(&mut writer)?;
-        writer.flush()?;
-        let file = writer.into_inner().map_err(std::io::Error::other)?;
-        if durable {
-            file.sync_all()?;
-        }
-        fs::rename(&temp_path, path)?;
-        Ok(())
-    })();
-
-    if let Err(e) = &result {
-        tracing::debug!(
-            "Cleaning up temp file after write error: {:?} ({})",
-            temp_path,
-            e
-        );
-        let _ = fs::remove_file(&temp_path);
-    }
-
-    result
-}
-
-/// Atomically write bincode-serialized data to a file without sync_all().
-///
-/// Data writes skip fsync because they are rebuildable — the status file
-/// is the crash-safety gatekeeper.
-fn write_bincode<T: Serialize + ?Sized>(path: &Path, data: &T) -> Result<(), StorageError> {
-    atomic_write_with(path, false, |writer| {
-        bincode::serialize_into(writer, data)?;
-        Ok(())
-    })
-}
-
-fn read_bincode<T: DeserializeOwned>(path: &Path) -> Result<T, StorageError> {
-    let file = fs::File::open(path)?;
-    let reader = BufReader::new(file);
-    let data = bincode::deserialize_from(reader)?;
-    Ok(data)
-}
-
-/// Map IO NotFound errors to StorageError::NotFound for bincode operations.
-fn map_not_found(err: StorageError, block_number: u64) -> StorageError {
-    match err {
-        StorageError::Io(ref io_err) if io_err.kind() == std::io::ErrorKind::NotFound => {
-            StorageError::NotFound(block_number)
-        }
-        other => other,
-    }
-}
-
-/// Map raw IO NotFound errors to StorageError::NotFound.
-fn map_io_not_found(err: std::io::Error, block_number: u64) -> StorageError {
-    if err.kind() == std::io::ErrorKind::NotFound {
-        StorageError::NotFound(block_number)
-    } else {
-        StorageError::Io(err)
-    }
-}
-
-/// Check if a file is a temp file (has `.tmp.{random}` suffix).
-fn is_temp_file(path: &Path) -> bool {
-    path.file_name()
-        .and_then(|n| n.to_str())
-        .is_some_and(|name| name.contains(".tmp."))
-}
-
-fn list_block_numbers(dir: &Path) -> Result<Vec<u64>, StorageError> {
-    if !dir.exists() {
-        return Ok(Vec::new());
-    }
-
-    let mut blocks = Vec::new();
-    for entry in fs::read_dir(dir)? {
-        let entry = entry?;
-        let path = entry.path();
-        if let Some(stem) = path.file_stem() {
-            if let Some(stem_str) = stem.to_str() {
-                if let Ok(block_number) = stem_str.parse::<u64>() {
-                    blocks.push(block_number);
-                }
-            }
-        }
-    }
-    blocks.sort_unstable();
-    Ok(blocks)
-}
-
-/// TOCTOU-safe file deletion. Ignores NotFound errors since the file
-/// may have been deleted between check and remove (or never existed).
-fn safe_delete(path: &Path) -> Result<(), StorageError> {
-    match fs::remove_file(path) {
-        Ok(()) => Ok(()),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(e) => Err(StorageError::Io(e)),
-    }
-}
-
-/// TOCTOU-safe directory deletion. Ignores NotFound errors since the directory
-/// may have been deleted between check and remove (or never existed).
-fn safe_delete_dir_all(path: &Path) -> Result<(), StorageError> {
-    match fs::remove_dir_all(path) {
-        Ok(()) => Ok(()),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(e) => Err(StorageError::Io(e)),
-    }
-}
+// Helper functions moved to `super::bincode_io`.
 
 #[cfg(test)]
 mod tests {

--- a/src/main.rs
+++ b/src/main.rs
@@ -839,7 +839,7 @@ async fn process_chain_live_only(
         let engine = TransformationEngine::new(
             runtime.registry.clone(),
             runtime.db_pool.clone().unwrap(),
-            rpc_client,
+            Some(rpc_client),
             TransformationEngineConfig {
                 chain_name: chain.name.clone(),
                 chain_id: chain.chain_id,
@@ -1685,7 +1685,7 @@ async fn process_chain(
         let engine = TransformationEngine::new(
             pipeline.runtime.registry.clone(),
             pipeline.runtime.db_pool.clone().unwrap(),
-            rpc_client,
+            Some(rpc_client),
             TransformationEngineConfig {
                 chain_name: pipeline.runtime.chain.name.clone(),
                 chain_id: pipeline.runtime.chain.chain_id,

--- a/src/main.rs
+++ b/src/main.rs
@@ -477,11 +477,12 @@ async fn main() -> anyhow::Result<()> {
                 #[cfg(feature = "solana")]
                 if chain.chain_type == types::chain::ChainType::Solana {
                     if live_only {
-                        tracing::warn!(
-                            chain = chain.name.as_str(),
-                            "Live-only mode not yet supported for Solana chains"
-                        );
-                        Ok(())
+                        solana::pipeline::process_solana_chain_live_only(
+                            &config,
+                            &chain,
+                            shared_db_pool,
+                        )
+                        .await
                     } else if repair_only {
                         tracing::warn!(
                             chain = chain.name.as_str(),
@@ -489,7 +490,8 @@ async fn main() -> anyhow::Result<()> {
                         );
                         Ok(())
                     } else if decode_only {
-                        solana::pipeline::decode_only_solana_chain(&config, &chain, repair_scope).await
+                        solana::pipeline::decode_only_solana_chain(&config, &chain, repair_scope)
+                            .await
                     } else {
                         solana::pipeline::process_solana_chain(
                             &config,

--- a/src/raw_data/historical/catchup/eth_calls.rs
+++ b/src/raw_data/historical/catchup/eth_calls.rs
@@ -893,13 +893,12 @@ pub async fn collect_eth_calls(
         let scoped_log_range_count = log_ranges
             .iter()
             .filter(|log_range| {
-                repair_scope.is_none_or(|scope| {
-                    scope.matches_range(log_range.start, log_range.end)
-                }) && !active_event_output_pairs_for_range(
-                    &catchup_event_call_configs,
-                    log_range.end,
-                )
-                .is_empty()
+                repair_scope.is_none_or(|scope| scope.matches_range(log_range.start, log_range.end))
+                    && !active_event_output_pairs_for_range(
+                        &catchup_event_call_configs,
+                        log_range.end,
+                    )
+                    .is_empty()
             })
             .count();
 

--- a/src/solana/decoding/accounts.rs
+++ b/src/solana/decoding/accounts.rs
@@ -17,10 +17,7 @@ pub struct SolanaAccountDecoder {
 
 impl SolanaAccountDecoder {
     pub fn new(decoders: Vec<Arc<dyn ProgramDecoder>>) -> Self {
-        let decoders = decoders
-            .into_iter()
-            .map(|d| (d.program_id(), d))
-            .collect();
+        let decoders = decoders.into_iter().map(|d| (d.program_id(), d)).collect();
         Self { decoders }
     }
 
@@ -148,10 +145,7 @@ mod tests {
             state.fields.get("supply"),
             Some(&DecodedValue::Uint64(1_000_000))
         );
-        assert_eq!(
-            state.fields.get("decimals"),
-            Some(&DecodedValue::Uint8(6))
-        );
+        assert_eq!(state.fields.get("decimals"), Some(&DecodedValue::Uint8(6)));
     }
 
     #[test]

--- a/src/solana/decoding/borsh_dynamic.rs
+++ b/src/solana/decoding/borsh_dynamic.rs
@@ -168,9 +168,9 @@ pub fn deserialize_value(
         }
 
         IdlType::Defined(name) => {
-            let type_def = defined_types.get(name).ok_or_else(|| {
-                SolanaDecodeError::UnknownType(name.clone())
-            })?;
+            let type_def = defined_types
+                .get(name)
+                .ok_or_else(|| SolanaDecodeError::UnknownType(name.clone()))?;
 
             match type_def {
                 IdlTypeDef::Struct { fields } => {
@@ -198,8 +198,7 @@ pub fn deserialize_value(
                                 DecodedValue::String(variant.name.clone()),
                             ));
                             for (field_name, field_type) in fields {
-                                let val =
-                                    deserialize_value(cursor, field_type, defined_types)?;
+                                let val = deserialize_value(cursor, field_type, defined_types)?;
                                 pairs.push((field_name.clone(), val));
                             }
                             Ok(DecodedValue::NamedTuple(pairs))
@@ -586,9 +585,12 @@ mod tests {
         data.extend_from_slice(&(-20i32).to_le_bytes());
 
         let mut cursor: &[u8] = &data;
-        let val =
-            deserialize_value(&mut cursor, &IdlType::Defined("Point".to_string()), &defined_types)
-                .unwrap();
+        let val = deserialize_value(
+            &mut cursor,
+            &IdlType::Defined("Point".to_string()),
+            &defined_types,
+        )
+        .unwrap();
 
         match &val {
             DecodedValue::NamedTuple(fields) => {
@@ -632,9 +634,12 @@ mod tests {
         // variant index = 1 => "Green"
         let data = [1u8];
         let mut cursor: &[u8] = &data;
-        let val =
-            deserialize_value(&mut cursor, &IdlType::Defined("Color".to_string()), &defined_types)
-                .unwrap();
+        let val = deserialize_value(
+            &mut cursor,
+            &IdlType::Defined("Color".to_string()),
+            &defined_types,
+        )
+        .unwrap();
 
         assert_eq!(val.as_string(), Some("Green"));
     }
@@ -671,9 +676,12 @@ mod tests {
         data.extend_from_slice(&10u32.to_le_bytes()); // h = 10
 
         let mut cursor: &[u8] = &data;
-        let val =
-            deserialize_value(&mut cursor, &IdlType::Defined("Shape".to_string()), &defined_types)
-                .unwrap();
+        let val = deserialize_value(
+            &mut cursor,
+            &IdlType::Defined("Shape".to_string()),
+            &defined_types,
+        )
+        .unwrap();
 
         match &val {
             DecodedValue::NamedTuple(fields) => {
@@ -716,9 +724,12 @@ mod tests {
         data.extend_from_slice(&42u64.to_le_bytes()); // inner.val = 42
 
         let mut cursor: &[u8] = &data;
-        let val =
-            deserialize_value(&mut cursor, &IdlType::Defined("Outer".to_string()), &defined_types)
-                .unwrap();
+        let val = deserialize_value(
+            &mut cursor,
+            &IdlType::Defined("Outer".to_string()),
+            &defined_types,
+        )
+        .unwrap();
 
         match &val {
             DecodedValue::NamedTuple(fields) => {
@@ -788,8 +799,11 @@ mod tests {
         // variant index 5 is out of range (only 1 variant exists)
         let data = [5u8];
         let mut cursor: &[u8] = &data;
-        let result =
-            deserialize_value(&mut cursor, &IdlType::Defined("Small".to_string()), &defined_types);
+        let result = deserialize_value(
+            &mut cursor,
+            &IdlType::Defined("Small".to_string()),
+            &defined_types,
+        );
         match result {
             Err(SolanaDecodeError::InvalidEnumVariant(5)) => {}
             other => panic!("expected InvalidEnumVariant(5), got {:?}", other),
@@ -838,7 +852,10 @@ mod tests {
                 fields: vec![
                     ("amount".to_string(), IdlType::U64),
                     ("authority".to_string(), IdlType::Pubkey),
-                    ("maybe_fee".to_string(), IdlType::Option(Box::new(IdlType::U32))),
+                    (
+                        "maybe_fee".to_string(),
+                        IdlType::Option(Box::new(IdlType::U32)),
+                    ),
                     ("tags".to_string(), IdlType::Vec(Box::new(IdlType::U8))),
                 ],
             },
@@ -880,10 +897,7 @@ mod tests {
 
                 // authority
                 assert_eq!(fields[1].0, "authority");
-                assert_eq!(
-                    fields[1].1.as_pubkey(),
-                    Some([0xAA; 32])
-                );
+                assert_eq!(fields[1].1.as_pubkey(), Some([0xAA; 32]));
 
                 // maybe_fee
                 assert_eq!(fields[2].0, "maybe_fee");
@@ -915,9 +929,16 @@ mod tests {
         data.extend_from_slice(&[0x01, 0x02]);
 
         let mut cursor: &[u8] = &data;
-        let result = deserialize_value(&mut cursor, &IdlType::Vec(Box::new(IdlType::U8)), &HashMap::new());
+        let result = deserialize_value(
+            &mut cursor,
+            &IdlType::Vec(Box::new(IdlType::U8)),
+            &HashMap::new(),
+        );
         // Must fail with UnexpectedEof, not OOM.
-        assert!(matches!(result, Err(SolanaDecodeError::UnexpectedEof { .. })));
+        assert!(matches!(
+            result,
+            Err(SolanaDecodeError::UnexpectedEof { .. })
+        ));
     }
 
     #[test]

--- a/src/solana/decoding/decoded_parquet.rs
+++ b/src/solana/decoding/decoded_parquet.rs
@@ -147,7 +147,10 @@ pub fn write_decoded_events_to_parquet(
     arrays.push(Arc::new(arr));
 
     // source_name
-    let arr: StringArray = events.iter().map(|e| Some(e.source_name.as_str())).collect();
+    let arr: StringArray = events
+        .iter()
+        .map(|e| Some(e.source_name.as_str()))
+        .collect();
     arrays.push(Arc::new(arr));
 
     // event_name
@@ -244,7 +247,15 @@ mod tests {
         let schema = build_decoded_event_schema();
 
         let events = vec![
-            make_decoded_event(100, "spl_token", "Transfer", [0xAA; 32], [0xBB; 64], 0, None),
+            make_decoded_event(
+                100,
+                "spl_token",
+                "Transfer",
+                [0xAA; 32],
+                [0xBB; 64],
+                0,
+                None,
+            ),
             make_decoded_event(
                 100,
                 "spl_token",

--- a/src/solana/decoding/events.rs
+++ b/src/solana/decoding/events.rs
@@ -18,10 +18,7 @@ pub struct SolanaEventDecoder {
 
 impl SolanaEventDecoder {
     pub fn new(decoders: Vec<Arc<dyn ProgramDecoder>>) -> Self {
-        let decoders = decoders
-            .into_iter()
-            .map(|d| (d.program_id(), d))
-            .collect();
+        let decoders = decoders.into_iter().map(|d| (d.program_id(), d)).collect();
         Self { decoders }
     }
 
@@ -162,10 +159,7 @@ mod tests {
         assert_eq!(event.event_name, "Transfer");
         assert_eq!(event.source_name, "spl_token");
         assert_eq!(event.contract_address, ChainAddress::Solana([1u8; 32]));
-        assert_eq!(
-            event.params.get("amount"),
-            Some(&DecodedValue::Uint64(42))
-        );
+        assert_eq!(event.params.get("amount"), Some(&DecodedValue::Uint64(42)));
     }
 
     #[test]

--- a/src/solana/decoding/idl.rs
+++ b/src/solana/decoding/idl.rs
@@ -90,11 +90,7 @@ enum IdlVersion {
 
 fn detect_version(root: &serde_json::Value) -> IdlVersion {
     // Check for metadata.spec (0.30+ marker).
-    if root
-        .get("metadata")
-        .and_then(|m| m.get("spec"))
-        .is_some()
-    {
+    if root.get("metadata").and_then(|m| m.get("spec")).is_some() {
         return IdlVersion::V030;
     }
 
@@ -193,7 +189,10 @@ fn parse_idl_type(
 
     // Object form: compound/reference types.
     let obj = value.as_object().ok_or_else(|| {
-        SolanaDecodeError::IdlParse(format!("expected string or object for IDL type, got: {}", value))
+        SolanaDecodeError::IdlParse(format!(
+            "expected string or object for IDL type, got: {}",
+            value
+        ))
     })?;
 
     if let Some(inner) = obj.get("option") {
@@ -216,9 +215,10 @@ fn parse_idl_type(
             ));
         }
         let inner_type = parse_idl_type(&arr[0], version)?;
-        let size = arr[1].as_u64().ok_or_else(|| {
-            SolanaDecodeError::IdlParse("array size must be a number".to_string())
-        })? as usize;
+        let size = arr[1]
+            .as_u64()
+            .ok_or_else(|| SolanaDecodeError::IdlParse("array size must be a number".to_string()))?
+            as usize;
         return Ok(IdlType::Array(Box::new(inner_type), size));
     }
 
@@ -248,9 +248,7 @@ fn parse_idl_type(
             IdlVersion::Legacy => {
                 // Legacy: {"defined": "TypeName"}
                 let name = defined.as_str().ok_or_else(|| {
-                    SolanaDecodeError::IdlParse(
-                        "legacy defined type must be a string".to_string(),
-                    )
+                    SolanaDecodeError::IdlParse("legacy defined type must be a string".to_string())
                 })?;
                 return Ok(IdlType::Defined(name.to_string()));
             }
@@ -285,10 +283,7 @@ fn parse_type_def(
         .get("kind")
         .and_then(|k| k.as_str())
         .ok_or_else(|| {
-            SolanaDecodeError::IdlParse(format!(
-                "type definition '{}' missing 'type.kind'",
-                name
-            ))
+            SolanaDecodeError::IdlParse(format!("type definition '{}' missing 'type.kind'", name))
         })?;
 
     match kind {
@@ -297,10 +292,7 @@ fn parse_type_def(
                 .get("fields")
                 .and_then(|f| f.as_array())
                 .ok_or_else(|| {
-                    SolanaDecodeError::IdlParse(format!(
-                        "struct '{}' missing 'fields' array",
-                        name
-                    ))
+                    SolanaDecodeError::IdlParse(format!("struct '{}' missing 'fields' array", name))
                 })?;
 
             let mut fields = Vec::with_capacity(fields_arr.len());
@@ -336,10 +328,7 @@ fn parse_type_def(
                 .get("variants")
                 .and_then(|v| v.as_array())
                 .ok_or_else(|| {
-                    SolanaDecodeError::IdlParse(format!(
-                        "enum '{}' missing 'variants' array",
-                        name
-                    ))
+                    SolanaDecodeError::IdlParse(format!("enum '{}' missing 'variants' array", name))
                 })?;
 
             let mut variants = Vec::with_capacity(variants_arr.len());
@@ -355,44 +344,44 @@ fn parse_type_def(
                     })?
                     .to_string();
 
-                let fields = if let Some(fields_arr) = variant.get("fields").and_then(|f| f.as_array())
-                {
-                    if fields_arr.is_empty() {
-                        None
-                    } else {
-                        let mut parsed = Vec::with_capacity(fields_arr.len());
-                        for (idx, field) in fields_arr.iter().enumerate() {
-                            if field.is_object() {
-                                // Named field: {"name": "x", "type": "u64"}
-                                let f_name = field
-                                    .get("name")
-                                    .and_then(|n| n.as_str())
-                                    .unwrap_or("")
-                                    .to_string();
-                                let f_name = if f_name.is_empty() {
-                                    format!("field_{}", idx)
+                let fields =
+                    if let Some(fields_arr) = variant.get("fields").and_then(|f| f.as_array()) {
+                        if fields_arr.is_empty() {
+                            None
+                        } else {
+                            let mut parsed = Vec::with_capacity(fields_arr.len());
+                            for (idx, field) in fields_arr.iter().enumerate() {
+                                if field.is_object() {
+                                    // Named field: {"name": "x", "type": "u64"}
+                                    let f_name = field
+                                        .get("name")
+                                        .and_then(|n| n.as_str())
+                                        .unwrap_or("")
+                                        .to_string();
+                                    let f_name = if f_name.is_empty() {
+                                        format!("field_{}", idx)
+                                    } else {
+                                        f_name
+                                    };
+                                    let f_type_val = field.get("type").ok_or_else(|| {
+                                        SolanaDecodeError::IdlParse(format!(
+                                            "variant field '{}' in enum '{}::{}' missing 'type'",
+                                            f_name, name, variant_name
+                                        ))
+                                    })?;
+                                    let f_type = parse_idl_type(f_type_val, version)?;
+                                    parsed.push((f_name, f_type));
                                 } else {
-                                    f_name
-                                };
-                                let f_type_val = field.get("type").ok_or_else(|| {
-                                    SolanaDecodeError::IdlParse(format!(
-                                        "variant field '{}' in enum '{}::{}' missing 'type'",
-                                        f_name, name, variant_name
-                                    ))
-                                })?;
-                                let f_type = parse_idl_type(f_type_val, version)?;
-                                parsed.push((f_name, f_type));
-                            } else {
-                                // Unnamed/tuple field: bare type like "u64" or {"vec": "u8"}
-                                let f_type = parse_idl_type(field, version)?;
-                                parsed.push((format!("field_{}", idx), f_type));
+                                    // Unnamed/tuple field: bare type like "u64" or {"vec": "u8"}
+                                    let f_type = parse_idl_type(field, version)?;
+                                    parsed.push((format!("field_{}", idx), f_type));
+                                }
                             }
+                            Some(parsed)
                         }
-                        Some(parsed)
-                    }
-                } else {
-                    None
-                };
+                    } else {
+                        None
+                    };
 
                 variants.push(IdlEnumVariant {
                     name: variant_name,
@@ -459,9 +448,7 @@ pub fn parse_idl(json: &str) -> Result<ParsedIdl, SolanaDecodeError> {
             let event_name = event_val
                 .get("name")
                 .and_then(|n| n.as_str())
-                .ok_or_else(|| {
-                    SolanaDecodeError::IdlParse("event missing 'name'".to_string())
-                })?
+                .ok_or_else(|| SolanaDecodeError::IdlParse("event missing 'name'".to_string()))?
                 .to_string();
 
             let fields = parse_fields_array(event_val, version)?;
@@ -514,9 +501,7 @@ pub fn parse_idl(json: &str) -> Result<ParsedIdl, SolanaDecodeError> {
             let acc_name = acc_val
                 .get("name")
                 .and_then(|n| n.as_str())
-                .ok_or_else(|| {
-                    SolanaDecodeError::IdlParse("account missing 'name'".to_string())
-                })?
+                .ok_or_else(|| SolanaDecodeError::IdlParse("account missing 'name'".to_string()))?
                 .to_string();
 
             // Get fields from the type definition if present, or from the defined_types map.
@@ -642,11 +627,7 @@ fn parse_account_names(value: &serde_json::Value) -> Vec<String> {
     names
 }
 
-fn collect_leaf_account_names(
-    accounts: &[serde_json::Value],
-    prefix: &str,
-    out: &mut Vec<String>,
-) {
+fn collect_leaf_account_names(accounts: &[serde_json::Value], prefix: &str, out: &mut Vec<String>) {
     for acc in accounts {
         let name = acc.get("name").and_then(|n| n.as_str()).unwrap_or("");
         // Composite group: has nested "accounts" array — recurse with prefix.
@@ -722,8 +703,11 @@ impl ProgramDecoder for AnchorDecoder {
         };
 
         let mut cursor: &[u8] = data;
-        let params =
-            borsh_dynamic::deserialize_struct_fields(&mut cursor, fields, &self.parsed_idl.defined_types)?;
+        let params = borsh_dynamic::deserialize_struct_fields(
+            &mut cursor,
+            fields,
+            &self.parsed_idl.defined_types,
+        )?;
 
         Ok(Some(DecodedEventFields {
             event_name: event_name.clone(),
@@ -1343,7 +1327,10 @@ mod tests {
         }"#;
 
         let parsed = parse_idl(idl_json).unwrap();
-        let type_def = parsed.defined_types.get("OrderStatus").expect("type present");
+        let type_def = parsed
+            .defined_types
+            .get("OrderStatus")
+            .expect("type present");
 
         if let IdlTypeDef::Enum { variants } = type_def {
             assert_eq!(variants.len(), 3);

--- a/src/solana/decoding/instructions.rs
+++ b/src/solana/decoding/instructions.rs
@@ -22,10 +22,7 @@ pub struct SolanaInstructionDecoder {
 
 impl SolanaInstructionDecoder {
     pub fn new(decoders: Vec<Arc<dyn ProgramDecoder>>) -> Self {
-        let decoders = decoders
-            .into_iter()
-            .map(|d| (d.program_id(), d))
-            .collect();
+        let decoders = decoders.into_iter().map(|d| (d.program_id(), d)).collect();
         Self { decoders }
     }
 
@@ -180,10 +177,7 @@ mod tests {
         assert_eq!(event.event_name, "Transfer");
         assert_eq!(event.event_signature, "Transfer");
         // Args are merged in
-        assert_eq!(
-            event.params.get("amount"),
-            Some(&DecodedValue::Uint64(100))
-        );
+        assert_eq!(event.params.get("amount"), Some(&DecodedValue::Uint64(100)));
         // Named accounts are merged in as ChainAddress with "accounts." prefix
         assert_eq!(
             event.params.get("accounts.source"),

--- a/src/solana/decoding/spl_token.rs
+++ b/src/solana/decoding/spl_token.rs
@@ -10,8 +10,8 @@ use super::traits::{
 
 /// SPL Token program ID: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
 const SPL_TOKEN_PROGRAM_ID: [u8; 32] = [
-    6, 221, 246, 225, 215, 101, 161, 147, 217, 203, 225, 70, 206, 235, 121, 172, 28, 180, 133,
-    237, 95, 91, 55, 145, 58, 140, 245, 133, 126, 255, 0, 169,
+    6, 221, 246, 225, 215, 101, 161, 147, 217, 203, 225, 70, 206, 235, 121, 172, 28, 180, 133, 237,
+    95, 91, 55, 145, 58, 140, 245, 133, 126, 255, 0, 169,
 ];
 
 /// Hand-written `ProgramDecoder` for the SPL Token program.
@@ -119,10 +119,7 @@ fn read_coption_u64(data: &[u8], offset: usize) -> Result<DecodedValue, SolanaDe
 /// Extract named accounts from the accounts slice, returning only as many as
 /// names are provided. Extra accounts are silently ignored, and missing accounts
 /// leave the name out of the result.
-fn extract_named_accounts(
-    accounts: &[[u8; 32]],
-    names: &[&str],
-) -> HashMap<String, [u8; 32]> {
+fn extract_named_accounts(accounts: &[[u8; 32]], names: &[&str]) -> HashMap<String, [u8; 32]> {
     let mut map = HashMap::new();
     for (i, name) in names.iter().enumerate() {
         if let Some(pubkey) = accounts.get(i) {
@@ -419,15 +416,9 @@ mod tests {
 
         let fields = result.unwrap();
         assert_eq!(fields.instruction_name, "Transfer");
-        assert_eq!(
-            fields.args.get("amount"),
-            Some(&DecodedValue::Uint64(1000))
-        );
+        assert_eq!(fields.args.get("amount"), Some(&DecodedValue::Uint64(1000)));
         assert_eq!(fields.named_accounts.get("source"), Some(&[10u8; 32]));
-        assert_eq!(
-            fields.named_accounts.get("destination"),
-            Some(&[20u8; 32])
-        );
+        assert_eq!(fields.named_accounts.get("destination"), Some(&[20u8; 32]));
         assert_eq!(fields.named_accounts.get("authority"), Some(&[30u8; 32]));
     }
 
@@ -448,17 +439,11 @@ mod tests {
 
         let fields = result.unwrap();
         assert_eq!(fields.instruction_name, "TransferChecked");
-        assert_eq!(
-            fields.args.get("amount"),
-            Some(&DecodedValue::Uint64(5000))
-        );
+        assert_eq!(fields.args.get("amount"), Some(&DecodedValue::Uint64(5000)));
         assert_eq!(fields.args.get("decimals"), Some(&DecodedValue::Uint8(6)));
         assert_eq!(fields.named_accounts.get("source"), Some(&[11u8; 32]));
         assert_eq!(fields.named_accounts.get("mint"), Some(&[22u8; 32]));
-        assert_eq!(
-            fields.named_accounts.get("destination"),
-            Some(&[33u8; 32])
-        );
+        assert_eq!(fields.named_accounts.get("destination"), Some(&[33u8; 32]));
         assert_eq!(fields.named_accounts.get("authority"), Some(&[44u8; 32]));
     }
 
@@ -474,7 +459,9 @@ mod tests {
     #[test]
     fn test_event_returns_none() {
         let decoder = SplTokenDecoder::new();
-        let result = decoder.decode_event(&[1, 2, 3, 4, 5, 6, 7, 8], &[10, 20]).unwrap();
+        let result = decoder
+            .decode_event(&[1, 2, 3, 4, 5, 6, 7, 8], &[10, 20])
+            .unwrap();
         assert!(result.is_none());
         assert!(decoder.event_types().is_empty());
     }
@@ -514,10 +501,7 @@ mod tests {
             fields.fields.get("supply"),
             Some(&DecodedValue::Uint64(1_000_000))
         );
-        assert_eq!(
-            fields.fields.get("decimals"),
-            Some(&DecodedValue::Uint8(9))
-        );
+        assert_eq!(fields.fields.get("decimals"), Some(&DecodedValue::Uint8(9)));
         assert_eq!(
             fields.fields.get("is_initialized"),
             Some(&DecodedValue::Bool(true))

--- a/src/solana/decoding/tasks.rs
+++ b/src/solana/decoding/tasks.rs
@@ -148,6 +148,14 @@ pub async fn decode_solana_events(
     chain_name: String,
     function_filter: Option<Arc<HashSet<String>>>,
     only_sources: Option<Arc<HashSet<String>>>,
+    live_storage: Option<crate::solana::live::storage::SolanaLiveStorage>,
+    // When true (live mode + discovery-managed account reads configured), sends
+    // a sentinel empty
+    // DecodedEventsMessage through transform_tx after all decoded groups for a
+    // slot. The bridge detects this and forwards RangeComplete to the discovery
+    // loop, which sends mark_complete_only to the reader AFTER all
+    // discovery-triggered account reads for the slot have been enqueued.
+    signal_slot_done: bool,
 ) {
     let schema = build_decoded_event_schema();
     let base_dir = decoded_solana_events_dir(&chain_name);
@@ -159,15 +167,12 @@ pub async fn decode_solana_events(
                 range_start,
                 range_end,
                 events,
-                live_mode: _,
+                live_mode,
             } => {
                 // Group raw events by program_id
                 let mut by_program: HashMap<[u8; 32], Vec<_>> = HashMap::new();
                 for event in events {
-                    by_program
-                        .entry(event.program_id)
-                        .or_default()
-                        .push(event);
+                    by_program.entry(event.program_id).or_default().push(event);
                 }
 
                 // Decode per-program, then regroup by (source_name, event_name)
@@ -198,53 +203,72 @@ pub async fn decode_solana_events(
                     by_trigger.retain(|(_, event_name), _| filter.contains(event_name.as_str()));
                 }
 
-                // Write decoded parquet per (source_name, event_name) group
-                let range_end_inclusive = if range_end > 0 { range_end - 1 } else { 0 };
-                let range_file = format!("{}-{}.parquet", range_start, range_end_inclusive);
+                // In live mode, skip parquet writes — decoded data flows through
+                // channels to the engine, and compaction handles parquet later.
+                // Mark the slot as events_decoded in live storage so the
+                // compaction service sees it as complete.
+                if !live_mode {
+                    let range_end_inclusive = if range_end > 0 { range_end - 1 } else { 0 };
+                    let range_file = format!("{}-{}.parquet", range_start, range_end_inclusive);
 
-                for ((source_name, event_name), events) in &by_trigger {
-                    if events.is_empty() {
-                        continue;
+                    for ((source_name, event_name), events) in &by_trigger {
+                        if events.is_empty() {
+                            continue;
+                        }
+                        let output_dir = base_dir.join(source_name).join(event_name);
+                        if let Err(e) = std::fs::create_dir_all(&output_dir) {
+                            tracing::error!(
+                                path = %output_dir.display(),
+                                error = %e,
+                                "Failed to create decoded events output directory"
+                            );
+                            continue;
+                        }
+                        let output_path = output_dir.join(&range_file);
+
+                        if let Err(e) =
+                            write_decoded_events_to_parquet(events, &schema, &output_path)
+                        {
+                            tracing::error!(
+                                path = %output_path.display(),
+                                error = %e,
+                                "Failed to write decoded events parquet"
+                            );
+                        } else {
+                            tracing::debug!(
+                                source = source_name.as_str(),
+                                event = event_name.as_str(),
+                                count = events.len(),
+                                path = %output_path.display(),
+                                "Wrote decoded events parquet"
+                            );
+                        }
                     }
-                    let output_dir = base_dir.join(source_name).join(event_name);
-                    if let Err(e) = std::fs::create_dir_all(&output_dir) {
-                        tracing::error!(
-                            path = %output_dir.display(),
+
+                    // Remove stale decoded parquet for this range. Function
+                    // filtering makes the output incomplete per-source, so
+                    // cleanup must be skipped. Source scoping restricts the
+                    // scan to in-scope sources only.
+                    if function_filter.is_none() {
+                        cleanup_stale_decoded_parquet(
+                            &base_dir,
+                            &by_trigger,
+                            &range_file,
+                            only_sources.as_deref(),
+                        );
+                    }
+                } else if let Some(ref storage) = live_storage {
+                    // In live mode, mark events_decoded in slot status.
+                    // range_start == range_end == slot for live ranges.
+                    if let Err(e) = storage.update_status_atomic(range_start, |s| {
+                        s.events_decoded = true;
+                    }) {
+                        tracing::warn!(
+                            slot = range_start,
                             error = %e,
-                            "Failed to create decoded events output directory"
-                        );
-                        continue;
-                    }
-                    let output_path = output_dir.join(&range_file);
-
-                    if let Err(e) = write_decoded_events_to_parquet(events, &schema, &output_path) {
-                        tracing::error!(
-                            path = %output_path.display(),
-                            error = %e,
-                            "Failed to write decoded events parquet"
-                        );
-                    } else {
-                        tracing::debug!(
-                            source = source_name.as_str(),
-                            event = event_name.as_str(),
-                            count = events.len(),
-                            path = %output_path.display(),
-                            "Wrote decoded events parquet"
+                            "Failed to mark events_decoded in live status"
                         );
                     }
-                }
-
-                // Remove stale decoded parquet for this range. Function
-                // filtering makes the output incomplete per-source, so
-                // cleanup must be skipped. Source scoping restricts the
-                // scan to in-scope sources only.
-                if function_filter.is_none() {
-                    cleanup_stale_decoded_parquet(
-                        &base_dir,
-                        &by_trigger,
-                        &range_file,
-                        only_sources.as_deref(),
-                    );
                 }
 
                 // Send one message per (source_name, event_name) group
@@ -285,6 +309,26 @@ pub async fn decode_solana_events(
                         return;
                     }
                 }
+
+                // Send a slot-done sentinel through the same channel as decoded
+                // events so it follows them through the bridge → discovery
+                // pipeline. The bridge converts this into a RangeComplete for
+                // the discovery loop, which then sends mark_complete_only to
+                // the reader after all discovery-triggered account reads for
+                // the slot have been enqueued.
+                if live_mode && signal_slot_done {
+                    if let Some(ref tx) = transform_tx {
+                        let _ = tx
+                            .send(DecodedEventsMessage {
+                                range_start,
+                                range_end,
+                                source_name: String::new(),
+                                event_name: String::new(),
+                                events: Vec::new(),
+                            })
+                            .await;
+                    }
+                }
             }
             DecoderMessage::AllComplete => break,
             _ => {} // Ignore EVM-specific messages
@@ -313,6 +357,7 @@ pub async fn decode_solana_instructions(
     chain_name: String,
     function_filter: Option<Arc<HashSet<String>>>,
     only_sources: Option<Arc<HashSet<String>>>,
+    live_storage: Option<crate::solana::live::storage::SolanaLiveStorage>,
 ) {
     let schema = build_decoded_event_schema();
     let base_dir = decoded_solana_instructions_dir(&chain_name);
@@ -324,15 +369,12 @@ pub async fn decode_solana_instructions(
                 range_start,
                 range_end,
                 instructions,
-                live_mode: _,
+                live_mode,
             } => {
                 // Group raw instructions by program_id
                 let mut by_program: HashMap<[u8; 32], Vec<_>> = HashMap::new();
                 for instr in instructions {
-                    by_program
-                        .entry(instr.program_id)
-                        .or_default()
-                        .push(instr);
+                    by_program.entry(instr.program_id).or_default().push(instr);
                 }
 
                 // Decode per-program, then regroup by (source_name, event_name)
@@ -350,8 +392,7 @@ pub async fn decode_solana_instructions(
                         }
                     };
 
-                    let decoded =
-                        decoder.decode_instruction_batch(program_instrs, source_name);
+                    let decoded = decoder.decode_instruction_batch(program_instrs, source_name);
                     for event in decoded {
                         let key = (event.source_name.clone(), event.event_name.clone());
                         by_trigger.entry(key).or_default().push(event);
@@ -363,50 +404,63 @@ pub async fn decode_solana_instructions(
                     by_trigger.retain(|(_, event_name), _| filter.contains(event_name.as_str()));
                 }
 
-                // Write decoded parquet per (source_name, instruction_name) group
-                let range_end_inclusive = if range_end > 0 { range_end - 1 } else { 0 };
-                let range_file = format!("{}-{}.parquet", range_start, range_end_inclusive);
+                if !live_mode {
+                    let range_end_inclusive = if range_end > 0 { range_end - 1 } else { 0 };
+                    let range_file = format!("{}-{}.parquet", range_start, range_end_inclusive);
 
-                for ((source_name, event_name), events) in &by_trigger {
-                    if events.is_empty() {
-                        continue;
+                    for ((source_name, event_name), events) in &by_trigger {
+                        if events.is_empty() {
+                            continue;
+                        }
+                        let output_dir = base_dir.join(source_name).join(event_name);
+                        if let Err(e) = std::fs::create_dir_all(&output_dir) {
+                            tracing::error!(
+                                path = %output_dir.display(),
+                                error = %e,
+                                "Failed to create decoded instructions output directory"
+                            );
+                            continue;
+                        }
+                        let output_path = output_dir.join(&range_file);
+
+                        if let Err(e) =
+                            write_decoded_events_to_parquet(events, &schema, &output_path)
+                        {
+                            tracing::error!(
+                                path = %output_path.display(),
+                                error = %e,
+                                "Failed to write decoded instructions parquet"
+                            );
+                        } else {
+                            tracing::debug!(
+                                source = source_name.as_str(),
+                                instruction = event_name.as_str(),
+                                count = events.len(),
+                                path = %output_path.display(),
+                                "Wrote decoded instructions parquet"
+                            );
+                        }
                     }
-                    let output_dir = base_dir.join(source_name).join(event_name);
-                    if let Err(e) = std::fs::create_dir_all(&output_dir) {
-                        tracing::error!(
-                            path = %output_dir.display(),
+
+                    // Remove stale decoded parquet — see decode_solana_events
+                    if function_filter.is_none() {
+                        cleanup_stale_decoded_parquet(
+                            &base_dir,
+                            &by_trigger,
+                            &range_file,
+                            only_sources.as_deref(),
+                        );
+                    }
+                } else if let Some(ref storage) = live_storage {
+                    if let Err(e) = storage.update_status_atomic(range_start, |s| {
+                        s.instructions_decoded = true;
+                    }) {
+                        tracing::warn!(
+                            slot = range_start,
                             error = %e,
-                            "Failed to create decoded instructions output directory"
-                        );
-                        continue;
-                    }
-                    let output_path = output_dir.join(&range_file);
-
-                    if let Err(e) = write_decoded_events_to_parquet(events, &schema, &output_path) {
-                        tracing::error!(
-                            path = %output_path.display(),
-                            error = %e,
-                            "Failed to write decoded instructions parquet"
-                        );
-                    } else {
-                        tracing::debug!(
-                            source = source_name.as_str(),
-                            instruction = event_name.as_str(),
-                            count = events.len(),
-                            path = %output_path.display(),
-                            "Wrote decoded instructions parquet"
+                            "Failed to mark instructions_decoded in live status"
                         );
                     }
-                }
-
-                // Remove stale decoded parquet — see decode_solana_events
-                if function_filter.is_none() {
-                    cleanup_stale_decoded_parquet(
-                        &base_dir,
-                        &by_trigger,
-                        &range_file,
-                        only_sources.as_deref(),
-                    );
                 }
 
                 // Send one message per (source_name, instruction_name) group
@@ -463,6 +517,8 @@ mod tests {
         DecodedAccountFields, DecodedEventFields, DecodedInstructionFields, ProgramDecoder,
         SolanaDecodeError,
     };
+    use crate::solana::live::storage::SolanaLiveStorage;
+    use crate::solana::live::types::LiveSlotStatus;
     use crate::solana::raw_data::types::{SolanaEventRecord, SolanaInstructionRecord};
     use crate::types::decoded::DecodedValue;
 
@@ -562,7 +618,10 @@ mod tests {
         let (complete_tx, mut complete_rx) = tokio::sync::mpsc::channel(10);
 
         let tmp_dir = tempfile::TempDir::new().unwrap();
-        let chain_name = format!("test-{}", tmp_dir.path().file_name().unwrap().to_str().unwrap());
+        let chain_name = format!(
+            "test-{}",
+            tmp_dir.path().file_name().unwrap().to_str().unwrap()
+        );
 
         // Create the expected output directory under a temp-like data dir
         // We need the test to write to a real dir so use the chain_name approach
@@ -575,6 +634,8 @@ mod tests {
             chain_name,
             None,
             None,
+            None,
+            false,
         ));
 
         // Send an event batch
@@ -608,23 +669,80 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn event_decoder_task_marks_live_slot_complete() {
+        let program_id = [3u8; 32];
+
+        let mut params = HashMap::new();
+        params.insert("amount".to_string(), DecodedValue::Uint64(7));
+
+        let decoder = Arc::new(SolanaEventDecoder::new(vec![Arc::new(MockDecoder {
+            id: program_id,
+            event_result: Some(DecodedEventFields {
+                event_name: "Transfer".to_string(),
+                params,
+            }),
+            instruction_result: None,
+        })]));
+
+        let mut names = HashMap::new();
+        names.insert(program_id, "spl_token".to_string());
+        let program_names = Arc::new(names);
+
+        let storage_root = tempfile::TempDir::new().unwrap();
+        let storage = SolanaLiveStorage::with_base_dir(storage_root.path().to_path_buf());
+        storage.ensure_dirs().unwrap();
+
+        let mut status = LiveSlotStatus::collected();
+        status.block_fetched = true;
+        status.events_extracted = true;
+        storage.write_status(100, &status).unwrap();
+
+        let (decoder_tx, decoder_rx) = tokio::sync::mpsc::channel(10);
+        let handle = tokio::spawn(decode_solana_events(
+            decoder,
+            program_names,
+            decoder_rx,
+            None,
+            None,
+            "test-live-events".to_string(),
+            None,
+            None,
+            Some(storage.clone()),
+            false,
+        ));
+
+        decoder_tx
+            .send(DecoderMessage::SolanaEventsReady {
+                range_start: 100,
+                range_end: 100,
+                events: vec![make_event_record(program_id)],
+                live_mode: true,
+            })
+            .await
+            .unwrap();
+        decoder_tx.send(DecoderMessage::AllComplete).await.unwrap();
+        handle.await.unwrap();
+
+        let updated = storage.read_status(100).unwrap();
+        assert!(updated.events_decoded);
+    }
+
+    #[tokio::test]
     async fn instruction_decoder_task_sends_instruction_complete() {
         let program_id = [2u8; 32];
 
         let mut args = HashMap::new();
         args.insert("amount".to_string(), DecodedValue::Uint64(100));
 
-        let decoder = Arc::new(SolanaInstructionDecoder::new(vec![Arc::new(
-            MockDecoder {
-                id: program_id,
-                event_result: None,
-                instruction_result: Some(DecodedInstructionFields {
-                    instruction_name: "Transfer".to_string(),
-                    args,
-                    named_accounts: HashMap::new(),
-                }),
-            },
-        )]));
+        let decoder = Arc::new(SolanaInstructionDecoder::new(vec![Arc::new(MockDecoder {
+            id: program_id,
+            event_result: None,
+            instruction_result: Some(DecodedInstructionFields {
+                instruction_name: "Transfer".to_string(),
+                args,
+                named_accounts: HashMap::new(),
+            }),
+        })]));
 
         let mut names = HashMap::new();
         names.insert(program_id, "spl_token".to_string());
@@ -641,6 +759,7 @@ mod tests {
             Some(transform_tx),
             Some(complete_tx),
             "test-solana-instr".to_string(),
+            None,
             None,
             None,
         ));
@@ -668,6 +787,65 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn instruction_decoder_task_marks_live_slot_complete() {
+        let program_id = [4u8; 32];
+
+        let mut args = HashMap::new();
+        args.insert("amount".to_string(), DecodedValue::Uint64(9));
+
+        let decoder = Arc::new(SolanaInstructionDecoder::new(vec![Arc::new(MockDecoder {
+            id: program_id,
+            event_result: None,
+            instruction_result: Some(DecodedInstructionFields {
+                instruction_name: "Transfer".to_string(),
+                args,
+                named_accounts: HashMap::new(),
+            }),
+        })]));
+
+        let mut names = HashMap::new();
+        names.insert(program_id, "spl_token".to_string());
+        let program_names = Arc::new(names);
+
+        let storage_root = tempfile::TempDir::new().unwrap();
+        let storage = SolanaLiveStorage::with_base_dir(storage_root.path().to_path_buf());
+        storage.ensure_dirs().unwrap();
+
+        let mut status = LiveSlotStatus::collected();
+        status.block_fetched = true;
+        status.instructions_extracted = true;
+        storage.write_status(200, &status).unwrap();
+
+        let (decoder_tx, decoder_rx) = tokio::sync::mpsc::channel(10);
+        let handle = tokio::spawn(decode_solana_instructions(
+            decoder,
+            program_names,
+            decoder_rx,
+            None,
+            None,
+            "test-live-instructions".to_string(),
+            None,
+            None,
+            Some(storage.clone()),
+        ));
+
+        decoder_tx
+            .send(DecoderMessage::SolanaInstructionsReady {
+                range_start: 200,
+                range_end: 200,
+                instructions: vec![make_instruction_record(program_id)],
+                live_mode: true,
+            })
+            .await
+            .unwrap();
+        decoder_tx.send(DecoderMessage::AllComplete).await.unwrap();
+        handle.await.unwrap();
+
+        let updated = storage.read_status(200).unwrap();
+        assert!(updated.instructions_decoded);
+    }
+
+    #[tokio::test]
     async fn decoder_task_exits_on_channel_close() {
         let decoder = Arc::new(SolanaEventDecoder::new(vec![]));
         let program_names = Arc::new(HashMap::new());
@@ -682,6 +860,8 @@ mod tests {
             "test-close".to_string(),
             None,
             None,
+            None,
+            false,
         ));
 
         // Drop sender to close channel
@@ -723,6 +903,8 @@ mod tests {
             "test-unknown".to_string(),
             None,
             None,
+            None,
+            false,
         ));
 
         // Send batch with one known and one unknown program event
@@ -730,10 +912,7 @@ mod tests {
             .send(DecoderMessage::SolanaEventsReady {
                 range_start: 0,
                 range_end: 1000,
-                events: vec![
-                    make_event_record(known_id),
-                    make_event_record(unknown_id),
-                ],
+                events: vec![make_event_record(known_id), make_event_record(unknown_id)],
                 live_mode: false,
             })
             .await

--- a/src/solana/discovery.rs
+++ b/src/solana/discovery.rs
@@ -9,6 +9,7 @@
 use std::collections::{HashMap, HashSet};
 use std::io;
 use std::str::FromStr;
+use std::sync::{Arc, RwLock};
 
 use serde::{Deserialize, Serialize};
 use solana_client::rpc_filter::{Memcmp, RpcFilterType};
@@ -18,6 +19,15 @@ use solana_sdk::pubkey::Pubkey;
 use crate::solana::rpc::{SolanaRpcClient, SolanaRpcError};
 use crate::storage::paths::solana_discovery_dir;
 use crate::types::config::solana::{SolanaDiscoveryConfig, SolanaPrograms};
+
+// ---------------------------------------------------------------------------
+// Shared types
+// ---------------------------------------------------------------------------
+
+/// Shared registry of known account addresses, grouped by program name and
+/// account type. The account_type grouping is preserved so the reader can
+/// apply per-type cadence filtering (EveryNSlots, Duration).
+pub type SharedKnownAccounts = Arc<RwLock<HashMap<String, HashMap<String, Vec<[u8; 32]>>>>>;
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -39,6 +49,7 @@ pub enum DiscoveryMessage {
     DecodedEvents {
         range_start: u64,
         range_end: u64,
+        block_time: Option<i64>,
         source_name: String,
         events: Vec<DiscoveryEventData>,
     },
@@ -371,6 +382,36 @@ impl DiscoveryManager {
             .sum()
     }
 
+    /// Snapshot known addresses filtered by an allowlist of
+    /// `(program_name, account_type)` pairs. Preserves the two-level grouping
+    /// so the reader can apply per-type cadence filtering.
+    pub fn snapshot_filtered(
+        &self,
+        allowed_types: &HashMap<String, HashSet<String>>,
+    ) -> HashMap<String, HashMap<String, Vec<[u8; 32]>>> {
+        self.known_accounts
+            .iter()
+            .filter_map(|(program_name, types)| {
+                let allowed = allowed_types.get(program_name)?;
+                let filtered: HashMap<String, Vec<[u8; 32]>> = types
+                    .iter()
+                    .filter(|(acct_type, _)| allowed.contains(acct_type.as_str()))
+                    .map(|(acct_type, set)| {
+                        (
+                            acct_type.clone(),
+                            set.iter().map(|pk| pk.to_bytes()).collect(),
+                        )
+                    })
+                    .collect();
+                if filtered.is_empty() {
+                    None
+                } else {
+                    Some((program_name.clone(), filtered))
+                }
+            })
+            .collect()
+    }
+
     // -----------------------------------------------------------------------
     // Private helpers
     // -----------------------------------------------------------------------
@@ -381,8 +422,7 @@ impl DiscoveryManager {
 
         for (program_name, account_types) in &self.known_accounts {
             for (account_type, pubkeys) in account_types {
-                let mut addresses: Vec<String> =
-                    pubkeys.iter().map(|pk| pk.to_string()).collect();
+                let mut addresses: Vec<String> = pubkeys.iter().map(|pk| pk.to_string()).collect();
                 addresses.sort();
 
                 known_accounts
@@ -680,10 +720,7 @@ mod tests {
             event_name: "SomeEvent".to_string(),
             fields: {
                 let mut fields = HashMap::new();
-                fields.insert(
-                    "addr".to_string(),
-                    DiscoveryFieldValue::Pubkey([99u8; 32]),
-                );
+                fields.insert("addr".to_string(), DiscoveryFieldValue::Pubkey([99u8; 32]));
                 fields
             },
         }];
@@ -807,10 +844,7 @@ mod tests {
             event_name: "VaultCreated".to_string(),
             fields: {
                 let mut fields = HashMap::new();
-                fields.insert(
-                    "vault".to_string(),
-                    DiscoveryFieldValue::Pubkey([2u8; 32]),
-                );
+                fields.insert("vault".to_string(), DiscoveryFieldValue::Pubkey([2u8; 32]));
                 fields
             },
         }];
@@ -906,5 +940,92 @@ mod tests {
         // Verify it shows up under "unknown" account type.
         let addrs = manager.known_addresses("test_program", "unknown");
         assert_eq!(addrs.len(), 1);
+    }
+
+    // -----------------------------------------------------------------------
+    // Test: snapshot_filtered
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn snapshot_filtered_includes_matching_types() {
+        let programs = make_programs_with_discovery();
+        let mut manager = DiscoveryManager::new(&programs);
+
+        let events = vec![
+            make_pool_initialized_event([1u8; 32]),
+            make_pool_initialized_event([2u8; 32]),
+        ];
+        manager.process_events("orca_whirlpool", &events);
+
+        // Allow all types for this program
+        let mut allowed = HashMap::new();
+        allowed.insert(
+            "orca_whirlpool".to_string(),
+            HashSet::from(["Whirlpool".to_string()]),
+        );
+
+        let snapshot = manager.snapshot_filtered(&allowed);
+        assert_eq!(snapshot.len(), 1);
+        assert_eq!(snapshot["orca_whirlpool"]["Whirlpool"].len(), 2);
+    }
+
+    #[test]
+    fn snapshot_filtered_excludes_non_matching_types() {
+        let mut programs = make_programs_with_discovery();
+        let prog = programs.get_mut("orca_whirlpool").unwrap();
+        prog.discovery
+            .as_mut()
+            .unwrap()
+            .push(SolanaDiscoveryConfig {
+                event_name: "PositionOpened".to_string(),
+                address_field: "position".to_string(),
+                account_type: Some("Position".to_string()),
+            });
+
+        let mut manager = DiscoveryManager::new(&programs);
+
+        // Discover Whirlpool
+        manager.process_events("orca_whirlpool", &[make_pool_initialized_event([1u8; 32])]);
+        // Discover Position
+        manager.process_events(
+            "orca_whirlpool",
+            &[DiscoveryEventData {
+                event_name: "PositionOpened".to_string(),
+                fields: {
+                    let mut f = HashMap::new();
+                    f.insert(
+                        "position".to_string(),
+                        DiscoveryFieldValue::Pubkey([2u8; 32]),
+                    );
+                    f
+                },
+            }],
+        );
+
+        assert_eq!(manager.total_known_addresses(), 2);
+
+        // Only allow Whirlpool, not Position
+        let mut allowed = HashMap::new();
+        allowed.insert(
+            "orca_whirlpool".to_string(),
+            HashSet::from(["Whirlpool".to_string()]),
+        );
+
+        let filtered = manager.snapshot_filtered(&allowed);
+        assert_eq!(filtered.len(), 1);
+        assert!(filtered["orca_whirlpool"].contains_key("Whirlpool"));
+        assert!(!filtered["orca_whirlpool"].contains_key("Position"));
+    }
+
+    #[test]
+    fn snapshot_filtered_empty_filter_returns_empty() {
+        let programs = make_programs_with_discovery();
+        let mut manager = DiscoveryManager::new(&programs);
+
+        manager.process_events("orca_whirlpool", &[make_pool_initialized_event([1u8; 32])]);
+
+        let empty: HashMap<String, HashSet<String>> = HashMap::new();
+        let filtered = manager.snapshot_filtered(&empty);
+        assert!(filtered.is_empty());
     }
 }

--- a/src/solana/live/accounts.rs
+++ b/src/solana/live/accounts.rs
@@ -478,11 +478,17 @@ impl SolanaLiveAccountReader {
 
         // Persist raw reads to live storage.
         if !all_reads.is_empty() {
+            let resolved_sources: Vec<&str> = decoded_by_source_and_type
+                .keys()
+                .map(|(source, _)| source.as_str())
+                .collect();
+
             self.storage.write_accounts(slot, &all_reads)?;
 
             tracing::debug!(
                 slot,
-                source = %source_name,
+                requested_source = %source_name,
+                resolved_sources = ?resolved_sources,
                 raw_reads = all_reads.len(),
                 decoded_types = decoded_by_source_and_type.len(),
                 "Account reads complete",
@@ -505,7 +511,7 @@ impl SolanaLiveAccountReader {
                 // prevent the reader from blocking.
                 tracing::debug!(
                     slot,
-                    source = %source_name,
+                    source = %effective_source,
                     error = %e,
                     "Account-states channel has no consumer (receiver dropped)",
                 );

--- a/src/solana/live/accounts.rs
+++ b/src/solana/live/accounts.rs
@@ -1,0 +1,515 @@
+//! Live account reader — event-triggered account state fetches.
+//!
+//! Reads Solana account state when triggered by decoded events or address
+//! discovery. This is the Solana analog of the EVM `LiveEthCallCollector`:
+//! instead of calling contract functions, it reads on-chain account data
+//! via `getMultipleAccounts` and decodes it through program-specific decoders.
+//!
+//! Live-only — no historical equivalent.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use solana_sdk::pubkey::Pubkey;
+use thiserror::Error;
+use tokio::sync::mpsc;
+
+use crate::live::bincode_io::StorageError;
+use crate::solana::decoding::accounts::SolanaAccountDecoder;
+use crate::solana::discovery::{DiscoveryAddresses, SharedKnownAccounts};
+use crate::solana::pipeline::AccountReadCadence;
+use crate::solana::rpc::{SolanaRpcClient, SolanaRpcError};
+use crate::transformations::engine::{
+    DecodedAccountStatesMessage, RangeCompleteKind, RangeCompleteMessage,
+};
+
+use super::storage::SolanaLiveStorage;
+use super::types::{AccountReadTrigger, LiveAccountRead};
+
+// ---------------------------------------------------------------------------
+// Error
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Error)]
+pub enum AccountReaderError {
+    #[error("RPC error: {0}")]
+    Rpc(#[from] SolanaRpcError),
+    #[error("Storage error: {0}")]
+    Storage(#[from] StorageError),
+    #[error("Channel send error: {0}")]
+    ChannelSend(String),
+}
+
+// ---------------------------------------------------------------------------
+// Account reader
+// ---------------------------------------------------------------------------
+
+/// Reads Solana account state when triggered by discovery or the collector.
+///
+/// Batches addresses into chunks of up to `batch_size` (max 100 for Solana's
+/// `getMultipleAccounts`), fetches data via RPC, writes raw reads to live
+/// storage, decodes through the `SolanaAccountDecoder`, and forwards decoded
+/// states to the transformation engine.
+pub struct SolanaLiveAccountReader {
+    rpc_client: Arc<SolanaRpcClient>,
+    account_decoder: Arc<SolanaAccountDecoder>,
+    storage: SolanaLiveStorage,
+    /// program_id bytes -> human-readable program/source name
+    program_names: Arc<HashMap<[u8; 32], String>>,
+    /// Max pubkeys per `getMultipleAccounts` call (Solana limit: 100).
+    batch_size: usize,
+    /// Shared registry of known account addresses from discovery.
+    /// When present, empty triggers read all known addresses instead of skipping.
+    known_accounts: Option<SharedKnownAccounts>,
+    /// Cadence configuration per (program, account_type). Absent entries
+    /// default to EverySlot.
+    cadence_map: HashMap<(String, String), AccountReadCadence>,
+    /// Whether slot-level account completion is deferred through the discovery
+    /// loop. When true, per-slot and discovery-triggered reads wait for the
+    /// `mark_complete_only` barrier sent after all discovery-managed reads for
+    /// that slot have been enqueued.
+    defer_account_completion: bool,
+}
+
+impl SolanaLiveAccountReader {
+    /// Create a new account reader.
+    ///
+    /// `batch_size` defaults to 100 (the Solana RPC limit for
+    /// `getMultipleAccounts`).
+    pub fn new(
+        rpc_client: Arc<SolanaRpcClient>,
+        account_decoder: Arc<SolanaAccountDecoder>,
+        storage: SolanaLiveStorage,
+        program_names: Arc<HashMap<[u8; 32], String>>,
+        known_accounts: Option<SharedKnownAccounts>,
+        cadence_map: HashMap<(String, String), AccountReadCadence>,
+        defer_account_completion: bool,
+    ) -> Self {
+        Self {
+            rpc_client,
+            account_decoder,
+            storage,
+            program_names,
+            batch_size: 100,
+            known_accounts,
+            cadence_map,
+            defer_account_completion,
+        }
+    }
+
+    /// Main event loop.
+    ///
+    /// Listens on two channels:
+    /// - `discovery_rx`: newly discovered addresses from the `DiscoveryManager`
+    /// - `trigger_rx`: explicit read triggers from the collector after a slot
+    ///   is fetched
+    ///
+    /// On either signal, fetches account data, decodes it, and sends decoded
+    /// account states downstream. Sends a `RangeCompleteMessage` with
+    /// `AccountStates` kind after processing each trigger or discovery batch.
+    pub async fn run(
+        self,
+        mut discovery_rx: mpsc::Receiver<DiscoveryAddresses>,
+        mut trigger_rx: mpsc::Receiver<AccountReadTrigger>,
+        account_states_tx: mpsc::Sender<DecodedAccountStatesMessage>,
+        account_complete_tx: mpsc::Sender<RangeCompleteMessage>,
+    ) -> Result<(), AccountReaderError> {
+        tracing::info!("Solana live account reader started");
+
+        // Cadence tracking: last slot and last block_time when each
+        // (program, account_type) group was actually read.
+        let mut last_read_slot: HashMap<(String, String), u64> = HashMap::new();
+        let mut last_read_time: HashMap<(String, String), i64> = HashMap::new();
+
+        // Slots where a read trigger failed. mark_complete_only will not
+        // mark these complete so catchup can retry on next restart.
+        let mut failed_slots: std::collections::HashSet<u64> = std::collections::HashSet::new();
+
+        loop {
+            tokio::select! {
+                Some(discovery) = discovery_rx.recv() => {
+                    let addresses: Vec<[u8; 32]> = discovery
+                        .addresses
+                        .iter()
+                        .map(|pk| pk.to_bytes())
+                        .collect();
+
+                    if addresses.is_empty() {
+                        continue;
+                    }
+
+                    let source_name = &discovery.program_name;
+
+                    tracing::debug!(
+                        source = %source_name,
+                        account_type = %discovery.account_type,
+                        count = addresses.len(),
+                        "Processing discovery addresses for account reads",
+                    );
+
+                    // Discovery addresses don't have a specific slot context;
+                    // use slot 0 to indicate "latest" — the RPC reads current state.
+                    if let Err(e) = self
+                        .read_and_decode_accounts(
+                            0,
+                            None,
+                            source_name,
+                            &addresses,
+                            &account_states_tx,
+                        )
+                        .await
+                    {
+                        tracing::error!(
+                            source = %source_name,
+                            error = %e,
+                            "Failed to read discovery accounts",
+                        );
+                    }
+                }
+
+                Some(trigger) = trigger_rx.recv() => {
+                    // mark_complete_only: sent by the discovery loop after all
+                    // decoded events for a slot have been processed. At this
+                    // point, per-slot reads and any discovery-triggered reads
+                    // for the slot have already been enqueued and processed.
+                    if trigger.mark_complete_only {
+                        if failed_slots.remove(&trigger.slot) {
+                            tracing::warn!(
+                                slot = trigger.slot,
+                                "Not marking account-complete: prior read failed for slot",
+                            );
+                            continue;
+                        }
+                        if let Err(e) = self.storage.update_status_atomic(trigger.slot, |s| {
+                            s.accounts_read = true;
+                            s.accounts_decoded = true;
+                        }) {
+                            tracing::warn!(
+                                slot = trigger.slot,
+                                error = %e,
+                                "Failed to update account status (slot may be skipped or deleted)",
+                            );
+                        }
+                        let complete_msg = RangeCompleteMessage {
+                            range_start: trigger.slot,
+                            range_end: trigger.slot + 1,
+                            kind: RangeCompleteKind::AccountStates,
+                        };
+                        if let Err(e) = account_complete_tx.send(complete_msg).await {
+                            // Expected when no transformation engine is wired:
+                            // the pipeline stubs this sender with a dropped
+                            // receiver to prevent the reader from blocking.
+                            tracing::debug!(
+                                slot = trigger.slot,
+                                error = %e,
+                                "Account-complete channel has no consumer (receiver dropped)",
+                            );
+                        }
+                        continue;
+                    }
+
+                    let mut had_error = false;
+
+                    if trigger.addresses.is_empty() {
+                        // Per-slot trigger from the collector: read known accounts
+                        // from the shared registry, applying cadence filtering.
+                        let known = self.known_accounts.as_ref()
+                            .map(|reg| reg.read().unwrap().clone())
+                            .unwrap_or_default();
+
+                        for (program_name, type_groups) in &known {
+                            for (acct_type, addresses) in type_groups {
+                                if addresses.is_empty() {
+                                    continue;
+                                }
+
+                                // Apply cadence filtering
+                                let key = (program_name.clone(), acct_type.clone());
+                                if let Some(cadence) = self.cadence_map.get(&key) {
+                                    let should_read = match cadence {
+                                        AccountReadCadence::EverySlot => true,
+                                        AccountReadCadence::EveryNSlots(n) => {
+                                            let last = last_read_slot
+                                                .get(&key)
+                                                .copied()
+                                                .unwrap_or(0);
+                                            trigger.slot >= last + n
+                                        }
+                                        AccountReadCadence::Duration { seconds } => {
+                                            if let Some(block_time) = trigger.block_time {
+                                                let last = last_read_time
+                                                    .get(&key)
+                                                    .copied()
+                                                    .unwrap_or(0);
+                                                block_time >= last + (*seconds as i64)
+                                            } else {
+                                                true
+                                            }
+                                        }
+                                    };
+                                    if !should_read {
+                                        continue;
+                                    }
+                                }
+
+                                tracing::debug!(
+                                    slot = trigger.slot,
+                                    source = %program_name,
+                                    account_type = %acct_type,
+                                    count = addresses.len(),
+                                    "Reading known accounts for slot",
+                                );
+
+                                if let Err(e) = self
+                                    .read_and_decode_accounts(
+                                        trigger.slot,
+                                        trigger.block_time,
+                                        program_name,
+                                        addresses,
+                                        &account_states_tx,
+                                    )
+                                    .await
+                                {
+                                    had_error = true;
+                                    tracing::error!(
+                                        slot = trigger.slot,
+                                        source = %program_name,
+                                        error = %e,
+                                        "Failed to read known accounts",
+                                    );
+                                } else {
+                                    last_read_slot.insert(key.clone(), trigger.slot);
+                                    if let Some(bt) = trigger.block_time {
+                                        last_read_time.insert(key, bt);
+                                    }
+                                }
+                            }
+                        }
+
+                        // When discovery can enqueue post-decode reads for a
+                        // live slot, defer account-complete to the
+                        // mark_complete_only trigger sent after the discovery
+                        // loop has processed that slot.
+                        if self.defer_account_completion {
+                            if had_error {
+                                failed_slots.insert(trigger.slot);
+                            }
+                            continue;
+                        }
+                    } else {
+                        // Explicit trigger: discovery (Once), OnEvents, or
+                        // event-driven reads with specific addresses.
+                        tracing::debug!(
+                            slot = trigger.slot,
+                            source = %trigger.source_name,
+                            count = trigger.addresses.len(),
+                            "Processing account read trigger",
+                        );
+
+                        if let Err(e) = self
+                            .read_and_decode_accounts(
+                                trigger.slot,
+                                trigger.block_time,
+                                &trigger.source_name,
+                                &trigger.addresses,
+                                &account_states_tx,
+                            )
+                            .await
+                        {
+                            had_error = true;
+                            tracing::error!(
+                                slot = trigger.slot,
+                                source = %trigger.source_name,
+                                error = %e,
+                                "Failed to read triggered accounts",
+                            );
+                        }
+
+                        // Discovery-triggered explicit reads participate in
+                        // the same deferred completion barrier. Record failure
+                        // for the later mark_complete_only handler, then
+                        // continue to the next trigger without marking the
+                        // slot complete here.
+                        if self.defer_account_completion {
+                            if had_error {
+                                failed_slots.insert(trigger.slot);
+                            }
+                            continue;
+                        }
+                    }
+
+                    if had_error {
+                        tracing::warn!(
+                            slot = trigger.slot,
+                            "Skipping account completion for slot due to read errors",
+                        );
+                        continue;
+                    }
+
+                    // Mark slot status and signal completion.
+                    if let Err(e) = self.storage.update_status_atomic(trigger.slot, |s| {
+                        s.accounts_read = true;
+                        s.accounts_decoded = true;
+                    }) {
+                        tracing::warn!(
+                            slot = trigger.slot,
+                            error = %e,
+                            "Failed to update account status (slot may be skipped or deleted)",
+                        );
+                    }
+
+                    let complete_msg = RangeCompleteMessage {
+                        range_start: trigger.slot,
+                        range_end: trigger.slot + 1,
+                        kind: RangeCompleteKind::AccountStates,
+                    };
+                    if let Err(e) = account_complete_tx.send(complete_msg).await {
+                        // Same as above — dropped receiver is the expected
+                        // steady state when no transformation engine runs.
+                        tracing::debug!(
+                            slot = trigger.slot,
+                            error = %e,
+                            "Account-complete channel has no consumer (receiver dropped)",
+                        );
+                    }
+                }
+
+                else => {
+                    tracing::info!("All account reader channels closed, shutting down");
+                    break;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Fetch, store, decode, and forward account states for a batch of
+    /// addresses.
+    ///
+    /// 1. Chunks `addresses` into batches of `self.batch_size` (100).
+    /// 2. Calls `rpc_client.get_multiple_accounts` for each chunk.
+    /// 3. Builds `LiveAccountRead` records and writes them to storage.
+    /// 4. Decodes each account via `account_decoder.decode_account`.
+    /// 5. Groups decoded states by `account_type`.
+    /// 6. Sends a `DecodedAccountStatesMessage` per group.
+    async fn read_and_decode_accounts(
+        &self,
+        slot: u64,
+        block_time: Option<i64>,
+        source_name: &str,
+        addresses: &[[u8; 32]],
+        account_states_tx: &mpsc::Sender<DecodedAccountStatesMessage>,
+    ) -> Result<(), AccountReaderError> {
+        let mut all_reads: Vec<LiveAccountRead> = Vec::new();
+        let mut decoded_by_type: HashMap<
+            String,
+            Vec<crate::transformations::context::DecodedAccountState>,
+        > = HashMap::new();
+
+        for chunk in addresses.chunks(self.batch_size) {
+            // Convert [u8; 32] to Pubkey for the RPC call.
+            let pubkeys: Vec<Pubkey> = chunk
+                .iter()
+                .map(|bytes| Pubkey::new_from_array(*bytes))
+                .collect();
+
+            let accounts = self.rpc_client.get_multiple_accounts(&pubkeys).await?;
+
+            for (i, maybe_account) in accounts.into_iter().enumerate() {
+                let address_bytes = chunk[i];
+
+                let account = match maybe_account {
+                    Some(a) => a,
+                    None => {
+                        tracing::trace!(
+                            address = hex::encode(address_bytes),
+                            slot,
+                            "Account not found on chain, skipping",
+                        );
+                        continue;
+                    }
+                };
+
+                let owner_bytes = account.owner.to_bytes();
+
+                // Build raw read for storage.
+                let live_read = LiveAccountRead {
+                    slot,
+                    block_time,
+                    account_address: address_bytes,
+                    owner: owner_bytes,
+                    data: account.data.clone(),
+                    lamports: account.lamports,
+                    executable: account.executable,
+                };
+                all_reads.push(live_read);
+
+                // Resolve a human-readable source name: prefer the trigger's
+                // source_name, fall back to program_names map.
+                let effective_source = if !source_name.is_empty() {
+                    source_name.to_string()
+                } else {
+                    self.program_names
+                        .get(&owner_bytes)
+                        .cloned()
+                        .unwrap_or_else(|| hex::encode(owner_bytes))
+                };
+
+                // Decode the account data.
+                if let Some(decoded) = self.account_decoder.decode_account(
+                    owner_bytes,
+                    address_bytes,
+                    &account.data,
+                    slot,
+                    block_time,
+                    &effective_source,
+                ) {
+                    decoded_by_type
+                        .entry(decoded.account_type.clone())
+                        .or_default()
+                        .push(decoded);
+                }
+            }
+        }
+
+        // Persist raw reads to live storage.
+        if !all_reads.is_empty() {
+            self.storage.write_accounts(slot, &all_reads)?;
+
+            tracing::debug!(
+                slot,
+                source = %source_name,
+                raw_reads = all_reads.len(),
+                decoded_types = decoded_by_type.len(),
+                "Account reads complete",
+            );
+        }
+
+        // Send decoded states downstream, grouped by account_type.
+        for (account_type, states) in decoded_by_type {
+            let msg = DecodedAccountStatesMessage {
+                range_start: slot,
+                range_end: slot + 1,
+                source_name: source_name.to_string(),
+                account_type,
+                account_states: states,
+            };
+
+            if let Err(e) = account_states_tx.send(msg).await {
+                // Expected when no transformation engine is wired: the
+                // pipeline stubs this sender with a dropped receiver to
+                // prevent the reader from blocking.
+                tracing::debug!(
+                    slot,
+                    source = %source_name,
+                    error = %e,
+                    "Account-states channel has no consumer (receiver dropped)",
+                );
+                break; // No point sending more to a closed channel
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/solana/live/accounts.rs
+++ b/src/solana/live/accounts.rs
@@ -97,6 +97,10 @@ impl SolanaLiveAccountReader {
         }
     }
 
+    fn should_defer_explicit_trigger_completion(&self, trigger: &AccountReadTrigger) -> bool {
+        self.defer_account_completion && trigger.await_completion_barrier
+    }
+
     /// Main event loop.
     ///
     /// Listens on two channels:
@@ -325,12 +329,11 @@ impl SolanaLiveAccountReader {
                             );
                         }
 
-                        // Discovery-triggered explicit reads participate in
-                        // the same deferred completion barrier. Record failure
-                        // for the later mark_complete_only handler, then
-                        // continue to the next trigger without marking the
-                        // slot complete here.
-                        if self.defer_account_completion {
+                        // Discovery-managed explicit reads participate in the
+                        // same deferred completion barrier. Startup Once reads
+                        // do not, even though they share the explicit-trigger
+                        // path.
+                        if self.should_defer_explicit_trigger_completion(&trigger) {
                             if had_error {
                                 failed_slots.insert(trigger.slot);
                             }
@@ -402,8 +405,8 @@ impl SolanaLiveAccountReader {
         account_states_tx: &mpsc::Sender<DecodedAccountStatesMessage>,
     ) -> Result<(), AccountReaderError> {
         let mut all_reads: Vec<LiveAccountRead> = Vec::new();
-        let mut decoded_by_type: HashMap<
-            String,
+        let mut decoded_by_source_and_type: HashMap<
+            (String, String),
             Vec<crate::transformations::context::DecodedAccountState>,
         > = HashMap::new();
 
@@ -465,8 +468,8 @@ impl SolanaLiveAccountReader {
                     block_time,
                     &effective_source,
                 ) {
-                    decoded_by_type
-                        .entry(decoded.account_type.clone())
+                    decoded_by_source_and_type
+                        .entry((effective_source.clone(), decoded.account_type.clone()))
                         .or_default()
                         .push(decoded);
                 }
@@ -481,17 +484,17 @@ impl SolanaLiveAccountReader {
                 slot,
                 source = %source_name,
                 raw_reads = all_reads.len(),
-                decoded_types = decoded_by_type.len(),
+                decoded_types = decoded_by_source_and_type.len(),
                 "Account reads complete",
             );
         }
 
-        // Send decoded states downstream, grouped by account_type.
-        for (account_type, states) in decoded_by_type {
+        // Send decoded states downstream, grouped by (effective_source, account_type).
+        for ((effective_source, account_type), states) in decoded_by_source_and_type {
             let msg = DecodedAccountStatesMessage {
                 range_start: slot,
                 range_end: slot + 1,
-                source_name: source_name.to_string(),
+                source_name: effective_source,
                 account_type,
                 account_states: states,
             };
@@ -511,5 +514,60 @@ impl SolanaLiveAccountReader {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_reader(defer_account_completion: bool) -> SolanaLiveAccountReader {
+        SolanaLiveAccountReader::new(
+            Arc::new(
+                SolanaRpcClient::new(
+                    "http://127.0.0.1:8899",
+                    crate::types::config::solana::SolanaCommitment::Confirmed,
+                    None,
+                    None,
+                )
+                .expect("rpc client"),
+            ),
+            Arc::new(SolanaAccountDecoder::new(Vec::new())),
+            SolanaLiveStorage::with_base_dir(
+                std::env::temp_dir().join("solana-live-account-reader-tests"),
+            ),
+            Arc::new(HashMap::new()),
+            None,
+            HashMap::new(),
+            defer_account_completion,
+        )
+    }
+
+    #[test]
+    fn explicit_trigger_completion_respects_barrier_flag() {
+        let reader = make_reader(true);
+        let startup_trigger = AccountReadTrigger {
+            slot: 42,
+            block_time: Some(1_700_000_123),
+            source_name: "program".to_string(),
+            addresses: vec![[0xAA; 32]],
+            await_completion_barrier: false,
+            mark_complete_only: false,
+        };
+        let discovery_trigger = AccountReadTrigger {
+            await_completion_barrier: true,
+            ..AccountReadTrigger {
+                slot: 42,
+                block_time: Some(1_700_000_123),
+                source_name: "program".to_string(),
+                addresses: vec![[0xBB; 32]],
+                await_completion_barrier: false,
+                mark_complete_only: false,
+            }
+        };
+
+        assert!(!reader.should_defer_explicit_trigger_completion(&startup_trigger));
+        assert!(reader.should_defer_explicit_trigger_completion(&discovery_trigger));
+        assert!(!make_reader(false).should_defer_explicit_trigger_completion(&discovery_trigger));
     }
 }

--- a/src/solana/live/catchup.rs
+++ b/src/solana/live/catchup.rs
@@ -1,0 +1,911 @@
+//! Solana live catchup service — restart recovery for incomplete slots.
+//!
+//! On restart, live mode may have slots that were partially processed:
+//! - Slots collected but block not fetched (collector crashed early)
+//! - Slots fetched but events/instructions not extracted
+//! - Slots extracted but not decoded
+//! - Slots decoded but not transformed (some handlers ran, others didn't)
+//!
+//! This service scans storage for incomplete slots and categorises them
+//! into resume buckets so the caller can replay each slot through the
+//! appropriate pipeline stage.
+
+use std::collections::HashSet;
+
+use crate::live::bincode_io::StorageError;
+
+use super::storage::SolanaLiveStorage;
+use super::types::{LiveSlotStatus, SolanaLivePipelineExpectations};
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// Which collection stage a slot needs to resume from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SlotCollectionResumeStage {
+    /// Block data was never fetched — restart from `getBlock`.
+    FetchBlock,
+    /// Block was fetched but events/instructions were not extracted.
+    ExtractEventsAndInstructions,
+}
+
+/// A single slot that needs collection resumed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SlotCollectionResumeRequest {
+    pub slot: u64,
+    pub stage: SlotCollectionResumeStage,
+}
+
+/// Aggregated result of scanning for incomplete slots.
+#[derive(Debug, Default)]
+pub struct SolanaCatchupScanResult {
+    /// Slots that need collection resumed from a specific stage.
+    pub slots_needing_collection_resume: Vec<SlotCollectionResumeRequest>,
+    /// Slots that need event decoding (events extracted but not decoded).
+    pub slots_needing_event_decode: Vec<u64>,
+    /// Slots that need instruction decoding (instructions extracted but not decoded).
+    pub slots_needing_instruction_decode: Vec<u64>,
+    /// Slots that need account reads (block fetched but accounts not read).
+    pub slots_needing_account_reads: Vec<u64>,
+    /// Slots that need transformation, with the set of handlers still pending.
+    /// `(slot, missing_handler_keys)`
+    pub slots_needing_transform: Vec<(u64, HashSet<String>)>,
+}
+
+impl SolanaCatchupScanResult {
+    /// Check if any catchup work is needed.
+    pub fn is_empty(&self) -> bool {
+        self.slots_needing_collection_resume.is_empty()
+            && self.slots_needing_event_decode.is_empty()
+            && self.slots_needing_instruction_decode.is_empty()
+            && self.slots_needing_account_reads.is_empty()
+            && self.slots_needing_transform.is_empty()
+    }
+
+    /// Total number of unique slots needing some form of catchup.
+    pub fn total_slots(&self) -> usize {
+        let mut slots: HashSet<u64> = HashSet::new();
+        slots.extend(
+            self.slots_needing_collection_resume
+                .iter()
+                .map(|req| req.slot),
+        );
+        slots.extend(&self.slots_needing_event_decode);
+        slots.extend(&self.slots_needing_instruction_decode);
+        slots.extend(&self.slots_needing_account_reads);
+        slots.extend(self.slots_needing_transform.iter().map(|(s, _)| *s));
+        slots.len()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Catchup service
+// ---------------------------------------------------------------------------
+
+/// Service for catching up incomplete slots on restart.
+///
+/// Parallels the EVM `LiveCatchupService` but operates on Solana slot
+/// status fields (`events_extracted`, `instructions_extracted`, etc.)
+/// instead of EVM-specific ones (`receipts_collected`, `logs_collected`).
+pub struct SolanaLiveCatchupService {
+    storage: SolanaLiveStorage,
+    /// Handler keys that should be complete for a slot to be considered done.
+    registered_handlers: HashSet<String>,
+    /// Runtime expectations for optional pipeline stages.
+    expectations: SolanaLivePipelineExpectations,
+}
+
+impl SolanaLiveCatchupService {
+    /// Create a new catchup service.
+    pub fn new(
+        chain_name: &str,
+        registered_handlers: HashSet<String>,
+        expectations: SolanaLivePipelineExpectations,
+    ) -> Self {
+        Self {
+            storage: SolanaLiveStorage::new(chain_name),
+            registered_handlers,
+            expectations,
+        }
+    }
+
+    /// Scan all stored slots and categorise incomplete ones into resume
+    /// buckets.
+    ///
+    /// For each slot that has a status file:
+    /// 1. Check collection completeness (block fetched, events/instructions
+    ///    extracted). If incomplete, add to `slots_needing_collection_resume`
+    ///    and skip further checks (earlier stages must complete first).
+    /// 2. Check decode completeness per expectation flags.
+    /// 3. Check account-read completeness.
+    /// 4. Check transformation completeness.
+    pub fn scan_incomplete_slots(&self) -> Result<SolanaCatchupScanResult, StorageError> {
+        let mut result = SolanaCatchupScanResult::default();
+
+        let slots = self.storage.list_slots()?;
+        if slots.is_empty() {
+            tracing::debug!("Catchup scan: no slots in storage");
+            return Ok(result);
+        }
+
+        tracing::debug!(
+            "Catchup scan: checking {} slots ({} to {})",
+            slots.len(),
+            slots.first().unwrap_or(&0),
+            slots.last().unwrap_or(&0),
+        );
+
+        for slot in slots {
+            let status = match self.storage.read_status(slot) {
+                Ok(s) => s,
+                Err(StorageError::NotFound(_)) => {
+                    tracing::warn!(slot, "Slot has data but no status file, skipping catchup",);
+                    continue;
+                }
+                Err(e) => return Err(e),
+            };
+
+            // 1. Collection resume — if the slot hasn't finished collection,
+            //    it needs to restart from the earliest incomplete stage.
+            if let Some(stage) = self.collection_resume_stage(&status) {
+                result
+                    .slots_needing_collection_resume
+                    .push(SlotCollectionResumeRequest { slot, stage });
+
+                // If we need to re-fetch the block, skip further checks.
+                // If we need to re-extract, we can still check decode for
+                // events/instructions that were already extracted in a
+                // previous partial run — but for simplicity we skip.
+                continue;
+            }
+
+            // 2. Event decode
+            if self.expectations.expect_event_decode && !status.events_decoded {
+                result.slots_needing_event_decode.push(slot);
+            }
+
+            // 3. Instruction decode
+            if self.expectations.expect_instruction_decode && !status.instructions_decoded {
+                result.slots_needing_instruction_decode.push(slot);
+            }
+
+            // 4. Account reads
+            if self.expectations.expect_account_reads
+                && (!status.accounts_read || !status.accounts_decoded)
+            {
+                result.slots_needing_account_reads.push(slot);
+            }
+
+            // 5. Transformation
+            if self.expectations.expect_transformations
+                && status.transform_inputs_ready_with(&self.expectations)
+                && !status.transformed
+            {
+                let missing = self.get_missing_handlers(&status);
+                if !missing.is_empty() {
+                    result.slots_needing_transform.push((slot, missing));
+                }
+            }
+        }
+
+        // Sort all buckets in ascending slot order.
+        result
+            .slots_needing_collection_resume
+            .sort_unstable_by_key(|req| req.slot);
+        result.slots_needing_event_decode.sort_unstable();
+        result.slots_needing_instruction_decode.sort_unstable();
+        result.slots_needing_account_reads.sort_unstable();
+        result
+            .slots_needing_transform
+            .sort_unstable_by_key(|(s, _)| *s);
+
+        Ok(result)
+    }
+
+    /// Determine which collection stage a slot needs to resume from, if any.
+    ///
+    /// Returns `None` when collection is complete (block fetched, events and
+    /// instructions extracted).
+    pub fn collection_resume_stage(
+        &self,
+        status: &LiveSlotStatus,
+    ) -> Option<SlotCollectionResumeStage> {
+        if !status.block_fetched {
+            return Some(SlotCollectionResumeStage::FetchBlock);
+        }
+
+        if !status.events_extracted || !status.instructions_extracted {
+            return Some(SlotCollectionResumeStage::ExtractEventsAndInstructions);
+        }
+
+        None
+    }
+
+    /// Return the set of registered handler keys that have *not* yet
+    /// completed for the given slot status.
+    pub fn get_missing_handlers(&self, status: &LiveSlotStatus) -> HashSet<String> {
+        self.registered_handlers
+            .difference(&status.completed_handlers)
+            .cloned()
+            .collect()
+    }
+
+    /// Reconstruct missing status files by inspecting which data files exist
+    /// for each slot.
+    ///
+    /// Walks `raw/slots/` to enumerate slot numbers, then for each slot
+    /// that is missing a status file, checks for the presence of other data
+    /// files (events, instructions, accounts) and builds a best-effort status.
+    ///
+    /// Returns the number of status files reconstructed.
+    pub fn reconstruct_missing_status_files(&self) -> Result<usize, StorageError> {
+        let slots = self.storage.list_slots()?;
+        let mut reconstructed = 0;
+
+        for slot in slots {
+            // Skip slots that already have a status file.
+            match self.storage.read_status(slot) {
+                Ok(_) => continue,
+                Err(StorageError::NotFound(_)) => { /* needs reconstruction */ }
+                Err(e) => return Err(e),
+            }
+
+            let status = self.reconstruct_status(slot)?;
+            self.storage.write_status(slot, &status)?;
+
+            tracing::info!(
+                slot,
+                collected = status.collected,
+                block_fetched = status.block_fetched,
+                events_extracted = status.events_extracted,
+                instructions_extracted = status.instructions_extracted,
+                events_decoded = status.events_decoded,
+                instructions_decoded = status.instructions_decoded,
+                accounts_read = status.accounts_read,
+                transformed = status.transformed,
+                "Reconstructed status file for slot",
+            );
+
+            reconstructed += 1;
+        }
+
+        if reconstructed > 0 {
+            tracing::info!(
+                count = reconstructed,
+                "Reconstructed missing status files from local storage",
+            );
+        }
+
+        Ok(reconstructed)
+    }
+
+    /// Build a `LiveSlotStatus` from data-file presence.
+    fn reconstruct_status(&self, slot: u64) -> Result<LiveSlotStatus, StorageError> {
+        let mut status = LiveSlotStatus::default();
+
+        // If we have a slot file at all, collection happened.
+        let slot_exists = self.storage.slot_exists(slot);
+        if slot_exists {
+            status.collected = true;
+            // If the slot file exists, the block was fetched (the collector
+            // writes the slot file after a successful getBlock).
+            status.block_fetched = true;
+        }
+
+        // Check for extracted raw data.
+        let events_exist = self.storage.read_events(slot).is_ok();
+        let instructions_exist = self.storage.read_instructions(slot).is_ok();
+        let accounts_exist = self.storage.read_accounts(slot).is_ok();
+
+        if events_exist {
+            status.events_extracted = true;
+        }
+        if instructions_exist {
+            status.instructions_extracted = true;
+        }
+
+        // Check for decoded data presence.
+        let decoded_events_exist = !self.storage.list_decoded_types("events", slot)?.is_empty();
+        let decoded_instructions_exist = !self
+            .storage
+            .list_decoded_types("instructions", slot)?
+            .is_empty();
+        let decoded_accounts_exist = !self
+            .storage
+            .list_decoded_types("accounts", slot)?
+            .is_empty();
+
+        // If events are empty (or decoded data exists), mark decoded.
+        let events_empty = events_exist
+            && self
+                .storage
+                .read_events(slot)
+                .map(|e| e.is_empty())
+                .unwrap_or(false);
+        if decoded_events_exist || !events_exist || events_empty {
+            status.events_decoded = true;
+        }
+
+        let instructions_empty = instructions_exist
+            && self
+                .storage
+                .read_instructions(slot)
+                .map(|i| i.is_empty())
+                .unwrap_or(false);
+        if decoded_instructions_exist || !instructions_exist || instructions_empty {
+            status.instructions_decoded = true;
+        }
+
+        // Account reads
+        if accounts_exist || decoded_accounts_exist {
+            status.accounts_read = true;
+        }
+        let accounts_empty = accounts_exist
+            && self
+                .storage
+                .read_accounts(slot)
+                .map(|a| a.is_empty())
+                .unwrap_or(false);
+        if decoded_accounts_exist || !accounts_exist || accounts_empty {
+            status.accounts_decoded = true;
+        }
+
+        // Apply expectation flags so disabled stages don't block completeness.
+        status.apply_expectations(&self.expectations);
+
+        // Transformation: if all decode inputs are ready and no handlers are
+        // registered, mark as transformed.
+        if status.transform_inputs_ready_with(&self.expectations) {
+            if !self.expectations.expect_transformations || self.registered_handlers.is_empty() {
+                status.transformed = true;
+            }
+        }
+
+        Ok(status)
+    }
+
+    /// Get the underlying storage reference (for external replay logic).
+    #[allow(dead_code)]
+    pub fn storage(&self) -> &SolanaLiveStorage {
+        &self.storage
+    }
+}
+
+// =========================================================================
+// Tests
+// =========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::solana::live::types::LiveSlot;
+    use tempfile::TempDir;
+
+    /// Create a test storage and catchup service with the given expectations.
+    fn test_setup(
+        handlers: HashSet<String>,
+        expectations: SolanaLivePipelineExpectations,
+    ) -> (SolanaLiveStorage, SolanaLiveCatchupService, TempDir) {
+        let tmp = TempDir::new().unwrap();
+        let storage = SolanaLiveStorage::with_base_dir(tmp.path().to_path_buf());
+        storage.ensure_dirs().unwrap();
+
+        let service = SolanaLiveCatchupService {
+            storage: SolanaLiveStorage::with_base_dir(tmp.path().to_path_buf()),
+            registered_handlers: handlers,
+            expectations,
+        };
+
+        (storage, service, tmp)
+    }
+
+    fn make_slot(slot: u64) -> LiveSlot {
+        LiveSlot {
+            slot,
+            block_time: Some(1_700_000_000),
+            block_height: Some(slot),
+            parent_slot: slot.saturating_sub(1),
+            blockhash: [0u8; 32],
+            previous_blockhash: [0u8; 32],
+            transaction_count: 5,
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // scan_incomplete_slots
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_scan_empty_storage() {
+        let (_storage, service, _tmp) = test_setup(
+            HashSet::from(["handler_a".to_string()]),
+            SolanaLivePipelineExpectations {
+                expect_event_decode: true,
+                ..Default::default()
+            },
+        );
+
+        let result = service.scan_incomplete_slots().unwrap();
+        assert!(result.is_empty());
+        assert_eq!(result.total_slots(), 0);
+    }
+
+    #[test]
+    fn test_scan_complete_slot() {
+        let (storage, service, _tmp) = test_setup(
+            HashSet::from(["handler_a".to_string()]),
+            SolanaLivePipelineExpectations {
+                expect_event_decode: true,
+                expect_instruction_decode: true,
+                expect_transformations: true,
+                ..Default::default()
+            },
+        );
+
+        storage.write_slot(100, &make_slot(100)).unwrap();
+
+        let mut status = LiveSlotStatus::collected();
+        status.block_fetched = true;
+        status.events_extracted = true;
+        status.instructions_extracted = true;
+        status.events_decoded = true;
+        status.instructions_decoded = true;
+        status.accounts_read = true;
+        status.accounts_decoded = true;
+        status.transformed = true;
+        status.completed_handlers.insert("handler_a".to_string());
+        storage.write_status(100, &status).unwrap();
+
+        let result = service.scan_incomplete_slots().unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_scan_needs_block_fetch() {
+        let (storage, service, _tmp) =
+            test_setup(HashSet::new(), SolanaLivePipelineExpectations::default());
+
+        storage.write_slot(200, &make_slot(200)).unwrap();
+
+        let mut status = LiveSlotStatus::collected();
+        // block_fetched is false by default
+        storage.write_status(200, &status).unwrap();
+
+        let result = service.scan_incomplete_slots().unwrap();
+        assert_eq!(result.slots_needing_collection_resume.len(), 1);
+        assert_eq!(
+            result.slots_needing_collection_resume[0],
+            SlotCollectionResumeRequest {
+                slot: 200,
+                stage: SlotCollectionResumeStage::FetchBlock,
+            }
+        );
+        // Should not appear in any other bucket.
+        assert!(result.slots_needing_event_decode.is_empty());
+        assert!(result.slots_needing_instruction_decode.is_empty());
+        assert!(result.slots_needing_transform.is_empty());
+    }
+
+    #[test]
+    fn test_scan_needs_extraction() {
+        let (storage, service, _tmp) =
+            test_setup(HashSet::new(), SolanaLivePipelineExpectations::default());
+
+        storage.write_slot(300, &make_slot(300)).unwrap();
+
+        let mut status = LiveSlotStatus::collected();
+        status.block_fetched = true;
+        // events_extracted and instructions_extracted are false
+        storage.write_status(300, &status).unwrap();
+
+        let result = service.scan_incomplete_slots().unwrap();
+        assert_eq!(result.slots_needing_collection_resume.len(), 1);
+        assert_eq!(
+            result.slots_needing_collection_resume[0].stage,
+            SlotCollectionResumeStage::ExtractEventsAndInstructions,
+        );
+    }
+
+    #[test]
+    fn test_scan_needs_event_decode() {
+        let (storage, service, _tmp) = test_setup(
+            HashSet::new(),
+            SolanaLivePipelineExpectations {
+                expect_event_decode: true,
+                ..Default::default()
+            },
+        );
+
+        storage.write_slot(400, &make_slot(400)).unwrap();
+
+        let mut status = LiveSlotStatus::collected();
+        status.block_fetched = true;
+        status.events_extracted = true;
+        status.instructions_extracted = true;
+        status.events_decoded = false;
+        status.apply_expectations(&SolanaLivePipelineExpectations {
+            expect_event_decode: true,
+            ..Default::default()
+        });
+        storage.write_status(400, &status).unwrap();
+
+        let result = service.scan_incomplete_slots().unwrap();
+        assert!(result.slots_needing_collection_resume.is_empty());
+        assert_eq!(result.slots_needing_event_decode, vec![400]);
+    }
+
+    #[test]
+    fn test_scan_needs_instruction_decode() {
+        let (storage, service, _tmp) = test_setup(
+            HashSet::new(),
+            SolanaLivePipelineExpectations {
+                expect_instruction_decode: true,
+                ..Default::default()
+            },
+        );
+
+        storage.write_slot(500, &make_slot(500)).unwrap();
+
+        let mut status = LiveSlotStatus::collected();
+        status.block_fetched = true;
+        status.events_extracted = true;
+        status.instructions_extracted = true;
+        status.instructions_decoded = false;
+        status.apply_expectations(&SolanaLivePipelineExpectations {
+            expect_instruction_decode: true,
+            ..Default::default()
+        });
+        storage.write_status(500, &status).unwrap();
+
+        let result = service.scan_incomplete_slots().unwrap();
+        assert!(result.slots_needing_collection_resume.is_empty());
+        assert_eq!(result.slots_needing_instruction_decode, vec![500]);
+    }
+
+    #[test]
+    fn test_scan_needs_account_reads() {
+        let (storage, service, _tmp) = test_setup(
+            HashSet::new(),
+            SolanaLivePipelineExpectations {
+                expect_account_reads: true,
+                ..Default::default()
+            },
+        );
+
+        storage.write_slot(600, &make_slot(600)).unwrap();
+
+        let mut status = LiveSlotStatus::collected();
+        status.block_fetched = true;
+        status.events_extracted = true;
+        status.instructions_extracted = true;
+        status.events_decoded = true;
+        status.instructions_decoded = true;
+        status.accounts_read = false;
+        status.accounts_decoded = false;
+        storage.write_status(600, &status).unwrap();
+
+        let result = service.scan_incomplete_slots().unwrap();
+        assert_eq!(result.slots_needing_account_reads, vec![600]);
+    }
+
+    #[test]
+    fn test_scan_needs_transform_missing_handler() {
+        let (storage, service, _tmp) = test_setup(
+            HashSet::from(["handler_a".to_string(), "handler_b".to_string()]),
+            SolanaLivePipelineExpectations {
+                expect_event_decode: true,
+                expect_instruction_decode: true,
+                expect_transformations: true,
+                ..Default::default()
+            },
+        );
+
+        storage.write_slot(700, &make_slot(700)).unwrap();
+
+        let mut status = LiveSlotStatus::collected();
+        status.block_fetched = true;
+        status.events_extracted = true;
+        status.instructions_extracted = true;
+        status.events_decoded = true;
+        status.instructions_decoded = true;
+        status.accounts_read = true;
+        status.accounts_decoded = true;
+        status.transformed = false;
+        status.completed_handlers.insert("handler_a".to_string());
+        storage.write_status(700, &status).unwrap();
+
+        let result = service.scan_incomplete_slots().unwrap();
+        assert!(result.slots_needing_collection_resume.is_empty());
+        assert!(result.slots_needing_event_decode.is_empty());
+        assert_eq!(result.slots_needing_transform.len(), 1);
+
+        let (slot_num, missing) = &result.slots_needing_transform[0];
+        assert_eq!(*slot_num, 700);
+        assert_eq!(missing.len(), 1);
+        assert!(missing.contains("handler_b"));
+    }
+
+    #[test]
+    fn test_scan_skips_missing_status() {
+        let (storage, service, _tmp) =
+            test_setup(HashSet::new(), SolanaLivePipelineExpectations::default());
+
+        // Write slot data but no status file.
+        storage.write_slot(800, &make_slot(800)).unwrap();
+
+        let result = service.scan_incomplete_slots().unwrap();
+        // Should be skipped entirely.
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_scan_ascending_order() {
+        let (storage, service, _tmp) =
+            test_setup(HashSet::new(), SolanaLivePipelineExpectations::default());
+
+        // Write slots out of order, all needing block fetch.
+        for &slot in &[903, 901, 902] {
+            storage.write_slot(slot, &make_slot(slot)).unwrap();
+            let status = LiveSlotStatus::collected();
+            storage.write_status(slot, &status).unwrap();
+        }
+
+        let result = service.scan_incomplete_slots().unwrap();
+        let slots: Vec<u64> = result
+            .slots_needing_collection_resume
+            .iter()
+            .map(|r| r.slot)
+            .collect();
+        assert_eq!(slots, vec![901, 902, 903]);
+    }
+
+    // -----------------------------------------------------------------------
+    // collection_resume_stage
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_collection_resume_stage_fetch_block() {
+        let (_, service, _tmp) = test_setup(HashSet::new(), Default::default());
+
+        let status = LiveSlotStatus::collected();
+        assert_eq!(
+            service.collection_resume_stage(&status),
+            Some(SlotCollectionResumeStage::FetchBlock),
+        );
+    }
+
+    #[test]
+    fn test_collection_resume_stage_extract() {
+        let (_, service, _tmp) = test_setup(HashSet::new(), Default::default());
+
+        let status = LiveSlotStatus {
+            collected: true,
+            block_fetched: true,
+            events_extracted: false,
+            instructions_extracted: false,
+            ..Default::default()
+        };
+        assert_eq!(
+            service.collection_resume_stage(&status),
+            Some(SlotCollectionResumeStage::ExtractEventsAndInstructions),
+        );
+    }
+
+    #[test]
+    fn test_collection_resume_stage_partial_extract() {
+        let (_, service, _tmp) = test_setup(HashSet::new(), Default::default());
+
+        // Events extracted but instructions not.
+        let status = LiveSlotStatus {
+            collected: true,
+            block_fetched: true,
+            events_extracted: true,
+            instructions_extracted: false,
+            ..Default::default()
+        };
+        assert_eq!(
+            service.collection_resume_stage(&status),
+            Some(SlotCollectionResumeStage::ExtractEventsAndInstructions),
+        );
+    }
+
+    #[test]
+    fn test_collection_resume_stage_complete() {
+        let (_, service, _tmp) = test_setup(HashSet::new(), Default::default());
+
+        let status = LiveSlotStatus {
+            collected: true,
+            block_fetched: true,
+            events_extracted: true,
+            instructions_extracted: true,
+            ..Default::default()
+        };
+        assert_eq!(service.collection_resume_stage(&status), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // get_missing_handlers
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_get_missing_handlers_all_missing() {
+        let (_, service, _tmp) = test_setup(
+            HashSet::from(["a".to_string(), "b".to_string(), "c".to_string()]),
+            Default::default(),
+        );
+
+        let status = LiveSlotStatus::default();
+        let missing = service.get_missing_handlers(&status);
+        assert_eq!(missing.len(), 3);
+    }
+
+    #[test]
+    fn test_get_missing_handlers_some_complete() {
+        let (_, service, _tmp) = test_setup(
+            HashSet::from(["a".to_string(), "b".to_string(), "c".to_string()]),
+            Default::default(),
+        );
+
+        let mut status = LiveSlotStatus::default();
+        status.completed_handlers.insert("a".to_string());
+        status.completed_handlers.insert("c".to_string());
+
+        let missing = service.get_missing_handlers(&status);
+        assert_eq!(missing.len(), 1);
+        assert!(missing.contains("b"));
+    }
+
+    #[test]
+    fn test_get_missing_handlers_all_complete() {
+        let (_, service, _tmp) = test_setup(HashSet::from(["x".to_string()]), Default::default());
+
+        let mut status = LiveSlotStatus::default();
+        status.completed_handlers.insert("x".to_string());
+
+        let missing = service.get_missing_handlers(&status);
+        assert!(missing.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // reconstruct_missing_status_files
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_reconstruct_no_missing_status() {
+        let (storage, service, _tmp) =
+            test_setup(HashSet::new(), SolanaLivePipelineExpectations::default());
+
+        storage.write_slot(100, &make_slot(100)).unwrap();
+        storage
+            .write_status(100, &LiveSlotStatus::collected())
+            .unwrap();
+
+        let count = service.reconstruct_missing_status_files().unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn test_reconstruct_missing_status_slot_only() {
+        let (storage, service, _tmp) =
+            test_setup(HashSet::new(), SolanaLivePipelineExpectations::default());
+
+        // Only the slot file exists — no status.
+        storage.write_slot(200, &make_slot(200)).unwrap();
+
+        let count = service.reconstruct_missing_status_files().unwrap();
+        assert_eq!(count, 1);
+
+        let status = storage.read_status(200).unwrap();
+        assert!(status.collected);
+        assert!(status.block_fetched);
+        // No events/instructions files, so extracted remains false.
+        assert!(!status.events_extracted);
+        assert!(!status.instructions_extracted);
+        // With default expectations (all disabled), decode + transform are true.
+        assert!(status.transformed);
+    }
+
+    #[test]
+    fn test_reconstruct_status_with_events_and_instructions() {
+        let (storage, service, _tmp) = test_setup(
+            HashSet::new(),
+            SolanaLivePipelineExpectations {
+                expect_event_decode: true,
+                expect_instruction_decode: true,
+                ..Default::default()
+            },
+        );
+
+        storage.write_slot(300, &make_slot(300)).unwrap();
+        // Write empty events and instructions (they exist but are empty).
+        storage.write_events(300, &[]).unwrap();
+        storage.write_instructions(300, &[]).unwrap();
+
+        let count = service.reconstruct_missing_status_files().unwrap();
+        assert_eq!(count, 1);
+
+        let status = storage.read_status(300).unwrap();
+        assert!(status.collected);
+        assert!(status.block_fetched);
+        assert!(status.events_extracted);
+        assert!(status.instructions_extracted);
+        // Events and instructions are empty, so decoded is true.
+        assert!(status.events_decoded);
+        assert!(status.instructions_decoded);
+    }
+
+    #[test]
+    fn test_reconstruct_status_with_accounts() {
+        let (storage, service, _tmp) = test_setup(
+            HashSet::new(),
+            SolanaLivePipelineExpectations {
+                expect_account_reads: true,
+                ..Default::default()
+            },
+        );
+
+        storage.write_slot(400, &make_slot(400)).unwrap();
+        storage.write_events(400, &[]).unwrap();
+        storage.write_instructions(400, &[]).unwrap();
+        // Write empty accounts.
+        storage.write_accounts(400, &[]).unwrap();
+
+        let count = service.reconstruct_missing_status_files().unwrap();
+        assert_eq!(count, 1);
+
+        let status = storage.read_status(400).unwrap();
+        assert!(status.accounts_read);
+        assert!(status.accounts_decoded);
+    }
+
+    #[test]
+    fn test_reconstruct_multiple_slots() {
+        let (storage, service, _tmp) =
+            test_setup(HashSet::new(), SolanaLivePipelineExpectations::default());
+
+        // Three slots, only one has a status file.
+        storage.write_slot(500, &make_slot(500)).unwrap();
+        storage.write_slot(501, &make_slot(501)).unwrap();
+        storage.write_slot(502, &make_slot(502)).unwrap();
+        storage
+            .write_status(501, &LiveSlotStatus::collected())
+            .unwrap();
+
+        let count = service.reconstruct_missing_status_files().unwrap();
+        assert_eq!(count, 2);
+
+        // 500 and 502 should have status now; 501 unchanged.
+        assert!(storage.read_status(500).is_ok());
+        assert!(storage.read_status(501).is_ok());
+        assert!(storage.read_status(502).is_ok());
+    }
+
+    // -----------------------------------------------------------------------
+    // SolanaCatchupScanResult helpers
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_scan_result_is_empty() {
+        let result = SolanaCatchupScanResult::default();
+        assert!(result.is_empty());
+        assert_eq!(result.total_slots(), 0);
+    }
+
+    #[test]
+    fn test_scan_result_total_slots_deduplicates() {
+        let result = SolanaCatchupScanResult {
+            slots_needing_collection_resume: vec![SlotCollectionResumeRequest {
+                slot: 100,
+                stage: SlotCollectionResumeStage::FetchBlock,
+            }],
+            slots_needing_event_decode: vec![100, 200],
+            slots_needing_instruction_decode: vec![200],
+            slots_needing_account_reads: vec![300],
+            slots_needing_transform: vec![(300, HashSet::from(["h".to_string()]))],
+        };
+        // Unique slots: 100, 200, 300
+        assert_eq!(result.total_slots(), 3);
+        assert!(!result.is_empty());
+    }
+}

--- a/src/solana/live/collector.rs
+++ b/src/solana/live/collector.rs
@@ -14,6 +14,8 @@ use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::{mpsc, Mutex};
 
+use solana_transaction_status::{EncodedTransaction, UiConfirmedBlock};
+
 use crate::decoding::DecoderMessage;
 use crate::live::bincode_io::StorageError;
 use crate::live::{LiveModeConfig, LiveProgressTracker};
@@ -25,7 +27,8 @@ use crate::transformations::engine::ReorgMessage;
 use super::reorg::{SolanaReorgDetector, SolanaReorgEvent};
 use super::storage::SolanaLiveStorage;
 use super::types::{
-    AccountReadTrigger, LiveSlot, LiveSlotStatus, SolanaLiveMessage, SolanaLivePipelineExpectations,
+    AccountReadTrigger, LiveSlot, LiveSlotStatus, LiveTransaction, SolanaLiveMessage,
+    SolanaLivePipelineExpectations,
 };
 
 // ---------------------------------------------------------------------------
@@ -274,7 +277,11 @@ impl SolanaLiveCollector {
                 status.block_fetched = true;
                 status.events_extracted = true;
                 status.instructions_extracted = true;
-                status.apply_expectations(&self.expectations);
+                status.events_decoded = true;
+                status.instructions_decoded = true;
+                status.accounts_read = true;
+                status.accounts_decoded = true;
+                status.transformed = true;
                 self.storage.write_status(slot, &status)?;
                 return Ok(());
             }
@@ -331,6 +338,11 @@ impl SolanaLiveCollector {
         // 9. Write events and instructions to storage
         self.storage.write_events(slot, &events)?;
         self.storage.write_instructions(slot, &instructions)?;
+
+        // 9b. Write transaction records so compaction can populate
+        //     transaction_signatures in the slots parquet.
+        let live_txs = extract_live_transactions(&block, slot);
+        self.storage.write_transactions(slot, &live_txs)?;
 
         // 10. Update status
         self.storage.update_status_atomic(slot, |s| {
@@ -427,6 +439,7 @@ impl SolanaLiveCollector {
                     block_time: slot_block_time,
                     source_name: String::new(),
                     addresses: Vec::new(),
+                    await_completion_barrier: false,
                     mark_complete_only: false,
                 })
                 .await;
@@ -624,6 +637,65 @@ impl SolanaLiveCollector {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/// Extract `LiveTransaction` records from a block for compaction-time signature lookup.
+fn extract_live_transactions(block: &UiConfirmedBlock, slot: u64) -> Vec<LiveTransaction> {
+    let transactions = match &block.transactions {
+        Some(txs) => txs,
+        None => return Vec::new(),
+    };
+    let block_time = block.block_time;
+    let mut result = Vec::with_capacity(transactions.len());
+
+    for encoded_tx in transactions {
+        let signature = match extract_signature(&encoded_tx.transaction) {
+            Some(s) => s,
+            None => continue,
+        };
+        let (is_err, err_msg, fee, compute_units_consumed, log_messages) =
+            match &encoded_tx.meta {
+                Some(meta) => {
+                    let is_err = meta.err.is_some();
+                    let err_msg = meta.err.as_ref().map(|e| e.to_string());
+                    let fee = meta.fee;
+                    let cu: Option<u64> = meta.compute_units_consumed.clone().into();
+                    let logs: Option<&Vec<String>> = meta.log_messages.as_ref().into();
+                    (is_err, err_msg, fee, cu, logs.cloned().unwrap_or_default())
+                }
+                None => (false, None, 0, None, Vec::new()),
+            };
+        result.push(LiveTransaction {
+            slot,
+            block_time,
+            signature,
+            is_err,
+            err_msg,
+            fee,
+            compute_units_consumed,
+            log_messages,
+            account_keys: Vec::new(),
+        });
+    }
+
+    result
+}
+
+fn extract_signature(encoded_tx: &EncodedTransaction) -> Option<[u8; 64]> {
+    if let Some(versioned_tx) = encoded_tx.decode() {
+        let sig = versioned_tx.signatures.first()?;
+        let mut out = [0u8; 64];
+        out.copy_from_slice(sig.as_ref());
+        return Some(out);
+    }
+    if let EncodedTransaction::Json(ui_tx) = encoded_tx {
+        let sig_str = ui_tx.signatures.first()?;
+        let sig: solana_sdk::signature::Signature = sig_str.parse().ok()?;
+        let mut out = [0u8; 64];
+        out.copy_from_slice(sig.as_ref());
+        return Some(out);
+    }
+    None
+}
 
 /// Parse a base58-encoded blockhash string into a 32-byte array.
 ///

--- a/src/solana/live/collector.rs
+++ b/src/solana/live/collector.rs
@@ -1,0 +1,692 @@
+//! Solana live slot collector that processes slots from WebSocket subscription.
+//!
+//! The collector:
+//! 1. Receives slot notifications from WebSocket subscription
+//! 2. Detects reorgs using parent-slot chain verification
+//! 3. Fetches full block data via RPC
+//! 4. Extracts events and instructions from transactions
+//! 5. Stores data in live storage format
+//! 6. Forwards to decoder channels
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use thiserror::Error;
+use tokio::sync::{mpsc, Mutex};
+
+use crate::decoding::DecoderMessage;
+use crate::live::bincode_io::StorageError;
+use crate::live::{LiveModeConfig, LiveProgressTracker};
+use crate::solana::raw_data::extraction::extract_events_and_instructions;
+use crate::solana::rpc::{SolanaRpcClient, SolanaRpcError};
+use crate::solana::ws::SolanaWsEvent;
+use crate::transformations::engine::ReorgMessage;
+
+use super::reorg::{SolanaReorgDetector, SolanaReorgEvent};
+use super::storage::SolanaLiveStorage;
+use super::types::{
+    AccountReadTrigger, LiveSlot, LiveSlotStatus, SolanaLiveMessage, SolanaLivePipelineExpectations,
+};
+
+// ---------------------------------------------------------------------------
+// Error
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Error)]
+pub enum SolanaCollectorError {
+    #[error("RPC error: {0}")]
+    Rpc(#[from] SolanaRpcError),
+    #[error("Storage error: {0}")]
+    Storage(#[from] StorageError),
+    #[error("Channel send error: {0}")]
+    ChannelSend(String),
+    #[error("WebSocket closed")]
+    WsClosed,
+}
+
+// ---------------------------------------------------------------------------
+// Collector
+// ---------------------------------------------------------------------------
+
+/// Collects live Solana slots from WebSocket and processes them.
+///
+/// Parallels the EVM `LiveCollector` but operates on Solana slots instead
+/// of EVM blocks, using parent-slot linkage for reorg detection and
+/// extracting events/instructions from on-chain transactions.
+pub struct SolanaLiveCollector {
+    chain_name: String,
+    rpc_client: Arc<SolanaRpcClient>,
+    storage: SolanaLiveStorage,
+    reorg_detector: SolanaReorgDetector,
+    config: LiveModeConfig,
+    configured_programs: HashSet<[u8; 32]>,
+    progress_tracker: Option<Arc<Mutex<LiveProgressTracker>>>,
+    expected_start_slot: Option<u64>,
+    expectations: SolanaLivePipelineExpectations,
+    /// Internal gaps discovered during catchup cleanup that must be
+    /// backfilled before the main WS loop begins.
+    startup_backfill_gaps: Vec<(u64, u64)>,
+}
+
+impl SolanaLiveCollector {
+    /// Create a new SolanaLiveCollector.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        chain_name: String,
+        rpc_client: Arc<SolanaRpcClient>,
+        storage: SolanaLiveStorage,
+        reorg_detector: SolanaReorgDetector,
+        config: LiveModeConfig,
+        configured_programs: HashSet<[u8; 32]>,
+        progress_tracker: Option<Arc<Mutex<LiveProgressTracker>>>,
+        expected_start_slot: Option<u64>,
+        expectations: SolanaLivePipelineExpectations,
+    ) -> Self {
+        Self {
+            chain_name,
+            rpc_client,
+            storage,
+            reorg_detector,
+            config,
+            configured_programs,
+            progress_tracker,
+            expected_start_slot,
+            expectations,
+            startup_backfill_gaps: Vec::new(),
+        }
+    }
+
+    /// Set internal gaps from catchup cleanup that need backfilling on startup.
+    pub fn with_startup_backfill_gaps(mut self, gaps: Vec<(u64, u64)>) -> Self {
+        self.startup_backfill_gaps = gaps;
+        self
+    }
+
+    /// Run the live collector.
+    ///
+    /// Listens for WebSocket slot events and processes each slot through the
+    /// full pipeline: fetch -> extract -> store -> forward to decoders.
+    pub async fn run(
+        mut self,
+        mut ws_rx: mpsc::UnboundedReceiver<SolanaWsEvent>,
+        live_tx: mpsc::Sender<SolanaLiveMessage>,
+        event_decoder_tx: Option<mpsc::Sender<DecoderMessage>>,
+        instr_decoder_tx: Option<mpsc::Sender<DecoderMessage>>,
+        transform_reorg_tx: Option<mpsc::Sender<ReorgMessage>>,
+        account_trigger_tx: Option<mpsc::Sender<AccountReadTrigger>>,
+    ) -> Result<(), SolanaCollectorError> {
+        // Ensure storage directories exist
+        self.storage.ensure_dirs()?;
+
+        // Seed reorg detector from existing storage on restart
+        self.seed_reorg_detector()?;
+
+        // Backfill internal gaps from catchup cleanup before entering the WS loop.
+        // These are holes created when incomplete slots were deleted during startup.
+        if !self.startup_backfill_gaps.is_empty() {
+            let gap_count: u64 = self
+                .startup_backfill_gaps
+                .iter()
+                .map(|(s, e)| e - s + 1)
+                .sum();
+            tracing::info!(
+                chain = %self.chain_name,
+                gaps = self.startup_backfill_gaps.len(),
+                total_slots = gap_count,
+                "Backfilling internal gaps from catchup cleanup",
+            );
+            let gaps = std::mem::take(&mut self.startup_backfill_gaps);
+            for (from, to) in gaps {
+                self.backfill_slots(
+                    from,
+                    to,
+                    &live_tx,
+                    &event_decoder_tx,
+                    &instr_decoder_tx,
+                    &transform_reorg_tx,
+                    &account_trigger_tx,
+                )
+                .await?;
+            }
+        }
+
+        tracing::info!(
+            chain = %self.chain_name,
+            reorg_depth = self.config.reorg_depth,
+            programs = self.configured_programs.len(),
+            "Solana live collector started",
+        );
+
+        while let Some(event) = ws_rx.recv().await {
+            match event {
+                SolanaWsEvent::NewSlot { slot, parent, .. } => {
+                    // Check for gap on first slot
+                    if let Some(expected) = self.expected_start_slot.take() {
+                        if slot > expected + 1 {
+                            tracing::warn!(
+                                chain = %self.chain_name,
+                                expected_next = expected + 1,
+                                received = slot,
+                                gap_size = slot - expected - 1,
+                                "Gap detected on first slot, backfilling",
+                            );
+                            self.backfill_slots(
+                                expected + 1,
+                                slot - 1,
+                                &live_tx,
+                                &event_decoder_tx,
+                                &instr_decoder_tx,
+                                &transform_reorg_tx,
+                                &account_trigger_tx,
+                            )
+                            .await?;
+                        }
+                    }
+
+                    if let Err(e) = self
+                        .process_slot(
+                            slot,
+                            parent,
+                            &live_tx,
+                            &event_decoder_tx,
+                            &instr_decoder_tx,
+                            &transform_reorg_tx,
+                            &account_trigger_tx,
+                        )
+                        .await
+                    {
+                        tracing::error!(
+                            chain = %self.chain_name,
+                            slot,
+                            error = %e,
+                            "Error processing slot",
+                        );
+                    }
+                }
+
+                SolanaWsEvent::Disconnected { .. } => {
+                    tracing::warn!(
+                        chain = %self.chain_name,
+                        "WebSocket disconnected",
+                    );
+                }
+
+                SolanaWsEvent::Reconnected {
+                    missed_from,
+                    missed_to,
+                } => {
+                    tracing::info!(
+                        chain = %self.chain_name,
+                        missed_from,
+                        missed_to,
+                        count = missed_to - missed_from + 1,
+                        "WebSocket reconnected, backfilling missed slots",
+                    );
+                    self.backfill_slots(
+                        missed_from,
+                        missed_to,
+                        &live_tx,
+                        &event_decoder_tx,
+                        &instr_decoder_tx,
+                        &transform_reorg_tx,
+                        &account_trigger_tx,
+                    )
+                    .await?;
+                }
+            }
+        }
+
+        tracing::info!(
+            chain = %self.chain_name,
+            "Solana live collector shutting down",
+        );
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // Slot processing
+    // -----------------------------------------------------------------------
+
+    /// Process a single slot through the full pipeline.
+    async fn process_slot(
+        &mut self,
+        slot: u64,
+        _parent_slot: u64,
+        live_tx: &mpsc::Sender<SolanaLiveMessage>,
+        event_decoder_tx: &Option<mpsc::Sender<DecoderMessage>>,
+        instr_decoder_tx: &Option<mpsc::Sender<DecoderMessage>>,
+        transform_reorg_tx: &Option<mpsc::Sender<ReorgMessage>>,
+        account_trigger_tx: &Option<mpsc::Sender<AccountReadTrigger>>,
+    ) -> Result<(), SolanaCollectorError> {
+        // 1. Fetch block
+        let block = self.rpc_client.get_block(slot).await?;
+
+        // 2. Skipped slot — mark as complete and return
+        let block = match block {
+            Some(b) => b,
+            None => {
+                tracing::debug!(
+                    chain = %self.chain_name,
+                    slot,
+                    "Slot was skipped, no block produced",
+                );
+                let mut status = LiveSlotStatus::collected();
+                status.block_fetched = true;
+                status.events_extracted = true;
+                status.instructions_extracted = true;
+                status.apply_expectations(&self.expectations);
+                self.storage.write_status(slot, &status)?;
+                return Ok(());
+            }
+        };
+
+        // 3. Parse blockhash to [u8; 32]
+        let blockhash_bytes = parse_blockhash(&block.blockhash);
+        let previous_blockhash_bytes = parse_blockhash(&block.previous_blockhash);
+
+        // 4. Check for reorg
+        if let Some(reorg_event) =
+            self.reorg_detector
+                .process_slot(slot, block.parent_slot, blockhash_bytes)
+        {
+            // 5. Handle reorg
+            self.handle_reorg(&reorg_event, live_tx, transform_reorg_tx)
+                .await?;
+        }
+
+        // 6. Build LiveSlot
+        let tx_count = block
+            .transactions
+            .as_ref()
+            .map(|txs| txs.len() as u32)
+            .unwrap_or(0);
+
+        let live_slot = LiveSlot {
+            slot,
+            block_time: block.block_time,
+            block_height: block.block_height,
+            parent_slot: block.parent_slot,
+            blockhash: blockhash_bytes,
+            previous_blockhash: previous_blockhash_bytes,
+            transaction_count: tx_count,
+        };
+
+        // 7. Write slot to storage and initial status
+        self.storage.write_slot(slot, &live_slot)?;
+        let mut status = LiveSlotStatus::collected();
+        status.block_fetched = true;
+        self.storage.write_status(slot, &status)?;
+
+        tracing::info!(
+            chain = %self.chain_name,
+            slot,
+            txs = tx_count,
+            "Slot collected",
+        );
+
+        // 8. Extract events and instructions
+        let (events, instructions) =
+            extract_events_and_instructions(&block, slot, &self.configured_programs);
+
+        // 9. Write events and instructions to storage
+        self.storage.write_events(slot, &events)?;
+        self.storage.write_instructions(slot, &instructions)?;
+
+        // 10. Update status
+        self.storage.update_status_atomic(slot, |s| {
+            s.events_extracted = true;
+            s.instructions_extracted = true;
+            s.apply_expectations(&self.expectations);
+        })?;
+
+        tracing::debug!(
+            chain = %self.chain_name,
+            slot,
+            events = events.len(),
+            instructions = instructions.len(),
+            "Events and instructions extracted",
+        );
+
+        // 11. Send slot to live message channel
+        let slot_block_time = live_slot.block_time;
+        if let Err(e) = live_tx.send(SolanaLiveMessage::Slot(live_slot)).await {
+            // Expected steady state when no live consumer is wired in
+            // (the receiver is intentionally dropped at pipeline setup to
+            // prevent the collector from blocking). Keep at debug to avoid
+            // log flooding in healthy runs.
+            tracing::debug!(
+                chain = %self.chain_name,
+                slot,
+                error = %e,
+                "Slot live channel has no consumer (receiver dropped)",
+            );
+        }
+
+        // 12. Forward events to event decoder
+        if let Some(decoder_tx) = event_decoder_tx {
+            if let Err(e) = decoder_tx
+                .send(DecoderMessage::SolanaEventsReady {
+                    range_start: slot,
+                    range_end: slot + 1,
+                    events,
+                    live_mode: true,
+                })
+                .await
+            {
+                tracing::warn!(
+                    chain = %self.chain_name,
+                    slot,
+                    error = %e,
+                    "Failed to send events to decoder (receiver dropped)",
+                );
+            }
+        }
+
+        // 13. Forward instructions to instruction decoder
+        if let Some(decoder_tx) = instr_decoder_tx {
+            if let Err(e) = decoder_tx
+                .send(DecoderMessage::SolanaInstructionsReady {
+                    range_start: slot,
+                    range_end: slot + 1,
+                    instructions,
+                    live_mode: true,
+                })
+                .await
+            {
+                tracing::warn!(
+                    chain = %self.chain_name,
+                    slot,
+                    error = %e,
+                    "Failed to send instructions to decoder (receiver dropped)",
+                );
+            }
+        }
+
+        // 14. If no decoders configured, mark decoded flags true immediately
+        if event_decoder_tx.is_none() {
+            self.storage.update_status_atomic(slot, |s| {
+                s.events_decoded = true;
+            })?;
+        }
+        if instr_decoder_tx.is_none() {
+            self.storage.update_status_atomic(slot, |s| {
+                s.instructions_decoded = true;
+            })?;
+        }
+
+        // 15. Trigger account reads for this slot. The account reader will
+        //     read all known addresses and mark accounts_read/accounts_decoded.
+        //     If there's no account reader, mark account flags directly so the
+        //     slot doesn't stay permanently incomplete.
+        if let Some(ref tx) = account_trigger_tx {
+            // Send an empty trigger — the reader reads per-slot known accounts
+            // from the shared registry, applying cadence filtering.
+            let _ = tx
+                .send(AccountReadTrigger {
+                    slot,
+                    block_time: slot_block_time,
+                    source_name: String::new(),
+                    addresses: Vec::new(),
+                    mark_complete_only: false,
+                })
+                .await;
+        } else if self.expectations.expect_account_reads {
+            // No account reader running; mark accounts complete directly
+            self.storage.update_status_atomic(slot, |s| {
+                s.accounts_read = true;
+                s.accounts_decoded = true;
+            })?;
+        }
+
+        // 16. If no handlers are registered, mark transformed=true
+        if let Some(ref tracker) = self.progress_tracker {
+            let guard = tracker.lock().await;
+            guard.mark_transformed_if_no_handlers(slot);
+            drop(guard);
+        }
+
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // Reorg handling
+    // -----------------------------------------------------------------------
+
+    /// Handle a detected reorg by cleaning up orphaned data and notifying
+    /// downstream consumers.
+    async fn handle_reorg(
+        &mut self,
+        event: &SolanaReorgEvent,
+        live_tx: &mpsc::Sender<SolanaLiveMessage>,
+        transform_reorg_tx: &Option<mpsc::Sender<ReorgMessage>>,
+    ) -> Result<(), SolanaCollectorError> {
+        tracing::warn!(
+            chain = %self.chain_name,
+            common_ancestor = event.common_ancestor,
+            orphaned = ?event.orphaned,
+            depth = event.depth,
+            is_deep = event.is_deep,
+            "Handling Solana reorg",
+        );
+
+        if event.is_deep {
+            tracing::error!(
+                chain = %self.chain_name,
+                new_slot = event.new_slot,
+                orphaned_count = event.orphaned.len(),
+                "DEEP REORG detected: reorg extends beyond retention window. \
+                 Orphaning all tracked slots as best-effort cleanup.",
+            );
+        }
+
+        // Delete storage for each orphaned slot
+        for &orphaned_slot in &event.orphaned {
+            if let Err(e) = self.storage.delete_all(orphaned_slot) {
+                tracing::warn!(
+                    chain = %self.chain_name,
+                    slot = orphaned_slot,
+                    error = %e,
+                    "Failed to delete orphaned slot data",
+                );
+            }
+        }
+
+        // Clear progress tracker for orphaned slots
+        if let Some(ref tracker) = self.progress_tracker {
+            let mut guard: tokio::sync::MutexGuard<'_, LiveProgressTracker> = tracker.lock().await;
+            for &orphaned_slot in &event.orphaned {
+                guard.clear_block(orphaned_slot);
+            }
+        }
+
+        // Notify live channel of reorg
+        if let Err(e) = live_tx
+            .send(SolanaLiveMessage::Reorg {
+                common_ancestor: event.common_ancestor,
+                orphaned: event.orphaned.clone(),
+            })
+            .await
+        {
+            // Same story as above: the live-channel receiver is
+            // intentionally dropped when no live consumer is wired.
+            tracing::debug!(
+                chain = %self.chain_name,
+                error = %e,
+                "Reorg live channel has no consumer (receiver dropped)",
+            );
+        }
+
+        // Notify transformation engine of reorg
+        if let Some(transform_tx) = transform_reorg_tx {
+            if let Err(e) = transform_tx
+                .send(ReorgMessage {
+                    common_ancestor: event.common_ancestor,
+                    orphaned: event.orphaned.clone(),
+                })
+                .await
+            {
+                tracing::warn!(
+                    chain = %self.chain_name,
+                    error = %e,
+                    "Failed to send reorg to transform engine (receiver dropped)",
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // Backfill
+    // -----------------------------------------------------------------------
+
+    /// Backfill a range of slots that were missed during a disconnect.
+    async fn backfill_slots(
+        &mut self,
+        from: u64,
+        to: u64,
+        live_tx: &mpsc::Sender<SolanaLiveMessage>,
+        event_decoder_tx: &Option<mpsc::Sender<DecoderMessage>>,
+        instr_decoder_tx: &Option<mpsc::Sender<DecoderMessage>>,
+        transform_reorg_tx: &Option<mpsc::Sender<ReorgMessage>>,
+        account_trigger_tx: &Option<mpsc::Sender<AccountReadTrigger>>,
+    ) -> Result<(), SolanaCollectorError> {
+        let count = to.saturating_sub(from) + 1;
+        tracing::info!(
+            chain = %self.chain_name,
+            from,
+            to,
+            count,
+            "Backfilling missed slots",
+        );
+
+        for slot in from..=to {
+            self.process_slot(
+                slot,
+                0,
+                live_tx,
+                event_decoder_tx,
+                instr_decoder_tx,
+                transform_reorg_tx,
+                account_trigger_tx,
+            )
+            .await?;
+        }
+
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // Startup
+    // -----------------------------------------------------------------------
+
+    /// Seed the reorg detector from recent slots in storage.
+    ///
+    /// Called on startup before the main loop so that reorg detection works
+    /// immediately for the first incoming slot, even if it forks from a slot
+    /// that was processed in a previous session.
+    fn seed_reorg_detector(&mut self) -> Result<(), SolanaCollectorError> {
+        match self
+            .storage
+            .get_recent_slots_for_reorg(self.config.reorg_depth)
+        {
+            Ok(recent) if !recent.is_empty() => {
+                tracing::info!(
+                    chain = %self.chain_name,
+                    count = recent.len(),
+                    "Seeding reorg detector from storage",
+                );
+                self.reorg_detector.seed(
+                    recent
+                        .into_iter()
+                        .map(|s| (s.slot, s.parent_slot, s.blockhash)),
+                );
+            }
+            Ok(_) => {
+                tracing::debug!(
+                    chain = %self.chain_name,
+                    "No recent slots in storage for reorg seeding",
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    chain = %self.chain_name,
+                    error = %e,
+                    "Failed to seed reorg detector from storage",
+                );
+            }
+        }
+
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Parse a base58-encoded blockhash string into a 32-byte array.
+///
+/// If decoding fails or produces fewer than 32 bytes, returns zeroed bytes
+/// for the remainder (defensive — should not happen with valid blockhashes).
+fn parse_blockhash(hash_str: &str) -> [u8; 32] {
+    let mut out = [0u8; 32];
+    match bs58::decode(hash_str).into_vec() {
+        Ok(bytes) => {
+            let len = bytes.len().min(32);
+            out[..len].copy_from_slice(&bytes[..len]);
+        }
+        Err(e) => {
+            tracing::warn!(
+                blockhash = hash_str,
+                error = %e,
+                "Failed to decode blockhash from base58",
+            );
+        }
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_blockhash_valid() {
+        // A known 32-byte value encoded as base58
+        let bytes = [0xAA; 32];
+        let encoded = bs58::encode(&bytes).into_string();
+        let decoded = parse_blockhash(&encoded);
+        assert_eq!(decoded, bytes);
+    }
+
+    #[test]
+    fn test_parse_blockhash_invalid() {
+        // Invalid base58 should return zeroes
+        let decoded = parse_blockhash("!!!invalid!!!");
+        assert_eq!(decoded, [0u8; 32]);
+    }
+
+    #[test]
+    fn test_parse_blockhash_short() {
+        // Shorter than 32 bytes should zero-pad
+        let bytes = [0xBB; 16];
+        let encoded = bs58::encode(&bytes).into_string();
+        let decoded = parse_blockhash(&encoded);
+        assert_eq!(&decoded[..16], &bytes[..]);
+        assert_eq!(&decoded[16..], &[0u8; 16]);
+    }
+
+    #[test]
+    fn test_error_display() {
+        let err = SolanaCollectorError::WsClosed;
+        assert_eq!(err.to_string(), "WebSocket closed");
+
+        let err = SolanaCollectorError::ChannelSend("test".into());
+        assert!(err.to_string().contains("test"));
+    }
+}

--- a/src/solana/live/compaction.rs
+++ b/src/solana/live/compaction.rs
@@ -21,11 +21,11 @@ use super::storage::SolanaLiveStorage;
 use super::types::SolanaLivePipelineExpectations;
 use crate::live::{LiveModeConfig, LiveProgressTracker, TransformRetryRequest};
 use crate::solana::raw_data::parquet::{
-    build_event_schema, build_instruction_schema, write_events_to_parquet,
-    write_instructions_to_parquet,
+    build_event_schema, build_instruction_schema, build_slot_schema, write_events_to_parquet,
+    write_instructions_to_parquet, write_slots_to_parquet,
 };
-use crate::solana::raw_data::types::{SolanaEventRecord, SolanaInstructionRecord};
-use crate::storage::paths::{raw_solana_events_dir, raw_solana_instructions_dir};
+use crate::solana::raw_data::types::{SolanaEventRecord, SolanaInstructionRecord, SolanaSlotRecord};
+use crate::storage::paths::{raw_solana_events_dir, raw_solana_instructions_dir, raw_solana_slots_dir};
 use crate::storage::skipped_slots;
 
 // ---------------------------------------------------------------------------
@@ -290,17 +290,40 @@ impl SolanaCompactionService {
         &self,
     ) -> Result<Vec<CompactableRange>, SolanaCompactionError> {
         let slots = self.storage.list_slots()?;
-        if slots.is_empty() {
+        let status_slots = self.storage.list_statuses()?;
+
+        if slots.is_empty() && status_slots.is_empty() {
             return Ok(Vec::new());
         }
 
         let range_size = self.config.range_size;
+        let slots_set: HashSet<u64> = slots.iter().copied().collect();
 
-        // Group slots by aligned range: range_start = (slot / range_size) * range_size
+        // Use max of all known slots (data + status-only) for the reorg boundary.
+        // Without this, ranges made entirely of skipped slots would have no
+        // data-slot max to compare against and would bypass the reorg check.
+        let latest_known = slots.iter().chain(status_slots.iter()).copied().max();
+
+        // Group data slots by aligned range.
         let mut ranges: BTreeMap<u64, Vec<u64>> = BTreeMap::new();
-        for slot_number in slots {
+        for &slot_number in &slots {
             let range_start = (slot_number / range_size) * range_size;
             ranges.entry(range_start).or_default().push(slot_number);
+        }
+
+        // Build a map of status-only (skipped) slots per range.  Ranges
+        // that have only skipped slots are inserted into `ranges` with an
+        // empty data-slot list so they become candidates below.
+        let mut status_only_by_range: BTreeMap<u64, Vec<u64>> = BTreeMap::new();
+        for &slot_number in &status_slots {
+            if !slots_set.contains(&slot_number) {
+                let range_start = (slot_number / range_size) * range_size;
+                status_only_by_range
+                    .entry(range_start)
+                    .or_default()
+                    .push(slot_number);
+                ranges.entry(range_start).or_default();
+            }
         }
 
         let mut compactable = Vec::new();
@@ -309,7 +332,7 @@ impl SolanaCompactionService {
         for (range_start, slot_numbers) in ranges {
             let range_end = range_start + range_size - 1;
 
-            // Check if all slots in this group are fully processed
+            // Check if all data slots in this range are fully processed.
             let mut all_complete = true;
             for &slot_number in &slot_numbers {
                 if let Ok(status) = self.storage.read_status(slot_number) {
@@ -322,10 +345,26 @@ impl SolanaCompactionService {
                     break;
                 }
 
-                // Check progress tracker
                 if !progress.is_block_complete(slot_number) {
                     all_complete = false;
                     break;
+                }
+            }
+
+            // Check status-only (skipped) slots in this range.  Skipped
+            // slots are not registered in the progress tracker, so we only
+            // check the persisted status file.
+            if all_complete {
+                if let Some(skipped) = status_only_by_range.get(&range_start) {
+                    for &slot_number in skipped {
+                        match self.storage.read_status(slot_number) {
+                            Ok(status) if status.is_complete_with(&self.expectations) => {}
+                            _ => {
+                                all_complete = false;
+                                break;
+                            }
+                        }
+                    }
                 }
             }
 
@@ -333,15 +372,15 @@ impl SolanaCompactionService {
                 continue;
             }
 
-            // Only compact ranges safely beyond reorg depth
-            if let Ok(Some(latest_slot)) = self.storage.max_slot_number() {
-                let safe_boundary = latest_slot.saturating_sub(self.config.reorg_depth);
+            // Only compact ranges safely beyond reorg depth.
+            if let Some(latest) = latest_known {
+                let safe_boundary = latest.saturating_sub(self.config.reorg_depth);
                 if range_end >= safe_boundary {
                     tracing::debug!(
                         chain = %self.chain_name,
                         range_start,
                         range_end,
-                        latest_slot,
+                        latest_slot = latest,
                         safe_boundary,
                         "Skipping Solana range: within reorg depth"
                     );
@@ -385,6 +424,7 @@ impl SolanaCompactionService {
 
         let mut all_events: Vec<SolanaEventRecord> = Vec::new();
         let mut all_instructions: Vec<SolanaInstructionRecord> = Vec::new();
+        let mut slot_records: Vec<SolanaSlotRecord> = Vec::new();
 
         for &slot_number in &slots_in_range {
             match self.storage.read_events(slot_number) {
@@ -418,6 +458,45 @@ impl SolanaCompactionService {
                 }
                 Err(e) => return Err(e.into()),
             }
+
+            // Build SolanaSlotRecord for the slots parquet.  Transactions are
+            // read for their signatures; if missing (e.g. events-only programs)
+            // the signatures list is left empty but the record is still written.
+            if let Ok(live_slot) = self.storage.read_slot(slot_number) {
+                let transaction_signatures: Vec<[u8; 64]> = self
+                    .storage
+                    .read_transactions(slot_number)
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|tx| tx.signature)
+                    .collect();
+                slot_records.push(SolanaSlotRecord {
+                    slot: live_slot.slot,
+                    block_time: live_slot.block_time,
+                    block_height: live_slot.block_height,
+                    parent_slot: live_slot.parent_slot,
+                    blockhash: live_slot.blockhash,
+                    previous_blockhash: live_slot.previous_blockhash,
+                    transaction_count: live_slot.transaction_count,
+                    transaction_signatures,
+                });
+            }
+        }
+
+        // Always write slots parquet so that find_resume_slot() can advance past
+        // this range on restart and collect_slots_selective() repair can merge
+        // unrepaired slot metadata.  The file is created even when empty (all
+        // slots in the range were skipped) to satisfy the parquet-existence check.
+        let slots_dir = raw_solana_slots_dir(&self.chain_name);
+        let slots_path = slots_dir.join(format!("{}-{}.parquet", range.start, range.end));
+        self.write_slots_parquet(&slot_records, &slots_path)?;
+        if !slot_records.is_empty() {
+            tracing::info!(
+                chain = %self.chain_name,
+                count = slot_records.len(),
+                path = %slots_path.display(),
+                "Wrote Solana slots parquet"
+            );
         }
 
         // Write events parquet to historical directory
@@ -517,6 +596,21 @@ impl SolanaCompactionService {
                 "Failed to write instructions parquet: {}",
                 e
             ))
+        })
+    }
+
+    /// Write slot records to a parquet file.
+    fn write_slots_parquet(
+        &self,
+        slots: &[SolanaSlotRecord],
+        path: &PathBuf,
+    ) -> Result<(), SolanaCompactionError> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let schema = build_slot_schema();
+        write_slots_to_parquet(slots, &schema, path).map_err(|e| {
+            SolanaCompactionError::ParquetWrite(format!("Failed to write slots parquet: {}", e))
         })
     }
 }
@@ -800,9 +894,12 @@ mod tests {
     #[tokio::test]
     async fn test_compact_range_empty_events_and_instructions() {
         let tmp = TempDir::new().unwrap();
-        let (service, expectations) = make_service(&tmp, 10);
+        let chain_name = "test-solana-empty-evt-instr";
+        let historical_dir = PathBuf::from(format!("data/{chain_name}"));
+        let _ = std::fs::remove_dir_all(&historical_dir);
 
-        // Create slots with empty events/instructions
+        let (service, expectations) = make_service_with_chain(&tmp, chain_name, 10);
+
         for i in 0..3 {
             let slot = make_slot(i);
             service.storage.write_slot(i, &slot).unwrap();
@@ -820,12 +917,160 @@ mod tests {
             slot_count: 3,
         };
 
-        // Should succeed without writing parquet (no data)
         service.compact_range(&range).await.unwrap();
 
-        // All slots should be cleaned up
+        // All live slots should be cleaned up
         let remaining = service.storage.list_slots().unwrap();
         assert!(remaining.is_empty());
+
+        // Slots parquet must exist even though events/instructions are empty
+        let slots_path = raw_solana_slots_dir(chain_name).join("0-9.parquet");
+        assert!(
+            slots_path.exists(),
+            "Slots parquet must be written for find_resume_slot to advance"
+        );
+
+        let _ = std::fs::remove_dir_all(&historical_dir);
+    }
+
+    #[tokio::test]
+    async fn test_compact_range_slots_parquet_has_correct_records() {
+        use crate::solana::raw_data::parquet::read_slots_from_parquet;
+
+        let tmp = TempDir::new().unwrap();
+        let chain_name = "test-solana-slots-parquet-records";
+        let historical_dir = PathBuf::from(format!("data/{chain_name}"));
+        let _ = std::fs::remove_dir_all(&historical_dir);
+
+        let (service, expectations) = make_service_with_chain(&tmp, chain_name, 10);
+
+        for i in 0..3u64 {
+            let slot = make_slot(i);
+            service.storage.write_slot(i, &slot).unwrap();
+            service
+                .storage
+                .write_status(i, &make_complete_status(&expectations))
+                .unwrap();
+            service.storage.write_events(i, &[]).unwrap();
+            service.storage.write_instructions(i, &[]).unwrap();
+        }
+
+        let range = CompactableRange {
+            start: 0,
+            end: 9,
+            slot_count: 3,
+        };
+        service.compact_range(&range).await.unwrap();
+
+        let slots_path = raw_solana_slots_dir(chain_name).join("0-9.parquet");
+        let records = read_slots_from_parquet(&slots_path).unwrap();
+        assert_eq!(records.len(), 3);
+        for (i, r) in records.iter().enumerate() {
+            assert_eq!(r.slot, i as u64);
+        }
+
+        let _ = std::fs::remove_dir_all(&historical_dir);
+    }
+
+    #[tokio::test]
+    async fn test_find_compactable_ranges_skipped_only() {
+        // Ranges composed entirely of skipped slots (status files only, no
+        // data files) must be discovered so their status dirs can be cleaned
+        // up and their skipped-slot markers reach skipped_slots.json.
+        let tmp = TempDir::new().unwrap();
+        let (service, expectations) = make_service(&tmp, 1); // range_size=1 triggers the bug
+
+        // Slots 5, 6, 7 are all skipped
+        for i in [5u64, 6, 7] {
+            let mut status = LiveSlotStatus::collected();
+            status.block_fetched = true;
+            status.events_extracted = true;
+            status.instructions_extracted = true;
+            status.apply_expectations(&expectations);
+            service.storage.write_status(i, &status).unwrap();
+        }
+
+        // A data slot far enough away that slots 5-7 are beyond reorg depth
+        // (reorg_depth=150, latest=200, safe_boundary=50 > 7)
+        let latest = make_slot(200);
+        service.storage.write_slot(200, &latest).unwrap();
+        service
+            .storage
+            .write_status(200, &make_complete_status(&expectations))
+            .unwrap();
+
+        let ranges = service.find_compactable_ranges().await.unwrap();
+        let range_starts: Vec<u64> = ranges.iter().map(|r| r.start).collect();
+
+        assert!(
+            range_starts.contains(&5),
+            "Skipped-only range 5 should be compactable"
+        );
+        assert!(
+            range_starts.contains(&6),
+            "Skipped-only range 6 should be compactable"
+        );
+        assert!(
+            range_starts.contains(&7),
+            "Skipped-only range 7 should be compactable"
+        );
+
+        for range in &ranges {
+            if [5u64, 6, 7].contains(&range.start) {
+                assert_eq!(
+                    range.slot_count, 0,
+                    "Status-only range should have slot_count=0"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_compact_skipped_only_range() {
+        // Compacting a range made entirely of skipped slots should clean up
+        // the status files, write skipped_slots.json, and emit a slots parquet
+        // so find_resume_slot can advance past the range.
+        let tmp = TempDir::new().unwrap();
+        let chain_name = "test-solana-skipped-only-compact";
+        let historical_dir = PathBuf::from(format!("data/{chain_name}"));
+        let _ = std::fs::remove_dir_all(&historical_dir);
+
+        let (service, expectations) = make_service_with_chain(&tmp, chain_name, 10);
+
+        for i in 0..10u64 {
+            let mut status = LiveSlotStatus::collected();
+            status.block_fetched = true;
+            status.events_extracted = true;
+            status.instructions_extracted = true;
+            status.apply_expectations(&expectations);
+            service.storage.write_status(i, &status).unwrap();
+        }
+
+        let range = CompactableRange {
+            start: 0,
+            end: 9,
+            slot_count: 0,
+        };
+        service.compact_range(&range).await.unwrap();
+
+        // All status files cleaned up
+        assert!(service.storage.list_statuses().unwrap().is_empty());
+
+        // All 10 slots recorded as skipped
+        let events_dir = raw_solana_events_dir(chain_name);
+        let skipped_index = skipped_slots::read_skipped_slots_index(&events_dir);
+        let rk = skipped_slots::range_key(0, 9);
+        let skipped = skipped_index.get(&rk).cloned().unwrap_or_default();
+        assert_eq!(skipped.len(), 10, "All 10 slots should be in skipped_slots.json");
+
+        // Slots parquet must exist for find_resume_slot
+        let slots_path = raw_solana_slots_dir(chain_name).join("0-9.parquet");
+        assert!(
+            slots_path.exists(),
+            "Slots parquet must be written even for all-skipped ranges"
+        );
+
+        let _ = std::fs::remove_dir_all(&historical_dir);
     }
 
     #[tokio::test]

--- a/src/solana/live/compaction.rs
+++ b/src/solana/live/compaction.rs
@@ -1,0 +1,929 @@
+//! Compaction service for merging live Solana slot data into historical parquet ranges.
+//!
+//! Periodically checks for complete slot ranges and compacts them:
+//! 1. Finds ranges where all slots are fully processed
+//! 2. Reads bincode data from live storage
+//! 3. Writes parquet files to historical raw data directories
+//! 4. Cleans up live storage
+//!
+//! Unlike EVM compaction, Solana ranges may have gaps from skipped slots.
+//! This is normal -- we compact whatever slots exist in the range.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use thiserror::Error;
+use tokio::sync::{mpsc, Mutex};
+
+use super::storage::SolanaLiveStorage;
+use super::types::SolanaLivePipelineExpectations;
+use crate::live::{LiveModeConfig, LiveProgressTracker, TransformRetryRequest};
+use crate::solana::raw_data::parquet::{
+    build_event_schema, build_instruction_schema, write_events_to_parquet,
+    write_instructions_to_parquet,
+};
+use crate::solana::raw_data::types::{SolanaEventRecord, SolanaInstructionRecord};
+use crate::storage::paths::{raw_solana_events_dir, raw_solana_instructions_dir};
+use crate::storage::skipped_slots;
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Error)]
+pub enum SolanaCompactionError {
+    #[error("Storage error: {0}")]
+    Storage(#[from] crate::live::bincode_io::StorageError),
+    #[error("Parquet write error: {0}")]
+    ParquetWrite(String),
+    #[error("Arrow error: {0}")]
+    Arrow(#[from] arrow::error::ArrowError),
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+// ---------------------------------------------------------------------------
+// Compactable range
+// ---------------------------------------------------------------------------
+
+/// A range of slots that can be compacted into historical parquet files.
+#[derive(Debug)]
+pub struct CompactableRange {
+    /// First slot number in the aligned range.
+    pub start: u64,
+    /// Last slot number in the aligned range (inclusive).
+    pub end: u64,
+    /// Number of slots with data in this range (may be less than end - start + 1 due to skipped slots).
+    pub slot_count: usize,
+}
+
+// ---------------------------------------------------------------------------
+// Compaction service
+// ---------------------------------------------------------------------------
+
+/// Service for compacting live Solana slot data into historical parquet ranges.
+///
+/// Runs in a background loop, periodically scanning for complete slot ranges
+/// that are safely beyond the reorg depth, then writing their data as parquet
+/// files and cleaning up the live bincode storage.
+pub struct SolanaCompactionService {
+    chain_name: String,
+    storage: SolanaLiveStorage,
+    config: LiveModeConfig,
+    progress_tracker: Arc<Mutex<LiveProgressTracker>>,
+    expectations: SolanaLivePipelineExpectations,
+    /// Channel to request transformation retries for stuck slots.
+    retry_tx: Option<mpsc::Sender<TransformRetryRequest>>,
+    /// When each transform-ready slot first became eligible for retry.
+    stuck_slots: std::sync::Mutex<HashMap<u64, Instant>>,
+    /// Minimum time a slot must remain transform-ready and incomplete before retrying.
+    retry_grace_period: Duration,
+}
+
+impl SolanaCompactionService {
+    /// Create a new SolanaCompactionService.
+    pub fn new(
+        chain_name: String,
+        config: LiveModeConfig,
+        progress_tracker: Arc<Mutex<LiveProgressTracker>>,
+        expectations: SolanaLivePipelineExpectations,
+    ) -> Self {
+        let storage = SolanaLiveStorage::new(&chain_name);
+        let retry_grace_period = Duration::from_secs(config.transform_retry_grace_period_secs);
+
+        Self {
+            chain_name,
+            storage,
+            config,
+            progress_tracker,
+            expectations,
+            retry_tx: None,
+            stuck_slots: std::sync::Mutex::new(HashMap::new()),
+            retry_grace_period,
+        }
+    }
+
+    /// Set the retry channel for transformation retries.
+    pub fn with_retry_tx(mut self, tx: mpsc::Sender<TransformRetryRequest>) -> Self {
+        self.retry_tx = Some(tx);
+        self
+    }
+
+    /// Run the compaction service loop.
+    ///
+    /// Runs until cancelled (when the containing task is dropped/aborted).
+    pub async fn run(self) {
+        let interval = Duration::from_secs(self.config.compaction_interval_secs);
+
+        tracing::info!(
+            chain = %self.chain_name,
+            ?interval,
+            "Solana compaction service started"
+        );
+
+        loop {
+            tokio::time::sleep(interval).await;
+            if let Err(e) = self.run_compaction_cycle().await {
+                tracing::error!(chain = %self.chain_name, "Compaction cycle failed: {}", e);
+            }
+        }
+    }
+
+    /// Run a single compaction cycle.
+    pub async fn run_compaction_cycle(&self) -> Result<(), SolanaCompactionError> {
+        // Check for stuck slots needing transformation retry
+        self.check_for_stuck_slots().await;
+
+        let ranges = self.find_compactable_ranges().await?;
+
+        if ranges.is_empty() {
+            tracing::debug!(chain = %self.chain_name, "No Solana ranges ready for compaction");
+            return Ok(());
+        }
+
+        for range in ranges {
+            tracing::info!(
+                chain = %self.chain_name,
+                start = range.start,
+                end = range.end,
+                slot_count = range.slot_count,
+                "Compacting Solana slot range"
+            );
+
+            if let Err(e) = self.compact_range(&range).await {
+                tracing::error!(
+                    chain = %self.chain_name,
+                    start = range.start,
+                    end = range.end,
+                    "Failed to compact Solana range: {}",
+                    e
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    // =========================================================================
+    // Stuck slot detection and retry
+    // =========================================================================
+
+    /// Check for slots that are stuck (decode inputs ready but not transformed)
+    /// and request retries via the retry channel.
+    async fn check_for_stuck_slots(&self) {
+        let Some(ref retry_tx) = self.retry_tx else {
+            return;
+        };
+
+        if !self.expectations.expect_transformations {
+            return;
+        }
+
+        let slots = match self.storage.list_slots() {
+            Ok(s) => s,
+            Err(_) => return,
+        };
+
+        let now = Instant::now();
+        let seen_slots: HashSet<u64> = slots.iter().copied().collect();
+
+        // Phase 1: Collect candidate stuck slots (sync mutex only, no await)
+        let mut candidates: Vec<(u64, HashSet<String>)> = Vec::new();
+        {
+            let mut stuck_slots = self.stuck_slots.lock().unwrap();
+
+            for &slot_number in &slots {
+                let status = match self.storage.read_status(slot_number) {
+                    Ok(s) => s,
+                    Err(_) => {
+                        stuck_slots.remove(&slot_number);
+                        continue;
+                    }
+                };
+
+                // Already transformed or inputs not ready -- not stuck
+                if status.transformed || !status.transform_inputs_ready_with(&self.expectations) {
+                    stuck_slots.remove(&slot_number);
+                    continue;
+                }
+
+                candidates.push((slot_number, status.failed_handlers));
+            }
+
+            // Remove entries for slots that no longer exist in storage
+            stuck_slots.retain(|slot, _| seen_slots.contains(slot));
+        }
+        // sync MutexGuard dropped here
+
+        // Phase 2: Check progress tracker (async, no sync mutex held)
+        let mut pending_retries = Vec::new();
+        for (slot_number, failed_handlers) in candidates {
+            let progress = self.progress_tracker.lock().await;
+            if progress.is_block_complete(slot_number) {
+                let mut stuck_slots = self.stuck_slots.lock().unwrap();
+                stuck_slots.remove(&slot_number);
+                continue;
+            }
+
+            let mut missing_handlers = progress.get_pending_handlers(slot_number);
+            drop(progress);
+
+            missing_handlers.extend(failed_handlers);
+
+            if missing_handlers.is_empty() {
+                let mut stuck_slots = self.stuck_slots.lock().unwrap();
+                stuck_slots.remove(&slot_number);
+                continue;
+            }
+
+            // Track when this slot first became stuck
+            let mut stuck_slots = self.stuck_slots.lock().unwrap();
+            let first_seen = stuck_slots.entry(slot_number).or_insert(now);
+            if now.duration_since(*first_seen) >= self.retry_grace_period {
+                pending_retries.push((slot_number, missing_handlers));
+            }
+        }
+
+        // Phase 3: Send retry requests
+        for (slot_number, missing_handlers) in pending_retries {
+            match retry_tx.try_send(TransformRetryRequest {
+                block_number: slot_number,
+                missing_handlers: Some(missing_handlers),
+            }) {
+                Ok(()) => {
+                    let mut stuck_slots = self.stuck_slots.lock().unwrap();
+                    stuck_slots.remove(&slot_number);
+                    tracing::info!(
+                        chain = %self.chain_name,
+                        slot = slot_number,
+                        "Requested transformation retry for stuck Solana slot"
+                    );
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        chain = %self.chain_name,
+                        slot = slot_number,
+                        "Retry channel full for Solana slot: {}",
+                        e
+                    );
+                }
+            }
+        }
+    }
+
+    // =========================================================================
+    // Range discovery
+    // =========================================================================
+
+    /// Find ranges of slots that are ready for compaction.
+    ///
+    /// A range is compactable when:
+    /// - All stored slots in the range are fully processed (`is_complete_with`)
+    /// - The entire range is safely beyond the reorg depth
+    ///
+    /// Solana ranges may have gaps from skipped slots. We compact whatever
+    /// slots exist in the aligned range -- we do not require every slot number
+    /// to have a corresponding block.
+    pub async fn find_compactable_ranges(
+        &self,
+    ) -> Result<Vec<CompactableRange>, SolanaCompactionError> {
+        let slots = self.storage.list_slots()?;
+        if slots.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let range_size = self.config.range_size;
+
+        // Group slots by aligned range: range_start = (slot / range_size) * range_size
+        let mut ranges: BTreeMap<u64, Vec<u64>> = BTreeMap::new();
+        for slot_number in slots {
+            let range_start = (slot_number / range_size) * range_size;
+            ranges.entry(range_start).or_default().push(slot_number);
+        }
+
+        let mut compactable = Vec::new();
+        let progress = self.progress_tracker.lock().await;
+
+        for (range_start, slot_numbers) in ranges {
+            let range_end = range_start + range_size - 1;
+
+            // Check if all slots in this group are fully processed
+            let mut all_complete = true;
+            for &slot_number in &slot_numbers {
+                if let Ok(status) = self.storage.read_status(slot_number) {
+                    if !status.is_complete_with(&self.expectations) {
+                        all_complete = false;
+                        break;
+                    }
+                } else {
+                    all_complete = false;
+                    break;
+                }
+
+                // Check progress tracker
+                if !progress.is_block_complete(slot_number) {
+                    all_complete = false;
+                    break;
+                }
+            }
+
+            if !all_complete {
+                continue;
+            }
+
+            // Only compact ranges safely beyond reorg depth
+            if let Ok(Some(latest_slot)) = self.storage.max_slot_number() {
+                let safe_boundary = latest_slot.saturating_sub(self.config.reorg_depth);
+                if range_end >= safe_boundary {
+                    tracing::debug!(
+                        chain = %self.chain_name,
+                        range_start,
+                        range_end,
+                        latest_slot,
+                        safe_boundary,
+                        "Skipping Solana range: within reorg depth"
+                    );
+                    continue;
+                }
+            }
+
+            compactable.push(CompactableRange {
+                start: range_start,
+                end: range_end,
+                slot_count: slot_numbers.len(),
+            });
+        }
+
+        Ok(compactable)
+    }
+
+    // =========================================================================
+    // Range compaction
+    // =========================================================================
+
+    /// Compact a single range: read live data, write parquet, delete live storage.
+    async fn compact_range(&self, range: &CompactableRange) -> Result<(), SolanaCompactionError> {
+        // Collect all events and instructions from live storage for slots in range.
+        // We iterate over stored slots (not all numbers in the range) because
+        // Solana has skipped slots with no blocks.
+        let stored_slots = self.storage.list_slots()?;
+        let status_slots = self.storage.list_statuses()?;
+        let slots_in_range: Vec<u64> = stored_slots
+            .into_iter()
+            .filter(|&s| s >= range.start && s <= range.end)
+            .collect();
+        let slots_in_range_set: HashSet<u64> = slots_in_range.iter().copied().collect();
+        let skipped_slots_in_range: Vec<u64> = status_slots
+            .into_iter()
+            .filter(|&s| s >= range.start && s <= range.end)
+            .filter(|s| !slots_in_range_set.contains(s))
+            .collect();
+        let mut slots_to_cleanup = slots_in_range.clone();
+        slots_to_cleanup.extend(skipped_slots_in_range.iter().copied());
+
+        let mut all_events: Vec<SolanaEventRecord> = Vec::new();
+        let mut all_instructions: Vec<SolanaInstructionRecord> = Vec::new();
+
+        for &slot_number in &slots_in_range {
+            match self.storage.read_events(slot_number) {
+                Ok(events) => all_events.extend(events),
+                Err(crate::live::bincode_io::StorageError::NotFound(_)) => {
+                    // Slot was deleted during compaction (reorg?), skip this range
+                    tracing::warn!(
+                        chain = %self.chain_name,
+                        slot = slot_number,
+                        start = range.start,
+                        end = range.end,
+                        "Slot deleted during compaction (reorg?), skipping range"
+                    );
+                    return Ok(());
+                }
+                Err(e) => return Err(e.into()),
+            }
+
+            match self.storage.read_instructions(slot_number) {
+                Ok(instructions) => all_instructions.extend(instructions),
+                Err(crate::live::bincode_io::StorageError::NotFound(_)) => {
+                    // Same as above -- slot vanished
+                    tracing::warn!(
+                        chain = %self.chain_name,
+                        slot = slot_number,
+                        start = range.start,
+                        end = range.end,
+                        "Slot instructions deleted during compaction (reorg?), skipping range"
+                    );
+                    return Ok(());
+                }
+                Err(e) => return Err(e.into()),
+            }
+        }
+
+        // Write events parquet to historical directory
+        if !all_events.is_empty() {
+            let events_dir = raw_solana_events_dir(&self.chain_name);
+            let events_path = events_dir.join(format!("{}-{}.parquet", range.start, range.end));
+            self.write_events_parquet(&all_events, &events_path)?;
+            tracing::info!(
+                chain = %self.chain_name,
+                count = all_events.len(),
+                path = %events_path.display(),
+                "Wrote Solana events parquet"
+            );
+        }
+
+        // Write instructions parquet to historical directory
+        if !all_instructions.is_empty() {
+            let instructions_dir = raw_solana_instructions_dir(&self.chain_name);
+            let instructions_path =
+                instructions_dir.join(format!("{}-{}.parquet", range.start, range.end));
+            self.write_instructions_parquet(&all_instructions, &instructions_path)?;
+            tracing::info!(
+                chain = %self.chain_name,
+                count = all_instructions.len(),
+                path = %instructions_path.display(),
+                "Wrote Solana instructions parquet"
+            );
+        }
+
+        // The skipped-slots sidecar is the authoritative completion marker for
+        // historical Solana ranges, so write it only after the parquet files.
+        let events_dir = raw_solana_events_dir(&self.chain_name);
+        let range_key = skipped_slots::range_key(range.start, range.end);
+        let mut skipped_index = skipped_slots::read_skipped_slots_index(&events_dir);
+        skipped_index.insert(range_key, skipped_slots_in_range.clone());
+        skipped_slots::write_skipped_slots_index(&events_dir, &skipped_index)?;
+
+        // Clean up live storage for all compacted slots, including skipped
+        // slots that only have status metadata.
+        for &slot_number in &slots_to_cleanup {
+            self.storage.delete_all(slot_number)?;
+        }
+
+        // Clean up progress tracker
+        {
+            let mut progress = self.progress_tracker.lock().await;
+            for &slot_number in &slots_to_cleanup {
+                progress.clear_block(slot_number);
+            }
+        }
+
+        tracing::info!(
+            chain = %self.chain_name,
+            start = range.start,
+            end = range.end,
+            slot_count = slots_in_range.len(),
+            skipped_slots = skipped_slots_in_range.len(),
+            events = all_events.len(),
+            instructions = all_instructions.len(),
+            "Successfully compacted Solana slot range"
+        );
+
+        Ok(())
+    }
+
+    // =========================================================================
+    // Parquet writing helpers
+    // =========================================================================
+
+    /// Write event records to a parquet file, reusing the existing schema and writer.
+    fn write_events_parquet(
+        &self,
+        events: &[SolanaEventRecord],
+        path: &PathBuf,
+    ) -> Result<(), SolanaCompactionError> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let schema = build_event_schema();
+        write_events_to_parquet(events, &schema, path).map_err(|e| {
+            SolanaCompactionError::ParquetWrite(format!("Failed to write events parquet: {}", e))
+        })
+    }
+
+    /// Write instruction records to a parquet file, reusing the existing schema and writer.
+    fn write_instructions_parquet(
+        &self,
+        instructions: &[SolanaInstructionRecord],
+        path: &PathBuf,
+    ) -> Result<(), SolanaCompactionError> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let schema = build_instruction_schema();
+        write_instructions_to_parquet(instructions, &schema, path).map_err(|e| {
+            SolanaCompactionError::ParquetWrite(format!(
+                "Failed to write instructions parquet: {}",
+                e
+            ))
+        })
+    }
+}
+
+impl std::fmt::Debug for SolanaCompactionService {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SolanaCompactionService")
+            .field("chain_name", &self.chain_name)
+            .field("range_size", &self.config.range_size)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::live::LiveProgressTracker;
+    use crate::solana::live::types::{LiveSlot, LiveSlotStatus};
+    use tempfile::TempDir;
+
+    fn make_config(range_size: u64) -> LiveModeConfig {
+        LiveModeConfig {
+            reorg_depth: 150,
+            compaction_interval_secs: 10,
+            range_size,
+            transform_retry_grace_period_secs: 30,
+        }
+    }
+
+    fn make_expectations() -> SolanaLivePipelineExpectations {
+        SolanaLivePipelineExpectations {
+            expect_event_decode: false,
+            expect_instruction_decode: false,
+            expect_account_reads: false,
+            expect_transformations: false,
+        }
+    }
+
+    fn make_complete_status(expectations: &SolanaLivePipelineExpectations) -> LiveSlotStatus {
+        let mut status = LiveSlotStatus {
+            collected: true,
+            block_fetched: true,
+            events_extracted: true,
+            instructions_extracted: true,
+            ..Default::default()
+        };
+        status.apply_expectations(expectations);
+        status
+    }
+
+    fn make_slot(slot: u64) -> LiveSlot {
+        LiveSlot {
+            slot,
+            block_time: Some(1_700_000_000 + slot as i64),
+            block_height: Some(slot),
+            parent_slot: slot.saturating_sub(1),
+            blockhash: [0u8; 32],
+            previous_blockhash: [0u8; 32],
+            transaction_count: 1,
+        }
+    }
+
+    /// Helper to build a service with a temp directory for storage.
+    fn make_service(
+        tmp: &TempDir,
+        range_size: u64,
+    ) -> (SolanaCompactionService, SolanaLivePipelineExpectations) {
+        make_service_with_chain(tmp, "test-solana", range_size)
+    }
+
+    fn make_service_with_chain(
+        tmp: &TempDir,
+        chain_name: &str,
+        range_size: u64,
+    ) -> (SolanaCompactionService, SolanaLivePipelineExpectations) {
+        let expectations = make_expectations();
+        let progress = Arc::new(Mutex::new(LiveProgressTracker::new(
+            0,
+            None,
+            chain_name.to_string(),
+        )));
+        let config = make_config(range_size);
+
+        let mut service =
+            SolanaCompactionService::new(chain_name.to_string(), config, progress, expectations);
+        // Override storage to use temp dir
+        service.storage = SolanaLiveStorage::with_base_dir(tmp.path().to_path_buf());
+        service.storage.ensure_dirs().unwrap();
+
+        (service, expectations)
+    }
+
+    #[tokio::test]
+    async fn test_find_compactable_ranges_empty() {
+        let tmp = TempDir::new().unwrap();
+        let (service, _) = make_service(&tmp, 1000);
+
+        let ranges = service.find_compactable_ranges().await.unwrap();
+        assert!(ranges.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_find_compactable_ranges_incomplete_slot() {
+        let tmp = TempDir::new().unwrap();
+        let (service, _) = make_service(&tmp, 1000);
+
+        // Write a slot with incomplete status
+        let slot = make_slot(500);
+        service.storage.write_slot(500, &slot).unwrap();
+        service
+            .storage
+            .write_status(500, &LiveSlotStatus::collected())
+            .unwrap();
+
+        let ranges = service.find_compactable_ranges().await.unwrap();
+        assert!(
+            ranges.is_empty(),
+            "Incomplete slot should not be compactable"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_find_compactable_ranges_within_reorg_depth() {
+        let tmp = TempDir::new().unwrap();
+        let (service, expectations) = make_service(&tmp, 10);
+
+        // Create slots 0..10 (a complete range of 10)
+        for i in 0..10 {
+            let slot = make_slot(i);
+            service.storage.write_slot(i, &slot).unwrap();
+            service
+                .storage
+                .write_status(i, &make_complete_status(&expectations))
+                .unwrap();
+        }
+
+        // Also create a "latest" slot that makes the range within reorg depth.
+        // reorg_depth=150, latest=100, safe_boundary=100-150=0 (saturating)
+        // range_end=9, safe_boundary=0 => 9 >= 0, so it's within reorg depth
+        // We need latest to be far enough that range_end < safe_boundary.
+        // With latest=100, safe=100-150=0 (saturating), range_end=9 >= 0 => skipped.
+        let latest = make_slot(100);
+        service.storage.write_slot(100, &latest).unwrap();
+        service
+            .storage
+            .write_status(100, &make_complete_status(&expectations))
+            .unwrap();
+
+        let ranges = service.find_compactable_ranges().await.unwrap();
+        // range 0-9: end=9, latest=100, safe_boundary=max(0,100-150)=0 => 9 >= 0 => skipped
+        assert!(
+            ranges.is_empty(),
+            "Range within reorg depth should not be compactable"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_find_compactable_ranges_beyond_reorg_depth() {
+        let tmp = TempDir::new().unwrap();
+        let (service, expectations) = make_service(&tmp, 10);
+
+        // Create slots 0..10 (range 0-9)
+        for i in 0..10 {
+            let slot = make_slot(i);
+            service.storage.write_slot(i, &slot).unwrap();
+            service
+                .storage
+                .write_status(i, &make_complete_status(&expectations))
+                .unwrap();
+        }
+
+        // Create a latest slot far enough away: 200
+        // safe_boundary = 200 - 150 = 50, range_end = 9 < 50 => compactable
+        let latest = make_slot(200);
+        service.storage.write_slot(200, &latest).unwrap();
+        service
+            .storage
+            .write_status(200, &make_complete_status(&expectations))
+            .unwrap();
+
+        let ranges = service.find_compactable_ranges().await.unwrap();
+        assert_eq!(ranges.len(), 1);
+        assert_eq!(ranges[0].start, 0);
+        assert_eq!(ranges[0].end, 9);
+        assert_eq!(ranges[0].slot_count, 10);
+    }
+
+    #[tokio::test]
+    async fn test_find_compactable_ranges_with_skipped_slots() {
+        let tmp = TempDir::new().unwrap();
+        let (service, expectations) = make_service(&tmp, 10);
+
+        // Create slots 0, 2, 5, 7, 9 (skipped: 1, 3, 4, 6, 8)
+        for i in [0, 2, 5, 7, 9] {
+            let slot = make_slot(i);
+            service.storage.write_slot(i, &slot).unwrap();
+            service
+                .storage
+                .write_status(i, &make_complete_status(&expectations))
+                .unwrap();
+        }
+
+        // Latest slot far enough away
+        let latest = make_slot(500);
+        service.storage.write_slot(500, &latest).unwrap();
+        service
+            .storage
+            .write_status(500, &make_complete_status(&expectations))
+            .unwrap();
+
+        let ranges = service.find_compactable_ranges().await.unwrap();
+        assert_eq!(ranges.len(), 1);
+        assert_eq!(ranges[0].start, 0);
+        assert_eq!(ranges[0].end, 9);
+        // Only 5 slots have data (skipped slots don't count)
+        assert_eq!(ranges[0].slot_count, 5);
+    }
+
+    #[tokio::test]
+    async fn test_compact_range_writes_parquet_and_cleans_up() {
+        let tmp = TempDir::new().unwrap();
+        let (service, expectations) = make_service(&tmp, 10);
+
+        // Create slots with events and instructions
+        for i in 0..5 {
+            let slot = make_slot(i);
+            service.storage.write_slot(i, &slot).unwrap();
+            service
+                .storage
+                .write_status(i, &make_complete_status(&expectations))
+                .unwrap();
+
+            let events = vec![SolanaEventRecord {
+                slot: i,
+                block_time: Some(1_700_000_000 + i as i64),
+                transaction_signature: [0xAA; 64],
+                program_id: [0xBB; 32],
+                event_discriminator: [0xCC; 8],
+                event_data: vec![1, 2, 3],
+                log_index: i as u32,
+                instruction_index: 0,
+                inner_instruction_index: None,
+            }];
+            service.storage.write_events(i, &events).unwrap();
+
+            let instructions = vec![SolanaInstructionRecord {
+                slot: i,
+                block_time: Some(1_700_000_000 + i as i64),
+                transaction_signature: [0xAA; 64],
+                program_id: [0xBB; 32],
+                data: vec![4, 5, 6],
+                accounts: vec![[0xDD; 32]],
+                instruction_index: 0,
+                inner_instruction_index: None,
+            }];
+            service
+                .storage
+                .write_instructions(i, &instructions)
+                .unwrap();
+        }
+
+        let range = CompactableRange {
+            start: 0,
+            end: 9,
+            slot_count: 5,
+        };
+
+        service.compact_range(&range).await.unwrap();
+
+        // Verify live storage is cleaned up
+        let remaining_slots = service.storage.list_slots().unwrap();
+        for i in 0..5 {
+            assert!(
+                !remaining_slots.contains(&i),
+                "Slot {} should be deleted after compaction",
+                i
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_compact_range_empty_events_and_instructions() {
+        let tmp = TempDir::new().unwrap();
+        let (service, expectations) = make_service(&tmp, 10);
+
+        // Create slots with empty events/instructions
+        for i in 0..3 {
+            let slot = make_slot(i);
+            service.storage.write_slot(i, &slot).unwrap();
+            service
+                .storage
+                .write_status(i, &make_complete_status(&expectations))
+                .unwrap();
+            service.storage.write_events(i, &[]).unwrap();
+            service.storage.write_instructions(i, &[]).unwrap();
+        }
+
+        let range = CompactableRange {
+            start: 0,
+            end: 9,
+            slot_count: 3,
+        };
+
+        // Should succeed without writing parquet (no data)
+        service.compact_range(&range).await.unwrap();
+
+        // All slots should be cleaned up
+        let remaining = service.storage.list_slots().unwrap();
+        assert!(remaining.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_compact_range_records_skipped_slots_and_cleans_statuses() {
+        let tmp = TempDir::new().unwrap();
+        let chain_name = "test-solana-compaction-skipped-slots";
+        let historical_dir = PathBuf::from(format!("data/{chain_name}"));
+        let _ = std::fs::remove_dir_all(&historical_dir);
+
+        let (service, expectations) = make_service_with_chain(&tmp, chain_name, 10);
+
+        for i in [0, 2, 5, 7, 9] {
+            let slot = make_slot(i);
+            service.storage.write_slot(i, &slot).unwrap();
+            service
+                .storage
+                .write_status(i, &make_complete_status(&expectations))
+                .unwrap();
+            service.storage.write_events(i, &[]).unwrap();
+            service.storage.write_instructions(i, &[]).unwrap();
+        }
+
+        for skipped in [1, 3, 4, 6, 8] {
+            service
+                .storage
+                .write_status(skipped, &make_complete_status(&expectations))
+                .unwrap();
+        }
+
+        let range = CompactableRange {
+            start: 0,
+            end: 9,
+            slot_count: 5,
+        };
+
+        service.compact_range(&range).await.unwrap();
+
+        let skipped_index =
+            skipped_slots::read_skipped_slots_index(&raw_solana_events_dir(chain_name));
+        let range_key = skipped_slots::range_key(range.start, range.end);
+        assert_eq!(skipped_index.get(&range_key), Some(&vec![1, 3, 4, 6, 8]));
+        assert!(service.storage.list_slots().unwrap().is_empty());
+        assert!(service.storage.list_statuses().unwrap().is_empty());
+
+        let _ = std::fs::remove_dir_all(&historical_dir);
+    }
+
+    #[tokio::test]
+    async fn test_stuck_slots_grace_period() {
+        let tmp = TempDir::new().unwrap();
+        let expectations = SolanaLivePipelineExpectations {
+            expect_event_decode: true,
+            expect_instruction_decode: true,
+            expect_account_reads: false,
+            expect_transformations: true,
+        };
+
+        let mut progress_tracker = LiveProgressTracker::new(0, None, "test-solana".to_string());
+        progress_tracker.register_handler("handler_a");
+        let progress = Arc::new(Mutex::new(progress_tracker));
+
+        let config = LiveModeConfig {
+            reorg_depth: 150,
+            compaction_interval_secs: 10,
+            range_size: 1000,
+            // Very long grace period so nothing triggers during test
+            transform_retry_grace_period_secs: 3600,
+        };
+
+        let (retry_tx, mut retry_rx) = mpsc::channel(10);
+
+        let mut service =
+            SolanaCompactionService::new("test-solana".to_string(), config, progress, expectations);
+        service.storage = SolanaLiveStorage::with_base_dir(tmp.path().to_path_buf());
+        service.storage.ensure_dirs().unwrap();
+        service = service.with_retry_tx(retry_tx);
+
+        // Create a slot that has decode inputs ready but is not transformed
+        let slot = make_slot(100);
+        service.storage.write_slot(100, &slot).unwrap();
+        let status = LiveSlotStatus {
+            collected: true,
+            block_fetched: true,
+            events_extracted: true,
+            instructions_extracted: true,
+            events_decoded: true,
+            instructions_decoded: true,
+            accounts_read: true,
+            accounts_decoded: true,
+            transformed: false,
+            ..Default::default()
+        };
+        service.storage.write_status(100, &status).unwrap();
+
+        // Check for stuck slots -- grace period is very long, so no retry should be sent
+        service.check_for_stuck_slots().await;
+
+        // No retry should have been sent (still within grace period)
+        assert!(retry_rx.try_recv().is_err());
+    }
+}

--- a/src/solana/live/mod.rs
+++ b/src/solana/live/mod.rs
@@ -1,0 +1,14 @@
+//! Solana live mode module for real-time slot processing.
+
+#[cfg(feature = "solana")]
+pub mod accounts;
+#[cfg(feature = "solana")]
+pub mod catchup;
+#[cfg(feature = "solana")]
+pub mod collector;
+#[cfg(feature = "solana")]
+pub mod compaction;
+pub mod reorg;
+#[cfg(feature = "solana")]
+pub mod storage;
+pub mod types;

--- a/src/solana/live/reorg.rs
+++ b/src/solana/live/reorg.rs
@@ -1,0 +1,685 @@
+//! Solana reorg detector using parent-slot chain verification.
+//!
+//! Tracks recent slots and their parent relationships to detect forks.
+//! Unlike EVM where blocks are sequential, Solana slots can be skipped,
+//! so the detector operates on parent_slot linkage rather than N-1 assumptions.
+
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, Copy)]
+struct TrackedSlot {
+    parent_slot: u64,
+    blockhash: [u8; 32],
+}
+
+/// Reorg event containing information about the detected fork.
+#[derive(Debug, Clone)]
+pub struct SolanaReorgEvent {
+    /// The slot number of the last valid slot (common ancestor).
+    pub common_ancestor: u64,
+    /// Slot numbers that were orphaned by the reorg.
+    pub orphaned: Vec<u64>,
+    /// The slot that triggered reorg detection.
+    pub new_slot: u64,
+    /// How deep the reorg went (number of orphaned slots).
+    pub depth: u64,
+    /// Whether the reorg extends beyond our retention window.
+    pub is_deep: bool,
+}
+
+/// Detects chain reorganizations on Solana by tracking recent slots and their
+/// parent-slot linkage.
+///
+/// Solana slots are not necessarily contiguous: the leader may skip slots, so
+/// the detector cannot assume slot N-1 is the parent. Instead it follows
+/// explicit `parent_slot` pointers stored alongside each tracked slot.
+///
+/// Recommended retention depths by commitment level:
+/// - `Processed`: 150
+/// - `Confirmed`: 32
+/// - `Finalized`: 0 (no reorg possible, but tracking is useful for gap detection)
+#[derive(Debug)]
+pub struct SolanaReorgDetector {
+    /// Recent slots: slot_number -> TrackedSlot.
+    recent_slots: BTreeMap<u64, TrackedSlot>,
+    /// How many recent slots to retain. Slots older than
+    /// `latest_slot - retention_depth` are pruned after each insertion.
+    retention_depth: u64,
+}
+
+impl SolanaReorgDetector {
+    /// Create a new detector with the given retention depth.
+    pub fn new(retention_depth: u64) -> Self {
+        Self {
+            recent_slots: BTreeMap::new(),
+            retention_depth,
+        }
+    }
+
+    /// Process a new slot and check for reorgs.
+    ///
+    /// Returns `Some(SolanaReorgEvent)` if a reorg is detected, `None` otherwise.
+    /// The slot is always inserted (or replaced) regardless of reorg status, and
+    /// old entries beyond the retention window are pruned.
+    pub fn process_slot(
+        &mut self,
+        slot: u64,
+        parent_slot: u64,
+        blockhash: [u8; 32],
+    ) -> Option<SolanaReorgEvent> {
+        let reorg_event = self.check_for_reorg(slot, parent_slot, blockhash);
+
+        // Remove orphaned slots from tracking so subsequent checks see the
+        // new canonical chain.
+        if let Some(ref event) = reorg_event {
+            for &orphaned_slot in &event.orphaned {
+                self.recent_slots.remove(&orphaned_slot);
+            }
+        }
+
+        // Insert (or replace) the new slot.
+        self.recent_slots.insert(
+            slot,
+            TrackedSlot {
+                parent_slot,
+                blockhash,
+            },
+        );
+
+        // Prune entries outside the retention window.
+        self.prune_old_slots(slot);
+
+        reorg_event
+    }
+
+    /// Seed the detector with known slots (e.g., loaded from storage on restart).
+    ///
+    /// Each item is `(slot, parent_slot, blockhash)`.
+    pub fn seed(&mut self, slots: impl IntoIterator<Item = (u64, u64, [u8; 32])>) {
+        for (slot, parent_slot, blockhash) in slots {
+            self.recent_slots.insert(
+                slot,
+                TrackedSlot {
+                    parent_slot,
+                    blockhash,
+                },
+            );
+        }
+    }
+
+    /// The highest tracked slot, or `None` if the detector is empty.
+    pub fn latest_slot(&self) -> Option<u64> {
+        self.recent_slots.keys().next_back().copied()
+    }
+
+    /// Number of slots currently tracked.
+    pub fn tracked_count(&self) -> usize {
+        self.recent_slots.len()
+    }
+
+    /// Clear all tracked slots (e.g., after a deep reorg recovery).
+    pub fn clear(&mut self) {
+        self.recent_slots.clear();
+    }
+
+    // ------------------------------------------------------------------
+    // Internal helpers
+    // ------------------------------------------------------------------
+
+    /// Core reorg-detection logic.
+    ///
+    /// Three cases trigger a reorg:
+    /// 1. We already track this slot number with a **different blockhash** (replacement).
+    /// 2. We track the parent_slot and its blockhash is consistent, but slots above
+    ///    the parent on our current chain differ (fork after parent).
+    /// 3. The parent_slot isn't tracked (or points to a different chain), meaning
+    ///    the fork is deeper than our window.
+    fn check_for_reorg(
+        &self,
+        slot: u64,
+        parent_slot: u64,
+        blockhash: [u8; 32],
+    ) -> Option<SolanaReorgEvent> {
+        if self.recent_slots.is_empty() {
+            return None;
+        }
+
+        // Case 1: same slot number, different blockhash -> replacement reorg.
+        if let Some(existing) = self.recent_slots.get(&slot) {
+            if existing.blockhash == blockhash {
+                // Duplicate delivery, not a reorg.
+                return None;
+            }
+
+            tracing::warn!(
+                slot,
+                tracked_hash = %hex::encode(existing.blockhash),
+                new_hash = %hex::encode(blockhash),
+                "replacement reorg detected at slot",
+            );
+
+            let (common_ancestor, orphaned, is_deep) = self.find_common_ancestor(slot, parent_slot);
+            let depth = orphaned.len() as u64;
+
+            return Some(SolanaReorgEvent {
+                common_ancestor,
+                orphaned,
+                new_slot: slot,
+                depth,
+                is_deep,
+            });
+        }
+
+        // Case 2 & 3: new slot that claims a parent.
+        // If we track the parent and it matches, check whether our chain above
+        // the parent diverges from the new slot.
+        if let Some(tracked_parent) = self.recent_slots.get(&parent_slot) {
+            // Parent exists in our chain. Are there any tracked slots above
+            // parent_slot that would be on a different fork?
+            // If the next slot we have above parent_slot is NOT this new slot,
+            // the new slot introduces a fork that orphans whatever we tracked
+            // above the parent.
+            let slots_above_parent: Vec<u64> = self
+                .recent_slots
+                .range((parent_slot + 1)..)
+                .map(|(&s, _)| s)
+                .collect();
+
+            if slots_above_parent.is_empty() {
+                // We're extending the tip; no reorg.
+                return None;
+            }
+
+            // Verify parent-slot chain consistency. Walk forward from
+            // parent_slot through our tracked entries and see if the chain
+            // that leads to `slot` is compatible.
+            // The simplest check: does the first slot above parent_slot claim
+            // parent_slot as its parent? If so, the chains are compatible only
+            // if that first slot IS this slot (which can't be, since we checked
+            // get() above and it was None). So there's a fork.
+            //
+            // However, if the existing chain above parent also has the same
+            // parent_slot, we need to walk further. In practice the chain above
+            // parent_slot may consist of entries whose parent chain traces back
+            // through parent_slot — those are on the OLD fork and become
+            // orphaned.
+
+            // Walk back from the highest existing slot to verify it chains
+            // through parent_slot. Collect everything above parent_slot that
+            // traces back through the parent — those are orphaned.
+            let orphaned = self.collect_descendants(parent_slot);
+            if orphaned.is_empty() {
+                return None;
+            }
+
+            tracing::warn!(
+                slot,
+                parent_slot,
+                parent_hash = %hex::encode(tracked_parent.blockhash),
+                orphaned_count = orphaned.len(),
+                "fork detected above tracked parent",
+            );
+
+            let depth = orphaned.len() as u64;
+            return Some(SolanaReorgEvent {
+                common_ancestor: parent_slot,
+                orphaned,
+                new_slot: slot,
+                depth,
+                is_deep: false,
+            });
+        }
+
+        // The parent_slot is not tracked at all. If we have any tracked slots,
+        // this could be a deep reorg that goes beyond our retention window, OR
+        // simply a large gap in slot numbers (e.g., after downtime).
+        //
+        // Heuristic: if the new slot is above our latest tracked slot and we
+        // have no tracked parent, it's likely a gap — not a reorg. But if the
+        // new slot is at or below our latest tracked slot, it's almost
+        // certainly a fork.
+        let latest = match self.latest_slot() {
+            Some(l) => l,
+            None => return None,
+        };
+
+        if slot > latest {
+            // Gap scenario: the new slot is ahead and we can't link it to our
+            // chain. Not a reorg — just missing data.
+            return None;
+        }
+
+        // The new slot is at or below our tip but its parent chain doesn't
+        // connect to anything we track. This is a deep reorg.
+        let (common_ancestor, orphaned, _) = self.find_common_ancestor(slot, parent_slot);
+        let depth = orphaned.len() as u64;
+
+        tracing::warn!(
+            slot,
+            parent_slot,
+            orphaned_count = orphaned.len(),
+            "deep reorg detected — parent outside retention window",
+        );
+
+        Some(SolanaReorgEvent {
+            common_ancestor,
+            orphaned,
+            new_slot: slot,
+            depth,
+            is_deep: true,
+        })
+    }
+
+    /// Walk backward through tracked slots to find the common ancestor between
+    /// the new chain (represented by `parent_slot`) and our existing chain.
+    ///
+    /// Returns `(common_ancestor_slot, orphaned_slots, is_deep)`.
+    fn find_common_ancestor(&self, new_slot: u64, new_parent_slot: u64) -> (u64, Vec<u64>, bool) {
+        // Collect the new chain's ancestry as far as we can trace it through
+        // our tracked slots.
+        let mut new_chain_ancestors = std::collections::BTreeSet::new();
+        let mut cursor = new_parent_slot;
+        loop {
+            if let Some(tracked) = self.recent_slots.get(&cursor) {
+                new_chain_ancestors.insert(cursor);
+                if tracked.parent_slot == cursor {
+                    // Self-referencing (genesis-like); stop.
+                    break;
+                }
+                cursor = tracked.parent_slot;
+            } else {
+                break;
+            }
+        }
+
+        // If we found any ancestors in common, the highest one that is on the
+        // new chain is the common ancestor. All tracked slots above it that
+        // are NOT in the new chain's ancestor set are orphaned.
+        if !new_chain_ancestors.is_empty() {
+            // The common ancestor is the *highest* slot that is shared between
+            // the old chain and the new chain.  Since we walked backward from
+            // `new_parent_slot`, the highest element in the set is
+            // `new_parent_slot` itself — the fork point.
+            let common_ancestor = *new_chain_ancestors.iter().next_back().unwrap();
+
+            // Orphaned: tracked slots above the common ancestor that are NOT
+            // in the new chain's ancestor set. This intentionally includes
+            // the old slot at `new_slot`'s number (if any) — the caller will
+            // remove orphans and then insert the replacement.
+            let orphaned: Vec<u64> = self
+                .recent_slots
+                .range((common_ancestor + 1)..)
+                .map(|(&s, _)| s)
+                .filter(|s| !new_chain_ancestors.contains(s))
+                .collect();
+
+            (common_ancestor, orphaned, false)
+        } else {
+            // Couldn't find any common ancestor in the retention window.
+            // Best-effort: orphan everything we track.
+            let common_ancestor = self
+                .recent_slots
+                .keys()
+                .next()
+                .copied()
+                .unwrap_or(new_slot)
+                .saturating_sub(1);
+
+            let orphaned: Vec<u64> = self.recent_slots.keys().copied().collect();
+
+            (common_ancestor, orphaned, true)
+        }
+    }
+
+    /// Collect all tracked slots above `ancestor` that chain back through it.
+    fn collect_descendants(&self, ancestor: u64) -> Vec<u64> {
+        // Simple approach: gather every tracked slot above `ancestor` whose
+        // parent chain eventually reaches `ancestor`.
+        let mut descendants = Vec::new();
+        for (&slot, tracked) in self.recent_slots.range((ancestor + 1)..) {
+            // Walk backward from this slot's parent to see if it reaches
+            // `ancestor`.
+            if self.chains_to(slot, ancestor) {
+                descendants.push(slot);
+            } else {
+                // If the slot doesn't chain back to ancestor, it belongs to
+                // a completely different fork — not relevant here.
+                let _ = tracked;
+            }
+        }
+        descendants
+    }
+
+    /// Check whether `slot` eventually chains back to `target` via parent
+    /// links in our tracked set.
+    fn chains_to(&self, slot: u64, target: u64) -> bool {
+        let mut cursor = slot;
+        let mut steps = 0u64;
+        loop {
+            if cursor == target {
+                return true;
+            }
+            if cursor < target || steps > self.retention_depth {
+                return false;
+            }
+            match self.recent_slots.get(&cursor) {
+                Some(tracked) => {
+                    if tracked.parent_slot == cursor {
+                        // Self-referencing; stop.
+                        return false;
+                    }
+                    cursor = tracked.parent_slot;
+                    steps += 1;
+                }
+                None => return false,
+            }
+        }
+    }
+
+    /// Remove tracked slots that fall outside the retention window.
+    fn prune_old_slots(&mut self, current_slot: u64) {
+        if self.retention_depth == 0 {
+            return;
+        }
+        let min_slot = current_slot.saturating_sub(self.retention_depth);
+        // BTreeMap::split_off returns everything >= key, which is exactly what
+        // we want to keep.
+        self.recent_slots = self.recent_slots.split_off(&min_slot);
+    }
+}
+
+impl Default for SolanaReorgDetector {
+    fn default() -> Self {
+        // Confirmed commitment default.
+        Self::new(32)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: build a blockhash deterministically from a u8 seed.
+    fn hash(seed: u8) -> [u8; 32] {
+        [seed; 32]
+    }
+
+    // ------------------------------------------------------------------
+    // Basic: sequential slots, no reorg
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn sequential_slots_no_reorg() {
+        let mut det = SolanaReorgDetector::new(10);
+
+        assert!(det.process_slot(100, 99, hash(1)).is_none());
+        assert!(det.process_slot(101, 100, hash(2)).is_none());
+        assert!(det.process_slot(102, 101, hash(3)).is_none());
+
+        assert_eq!(det.tracked_count(), 3);
+        assert_eq!(det.latest_slot(), Some(102));
+    }
+
+    // ------------------------------------------------------------------
+    // Skipped slots: non-contiguous but valid chain
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn skipped_slots_no_reorg() {
+        let mut det = SolanaReorgDetector::new(20);
+
+        // Slots 100, 103, 107 — gaps are normal on Solana.
+        assert!(det.process_slot(100, 99, hash(1)).is_none());
+        assert!(det.process_slot(103, 100, hash(2)).is_none());
+        assert!(det.process_slot(107, 103, hash(3)).is_none());
+
+        assert_eq!(det.tracked_count(), 3);
+        assert_eq!(det.latest_slot(), Some(107));
+    }
+
+    // ------------------------------------------------------------------
+    // Simple reorg: replacement of a single slot
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn single_slot_replacement_reorg() {
+        let mut det = SolanaReorgDetector::new(10);
+
+        det.process_slot(100, 99, hash(1));
+        det.process_slot(105, 100, hash(2));
+        det.process_slot(110, 105, hash(3));
+
+        // Slot 110 re-appears with a different blockhash, still claiming
+        // parent 105 (single-slot replacement).
+        let event = det.process_slot(110, 105, hash(33));
+        assert!(event.is_some());
+
+        let event = event.unwrap();
+        assert_eq!(event.new_slot, 110);
+        assert_eq!(event.common_ancestor, 105);
+        assert_eq!(event.orphaned, vec![110]);
+        assert_eq!(event.depth, 1);
+        assert!(!event.is_deep);
+    }
+
+    // ------------------------------------------------------------------
+    // Multi-slot reorg: several slots orphaned
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn multi_slot_fork_reorg() {
+        let mut det = SolanaReorgDetector::new(20);
+
+        // Build chain: 100 -> 105 -> 110 -> 115
+        det.process_slot(100, 99, hash(1));
+        det.process_slot(105, 100, hash(2));
+        det.process_slot(110, 105, hash(3));
+        det.process_slot(115, 110, hash(4));
+
+        // New slot 112 arrives claiming parent 100 — this forks off after 100,
+        // orphaning 105, 110, 115.
+        let event = det.process_slot(112, 100, hash(50));
+        assert!(event.is_some());
+
+        let event = event.unwrap();
+        assert_eq!(event.common_ancestor, 100);
+        assert!(event.orphaned.contains(&105));
+        assert!(event.orphaned.contains(&110));
+        assert!(event.orphaned.contains(&115));
+        assert_eq!(event.depth, 3);
+        assert!(!event.is_deep);
+    }
+
+    // ------------------------------------------------------------------
+    // Replacement reorg that re-parents
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn replacement_reorg_different_parent() {
+        let mut det = SolanaReorgDetector::new(20);
+
+        // Chain: 100 -> 105 -> 110
+        det.process_slot(100, 99, hash(1));
+        det.process_slot(105, 100, hash(2));
+        det.process_slot(110, 105, hash(3));
+
+        // Slot 110 re-appears with a different hash AND a different parent (100
+        // instead of 105), orphaning slot 105 and old 110.
+        let event = det.process_slot(110, 100, hash(33));
+        assert!(event.is_some());
+
+        let event = event.unwrap();
+        assert_eq!(event.common_ancestor, 100);
+        assert!(event.orphaned.contains(&105));
+        assert!(event.orphaned.contains(&110));
+        assert_eq!(event.depth, 2);
+        assert!(!event.is_deep);
+    }
+
+    // ------------------------------------------------------------------
+    // Deep reorg beyond retention
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn deep_reorg_beyond_retention() {
+        let mut det = SolanaReorgDetector::new(5);
+
+        // Build a short chain.
+        det.process_slot(100, 99, hash(1));
+        det.process_slot(101, 100, hash(2));
+        det.process_slot(102, 101, hash(3));
+
+        // New slot 102 with a parent that is NOT tracked at all (slot 50),
+        // signaling a deep reorg.
+        let event = det.process_slot(102, 50, hash(99));
+        assert!(event.is_some());
+
+        let event = event.unwrap();
+        assert!(event.is_deep);
+        // All previously tracked slots should be orphaned.
+        assert!(event.orphaned.contains(&100));
+        assert!(event.orphaned.contains(&101));
+        assert!(event.orphaned.contains(&102));
+    }
+
+    // ------------------------------------------------------------------
+    // Seed from storage and detect
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn seed_and_detect_reorg() {
+        let mut det = SolanaReorgDetector::new(20);
+
+        det.seed(vec![
+            (200, 199, hash(10)),
+            (205, 200, hash(11)),
+            (210, 205, hash(12)),
+        ]);
+
+        assert_eq!(det.tracked_count(), 3);
+        assert_eq!(det.latest_slot(), Some(210));
+
+        // Normal extension — no reorg.
+        assert!(det.process_slot(215, 210, hash(13)).is_none());
+
+        // Fork: slot 212 claims parent 200, orphaning 205 and 210.
+        let event = det.process_slot(212, 200, hash(50));
+        assert!(event.is_some());
+
+        let event = event.unwrap();
+        assert_eq!(event.common_ancestor, 200);
+        assert!(event.orphaned.contains(&205));
+        assert!(event.orphaned.contains(&210));
+        // 215 was on the old fork (chains through 210) so it's orphaned too.
+        assert!(event.orphaned.contains(&215));
+        assert!(!event.is_deep);
+    }
+
+    // ------------------------------------------------------------------
+    // Empty detector returns None
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn empty_detector_returns_none() {
+        let mut det = SolanaReorgDetector::new(10);
+
+        assert!(det.process_slot(100, 99, hash(1)).is_none());
+        assert!(det.latest_slot().is_some()); // now has one entry
+    }
+
+    #[test]
+    fn empty_detector_latest_slot_is_none() {
+        let det = SolanaReorgDetector::new(10);
+        assert_eq!(det.latest_slot(), None);
+        assert_eq!(det.tracked_count(), 0);
+    }
+
+    // ------------------------------------------------------------------
+    // Clear resets state
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn clear_resets_state() {
+        let mut det = SolanaReorgDetector::new(10);
+
+        det.process_slot(100, 99, hash(1));
+        det.process_slot(101, 100, hash(2));
+        assert_eq!(det.tracked_count(), 2);
+
+        det.clear();
+        assert_eq!(det.tracked_count(), 0);
+        assert_eq!(det.latest_slot(), None);
+    }
+
+    // ------------------------------------------------------------------
+    // Pruning respects retention depth with skipped slots
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn pruning_with_skipped_slots() {
+        let mut det = SolanaReorgDetector::new(10);
+
+        // Insert slots with gaps.
+        det.process_slot(100, 99, hash(1));
+        det.process_slot(103, 100, hash(2));
+        det.process_slot(106, 103, hash(3));
+        det.process_slot(109, 106, hash(4));
+        det.process_slot(112, 109, hash(5));
+
+        // All slots are within 112 - 10 = 102..112, so slot 100 should be
+        // pruned.
+        assert!(det.recent_slots.get(&100).is_none());
+        assert!(det.recent_slots.get(&103).is_some());
+        assert_eq!(det.latest_slot(), Some(112));
+    }
+
+    // ------------------------------------------------------------------
+    // Duplicate slot delivery is not a reorg
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn duplicate_slot_not_reorg() {
+        let mut det = SolanaReorgDetector::new(10);
+
+        det.process_slot(100, 99, hash(1));
+        det.process_slot(105, 100, hash(2));
+
+        // Exact same slot delivered again — no reorg.
+        assert!(det.process_slot(105, 100, hash(2)).is_none());
+        assert_eq!(det.tracked_count(), 2);
+    }
+
+    // ------------------------------------------------------------------
+    // After reorg, orphaned slots are removed from tracking
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn orphaned_slots_removed_after_reorg() {
+        let mut det = SolanaReorgDetector::new(20);
+
+        det.process_slot(100, 99, hash(1));
+        det.process_slot(105, 100, hash(2));
+        det.process_slot(110, 105, hash(3));
+
+        // Fork after 100, orphaning 105 and 110.
+        let event = det.process_slot(108, 100, hash(50));
+        assert!(event.is_some());
+
+        // 105 and 110 should be gone.
+        assert!(det.recent_slots.get(&105).is_none());
+        assert!(det.recent_slots.get(&110).is_none());
+        // 100 and the new 108 should remain.
+        assert!(det.recent_slots.get(&100).is_some());
+        assert!(det.recent_slots.get(&108).is_some());
+    }
+
+    // ------------------------------------------------------------------
+    // Default uses confirmed commitment depth (32)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn default_retention_depth() {
+        let det = SolanaReorgDetector::default();
+        assert_eq!(det.retention_depth, 32);
+    }
+}

--- a/src/solana/live/reorg.rs
+++ b/src/solana/live/reorg.rs
@@ -378,12 +378,10 @@ impl SolanaReorgDetector {
 
     /// Remove tracked slots that fall outside the retention window.
     fn prune_old_slots(&mut self, current_slot: u64) {
-        if self.retention_depth == 0 {
-            return;
-        }
         let min_slot = current_slot.saturating_sub(self.retention_depth);
         // BTreeMap::split_off returns everything >= key, which is exactly what
-        // we want to keep.
+        // we want to keep.  When retention_depth == 0 this keeps only the
+        // current slot, preventing unbounded growth in finalized mode.
         self.recent_slots = self.recent_slots.split_off(&min_slot);
     }
 }

--- a/src/solana/live/storage.rs
+++ b/src/solana/live/storage.rs
@@ -1,0 +1,887 @@
+//! Storage for Solana live mode slot data.
+//!
+//! Uses bincode for fast serialization, with JSON for status files.
+//! Directory structure:
+//! ```text
+//! data/{chain}/live/
+//! ├── raw/
+//! │   ├── slots/{slot}.bin
+//! │   ├── transactions/{slot}.bin
+//! │   ├── events/{slot}.bin
+//! │   ├── instructions/{slot}.bin
+//! │   └── accounts/{slot}.bin
+//! ├── decoded/
+//! │   ├── events/{slot}/{source}/{event_name}.bin
+//! │   ├── instructions/{slot}/{source}/{instruction_name}.bin
+//! │   └── accounts/{slot}/{source}/{account_type}.bin
+//! ├── snapshots/{slot}.bin
+//! └── status/{slot}.json
+//! ```
+
+use std::fs;
+use std::io::BufReader;
+use std::path::{Path, PathBuf};
+
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+use crate::live::bincode_io::{
+    atomic_write_with, is_temp_file, list_numbered_entries, map_io_not_found, map_not_found,
+    read_bincode, safe_delete, safe_delete_dir_all, write_bincode, StorageError,
+};
+use crate::live::LiveUpsertSnapshot;
+use crate::solana::raw_data::types::{SolanaEventRecord, SolanaInstructionRecord};
+use crate::storage_entity;
+
+use super::types::{LiveAccountRead, LiveSlot, LiveSlotStatus, LiveTransaction};
+
+/// Storage manager for Solana live mode slot data.
+#[derive(Debug, Clone)]
+pub struct SolanaLiveStorage {
+    base_dir: PathBuf,
+    /// When true, status writes call sync_all() for crash durability.
+    /// Data writes (slots, transactions, etc.) never sync -- they are
+    /// rebuildable, and the status file is the crash-safety gatekeeper.
+    /// Controlled by `DOPPLER_DURABLE_WRITES` env var (default: true).
+    durable_writes: bool,
+}
+
+impl SolanaLiveStorage {
+    /// Create a new SolanaLiveStorage for the given chain.
+    pub fn new(chain_name: &str) -> Self {
+        let base_dir = PathBuf::from(format!("data/{}/live", chain_name));
+        let durable_writes = std::env::var("DOPPLER_DURABLE_WRITES")
+            .map(|v| v != "false" && v != "0")
+            .unwrap_or(true);
+        Self {
+            base_dir,
+            durable_writes,
+        }
+    }
+
+    /// Create a new SolanaLiveStorage with a custom base directory.
+    #[allow(dead_code)]
+    pub fn with_base_dir(base_dir: PathBuf) -> Self {
+        Self {
+            base_dir,
+            durable_writes: true,
+        }
+    }
+
+    /// Get the base directory for this storage.
+    #[allow(dead_code)]
+    pub fn base_dir(&self) -> &Path {
+        &self.base_dir
+    }
+
+    /// Ensure all subdirectories exist and clean up leftover .tmp files.
+    pub fn ensure_dirs(&self) -> Result<(), StorageError> {
+        let subdirs = [
+            "raw/slots",
+            "raw/transactions",
+            "raw/events",
+            "raw/instructions",
+            "raw/accounts",
+            "decoded/events",
+            "decoded/instructions",
+            "decoded/accounts",
+            "snapshots",
+            "status",
+        ];
+
+        for subdir in &subdirs {
+            fs::create_dir_all(self.base_dir.join(subdir))?;
+        }
+
+        // Clean up leftover .tmp files from interrupted writes
+        self.cleanup_temp_files(&subdirs)?;
+
+        Ok(())
+    }
+
+    /// Clean up leftover temp files from interrupted writes.
+    /// Matches files with `.tmp.{random}` suffix pattern.
+    fn cleanup_temp_files(&self, subdirs: &[&str]) -> Result<(), StorageError> {
+        for subdir in subdirs {
+            let dir = self.base_dir.join(subdir);
+            if !dir.exists() {
+                continue;
+            }
+
+            if let Ok(entries) = fs::read_dir(&dir) {
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    if is_temp_file(&path) {
+                        tracing::debug!("Cleaning up leftover temp file: {:?}", path);
+                        let _ = fs::remove_file(&path);
+                    }
+                    // Recursively clean subdirectories (for decoded/{category}/{slot}/{source})
+                    if path.is_dir() {
+                        self.cleanup_temp_files_recursive(&path)?;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Recursively clean up temp files in nested directories.
+    fn cleanup_temp_files_recursive(&self, dir: &Path) -> Result<(), StorageError> {
+        if let Ok(entries) = fs::read_dir(dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    self.cleanup_temp_files_recursive(&path)?;
+                } else if is_temp_file(&path) {
+                    tracing::debug!("Cleaning up leftover temp file: {:?}", path);
+                    let _ = fs::remove_file(&path);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    // =========================================================================
+    // Slot operations (manual — uses `ref` pattern for single struct)
+    // =========================================================================
+
+    storage_entity!(ref slot, LiveSlot, "raw/slots");
+
+    /// List all slot numbers in storage, sorted ascending.
+    pub fn list_slots(&self) -> Result<Vec<u64>, StorageError> {
+        list_numbered_entries(&self.base_dir.join("raw/slots"))
+    }
+
+    /// List all slot numbers that have status files, sorted ascending.
+    ///
+    /// This includes skipped slots (which write only a status file, no slot
+    /// data) and is used by `find_gaps()` to avoid false positives.
+    pub fn list_statuses(&self) -> Result<Vec<u64>, StorageError> {
+        list_numbered_entries(&self.base_dir.join("status"))
+    }
+
+    /// Check if a slot exists in storage.
+    #[allow(dead_code)]
+    pub fn slot_exists(&self, slot: u64) -> bool {
+        self.slot_path(slot).exists()
+    }
+
+    // =========================================================================
+    // Transaction operations (macro-generated)
+    // =========================================================================
+
+    storage_entity!(slice transactions, LiveTransaction, "raw/transactions");
+
+    // =========================================================================
+    // Event operations (macro-generated)
+    // =========================================================================
+
+    storage_entity!(slice events, SolanaEventRecord, "raw/events");
+
+    // =========================================================================
+    // Instruction operations (macro-generated)
+    // =========================================================================
+
+    storage_entity!(slice instructions, SolanaInstructionRecord, "raw/instructions");
+
+    // =========================================================================
+    // Account read operations (macro-generated)
+    // =========================================================================
+
+    storage_entity!(slice accounts, LiveAccountRead, "raw/accounts");
+
+    // =========================================================================
+    // Status operations (manual, JSON format for debuggability)
+    // =========================================================================
+
+    fn status_path(&self, slot: u64) -> PathBuf {
+        self.base_dir.join(format!("status/{}.json", slot))
+    }
+
+    /// Write status for a slot. Syncs to disk when durable_writes is enabled.
+    pub fn write_status(&self, slot: u64, status: &LiveSlotStatus) -> Result<(), StorageError> {
+        let path = self.status_path(slot);
+        atomic_write_with(&path, self.durable_writes, |writer| {
+            serde_json::to_writer_pretty(writer, status)?;
+            Ok(())
+        })
+    }
+
+    /// Read status for a slot.
+    pub fn read_status(&self, slot: u64) -> Result<LiveSlotStatus, StorageError> {
+        let path = self.status_path(slot);
+        let file = fs::File::open(&path).map_err(|e| map_io_not_found(e, slot))?;
+        let reader = BufReader::new(file);
+        let status = serde_json::from_reader(reader)?;
+        Ok(status)
+    }
+
+    /// Atomically update status for a slot using a closure.
+    ///
+    /// This provides atomic read-modify-write semantics by using file locking
+    /// to prevent concurrent updates from overwriting each other's changes.
+    /// The closure receives the current status and can modify it in place.
+    ///
+    /// If the status file doesn't exist, returns NotFound error.
+    pub fn update_status_atomic<F>(&self, slot: u64, update_fn: F) -> Result<(), StorageError>
+    where
+        F: FnOnce(&mut LiveSlotStatus),
+    {
+        use fs2::FileExt;
+
+        let path = self.status_path(slot);
+        let lock_path = path.with_extension("json.lock");
+
+        // Use a separate lock file so the status file has no open handles during rename.
+        // This keeps the lock held through the entire read-modify-write-rename cycle
+        // (no lost-update race) while keeping the rename target handle-free.
+        let lock_file = fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&lock_path)
+            .map_err(StorageError::Io)?;
+
+        lock_file
+            .lock_exclusive()
+            .map_err(|e| StorageError::Io(std::io::Error::other(e)))?;
+
+        // Read current status while holding lock
+        let data = fs::read(&path).map_err(|e| map_io_not_found(e, slot))?;
+        let mut status: LiveSlotStatus = serde_json::from_slice(&data)?;
+
+        // Apply the update
+        update_fn(&mut status);
+
+        // Write to temp file, then rename -- all while holding the lock
+        atomic_write_with(&path, self.durable_writes, |writer| {
+            serde_json::to_writer_pretty(writer, &status)?;
+            Ok(())
+        })
+        // lock_file dropped here, releasing the exclusive lock
+    }
+
+    /// Delete status for a slot.
+    pub fn delete_status(&self, slot: u64) -> Result<(), StorageError> {
+        let path = self.status_path(slot);
+        safe_delete(&path)?;
+        safe_delete(&path.with_extension("json.lock"))
+    }
+
+    // =========================================================================
+    // Decoded data operations (generic, nested paths)
+    // =========================================================================
+
+    /// Write decoded data for a specific category/source/name combination.
+    ///
+    /// Path: `decoded/{category}/{slot}/{source}/{name}.bin`
+    pub fn write_decoded<T: Serialize>(
+        &self,
+        category: &str,
+        slot: u64,
+        source: &str,
+        name: &str,
+        data: &[T],
+    ) -> Result<(), StorageError> {
+        let path = self.base_dir.join(format!(
+            "decoded/{}/{}/{}/{}.bin",
+            category, slot, source, name
+        ));
+        write_bincode(&path, data)
+    }
+
+    /// Read decoded data for a specific category/source/name combination.
+    ///
+    /// Path: `decoded/{category}/{slot}/{source}/{name}.bin`
+    pub fn read_decoded<T: DeserializeOwned>(
+        &self,
+        category: &str,
+        slot: u64,
+        source: &str,
+        name: &str,
+    ) -> Result<Vec<T>, StorageError> {
+        let path = self.base_dir.join(format!(
+            "decoded/{}/{}/{}/{}.bin",
+            category, slot, source, name
+        ));
+        read_bincode(&path).map_err(|e| map_not_found(e, slot))
+    }
+
+    /// Delete all decoded data for a specific category and slot.
+    ///
+    /// Removes the entire `decoded/{category}/{slot}/` directory tree.
+    pub fn delete_all_decoded(&self, category: &str, slot: u64) -> Result<(), StorageError> {
+        safe_delete_dir_all(&self.base_dir.join(format!("decoded/{}/{}", category, slot)))
+    }
+
+    /// List all (source, name) pairs with decoded data for a category and slot.
+    pub fn list_decoded_types(
+        &self,
+        category: &str,
+        slot: u64,
+    ) -> Result<Vec<(String, String)>, StorageError> {
+        let slot_dir = self.base_dir.join(format!("decoded/{}/{}", category, slot));
+        if !slot_dir.exists() {
+            return Ok(Vec::new());
+        }
+
+        let mut results = Vec::new();
+        for source_entry in fs::read_dir(&slot_dir)? {
+            let source_entry = source_entry?;
+            let source_name = source_entry.file_name().to_string_lossy().into_owned();
+
+            if source_entry.path().is_dir() {
+                for file_entry in fs::read_dir(source_entry.path())? {
+                    let file_entry = file_entry?;
+                    if let Some(stem) = file_entry.path().file_stem() {
+                        let name = stem.to_string_lossy().into_owned();
+                        results.push((source_name.clone(), name));
+                    }
+                }
+            }
+        }
+
+        Ok(results)
+    }
+
+    // =========================================================================
+    // Snapshot operations (for reorg rollback)
+    // =========================================================================
+
+    fn snapshots_path(&self, slot: u64) -> PathBuf {
+        self.base_dir.join(format!("snapshots/{}.bin", slot))
+    }
+
+    /// Write upsert snapshots for a slot. No-op when the slice is empty.
+    pub fn write_snapshots(
+        &self,
+        slot: u64,
+        snapshots: &[LiveUpsertSnapshot],
+    ) -> Result<(), StorageError> {
+        if snapshots.is_empty() {
+            return Ok(());
+        }
+        write_bincode(&self.snapshots_path(slot), snapshots)
+    }
+
+    /// Read upsert snapshots for a slot.
+    pub fn read_snapshots(&self, slot: u64) -> Result<Vec<LiveUpsertSnapshot>, StorageError> {
+        read_bincode(&self.snapshots_path(slot)).map_err(|e| map_not_found(e, slot))
+    }
+
+    /// Delete upsert snapshots for a slot.
+    pub fn delete_snapshots(&self, slot: u64) -> Result<(), StorageError> {
+        safe_delete(&self.snapshots_path(slot))
+    }
+
+    // =========================================================================
+    // Reorg detection helpers
+    // =========================================================================
+
+    /// Get recent slots for seeding the reorg detector on restart.
+    ///
+    /// Returns up to `count` most recent slots.
+    pub fn get_recent_slots_for_reorg(&self, count: u64) -> Result<Vec<LiveSlot>, StorageError> {
+        let slots = self.list_slots()?;
+        let start = slots.len().saturating_sub(count as usize);
+
+        let mut result = Vec::with_capacity(slots.len() - start);
+        for &slot_number in &slots[start..] {
+            if let Ok(slot) = self.read_slot(slot_number) {
+                result.push(slot);
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Get the maximum slot number in storage.
+    pub fn max_slot_number(&self) -> Result<Option<u64>, StorageError> {
+        Ok(self.list_slots()?.into_iter().max())
+    }
+
+    /// Find gaps between stored slots.
+    ///
+    /// Returns ranges of missing slot numbers as (start, end) tuples (inclusive).
+    /// Unions slot data files with status files so that skipped Solana slots
+    /// (which write only a status file, no slot data) are not reported as gaps.
+    pub fn find_gaps(&self) -> Result<Vec<(u64, u64)>, StorageError> {
+        let mut all_known = std::collections::BTreeSet::new();
+        all_known.extend(self.list_slots()?);
+        all_known.extend(self.list_statuses()?);
+
+        let slots: Vec<u64> = all_known.into_iter().collect();
+        if slots.len() < 2 {
+            return Ok(Vec::new());
+        }
+
+        let mut gaps = Vec::new();
+        for window in slots.windows(2) {
+            if window[1] > window[0] + 1 {
+                gaps.push((window[0] + 1, window[1] - 1));
+            }
+        }
+        Ok(gaps)
+    }
+
+    // =========================================================================
+    // Bulk operations
+    // =========================================================================
+
+    /// Delete all data for a slot (including decoded data and snapshots).
+    pub fn delete_all(&self, slot: u64) -> Result<(), StorageError> {
+        self.delete_slot(slot)?;
+        self.delete_transactions(slot)?;
+        self.delete_events(slot)?;
+        self.delete_instructions(slot)?;
+        self.delete_accounts(slot)?;
+        self.delete_status(slot)?;
+        self.delete_all_decoded("events", slot)?;
+        self.delete_all_decoded("instructions", slot)?;
+        self.delete_all_decoded("accounts", slot)?;
+        self.delete_snapshots(slot)?;
+        Ok(())
+    }
+
+    /// Delete all data for a range of slots (inclusive).
+    #[allow(dead_code)]
+    pub fn delete_range(&self, start: u64, end: u64) -> Result<(), StorageError> {
+        for slot in start..=end {
+            self.delete_all(slot)?;
+        }
+        Ok(())
+    }
+}
+
+// =========================================================================
+// ProgressStatusStorage impl (for LiveProgressTracker)
+// =========================================================================
+
+impl crate::live::ProgressStatusStorage for SolanaLiveStorage {
+    fn update_handler_completion(
+        &self,
+        number: u64,
+        handler_key: &str,
+        all_complete: bool,
+    ) -> Result<(), StorageError> {
+        let hk = handler_key.to_string();
+        self.update_status_atomic(number, move |status| {
+            status.completed_handlers.insert(hk);
+            if all_complete {
+                status.transformed = true;
+            }
+        })
+    }
+
+    fn mark_transformed(&self, number: u64) -> Result<(), StorageError> {
+        self.update_status_atomic(number, |status| {
+            status.transformed = true;
+        })
+    }
+
+    fn read_handler_sets(
+        &self,
+        number: u64,
+    ) -> Result<
+        (
+            std::collections::HashSet<String>,
+            std::collections::HashSet<String>,
+        ),
+        StorageError,
+    > {
+        let status = self.read_status(number)?;
+        Ok((status.failed_handlers, status.completed_handlers))
+    }
+
+    fn update_handler_sets_atomic(
+        &self,
+        number: u64,
+        update_fn: &mut dyn FnMut(
+            &mut std::collections::HashSet<String>,
+            &mut std::collections::HashSet<String>,
+            &mut bool,
+        ),
+    ) -> Result<(), StorageError> {
+        self.update_status_atomic(number, |status| {
+            update_fn(
+                &mut status.completed_handlers,
+                &mut status.failed_handlers,
+                &mut status.transformed,
+            );
+        })
+    }
+}
+
+// =========================================================================
+// Tests
+// =========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn test_storage() -> (SolanaLiveStorage, TempDir) {
+        let tmp = TempDir::new().unwrap();
+        let storage = SolanaLiveStorage::with_base_dir(tmp.path().to_path_buf());
+        storage.ensure_dirs().unwrap();
+        (storage, tmp)
+    }
+
+    #[test]
+    fn test_slot_roundtrip() {
+        let (storage, _tmp) = test_storage();
+
+        let slot = LiveSlot {
+            slot: 250_000_000,
+            block_time: Some(1_700_000_000),
+            block_height: Some(200_000_000),
+            parent_slot: 249_999_999,
+            blockhash: [0xAA; 32],
+            previous_blockhash: [0xBB; 32],
+            transaction_count: 42,
+        };
+
+        storage.write_slot(slot.slot, &slot).unwrap();
+        let read_slot = storage.read_slot(250_000_000).unwrap();
+
+        assert_eq!(read_slot.slot, slot.slot);
+        assert_eq!(read_slot.block_time, slot.block_time);
+        assert_eq!(read_slot.blockhash, slot.blockhash);
+        assert_eq!(read_slot.transaction_count, 42);
+    }
+
+    #[test]
+    fn test_transactions_roundtrip() {
+        let (storage, _tmp) = test_storage();
+
+        let txs = vec![
+            LiveTransaction {
+                slot: 100,
+                block_time: Some(1_700_000_000),
+                signature: [0xCC; 64],
+                is_err: false,
+                err_msg: None,
+                fee: 5000,
+                compute_units_consumed: Some(200_000),
+                log_messages: vec!["Program log: hello".to_string()],
+                account_keys: vec![[0xDD; 32]],
+            },
+            LiveTransaction {
+                slot: 100,
+                block_time: Some(1_700_000_000),
+                signature: [0xEE; 64],
+                is_err: true,
+                err_msg: Some("InstructionError".to_string()),
+                fee: 5000,
+                compute_units_consumed: None,
+                log_messages: vec![],
+                account_keys: vec![],
+            },
+        ];
+
+        storage.write_transactions(100, &txs).unwrap();
+        let read_txs = storage.read_transactions(100).unwrap();
+
+        assert_eq!(read_txs.len(), 2);
+        assert_eq!(read_txs[0].signature, [0xCC; 64]);
+        assert!(!read_txs[0].is_err);
+        assert!(read_txs[1].is_err);
+        assert_eq!(read_txs[1].err_msg, Some("InstructionError".to_string()));
+    }
+
+    #[test]
+    fn test_status_roundtrip() {
+        let (storage, _tmp) = test_storage();
+
+        let mut status = LiveSlotStatus::default();
+        status.collected = true;
+        status.block_fetched = true;
+        status.events_extracted = false;
+        status.completed_handlers.insert("handler_a".to_string());
+
+        storage.write_status(100, &status).unwrap();
+        let read_status = storage.read_status(100).unwrap();
+
+        assert!(read_status.collected);
+        assert!(read_status.block_fetched);
+        assert!(!read_status.events_extracted);
+        assert!(read_status.completed_handlers.contains("handler_a"));
+    }
+
+    #[test]
+    fn test_status_atomic_update() {
+        let (storage, _tmp) = test_storage();
+
+        let status = LiveSlotStatus::collected();
+        storage.write_status(200, &status).unwrap();
+
+        storage
+            .update_status_atomic(200, |s| {
+                s.block_fetched = true;
+                s.events_extracted = true;
+                s.completed_handlers.insert("handler_x".to_string());
+            })
+            .unwrap();
+
+        let updated = storage.read_status(200).unwrap();
+        assert!(updated.collected);
+        assert!(updated.block_fetched);
+        assert!(updated.events_extracted);
+        assert!(!updated.instructions_extracted);
+        assert!(updated.completed_handlers.contains("handler_x"));
+    }
+
+    #[test]
+    fn test_list_slots() {
+        let (storage, _tmp) = test_storage();
+
+        for num in [300, 302, 301] {
+            let slot = LiveSlot {
+                slot: num,
+                block_time: None,
+                block_height: None,
+                parent_slot: num.saturating_sub(1),
+                blockhash: [0u8; 32],
+                previous_blockhash: [0u8; 32],
+                transaction_count: 0,
+            };
+            storage.write_slot(num, &slot).unwrap();
+        }
+
+        let slots = storage.list_slots().unwrap();
+        assert_eq!(slots, vec![300, 301, 302]);
+    }
+
+    #[test]
+    fn test_slot_exists() {
+        let (storage, _tmp) = test_storage();
+
+        assert!(!storage.slot_exists(999));
+
+        let slot = LiveSlot {
+            slot: 999,
+            block_time: None,
+            block_height: None,
+            parent_slot: 998,
+            blockhash: [0u8; 32],
+            previous_blockhash: [0u8; 32],
+            transaction_count: 0,
+        };
+        storage.write_slot(999, &slot).unwrap();
+
+        assert!(storage.slot_exists(999));
+    }
+
+    #[test]
+    fn test_ensure_dirs() {
+        let tmp = TempDir::new().unwrap();
+        let storage = SolanaLiveStorage::with_base_dir(tmp.path().to_path_buf());
+        storage.ensure_dirs().unwrap();
+
+        assert!(tmp.path().join("raw/slots").is_dir());
+        assert!(tmp.path().join("raw/transactions").is_dir());
+        assert!(tmp.path().join("raw/events").is_dir());
+        assert!(tmp.path().join("raw/instructions").is_dir());
+        assert!(tmp.path().join("raw/accounts").is_dir());
+        assert!(tmp.path().join("decoded/events").is_dir());
+        assert!(tmp.path().join("decoded/instructions").is_dir());
+        assert!(tmp.path().join("decoded/accounts").is_dir());
+        assert!(tmp.path().join("snapshots").is_dir());
+        assert!(tmp.path().join("status").is_dir());
+    }
+
+    #[test]
+    fn test_delete_all() {
+        let (storage, _tmp) = test_storage();
+
+        let slot = LiveSlot {
+            slot: 500,
+            block_time: None,
+            block_height: None,
+            parent_slot: 499,
+            blockhash: [0u8; 32],
+            previous_blockhash: [0u8; 32],
+            transaction_count: 0,
+        };
+        storage.write_slot(500, &slot).unwrap();
+        storage
+            .write_status(500, &LiveSlotStatus::default())
+            .unwrap();
+
+        assert!(storage.slot_exists(500));
+        storage.delete_all(500).unwrap();
+        assert!(!storage.slot_exists(500));
+    }
+
+    #[test]
+    fn test_find_gaps() {
+        let (storage, _tmp) = test_storage();
+
+        // Create slots with gaps: 100, 101, 105, 106, 110
+        for num in [100, 101, 105, 106, 110] {
+            let slot = LiveSlot {
+                slot: num,
+                block_time: None,
+                block_height: None,
+                parent_slot: num.saturating_sub(1),
+                blockhash: [0u8; 32],
+                previous_blockhash: [0u8; 32],
+                transaction_count: 0,
+            };
+            storage.write_slot(num, &slot).unwrap();
+        }
+
+        let gaps = storage.find_gaps().unwrap();
+        assert_eq!(gaps, vec![(102, 104), (107, 109)]);
+    }
+
+    #[test]
+    fn test_find_gaps_empty() {
+        let (storage, _tmp) = test_storage();
+        let gaps = storage.find_gaps().unwrap();
+        assert!(gaps.is_empty());
+    }
+
+    #[test]
+    fn test_find_gaps_with_skipped_slots() {
+        let (storage, _tmp) = test_storage();
+
+        // Create slots 100, 101, 103, 104 with slot files
+        for num in [100, 101, 103, 104] {
+            let slot = LiveSlot {
+                slot: num,
+                block_time: None,
+                block_height: None,
+                parent_slot: num.saturating_sub(1),
+                blockhash: [0u8; 32],
+                previous_blockhash: [0u8; 32],
+                transaction_count: 0,
+            };
+            storage.write_slot(num, &slot).unwrap();
+        }
+
+        // Slot 102 was skipped — write only a status file (no slot data)
+        let mut status = LiveSlotStatus::collected();
+        status.block_fetched = true;
+        status.events_extracted = true;
+        status.instructions_extracted = true;
+        storage.write_status(102, &status).unwrap();
+
+        // No gaps: slot 102 has a status file so find_gaps() sees it
+        let gaps = storage.find_gaps().unwrap();
+        assert!(gaps.is_empty(), "Expected no gaps but got {:?}", gaps);
+    }
+
+    #[test]
+    fn test_max_slot_number() {
+        let (storage, _tmp) = test_storage();
+
+        assert_eq!(storage.max_slot_number().unwrap(), None);
+
+        for num in [50, 100, 75] {
+            let slot = LiveSlot {
+                slot: num,
+                block_time: None,
+                block_height: None,
+                parent_slot: num.saturating_sub(1),
+                blockhash: [0u8; 32],
+                previous_blockhash: [0u8; 32],
+                transaction_count: 0,
+            };
+            storage.write_slot(num, &slot).unwrap();
+        }
+
+        assert_eq!(storage.max_slot_number().unwrap(), Some(100));
+    }
+
+    #[test]
+    fn test_decoded_roundtrip() {
+        let (storage, _tmp) = test_storage();
+
+        let data: Vec<u64> = vec![1, 2, 3, 42];
+        storage
+            .write_decoded("events", 100, "my_program", "Transfer", &data)
+            .unwrap();
+
+        let read_data: Vec<u64> = storage
+            .read_decoded("events", 100, "my_program", "Transfer")
+            .unwrap();
+        assert_eq!(read_data, vec![1, 2, 3, 42]);
+    }
+
+    #[test]
+    fn test_decoded_list_types() {
+        let (storage, _tmp) = test_storage();
+
+        let data: Vec<u64> = vec![1];
+        storage
+            .write_decoded("events", 100, "program_a", "Transfer", &data)
+            .unwrap();
+        storage
+            .write_decoded("events", 100, "program_a", "Mint", &data)
+            .unwrap();
+        storage
+            .write_decoded("events", 100, "program_b", "Swap", &data)
+            .unwrap();
+
+        let mut types = storage.list_decoded_types("events", 100).unwrap();
+        types.sort();
+
+        assert_eq!(types.len(), 3);
+        assert!(types.contains(&("program_a".to_string(), "Mint".to_string())));
+        assert!(types.contains(&("program_a".to_string(), "Transfer".to_string())));
+        assert!(types.contains(&("program_b".to_string(), "Swap".to_string())));
+    }
+
+    #[test]
+    fn test_decoded_delete_all() {
+        let (storage, _tmp) = test_storage();
+
+        let data: Vec<u64> = vec![1];
+        storage
+            .write_decoded("events", 100, "program_a", "Transfer", &data)
+            .unwrap();
+
+        storage.delete_all_decoded("events", 100).unwrap();
+
+        let types = storage.list_decoded_types("events", 100).unwrap();
+        assert!(types.is_empty());
+    }
+
+    #[test]
+    fn test_snapshots_empty_noop() {
+        let (storage, _tmp) = test_storage();
+
+        // Writing empty snapshots should be a no-op
+        storage.write_snapshots(100, &[]).unwrap();
+
+        // Reading should fail with NotFound since nothing was written
+        let result = storage.read_snapshots(100);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_recent_slots_for_reorg() {
+        let (storage, _tmp) = test_storage();
+
+        for num in 100..110 {
+            let slot = LiveSlot {
+                slot: num,
+                block_time: None,
+                block_height: None,
+                parent_slot: num.saturating_sub(1),
+                blockhash: [num as u8; 32],
+                previous_blockhash: [(num - 1) as u8; 32],
+                transaction_count: 0,
+            };
+            storage.write_slot(num, &slot).unwrap();
+        }
+
+        let recent = storage.get_recent_slots_for_reorg(3).unwrap();
+        assert_eq!(recent.len(), 3);
+        assert_eq!(recent[0].slot, 107);
+        assert_eq!(recent[1].slot, 108);
+        assert_eq!(recent[2].slot, 109);
+    }
+}

--- a/src/solana/live/types.rs
+++ b/src/solana/live/types.rs
@@ -1,0 +1,448 @@
+//! Types for Solana live mode slot processing.
+
+use std::collections::HashSet;
+
+use serde::{Deserialize, Serialize};
+
+/// A slot in live mode, stored as bincode for fast serialization.
+/// Parallels the EVM `LiveBlock` but with Solana slot fields.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LiveSlot {
+    pub slot: u64,
+    pub block_time: Option<i64>,
+    pub block_height: Option<u64>,
+    pub parent_slot: u64,
+    pub blockhash: [u8; 32],
+    pub previous_blockhash: [u8; 32],
+    pub transaction_count: u32,
+}
+
+impl LiveSlot {
+    /// Create a new LiveSlot from raw data.
+    #[allow(dead_code)]
+    pub fn new(
+        slot: u64,
+        block_time: Option<i64>,
+        block_height: Option<u64>,
+        parent_slot: u64,
+        blockhash: [u8; 32],
+        previous_blockhash: [u8; 32],
+        transaction_count: u32,
+    ) -> Self {
+        Self {
+            slot,
+            block_time,
+            block_height,
+            parent_slot,
+            blockhash,
+            previous_blockhash,
+            transaction_count,
+        }
+    }
+}
+
+/// Transaction metadata for live mode (debugging/audit trail).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LiveTransaction {
+    pub slot: u64,
+    pub block_time: Option<i64>,
+    #[serde(with = "serde_big_array::BigArray")]
+    pub signature: [u8; 64],
+    pub is_err: bool,
+    pub err_msg: Option<String>,
+    pub fee: u64,
+    pub compute_units_consumed: Option<u64>,
+    pub log_messages: Vec<String>,
+    pub account_keys: Vec<[u8; 32]>,
+}
+
+/// Raw account state fetch result (live-only).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LiveAccountRead {
+    pub slot: u64,
+    pub block_time: Option<i64>,
+    pub account_address: [u8; 32],
+    pub owner: [u8; 32],
+    pub data: Vec<u8>,
+    pub lamports: u64,
+    pub executable: bool,
+}
+
+/// Status tracking for a live slot's processing pipeline.
+/// Parallels EVM's `LiveBlockStatus`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct LiveSlotStatus {
+    /// Slot notification received from WebSocket.
+    pub collected: bool,
+    /// Full block data fetched via getBlock RPC.
+    pub block_fetched: bool,
+    /// Events extracted from block transactions.
+    pub events_extracted: bool,
+    /// Instructions extracted from block transactions.
+    pub instructions_extracted: bool,
+    /// Events decoded via program decoders.
+    pub events_decoded: bool,
+    /// Instructions decoded via program decoders.
+    pub instructions_decoded: bool,
+    /// Account state reads completed (live-only).
+    pub accounts_read: bool,
+    /// Account state decoded via program decoders (live-only).
+    pub accounts_decoded: bool,
+    /// All transformation handlers complete.
+    pub transformed: bool,
+    /// Handler keys that have completed processing for this slot.
+    #[serde(default)]
+    pub completed_handlers: HashSet<String>,
+    /// Handler keys that failed processing (will be retried).
+    #[serde(default)]
+    pub failed_handlers: HashSet<String>,
+}
+
+impl LiveSlotStatus {
+    /// Create a new status indicating only initial collection.
+    pub fn collected() -> Self {
+        Self {
+            collected: true,
+            ..Default::default()
+        }
+    }
+
+    /// Check if the slot is fully processed and ready for compaction.
+    pub fn is_complete(&self) -> bool {
+        self.collected
+            && self.block_fetched
+            && self.events_extracted
+            && self.instructions_extracted
+            && self.events_decoded
+            && self.instructions_decoded
+            && self.accounts_read
+            && self.accounts_decoded
+            && self.transformed
+    }
+
+    /// Check completeness using the active runtime pipeline expectations.
+    pub fn is_complete_with(&self, expectations: &SolanaLivePipelineExpectations) -> bool {
+        self.collected
+            && self.block_fetched
+            && self.events_extracted
+            && self.instructions_extracted
+            && (!expectations.expect_event_decode || self.events_decoded)
+            && (!expectations.expect_instruction_decode || self.instructions_decoded)
+            && (!expectations.expect_account_reads || self.accounts_read)
+            && (!expectations.expect_account_reads || self.accounts_decoded)
+            && (!expectations.expect_transformations || self.transformed)
+    }
+
+    /// Check whether all inputs needed for transformation are ready.
+    ///
+    /// Returns true when all expected decode stages have completed,
+    /// meaning transformation handlers can safely run.
+    pub fn transform_inputs_ready_with(
+        &self,
+        expectations: &SolanaLivePipelineExpectations,
+    ) -> bool {
+        (!expectations.expect_event_decode || self.events_decoded)
+            && (!expectations.expect_instruction_decode || self.instructions_decoded)
+            && (!expectations.expect_account_reads || self.accounts_decoded)
+    }
+
+    /// Normalize optional stage flags to match disabled runtime expectations.
+    ///
+    /// Stages that are not expected by the pipeline are set to `true` so that
+    /// completeness checks pass without waiting for them.
+    pub fn apply_expectations(&mut self, expectations: &SolanaLivePipelineExpectations) {
+        if !expectations.expect_event_decode {
+            self.events_decoded = true;
+        }
+
+        if !expectations.expect_instruction_decode {
+            self.instructions_decoded = true;
+        }
+
+        if !expectations.expect_account_reads {
+            self.accounts_read = true;
+            self.accounts_decoded = true;
+        }
+
+        if !expectations.expect_transformations {
+            self.transformed = true;
+        }
+    }
+}
+
+/// Runtime expectations for optional live-mode stages.
+///
+/// These are derived from the active pipeline wiring rather than persisted in
+/// status files, allowing status reconstruction to remain backward compatible.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SolanaLivePipelineExpectations {
+    /// Whether decoded event output is expected from the live decoder.
+    pub expect_event_decode: bool,
+    /// Whether decoded instruction output is expected from the live decoder.
+    pub expect_instruction_decode: bool,
+    /// Whether live account reads are enabled for this chain.
+    pub expect_account_reads: bool,
+    /// Whether transformation handlers are expected to run for the slot.
+    pub expect_transformations: bool,
+}
+
+/// Messages for Solana live mode processing.
+#[derive(Debug)]
+pub enum SolanaLiveMessage {
+    /// A new slot was received.
+    Slot(LiveSlot),
+    /// A reorg was detected (slot fork).
+    Reorg {
+        /// The slot number of the common ancestor (last valid slot).
+        common_ancestor: u64,
+        /// Slot numbers that were orphaned.
+        orphaned: Vec<u64>,
+    },
+    /// All live processing should stop (shutdown signal).
+    Shutdown,
+}
+
+/// Trigger for the account reader from the collector.
+///
+/// Sent after block data is fetched to initiate account state reads
+/// for addresses relevant to a particular source/program.
+#[derive(Debug)]
+pub struct AccountReadTrigger {
+    pub slot: u64,
+    pub block_time: Option<i64>,
+    pub source_name: String,
+    pub addresses: Vec<[u8; 32]>,
+    /// When true, skip reads and just mark account flags complete.
+    /// Sent by the discovery loop after it has enqueued all expected
+    /// discovery-managed account reads for a slot.
+    pub mark_complete_only: bool,
+}
+
+// =========================================================================
+// Tests
+// =========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_live_slot_new() {
+        let slot = LiveSlot::new(
+            100,
+            Some(1_700_000_000),
+            Some(90),
+            99,
+            [1u8; 32],
+            [2u8; 32],
+            42,
+        );
+        assert_eq!(slot.slot, 100);
+        assert_eq!(slot.block_time, Some(1_700_000_000));
+        assert_eq!(slot.block_height, Some(90));
+        assert_eq!(slot.parent_slot, 99);
+        assert_eq!(slot.transaction_count, 42);
+    }
+
+    #[test]
+    fn test_live_slot_serde_roundtrip() {
+        let slot = LiveSlot {
+            slot: 250_000_000,
+            block_time: Some(1_700_000_000),
+            block_height: Some(200_000_000),
+            parent_slot: 249_999_999,
+            blockhash: [0xAA; 32],
+            previous_blockhash: [0xBB; 32],
+            transaction_count: 100,
+        };
+
+        let bytes = bincode::serialize(&slot).unwrap();
+        let deserialized: LiveSlot = bincode::deserialize(&bytes).unwrap();
+
+        assert_eq!(deserialized.slot, slot.slot);
+        assert_eq!(deserialized.block_time, slot.block_time);
+        assert_eq!(deserialized.blockhash, slot.blockhash);
+        assert_eq!(deserialized.transaction_count, slot.transaction_count);
+    }
+
+    #[test]
+    fn test_live_transaction_serde_roundtrip() {
+        let tx = LiveTransaction {
+            slot: 100,
+            block_time: Some(1_700_000_000),
+            signature: [0xCC; 64],
+            is_err: false,
+            err_msg: None,
+            fee: 5000,
+            compute_units_consumed: Some(200_000),
+            log_messages: vec!["Program log: hello".to_string()],
+            account_keys: vec![[0xDD; 32], [0xEE; 32]],
+        };
+
+        let bytes = bincode::serialize(&tx).unwrap();
+        let deserialized: LiveTransaction = bincode::deserialize(&bytes).unwrap();
+
+        assert_eq!(deserialized.slot, 100);
+        assert_eq!(deserialized.signature, [0xCC; 64]);
+        assert_eq!(deserialized.fee, 5000);
+        assert_eq!(deserialized.log_messages.len(), 1);
+        assert_eq!(deserialized.account_keys.len(), 2);
+    }
+
+    #[test]
+    fn test_live_account_read_serde_roundtrip() {
+        let read = LiveAccountRead {
+            slot: 100,
+            block_time: Some(1_700_000_000),
+            account_address: [0x11; 32],
+            owner: [0x22; 32],
+            data: vec![1, 2, 3, 4, 5],
+            lamports: 1_000_000_000,
+            executable: false,
+        };
+
+        let bytes = bincode::serialize(&read).unwrap();
+        let deserialized: LiveAccountRead = bincode::deserialize(&bytes).unwrap();
+
+        assert_eq!(deserialized.account_address, [0x11; 32]);
+        assert_eq!(deserialized.lamports, 1_000_000_000);
+        assert!(!deserialized.executable);
+        assert_eq!(deserialized.data, vec![1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn test_status_collected() {
+        let status = LiveSlotStatus::collected();
+        assert!(status.collected);
+        assert!(!status.block_fetched);
+        assert!(!status.events_extracted);
+        assert!(!status.transformed);
+    }
+
+    #[test]
+    fn test_status_is_complete() {
+        let mut status = LiveSlotStatus {
+            collected: true,
+            block_fetched: true,
+            events_extracted: true,
+            instructions_extracted: true,
+            events_decoded: true,
+            instructions_decoded: true,
+            accounts_read: true,
+            accounts_decoded: true,
+            transformed: true,
+            ..Default::default()
+        };
+        assert!(status.is_complete());
+
+        status.events_decoded = false;
+        assert!(!status.is_complete());
+    }
+
+    #[test]
+    fn test_status_is_complete_with_expectations() {
+        let status = LiveSlotStatus {
+            collected: true,
+            block_fetched: true,
+            events_extracted: true,
+            instructions_extracted: true,
+            events_decoded: false,
+            instructions_decoded: false,
+            accounts_read: false,
+            accounts_decoded: false,
+            transformed: false,
+            ..Default::default()
+        };
+
+        // No optional stages expected => complete
+        let expectations = SolanaLivePipelineExpectations::default();
+        assert!(status.is_complete_with(&expectations));
+
+        // Expect event decode => not complete
+        let expectations = SolanaLivePipelineExpectations {
+            expect_event_decode: true,
+            ..Default::default()
+        };
+        assert!(!status.is_complete_with(&expectations));
+    }
+
+    #[test]
+    fn test_status_transform_inputs_ready() {
+        let status = LiveSlotStatus {
+            events_decoded: true,
+            instructions_decoded: true,
+            accounts_decoded: false,
+            ..Default::default()
+        };
+
+        let expectations = SolanaLivePipelineExpectations {
+            expect_event_decode: true,
+            expect_instruction_decode: true,
+            expect_account_reads: false,
+            expect_transformations: true,
+        };
+        assert!(status.transform_inputs_ready_with(&expectations));
+
+        let expectations_with_accounts = SolanaLivePipelineExpectations {
+            expect_event_decode: true,
+            expect_instruction_decode: true,
+            expect_account_reads: true,
+            expect_transformations: true,
+        };
+        assert!(!status.transform_inputs_ready_with(&expectations_with_accounts));
+    }
+
+    #[test]
+    fn test_status_apply_expectations() {
+        let mut status = LiveSlotStatus::default();
+        assert!(!status.events_decoded);
+        assert!(!status.instructions_decoded);
+        assert!(!status.accounts_read);
+        assert!(!status.accounts_decoded);
+        assert!(!status.transformed);
+
+        let expectations = SolanaLivePipelineExpectations {
+            expect_event_decode: false,
+            expect_instruction_decode: true,
+            expect_account_reads: false,
+            expect_transformations: false,
+        };
+
+        status.apply_expectations(&expectations);
+
+        assert!(status.events_decoded);
+        assert!(!status.instructions_decoded);
+        assert!(status.accounts_read);
+        assert!(status.accounts_decoded);
+        assert!(status.transformed);
+    }
+
+    #[test]
+    fn test_status_completed_handlers() {
+        let mut status = LiveSlotStatus::default();
+        status.completed_handlers.insert("handler_a".to_string());
+        status.completed_handlers.insert("handler_b".to_string());
+        status.failed_handlers.insert("handler_c".to_string());
+
+        assert!(status.completed_handlers.contains("handler_a"));
+        assert!(status.completed_handlers.contains("handler_b"));
+        assert!(status.failed_handlers.contains("handler_c"));
+        assert_eq!(status.completed_handlers.len(), 2);
+        assert_eq!(status.failed_handlers.len(), 1);
+    }
+
+    #[test]
+    fn test_status_json_roundtrip() {
+        let mut status = LiveSlotStatus::collected();
+        status.block_fetched = true;
+        status.completed_handlers.insert("my_handler".to_string());
+
+        let json = serde_json::to_string_pretty(&status).unwrap();
+        let deserialized: LiveSlotStatus = serde_json::from_str(&json).unwrap();
+
+        assert!(deserialized.collected);
+        assert!(deserialized.block_fetched);
+        assert!(!deserialized.events_extracted);
+        assert!(deserialized.completed_handlers.contains("my_handler"));
+    }
+}

--- a/src/solana/live/types.rs
+++ b/src/solana/live/types.rs
@@ -212,6 +212,11 @@ pub struct AccountReadTrigger {
     pub block_time: Option<i64>,
     pub source_name: String,
     pub addresses: Vec<[u8; 32]>,
+    /// When true, this explicit read participates in the deferred
+    /// `mark_complete_only` barrier when deferred account completion is active.
+    /// Startup Once reads set this false because they are not followed by that
+    /// slot-scoped barrier.
+    pub await_completion_barrier: bool,
     /// When true, skip reads and just mark account flags complete.
     /// Sent by the discovery loop after it has enqueued all expected
     /// discovery-managed account reads for a slot.

--- a/src/solana/mod.rs
+++ b/src/solana/mod.rs
@@ -1,3 +1,4 @@
+pub mod live;
 pub mod rpc;
 pub mod ws;
 

--- a/src/solana/pipeline.rs
+++ b/src/solana/pipeline.rs
@@ -3,7 +3,7 @@
 //! Wires together raw data collection, decoding, and transformation for Solana
 //! chains. Parallel to the EVM pipeline functions in `main.rs`.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
 
 use anyhow::Context;
@@ -12,24 +12,39 @@ use tokio::task::JoinSet;
 
 use crate::db::DbPool;
 use crate::decoding::DecoderMessage;
+use crate::live::LiveModeConfig;
 use crate::live::LiveProgressTracker;
+use crate::solana::decoding::accounts::SolanaAccountDecoder;
 use crate::solana::decoding::events::SolanaEventDecoder;
 use crate::solana::decoding::idl::AnchorDecoder;
 use crate::solana::decoding::instructions::SolanaInstructionDecoder;
 use crate::solana::decoding::spl_token::SplTokenDecoder;
 use crate::solana::decoding::tasks::{decode_solana_events, decode_solana_instructions};
 use crate::solana::decoding::traits::ProgramDecoder;
+use crate::solana::discovery::{DiscoveryManager, SharedKnownAccounts};
+use crate::solana::live::accounts::SolanaLiveAccountReader;
+use crate::solana::live::catchup::{SolanaCatchupScanResult, SolanaLiveCatchupService};
+use crate::solana::live::collector::SolanaLiveCollector;
+use crate::solana::live::compaction::SolanaCompactionService;
+use crate::solana::live::reorg::SolanaReorgDetector;
+use crate::solana::live::storage::SolanaLiveStorage;
+use crate::solana::live::types::{AccountReadTrigger, SolanaLivePipelineExpectations};
 use crate::solana::raw_data::catchup::signature_driven_backfill;
 use crate::solana::raw_data::parquet::{read_events_from_parquet, read_instructions_from_parquet};
 use crate::solana::rpc::SolanaRpcClient;
+use crate::solana::ws::SolanaWsClient;
 use crate::storage::paths::{
     raw_solana_events_dir, raw_solana_instructions_dir, scan_parquet_ranges,
 };
+use crate::transformations::engine::{
+    ExecutionMode, ReorgMessage, TransformationEngine, TransformationEngineConfig,
+};
 use crate::transformations::registry::{build_registry_for_solana_chain, TransformationRegistry};
 use crate::types::config::chain::ChainConfig;
+use crate::types::config::contract::{Contracts, FactoryCollections};
 use crate::types::config::defaults;
 use crate::types::config::indexer::IndexerConfig;
-use crate::types::config::solana::SolanaPrograms;
+use crate::types::config::solana::{SolanaCommitment, SolanaPrograms};
 use crate::types::shared::repair::RepairScope;
 
 // ---------------------------------------------------------------------------
@@ -114,9 +129,8 @@ impl SolanaChainRuntime {
         let chain = Arc::new(chain.clone());
 
         // Build RPC client
-        let rpc_url = std::env::var(&chain.rpc_url_env_var).with_context(|| {
-            format!("env var {} not set for Solana RPC", chain.rpc_url_env_var)
-        })?;
+        let rpc_url = std::env::var(&chain.rpc_url_env_var)
+            .with_context(|| format!("env var {} not set for Solana RPC", chain.rpc_url_env_var))?;
         let rpc_client = Arc::new(SolanaRpcClient::new(
             &rpc_url,
             chain.commitment,
@@ -174,7 +188,9 @@ impl SolanaChainRuntime {
             None
         };
 
-        // Create progress tracker
+        // Create progress tracker with Solana status storage backend
+        // so handler completion flags are written to LiveSlotStatus files
+        // instead of the EVM LiveBlockStatus default.
         let progress_tracker = if transformations_enabled {
             let tracker = Arc::new(Mutex::new(LiveProgressTracker::new(
                 chain.chain_id as i64,
@@ -183,6 +199,9 @@ impl SolanaChainRuntime {
             )));
             {
                 let mut t = tracker.lock().await;
+                t.set_status_storage(Arc::new(
+                    crate::solana::live::storage::SolanaLiveStorage::new(&chain.name),
+                ));
                 for handler in registry.all_handlers() {
                     t.register_handler(&handler.handler_key());
                 }
@@ -369,16 +388,14 @@ pub async fn process_solana_chain(
     };
 
     // Transformation channels (decoders → engine)
-    // Currently unused since no Solana handlers exist yet, but wired up
-    // so the decoder tasks have somewhere to send when handlers are added.
-    let (transform_events_tx, _transform_events_rx) = if runtime.transformations_enabled {
+    let (transform_events_tx, transform_events_rx) = if runtime.transformations_enabled {
         let (tx, rx) = mpsc::channel(channel_capacity);
         (Some(tx), Some(rx))
     } else {
         (None, None)
     };
 
-    let (transform_complete_tx, _transform_complete_rx) = if runtime.transformations_enabled {
+    let (transform_complete_tx, transform_complete_rx) = if runtime.transformations_enabled {
         let (tx, rx) = mpsc::channel(channel_capacity);
         (Some(tx), Some(rx))
     } else {
@@ -442,8 +459,19 @@ pub async fn process_solana_chain(
         let ff = function_filter.clone();
 
         tasks.spawn(async move {
-            decode_solana_events(event_decoder, program_names, event_rx, tx, complete, chain_name, ff, None)
-                .await;
+            decode_solana_events(
+                event_decoder,
+                program_names,
+                event_rx,
+                tx,
+                complete,
+                chain_name,
+                ff,
+                None,
+                None,
+                false,
+            )
+            .await;
             Ok(())
         });
     }
@@ -470,6 +498,7 @@ pub async fn process_solana_chain(
                 chain_name,
                 ff,
                 None,
+                None,
             )
             .await;
             Ok(())
@@ -483,11 +512,60 @@ pub async fn process_solana_chain(
     // Drop the original instr_decoder_tx so only the backfill task's clone remains
     drop(instr_decoder_tx);
 
-    // TODO: Spawn TransformationEngine when Solana handlers exist.
-    // Currently `transformations_enabled` is always false (no handlers registered).
-    // When handlers are added, the engine will need to accept a Solana RPC client
-    // (or make the EVM client optional). Wire _transform_events_rx and
-    // _transform_complete_rx into engine.run() at that point.
+    // Transformation engine (historical mode)
+    if runtime.transformations_enabled {
+        let tc = config
+            .transformations
+            .as_ref()
+            .expect("transformations_enabled requires transformations config");
+
+        let engine_config = TransformationEngineConfig {
+            chain_name: chain.name.clone(),
+            chain_id: chain.chain_id as u64,
+            mode: ExecutionMode::Streaming,
+            contracts: Contracts::new(),
+            factory_collections: FactoryCollections::new(),
+            handler_concurrency: tc.handler_concurrency,
+            expect_log_completion: runtime.features.has_events,
+            expect_eth_call_completion: false,
+            expect_account_state_completion: false,
+            expect_instruction_completion: runtime.features.has_instructions,
+        };
+
+        let engine = TransformationEngine::new(
+            runtime.registry.clone(),
+            runtime.db_pool.clone().unwrap(),
+            None,
+            engine_config,
+            runtime.progress_tracker.clone(),
+        )
+        .await
+        .context("failed to create transformation engine")?;
+
+        engine
+            .initialize()
+            .await
+            .context("failed to initialize transformation engine")?;
+
+        let (_dummy_calls_tx, dummy_calls_rx) = mpsc::channel(1);
+        let events_rx = transform_events_rx.unwrap();
+        let complete_rx = transform_complete_rx.unwrap();
+
+        tasks.spawn(async move {
+            engine
+                .run(
+                    events_rx,
+                    dummy_calls_rx,
+                    None,
+                    complete_rx,
+                    None,
+                    None,
+                    None,
+                )
+                .await
+                .map_err(|e| anyhow::anyhow!("Transformation engine error: {}", e))
+        });
+    }
 
     // --- Wait for all tasks ---
 
@@ -495,25 +573,1038 @@ pub async fn process_solana_chain(
         result.context("Solana pipeline task panicked")??;
     }
 
-    tracing::info!(chain = chain.name.as_str(), "Solana historical pipeline complete");
+    tracing::info!(
+        chain = chain.name.as_str(),
+        "Solana historical pipeline complete"
+    );
 
-    // --- Live mode stub ---
+    // --- Live mode ---
 
     if !catch_up_only {
-        let live_mode = config
-            .raw_data_collection
-            .live_mode
-            .unwrap_or(false);
+        let live_mode = config.raw_data_collection.live_mode.unwrap_or(false);
         if live_mode {
-            tracing::warn!(
-                chain = chain.name.as_str(),
-                "Solana live mode not yet implemented — skipping. \
-                 Live collector, reorg detection, and account reader are Phase 8."
-            );
+            run_solana_live_mode(config, &runtime).await?;
         }
     }
 
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Live mode pipeline
+// ---------------------------------------------------------------------------
+
+fn collect_incomplete_live_slots(scan: &SolanaCatchupScanResult) -> BTreeSet<u64> {
+    let mut slots = BTreeSet::new();
+    slots.extend(
+        scan.slots_needing_collection_resume
+            .iter()
+            .map(|request| request.slot),
+    );
+    slots.extend(scan.slots_needing_event_decode.iter().copied());
+    slots.extend(scan.slots_needing_instruction_decode.iter().copied());
+    slots.extend(scan.slots_needing_account_reads.iter().copied());
+    slots.extend(scan.slots_needing_transform.iter().map(|(slot, _)| *slot));
+    slots
+}
+
+fn compute_live_expected_start_slot(
+    tip_after_cleanup: Option<u64>,
+    deleted_slots: &BTreeSet<u64>,
+) -> Option<u64> {
+    tip_after_cleanup.or_else(|| {
+        deleted_slots
+            .first()
+            .copied()
+            .and_then(|slot| slot.checked_sub(1))
+    })
+}
+
+/// Cadence for a per-slot account read group.
+#[derive(Debug, Clone)]
+pub enum AccountReadCadence {
+    EverySlot,
+    EveryNSlots(u64),
+    Duration { seconds: u64 },
+}
+
+/// Build the set of `(program_name, account_type)` pairs whose configured
+/// [`Frequency`] means they should be read on per-slot triggers
+/// (`EveryBlock`, `EveryNBlocks`, `Duration`).
+fn build_per_slot_account_types(programs: &SolanaPrograms) -> HashMap<String, HashSet<String>> {
+    use crate::types::config::eth_call::Frequency;
+
+    programs
+        .iter()
+        .filter_map(|(name, config)| {
+            let accounts = config.accounts.as_ref()?;
+            let types: HashSet<String> = accounts
+                .iter()
+                .filter(|a| {
+                    matches!(
+                        a.frequency,
+                        Frequency::EveryBlock | Frequency::EveryNBlocks(_) | Frequency::Duration(_)
+                    )
+                })
+                .map(|a| a.account_type.clone())
+                .collect();
+            if types.is_empty() {
+                None
+            } else {
+                Some((name.clone(), types))
+            }
+        })
+        .collect()
+}
+
+/// Build cadence info for per-slot account types.
+/// Returns a map from `(program_name, account_type)` → `AccountReadCadence`.
+fn build_cadence_map(programs: &SolanaPrograms) -> HashMap<(String, String), AccountReadCadence> {
+    use crate::types::config::eth_call::Frequency;
+
+    let mut map = HashMap::new();
+    for (name, config) in programs {
+        if let Some(ref accounts) = config.accounts {
+            for a in accounts {
+                let cadence = match &a.frequency {
+                    Frequency::EveryBlock => AccountReadCadence::EverySlot,
+                    Frequency::EveryNBlocks(n) => AccountReadCadence::EveryNSlots(*n),
+                    Frequency::Duration(s) => AccountReadCadence::Duration { seconds: *s },
+                    _ => continue, // Once / OnEvents not in per-slot path
+                };
+                map.insert((name.clone(), a.account_type.clone()), cadence);
+            }
+        }
+    }
+    map
+}
+
+/// Build the set of Once-frequency account types (program → account_types).
+fn build_once_account_types(programs: &SolanaPrograms) -> HashMap<String, HashSet<String>> {
+    use crate::types::config::eth_call::Frequency;
+
+    programs
+        .iter()
+        .filter_map(|(name, config)| {
+            let accounts = config.accounts.as_ref()?;
+            let types: HashSet<String> = accounts
+                .iter()
+                .filter(|a| matches!(a.frequency, Frequency::Once))
+                .map(|a| a.account_type.clone())
+                .collect();
+            if types.is_empty() {
+                None
+            } else {
+                Some((name.clone(), types))
+            }
+        })
+        .collect()
+}
+
+/// Build the OnEvents lookup: `(source_name, event_name)` → list of
+/// account types whose known addresses should be read when that event fires.
+fn build_on_events_lookup(programs: &SolanaPrograms) -> HashMap<(String, String), Vec<String>> {
+    use crate::types::config::eth_call::Frequency;
+
+    let mut map: HashMap<(String, String), Vec<String>> = HashMap::new();
+    for (_name, config) in programs {
+        if let Some(ref accounts) = config.accounts {
+            for a in accounts {
+                if let Frequency::OnEvents(ref triggers) = a.frequency {
+                    for trigger in triggers.iter() {
+                        // In Solana, EventTriggerConfig.source is the program name
+                        // and .event is the decoded event name.
+                        let key = (trigger.source.clone(), trigger.event.clone());
+                        map.entry(key).or_default().push(a.account_type.clone());
+                    }
+                }
+            }
+        }
+    }
+    map
+}
+
+/// In live mode, defer slot-level account completion through the discovery loop
+/// whenever decoded events can enqueue account reads after the collector's
+/// per-slot trigger. This covers both newly discovered addresses and OnEvents
+/// reads.
+fn should_defer_live_account_completion(features: &SolanaChainFeatures) -> bool {
+    features.has_account_reads && features.has_discovery && features.has_events
+}
+
+fn decoded_events_block_time(
+    events: &[crate::transformations::context::DecodedEvent],
+) -> Option<i64> {
+    events
+        .first()
+        .and_then(|event| i64::try_from(event.block_timestamp).ok())
+}
+
+async fn resolve_startup_once_trigger_metadata(
+    rpc_client: &SolanaRpcClient,
+    live_storage: &SolanaLiveStorage,
+) -> (u64, Option<i64>) {
+    match rpc_client.get_slot().await {
+        Ok(slot) => {
+            let block_time = match rpc_client.get_block(slot).await {
+                Ok(Some(block)) => block.block_time,
+                Ok(None) => None,
+                Err(error) => {
+                    tracing::warn!(
+                        slot,
+                        error = %error,
+                        "Failed to fetch block metadata for startup Once account reads",
+                    );
+                    None
+                }
+            };
+            (slot, block_time)
+        }
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                "Failed to fetch current slot for startup Once account reads",
+            );
+            if let Ok(Some(slot)) = live_storage.max_slot_number() {
+                let block_time = live_storage.read_slot(slot).ok().and_then(|s| s.block_time);
+                (slot, block_time)
+            } else {
+                (0, None)
+            }
+        }
+    }
+}
+
+/// Run the Solana live mode pipeline.
+///
+/// 1. Set up live storage and reorg detector
+/// 2. Subscribe to slot notifications via WebSocket
+/// 3. Spawn live collector, decoder tasks, compaction service
+/// 4. Wait for all tasks (runs until shutdown)
+async fn run_solana_live_mode(
+    config: &IndexerConfig,
+    runtime: &SolanaChainRuntime,
+) -> anyhow::Result<()> {
+    let chain = &runtime.chain;
+
+    // Resolve WebSocket URL
+    let ws_url = match &chain.ws_url_env_var {
+        Some(env_var) => std::env::var(env_var).with_context(|| {
+            format!(
+                "env var {} not set for Solana WebSocket (required for live mode)",
+                env_var
+            )
+        })?,
+        None => {
+            anyhow::bail!(
+                "ws_url_env_var not configured for chain '{}' — required for live mode",
+                chain.name
+            );
+        }
+    };
+
+    // Reorg depth based on commitment level
+    let reorg_depth = match chain.commitment {
+        SolanaCommitment::Processed => 150,
+        SolanaCommitment::Confirmed => 32,
+        SolanaCommitment::Finalized => 0,
+    };
+
+    let range_size = config
+        .raw_data_collection
+        .parquet_block_range
+        .unwrap_or(1000) as u64;
+
+    let live_config = LiveModeConfig {
+        reorg_depth,
+        compaction_interval_secs: 60,
+        range_size,
+        transform_retry_grace_period_secs: 120,
+    };
+
+    let channel_capacity = config
+        .raw_data_collection
+        .channel_capacity
+        .unwrap_or(defaults::raw_data::CHANNEL_CAPACITY);
+
+    // Build pipeline expectations from features
+    let expectations = SolanaLivePipelineExpectations {
+        expect_event_decode: runtime.features.has_events,
+        expect_instruction_decode: runtime.features.has_instructions,
+        expect_account_reads: runtime.features.has_account_reads,
+        expect_transformations: runtime.transformations_enabled,
+    };
+
+    // Set up live storage
+    let live_storage = SolanaLiveStorage::new(&chain.name);
+    live_storage
+        .ensure_dirs()
+        .context("failed to create live storage directories")?;
+
+    // Set up reorg detector
+    let mut reorg_detector = SolanaReorgDetector::new(reorg_depth);
+
+    // Seed from existing storage
+    let recent_slots = live_storage.get_recent_slots_for_reorg(reorg_depth)?;
+    reorg_detector.seed(
+        recent_slots
+            .iter()
+            .map(|s| (s.slot, s.parent_slot, s.blockhash)),
+    );
+
+    // Run catchup scan for incomplete slots from previous session.
+    // Delete incomplete slots so the collector re-fetches them when it
+    // sees the gap between the cleaned-up tip and the first WebSocket slot.
+    let mut deleted_slots = BTreeSet::new();
+    {
+        let registered_handlers: HashSet<String> =
+            if let Some(ref tracker) = runtime.progress_tracker {
+                tracker.lock().await.handler_keys().clone()
+            } else {
+                HashSet::new()
+            };
+
+        let catchup = SolanaLiveCatchupService::new(&chain.name, registered_handlers, expectations);
+
+        let reconstructed = catchup.reconstruct_missing_status_files()?;
+        if reconstructed > 0 {
+            tracing::info!(
+                chain = chain.name.as_str(),
+                reconstructed,
+                "Reconstructed missing status files"
+            );
+        }
+
+        let scan = catchup.scan_incomplete_slots()?;
+        if !scan.is_empty() {
+            // Delete every incomplete slot so the collector re-fetches it.
+            // This moves the effective live tip back to the last complete slot,
+            // allowing first-slot gap detection to replay the cleaned ranges.
+            for slot in collect_incomplete_live_slots(&scan) {
+                match live_storage.delete_all(slot) {
+                    Ok(()) => {
+                        deleted_slots.insert(slot);
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            slot,
+                            error = %e,
+                            "Failed to delete incomplete slot during catchup cleanup"
+                        );
+                    }
+                }
+            }
+
+            tracing::info!(
+                chain = chain.name.as_str(),
+                collection_resume = scan.slots_needing_collection_resume.len(),
+                event_decode = scan.slots_needing_event_decode.len(),
+                instruction_decode = scan.slots_needing_instruction_decode.len(),
+                account_reads = scan.slots_needing_account_reads.len(),
+                transform = scan.slots_needing_transform.len(),
+                deleted = deleted_slots.len(),
+                "Catchup: deleted incomplete slots for re-collection"
+            );
+        }
+    }
+
+    let expected_start_slot =
+        compute_live_expected_start_slot(live_storage.max_slot_number()?, &deleted_slots);
+
+    // Detect internal gaps left after catchup deletions (e.g. slot 100 deleted
+    // while slot 200 survives). The collector backfills these before the WS loop.
+    let startup_gaps = live_storage.find_gaps()?;
+
+    // Load discovery state
+    let discovery_manager = if runtime.features.has_discovery {
+        let mut manager = DiscoveryManager::load_persisted(&chain.name, &chain.solana_programs);
+        tracing::info!(
+            chain = chain.name.as_str(),
+            "Loaded discovery manager with persisted state"
+        );
+
+        // Bootstrap from getProgramAccounts if this is the first run
+        if let Err(e) = manager
+            .bootstrap(&runtime.rpc_client, &chain.solana_programs)
+            .await
+        {
+            tracing::warn!(
+                chain = chain.name.as_str(),
+                error = %e,
+                "Discovery bootstrap failed (will rely on event-driven discovery)"
+            );
+        }
+
+        Some(manager)
+    } else {
+        None
+    };
+
+    // Build frequency-derived lookups from config.
+    let per_slot_account_types = build_per_slot_account_types(&chain.solana_programs);
+    let once_account_types = build_once_account_types(&chain.solana_programs);
+    let on_events_lookup = build_on_events_lookup(&chain.solana_programs);
+    let cadence_map = build_cadence_map(&chain.solana_programs);
+
+    // Shared registry for known account addresses whose frequency requires
+    // per-slot reads. Preserves (program, account_type) grouping for cadence.
+    let known_accounts_registry: Option<SharedKnownAccounts> =
+        discovery_manager.as_ref().map(|m| {
+            Arc::new(std::sync::RwLock::new(
+                m.snapshot_filtered(&per_slot_account_types),
+            ))
+        });
+
+    // Once-frequency addresses that need an initial read at startup.
+    let once_startup_addresses: Vec<(String, String, Vec<[u8; 32]>)> = discovery_manager
+        .as_ref()
+        .map(|m| {
+            let snapshot = m.snapshot_filtered(&once_account_types);
+            snapshot
+                .into_iter()
+                .flat_map(|(prog, types)| {
+                    types
+                        .into_iter()
+                        .map(move |(acct_type, addrs)| (prog.clone(), acct_type, addrs))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    let once_startup_trigger_metadata = if once_startup_addresses.is_empty() {
+        None
+    } else {
+        Some(resolve_startup_once_trigger_metadata(&runtime.rpc_client, &live_storage).await)
+    };
+
+    tracing::info!(
+        chain = chain.name.as_str(),
+        reorg_depth,
+        commitment = ?chain.commitment,
+        seeded_slots = reorg_detector.tracked_count(),
+        last_slot = ?expected_start_slot,
+        "Starting Solana live mode"
+    );
+
+    // --- Create channels ---
+
+    let (ws_tx, ws_rx) = mpsc::unbounded_channel();
+    // Receiver is dropped immediately so live_tx.send() returns Err
+    // instead of blocking after the buffer fills. The collector already
+    // handles send errors gracefully. A real consumer will be wired in
+    // when Solana live handlers are added.
+    let (live_tx, _) = mpsc::channel(channel_capacity);
+
+    // Decoder channels (collector → decoders)
+    let (event_decoder_tx, event_decoder_rx) = if runtime.features.has_events {
+        let (tx, rx) = mpsc::channel::<DecoderMessage>(channel_capacity);
+        (Some(tx), Some(rx))
+    } else {
+        (None, None)
+    };
+
+    let (instr_decoder_tx, instr_decoder_rx) = if runtime.features.has_instructions {
+        let (tx, rx) = mpsc::channel::<DecoderMessage>(channel_capacity);
+        (Some(tx), Some(rx))
+    } else {
+        (None, None)
+    };
+
+    // Transformation channels (decoders → engine)
+    let (transform_events_tx, transform_events_rx) = if runtime.transformations_enabled {
+        let (tx, rx) = mpsc::channel(channel_capacity);
+        (Some(tx), Some(rx))
+    } else {
+        (None, None)
+    };
+
+    let (transform_complete_tx, transform_complete_rx) = if runtime.transformations_enabled {
+        let (tx, rx) = mpsc::channel(channel_capacity);
+        (Some(tx), Some(rx))
+    } else {
+        (None, None)
+    };
+
+    // Reorg channel (collector → engine)
+    let (transform_reorg_tx, transform_reorg_rx) = if runtime.transformations_enabled {
+        let (tx, rx) = mpsc::channel::<ReorgMessage>(channel_capacity);
+        (Some(tx), Some(rx))
+    } else {
+        (None, None)
+    };
+
+    // Retry channel (compaction → engine)
+    let (transform_retry_tx, transform_retry_rx) = if runtime.transformations_enabled {
+        let (tx, rx) = mpsc::channel(channel_capacity);
+        (Some(tx), Some(rx))
+    } else {
+        (None, None)
+    };
+
+    // Discovery channels — the bridge task (spawned below) taps decoded events
+    // and forwards DiscoveryMessages to this channel.
+    let (discovery_tx, discovery_rx) = if runtime.features.has_discovery {
+        let (tx, rx) = mpsc::channel(channel_capacity);
+        (Some(tx), Some(rx))
+    } else {
+        (None, None)
+    };
+
+    // Account reader channels
+    let (account_states_tx, account_states_rx) = if runtime.features.has_account_reads {
+        let (tx, rx) = mpsc::channel(channel_capacity);
+        (Some(tx), Some(rx))
+    } else {
+        (None, None)
+    };
+    let (account_trigger_tx, account_trigger_rx) = if runtime.features.has_account_reads {
+        let (tx, rx) = mpsc::channel::<AccountReadTrigger>(channel_capacity);
+        (Some(tx), Some(rx))
+    } else {
+        (None, None)
+    };
+
+    // --- Spawn tasks ---
+
+    let mut tasks: JoinSet<anyhow::Result<()>> = JoinSet::new();
+
+    // WebSocket subscription
+    let ws_client = Arc::new(SolanaWsClient::with_default_config(
+        &ws_url,
+        runtime.rpc_client.clone(),
+    ));
+    {
+        let handle = ws_client.clone().subscribe(ws_tx);
+        tasks.spawn(async move {
+            handle
+                .await
+                .map_err(|e| anyhow::anyhow!("WebSocket task panicked: {}", e))?
+                .map_err(|e| anyhow::anyhow!("WebSocket subscription error: {}", e))
+        });
+    }
+
+    // Live collector
+    {
+        let collector = SolanaLiveCollector::new(
+            chain.name.clone(),
+            runtime.rpc_client.clone(),
+            live_storage.clone(),
+            reorg_detector,
+            live_config.clone(),
+            runtime.configured_programs.clone(),
+            runtime.progress_tracker.clone(),
+            expected_start_slot,
+            expectations,
+        )
+        .with_startup_backfill_gaps(startup_gaps);
+
+        let lt = live_tx.clone();
+        let edt = event_decoder_tx.clone();
+        let idt = instr_decoder_tx.clone();
+        let trt = transform_reorg_tx.clone();
+        let att = account_trigger_tx.clone();
+
+        tasks.spawn(async move {
+            collector
+                .run(ws_rx, lt, edt, idt, trt, att)
+                .await
+                .map_err(|e| anyhow::anyhow!("Solana live collector error: {}", e))
+        });
+    }
+
+    // When discovery is active, decoders write to an intermediate channel.
+    // A bridge task forwards to both the transform engine and the discovery
+    // manager. When discovery is inactive, decoders write to transform_events_tx
+    // directly.
+    let (decoder_events_tx, decoder_events_rx) = if runtime.features.has_discovery {
+        let (tx, rx) = mpsc::channel(channel_capacity);
+        (Some(tx), Some(rx))
+    } else {
+        (None, None)
+    };
+
+    // Decide where decoder sends events: bridge channel if discovery, engine directly otherwise.
+    let events_dest_tx = decoder_events_tx
+        .clone()
+        .or_else(|| transform_events_tx.clone());
+
+    // Event decoder task (live mode)
+    let defer_live_account_completion = should_defer_live_account_completion(&runtime.features);
+    if let Some(event_rx) = event_decoder_rx {
+        let event_decoder = Arc::new(SolanaEventDecoder::new(runtime.decoders.clone()));
+        let program_names = runtime.program_names.clone();
+        let tx = events_dest_tx.clone();
+        let complete = transform_complete_tx.clone();
+        let chain_name = runtime.chain.name.clone();
+        let storage_for_decoder = live_storage.clone();
+
+        tasks.spawn(async move {
+            decode_solana_events(
+                event_decoder,
+                program_names,
+                event_rx,
+                tx,
+                complete,
+                chain_name,
+                None,
+                None,
+                Some(storage_for_decoder),
+                defer_live_account_completion,
+            )
+            .await;
+            Ok(())
+        });
+    }
+    drop(event_decoder_tx);
+
+    // Instruction decoder task (live mode)
+    if let Some(instr_rx) = instr_decoder_rx {
+        let instr_decoder = Arc::new(SolanaInstructionDecoder::new(runtime.decoders.clone()));
+        let program_names = runtime.program_names.clone();
+        let tx = events_dest_tx.clone();
+        let complete = transform_complete_tx.clone();
+        let chain_name = runtime.chain.name.clone();
+        let storage_for_decoder = live_storage.clone();
+
+        tasks.spawn(async move {
+            decode_solana_instructions(
+                instr_decoder,
+                program_names,
+                instr_rx,
+                tx,
+                complete,
+                chain_name,
+                None,
+                None,
+                Some(storage_for_decoder),
+            )
+            .await;
+            Ok(())
+        });
+    }
+    drop(instr_decoder_tx);
+    drop(events_dest_tx);
+    drop(decoder_events_tx);
+    // Save a clone for the account reader before dropping the original
+    let account_reader_complete_tx = transform_complete_tx.clone();
+    drop(transform_complete_tx);
+
+    // Discovery bridge task: reads decoded events from the intermediate channel,
+    // forwards to both the transform engine and the discovery manager.
+    if let (Some(mut bridge_rx), Some(disc_tx)) = (decoder_events_rx, discovery_tx) {
+        let engine_tx = transform_events_tx.clone();
+
+        tasks.spawn(async move {
+            use crate::solana::discovery::{
+                DiscoveryEventData, DiscoveryFieldValue, DiscoveryMessage,
+            };
+            use crate::transformations::engine::DecodedEventsMessage;
+
+            while let Some(msg) = bridge_rx.recv().await {
+                // Slot-done sentinel: empty source_name + empty events.
+                // Sent by the decoder after all decoded groups for a slot.
+                // Forward as RangeComplete to the discovery loop (same
+                // channel as events → guarantees ordering).
+                if msg.source_name.is_empty() && msg.events.is_empty() {
+                    let _ = disc_tx
+                        .send(DiscoveryMessage::RangeComplete {
+                            range_start: msg.range_start,
+                            range_end: msg.range_end,
+                        })
+                        .await;
+                    continue;
+                }
+
+                // Forward to engine
+                if let Some(ref tx) = engine_tx {
+                    let engine_msg = DecodedEventsMessage {
+                        range_start: msg.range_start,
+                        range_end: msg.range_end,
+                        source_name: msg.source_name.clone(),
+                        event_name: msg.event_name.clone(),
+                        events: msg.events.clone(),
+                    };
+                    if tx.send(engine_msg).await.is_err() {
+                        tracing::debug!("Transform events channel closed in bridge");
+                    }
+                }
+
+                // Convert to DiscoveryMessage and forward to discovery manager
+                let discovery_events: Vec<DiscoveryEventData> = msg
+                    .events
+                    .iter()
+                    .map(|e| {
+                        let fields = e
+                            .params
+                            .iter()
+                            .map(|(k, v)| {
+                                let field_val = match v.as_pubkey() {
+                                    Some(bytes) => DiscoveryFieldValue::Pubkey(bytes),
+                                    None => DiscoveryFieldValue::Other,
+                                };
+                                (k.clone(), field_val)
+                            })
+                            .collect();
+                        DiscoveryEventData {
+                            event_name: e.event_name.clone(),
+                            fields,
+                        }
+                    })
+                    .collect();
+                let block_time = decoded_events_block_time(&msg.events);
+
+                if !discovery_events.is_empty() {
+                    let _ = disc_tx
+                        .send(DiscoveryMessage::DecodedEvents {
+                            range_start: msg.range_start,
+                            range_end: msg.range_end,
+                            block_time,
+                            source_name: msg.source_name,
+                            events: discovery_events,
+                        })
+                        .await;
+                }
+            }
+            Ok(())
+        });
+    }
+    drop(transform_events_tx);
+
+    // Discovery manager loop — consumes DiscoveryMessages, drives address
+    // discovery, and triggers discovery-managed account reads.
+    if let (Some(mut manager_instance), Some(mut rx)) = (discovery_manager, discovery_rx) {
+        let chain_name = chain.name.clone();
+        let account_tx = account_trigger_tx.clone();
+        let registry_for_discovery = known_accounts_registry.clone();
+        let per_slot_types_for_discovery = per_slot_account_types.clone();
+        let on_events_for_discovery = on_events_lookup.clone();
+        let defer_live_account_completion = defer_live_account_completion;
+
+        tasks.spawn(async move {
+            use crate::solana::discovery::DiscoveryMessage;
+
+            while let Some(msg) = rx.recv().await {
+                match msg {
+                    DiscoveryMessage::DecodedEvents {
+                        range_start,
+                        block_time,
+                        source_name,
+                        events,
+                        ..
+                    } => {
+                        // 1. Process for address discovery
+                        let new_addrs = manager_instance.process_events(&source_name, &events);
+                        if !new_addrs.is_empty() {
+                            if let Err(e) = manager_instance.persist(&chain_name) {
+                                tracing::warn!(
+                                    chain = chain_name.as_str(),
+                                    error = %e,
+                                    "Failed to persist discovery state after new addresses",
+                                );
+                            }
+                            // Update the shared per-slot registry
+                            if let Some(ref registry) = registry_for_discovery {
+                                *registry.write().unwrap() = manager_instance
+                                    .snapshot_filtered(&per_slot_types_for_discovery);
+                            }
+                        }
+                        // Send triggers for newly discovered addresses (Once reads)
+                        for addrs in new_addrs {
+                            if let Some(ref tx) = account_tx {
+                                let addresses: Vec<[u8; 32]> =
+                                    addrs.addresses.iter().map(|p| p.to_bytes()).collect();
+                                if !addresses.is_empty() {
+                                    let _ = tx
+                                        .send(AccountReadTrigger {
+                                            slot: range_start,
+                                            block_time,
+                                            source_name: addrs.program_name.clone(),
+                                            addresses,
+                                            mark_complete_only: false,
+                                        })
+                                        .await;
+                                }
+                            }
+                        }
+
+                        // 2. Check OnEvents rules: if any decoded event matches
+                        //    an OnEvents trigger, read all known addresses for the
+                        //    matching account types.
+                        if !on_events_for_discovery.is_empty() {
+                            for event in &events {
+                                let key =
+                                    (source_name.clone(), event.event_name.clone());
+                                if let Some(account_types) =
+                                    on_events_for_discovery.get(&key)
+                                {
+                                    for acct_type in account_types {
+                                        let addrs = manager_instance
+                                            .known_addresses(&source_name, acct_type);
+                                        if addrs.is_empty() {
+                                            continue;
+                                        }
+                                        if let Some(ref tx) = account_tx {
+                                            let addresses: Vec<[u8; 32]> = addrs
+                                                .iter()
+                                                .map(|pk| pk.to_bytes())
+                                                .collect();
+                                            let _ = tx
+                                                .send(AccountReadTrigger {
+                                                    slot: range_start,
+                                                    block_time,
+                                                    source_name: source_name.clone(),
+                                                    addresses,
+                                                    mark_complete_only: false,
+                                                })
+                                                .await;
+                                        }
+                                    }
+                                }
+                            }
+
+                        }
+                    }
+                    DiscoveryMessage::RangeComplete {
+                        range_start, ..
+                    } => {
+                        // All events for this slot have been decoded and
+                        // forwarded through this loop. Any discovery-triggered
+                        // reads for this slot have already been enqueued on
+                        // account_tx above.
+                        // Now signal the reader that account reads are done.
+                        if defer_live_account_completion {
+                            if let Some(ref tx) = account_tx {
+                                let _ = tx
+                                    .send(AccountReadTrigger {
+                                        slot: range_start,
+                                        block_time: None,
+                                        source_name: String::new(),
+                                        addresses: Vec::new(),
+                                        mark_complete_only: true,
+                                    })
+                                    .await;
+                            }
+                        }
+                    }
+                    DiscoveryMessage::AllComplete => break,
+                }
+            }
+
+            if let Err(e) = manager_instance.persist(&chain_name) {
+                tracing::warn!(chain = chain_name.as_str(), error = %e, "Failed to persist discovery state");
+            }
+            Ok(())
+        });
+    }
+    // Live account reader — runs whenever account reads are configured,
+    // regardless of whether transformations are enabled, so that slots
+    // can reach the accounts_read/accounts_decoded completion flags.
+    // Spawned BEFORE the Once startup sends so the consumer is draining.
+    if let Some(trigger_rx) = account_trigger_rx {
+        let account_decoder = Arc::new(SolanaAccountDecoder::new(runtime.decoders.clone()));
+        let reader = SolanaLiveAccountReader::new(
+            runtime.rpc_client.clone(),
+            account_decoder,
+            live_storage.clone(),
+            runtime.program_names.clone(),
+            known_accounts_registry.clone(),
+            cadence_map.clone(),
+            defer_live_account_completion,
+        );
+
+        // Discovery feeds through trigger_tx, so the reader only needs trigger_rx.
+        let (_disc_tx, disc_rx) = mpsc::channel(1);
+
+        // Route decoded states and completion signals into the transform engine
+        // channels when available, otherwise create stubs so the reader can run.
+        // When the engine is not running (!transformations_enabled), use a
+        // dropped-receiver stub so sends fail immediately instead of blocking
+        // after the buffer fills.
+        let states_tx = if runtime.transformations_enabled {
+            account_states_tx
+                .clone()
+                .unwrap_or_else(|| mpsc::channel(1).0)
+        } else {
+            mpsc::channel(1).0
+        };
+        let complete_tx = if runtime.transformations_enabled {
+            account_reader_complete_tx.unwrap_or_else(|| mpsc::channel(1).0)
+        } else {
+            mpsc::channel(1).0
+        };
+
+        tasks.spawn(async move {
+            reader
+                .run(disc_rx, trigger_rx, states_tx, complete_tx)
+                .await
+                .map_err(|e| anyhow::anyhow!("Account reader error: {}", e))
+        });
+    }
+
+    // Send initial read triggers for Once-frequency addresses that were
+    // loaded from persisted discovery state or found during bootstrap.
+    // Sent after the reader is spawned so the consumer is draining the channel.
+    if !once_startup_addresses.is_empty() {
+        if let Some(ref tx) = account_trigger_tx {
+            let (startup_slot, startup_block_time) =
+                once_startup_trigger_metadata.unwrap_or((0, None));
+            for (program_name, _acct_type, addresses) in &once_startup_addresses {
+                if addresses.is_empty() {
+                    continue;
+                }
+                tracing::info!(
+                    chain = chain.name.as_str(),
+                    source = %program_name,
+                    count = addresses.len(),
+                    "Sending initial Once read for startup-known accounts",
+                );
+                let _ = tx
+                    .send(AccountReadTrigger {
+                        slot: startup_slot,
+                        block_time: startup_block_time,
+                        source_name: program_name.clone(),
+                        addresses: addresses.clone(),
+                        mark_complete_only: false,
+                    })
+                    .await;
+            }
+        }
+    }
+    drop(account_trigger_tx);
+
+    // Compaction service — always runs in live mode, even without transformation
+    // handlers, since it's responsible for moving bincode → parquet and cleaning
+    // up live storage.
+    {
+        // If no progress tracker exists (no handlers), create a stub tracker
+        // so the compaction service can track slot completeness.
+        let tracker = match &runtime.progress_tracker {
+            Some(t) => t.clone(),
+            None => {
+                let mut t =
+                    LiveProgressTracker::new(chain.chain_id as i64, None, chain.name.clone());
+                t.set_status_storage(Arc::new(
+                    crate::solana::live::storage::SolanaLiveStorage::new(&chain.name),
+                ));
+                Arc::new(Mutex::new(t))
+            }
+        };
+
+        let mut compaction = SolanaCompactionService::new(
+            chain.name.clone(),
+            live_config.clone(),
+            tracker,
+            expectations,
+        );
+        // Keep Solana live retries disabled until RetryProcessor can replay
+        // Solana live artifacts instead of the EVM-only retry inputs.
+        tasks.spawn(async move {
+            compaction.run().await;
+            Ok(())
+        });
+    }
+
+    // Transformation engine
+    if runtime.transformations_enabled {
+        let tc = config
+            .transformations
+            .as_ref()
+            .expect("transformations_enabled requires transformations config");
+
+        let engine_config = TransformationEngineConfig {
+            chain_name: chain.name.clone(),
+            chain_id: chain.chain_id as u64,
+            mode: ExecutionMode::Streaming,
+            contracts: Contracts::new(),
+            factory_collections: FactoryCollections::new(),
+            handler_concurrency: tc.handler_concurrency,
+            expect_log_completion: expectations.expect_event_decode,
+            expect_eth_call_completion: false,
+            expect_account_state_completion: expectations.expect_account_reads,
+            expect_instruction_completion: expectations.expect_instruction_decode,
+        };
+
+        let engine = TransformationEngine::new(
+            runtime.registry.clone(),
+            runtime.db_pool.clone().unwrap(),
+            None, // No EVM RPC client for Solana
+            engine_config,
+            runtime.progress_tracker.clone(),
+        )
+        .await
+        .context("failed to create transformation engine")?;
+
+        engine
+            .initialize()
+            .await
+            .context("failed to initialize transformation engine")?;
+
+        // Dummy calls channel (Solana has no eth_calls)
+        let (_dummy_calls_tx, dummy_calls_rx) = mpsc::channel(1);
+
+        let events_rx = transform_events_rx.unwrap();
+        let complete_rx = transform_complete_rx.unwrap();
+
+        tasks.spawn(async move {
+            engine
+                .run(
+                    events_rx,
+                    dummy_calls_rx,
+                    account_states_rx,
+                    complete_rx,
+                    transform_reorg_rx,
+                    transform_retry_rx,
+                    None,
+                )
+                .await
+                .map_err(|e| anyhow::anyhow!("Transformation engine error: {}", e))
+        });
+    }
+
+    // --- Run until shutdown ---
+
+    tracing::info!(chain = chain.name.as_str(), "Solana live mode running");
+
+    while let Some(result) = tasks.join_next().await {
+        match result {
+            Ok(Ok(())) => {
+                tracing::info!(chain = chain.name.as_str(), "Live mode task completed");
+            }
+            Ok(Err(e)) => {
+                tracing::error!(chain = chain.name.as_str(), "Live mode task error: {}", e);
+                return Err(e);
+            }
+            Err(e) => {
+                tracing::error!(
+                    chain = chain.name.as_str(),
+                    "Live mode task panicked: {}",
+                    e
+                );
+                return Err(anyhow::anyhow!("Live mode task panicked: {}", e));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Live-only pipeline
+// ---------------------------------------------------------------------------
+
+/// Run Solana live mode without historical backfill.
+///
+/// Skips signature-driven backfill and goes straight to live slot processing.
+pub async fn process_solana_chain_live_only(
+    config: &IndexerConfig,
+    chain: &ChainConfig,
+    shared_db_pool: Option<Arc<DbPool>>,
+) -> anyhow::Result<()> {
+    tracing::info!(
+        chain = chain.name.as_str(),
+        "Starting Solana live-only pipeline"
+    );
+    let runtime = SolanaChainRuntime::build(config, chain, shared_db_pool).await?;
+    run_solana_live_mode(config, &runtime).await
 }
 
 // ---------------------------------------------------------------------------
@@ -574,7 +1665,19 @@ pub async fn decode_only_solana_chain(
         let ss = only_sources.clone();
 
         tasks.spawn(async move {
-            decode_solana_events(event_decoder, names, rx, None, None, chain_name, ff, ss).await;
+            decode_solana_events(
+                event_decoder,
+                names,
+                rx,
+                None,
+                None,
+                chain_name,
+                ff,
+                ss,
+                None,
+                false,
+            )
+            .await;
             Ok(())
         });
 
@@ -603,7 +1706,18 @@ pub async fn decode_only_solana_chain(
         let ss = only_sources.clone();
 
         tasks.spawn(async move {
-            decode_solana_instructions(instr_decoder, names, rx, None, None, chain_name, ff, ss).await;
+            decode_solana_instructions(
+                instr_decoder,
+                names,
+                rx,
+                None,
+                None,
+                chain_name,
+                ff,
+                ss,
+                None,
+            )
+            .await;
             Ok(())
         });
 
@@ -829,6 +1943,7 @@ async fn feed_raw_instructions_to_decoder(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::solana::live::catchup::{SlotCollectionResumeRequest, SlotCollectionResumeStage};
     use crate::types::config::solana::{
         SolanaAccountReadConfig, SolanaDiscoveryConfig, SolanaEventConfig, SolanaProgramConfig,
     };
@@ -890,7 +2005,10 @@ mod tests {
 
     #[test]
     fn features_idl_program() {
-        let programs = make_programs(vec![("whirlpool", idl_program("11111111111111111111111111111111"))]);
+        let programs = make_programs(vec![(
+            "whirlpool",
+            idl_program("11111111111111111111111111111111"),
+        )]);
         let features = SolanaChainFeatures::detect(&programs);
         assert!(features.has_events);
         assert!(features.has_instructions);
@@ -900,7 +2018,10 @@ mod tests {
 
     #[test]
     fn features_builtin_decoder() {
-        let programs = make_programs(vec![("spl_token", builtin_program("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA", "spl_token"))]);
+        let programs = make_programs(vec![(
+            "spl_token",
+            builtin_program("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA", "spl_token"),
+        )]);
         let features = SolanaChainFeatures::detect(&programs);
         assert!(features.has_events);
         assert!(features.has_instructions);
@@ -908,7 +2029,10 @@ mod tests {
 
     #[test]
     fn features_bare_program_no_capabilities() {
-        let programs = make_programs(vec![("bare", bare_program("11111111111111111111111111111111"))]);
+        let programs = make_programs(vec![(
+            "bare",
+            bare_program("11111111111111111111111111111111"),
+        )]);
         let features = SolanaChainFeatures::detect(&programs);
         assert!(!features.has_events);
         assert!(!features.has_instructions);
@@ -954,6 +2078,42 @@ mod tests {
     }
 
     #[test]
+    fn live_account_completion_defers_for_discovery_once_reads_without_on_events() {
+        let mut prog = idl_program("11111111111111111111111111111111");
+        prog.discovery = Some(vec![SolanaDiscoveryConfig {
+            event_name: "PoolCreated".to_string(),
+            address_field: "pool".to_string(),
+            account_type: Some("Pool".to_string()),
+        }]);
+        prog.accounts = Some(vec![SolanaAccountReadConfig {
+            name: "pool_state".to_string(),
+            account_type: "Pool".to_string(),
+            frequency: crate::types::config::eth_call::Frequency::Once,
+        }]);
+
+        let programs = make_programs(vec![("test", prog)]);
+        let features = SolanaChainFeatures::detect(&programs);
+
+        assert!(build_on_events_lookup(&programs).is_empty());
+        assert!(should_defer_live_account_completion(&features));
+    }
+
+    #[test]
+    fn live_account_completion_does_not_defer_without_account_reads() {
+        let mut prog = idl_program("11111111111111111111111111111111");
+        prog.discovery = Some(vec![SolanaDiscoveryConfig {
+            event_name: "PoolCreated".to_string(),
+            address_field: "pool".to_string(),
+            account_type: Some("Pool".to_string()),
+        }]);
+
+        let programs = make_programs(vec![("test", prog)]);
+        let features = SolanaChainFeatures::detect(&programs);
+
+        assert!(!should_defer_live_account_completion(&features));
+    }
+
+    #[test]
     fn parse_program_id_valid() {
         // 11111111111111111111111111111111 is the system program
         let bytes = parse_program_id("11111111111111111111111111111111").unwrap();
@@ -987,11 +2147,72 @@ mod tests {
         assert_eq!(names.get(&first_key), Some(&"spl_token".to_string()));
     }
 
+    #[test]
+    fn collect_incomplete_live_slots_deduplicates_all_resume_buckets() {
+        let scan = SolanaCatchupScanResult {
+            slots_needing_collection_resume: vec![SlotCollectionResumeRequest {
+                slot: 100,
+                stage: SlotCollectionResumeStage::FetchBlock,
+            }],
+            slots_needing_event_decode: vec![101, 102],
+            slots_needing_instruction_decode: vec![102, 103],
+            slots_needing_account_reads: vec![104],
+            slots_needing_transform: vec![
+                (103, HashSet::from(["handler_a".to_string()])),
+                (105, HashSet::from(["handler_b".to_string()])),
+            ],
+        };
+
+        let slots: Vec<u64> = collect_incomplete_live_slots(&scan).into_iter().collect();
+        assert_eq!(slots, vec![100, 101, 102, 103, 104, 105]);
+    }
+
+    #[test]
+    fn compute_live_expected_start_slot_prefers_remaining_tip() {
+        let deleted_slots = BTreeSet::from([101, 102]);
+        assert_eq!(
+            compute_live_expected_start_slot(Some(100), &deleted_slots),
+            Some(100)
+        );
+    }
+
+    #[test]
+    fn compute_live_expected_start_slot_falls_back_before_deleted_tip() {
+        let deleted_slots = BTreeSet::from([101, 102]);
+        assert_eq!(
+            compute_live_expected_start_slot(None, &deleted_slots),
+            Some(100)
+        );
+    }
+
+    #[test]
+    fn decoded_events_block_time_uses_first_event_timestamp() {
+        use crate::transformations::context::{DecodedEvent, DecodedValue};
+        use crate::types::chain::{ChainAddress, LogPosition, TxId};
+
+        let events = vec![DecodedEvent {
+            block_number: 100,
+            block_timestamp: 1_700_000_123,
+            transaction_id: TxId::Solana([0xAA; 64]),
+            position: LogPosition::Solana {
+                instruction_index: 0,
+                inner_instruction_index: None,
+            },
+            contract_address: ChainAddress::Solana([0xBB; 32]),
+            source_name: "whirlpool".to_string(),
+            event_name: "Swap".to_string(),
+            event_signature: "Swap".to_string(),
+            params: HashMap::from([("amount".to_string(), DecodedValue::Uint64(1))]),
+        }];
+
+        assert_eq!(decoded_events_block_time(&events), Some(1_700_000_123));
+    }
+
     /// Build a minimal ChainConfig for testing.
     fn test_chain_config(programs: SolanaPrograms) -> ChainConfig {
         use crate::types::chain::ChainType;
-        use crate::types::config::contract::{Contracts, FactoryCollections};
         use crate::types::config::chain::RpcConfig;
+        use crate::types::config::contract::{Contracts, FactoryCollections};
         use crate::types::config::solana::SolanaCommitment;
 
         ChainConfig {
@@ -1008,5 +2229,63 @@ mod tests {
             solana_programs: programs,
             commitment: SolanaCommitment::default(),
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests: build_per_slot_account_types
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn per_slot_types_includes_every_block() {
+        let mut prog = idl_program("11111111111111111111111111111111");
+        prog.accounts = Some(vec![SolanaAccountReadConfig {
+            name: "pool".to_string(),
+            account_type: "Pool".to_string(),
+            frequency: crate::types::config::eth_call::Frequency::EveryBlock,
+        }]);
+        let programs = make_programs(vec![("test", prog)]);
+
+        let result = build_per_slot_account_types(&programs);
+        assert!(result["test"].contains("Pool"));
+    }
+
+    #[test]
+    fn per_slot_types_excludes_once() {
+        let mut prog = idl_program("11111111111111111111111111111111");
+        prog.accounts = Some(vec![SolanaAccountReadConfig {
+            name: "pool".to_string(),
+            account_type: "Pool".to_string(),
+            frequency: crate::types::config::eth_call::Frequency::Once,
+        }]);
+        let programs = make_programs(vec![("test", prog)]);
+
+        let result = build_per_slot_account_types(&programs);
+        // "test" should not appear at all (no per-slot types)
+        assert!(
+            !result.contains_key("test"),
+            "Once frequency should be excluded from per-slot types"
+        );
+    }
+
+    #[test]
+    fn per_slot_types_mixed_frequencies() {
+        let mut prog = idl_program("11111111111111111111111111111111");
+        prog.accounts = Some(vec![
+            SolanaAccountReadConfig {
+                name: "pool".to_string(),
+                account_type: "Pool".to_string(),
+                frequency: crate::types::config::eth_call::Frequency::EveryBlock,
+            },
+            SolanaAccountReadConfig {
+                name: "position".to_string(),
+                account_type: "Position".to_string(),
+                frequency: crate::types::config::eth_call::Frequency::Once,
+            },
+        ]);
+        let programs = make_programs(vec![("test", prog)]);
+
+        let result = build_per_slot_account_types(&programs);
+        assert!(result["test"].contains("Pool"));
+        assert!(!result["test"].contains("Position"));
     }
 }

--- a/src/solana/pipeline.rs
+++ b/src/solana/pipeline.rs
@@ -21,7 +21,7 @@ use crate::solana::decoding::instructions::SolanaInstructionDecoder;
 use crate::solana::decoding::spl_token::SplTokenDecoder;
 use crate::solana::decoding::tasks::{decode_solana_events, decode_solana_instructions};
 use crate::solana::decoding::traits::ProgramDecoder;
-use crate::solana::discovery::{DiscoveryManager, SharedKnownAccounts};
+use crate::solana::discovery::{DiscoveryEventData, DiscoveryManager, SharedKnownAccounts};
 use crate::solana::live::accounts::SolanaLiveAccountReader;
 use crate::solana::live::catchup::{SolanaCatchupScanResult, SolanaLiveCatchupService};
 use crate::solana::live::collector::SolanaLiveCollector;
@@ -37,9 +37,12 @@ use crate::storage::paths::{
     raw_solana_events_dir, raw_solana_instructions_dir, scan_parquet_ranges,
 };
 use crate::transformations::engine::{
-    ExecutionMode, ReorgMessage, TransformationEngine, TransformationEngineConfig,
+    DecodedEventsMessage, ExecutionMode, ReorgMessage, TransformationEngine,
+    TransformationEngineConfig,
 };
-use crate::transformations::registry::{build_registry_for_solana_chain, TransformationRegistry};
+use crate::transformations::registry::{
+    build_registry_for_solana_chain, extract_event_name, TransformationRegistry,
+};
 use crate::types::config::chain::ChainConfig;
 use crate::types::config::contract::{Contracts, FactoryCollections};
 use crate::types::config::defaults;
@@ -57,6 +60,7 @@ pub struct SolanaChainFeatures {
     pub has_events: bool,
     pub has_instructions: bool,
     pub has_discovery: bool,
+    pub has_on_events_account_reads: bool,
     pub has_account_reads: bool,
 }
 
@@ -65,6 +69,7 @@ impl SolanaChainFeatures {
         let mut has_events = false;
         let mut has_instructions = false;
         let mut has_discovery = false;
+        let mut has_on_events_account_reads = false;
         let mut has_account_reads = false;
 
         for program in programs.values() {
@@ -87,6 +92,13 @@ impl SolanaChainFeatures {
 
             if program.accounts.as_ref().is_some_and(|a| !a.is_empty()) {
                 has_account_reads = true;
+                if program.accounts.as_ref().is_some_and(|accounts| {
+                    accounts
+                        .iter()
+                        .any(|account| account.frequency.is_on_events())
+                }) {
+                    has_on_events_account_reads = true;
+                }
             }
         }
 
@@ -94,6 +106,7 @@ impl SolanaChainFeatures {
             has_events,
             has_instructions,
             has_discovery,
+            has_on_events_account_reads,
             has_account_reads,
         }
     }
@@ -216,6 +229,7 @@ impl SolanaChainRuntime {
             has_events = features.has_events,
             has_instructions = features.has_instructions,
             has_discovery = features.has_discovery,
+            has_on_events_account_reads = features.has_on_events_account_reads,
             has_account_reads = features.has_account_reads,
             transformations_enabled,
             programs = chain.solana_programs.len(),
@@ -701,21 +715,31 @@ fn build_once_account_types(programs: &SolanaPrograms) -> HashMap<String, HashSe
         .collect()
 }
 
-/// Build the OnEvents lookup: `(source_name, event_name)` → list of
-/// account types whose known addresses should be read when that event fires.
-fn build_on_events_lookup(programs: &SolanaPrograms) -> HashMap<(String, String), Vec<String>> {
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct OnEventAccountReadTarget {
+    owner_program: String,
+    account_type: String,
+}
+
+type OnEventsLookup = HashMap<(String, String), Vec<OnEventAccountReadTarget>>;
+
+/// Build the OnEvents lookup: `(trigger_source, decoded_event_name)` → list of
+/// account owner/account type pairs whose known addresses should be read when
+/// that event fires.
+fn build_on_events_lookup(programs: &SolanaPrograms) -> OnEventsLookup {
     use crate::types::config::eth_call::Frequency;
 
-    let mut map: HashMap<(String, String), Vec<String>> = HashMap::new();
-    for (_name, config) in programs {
+    let mut map: OnEventsLookup = HashMap::new();
+    for (owner_program, config) in programs {
         if let Some(ref accounts) = config.accounts {
             for a in accounts {
                 if let Frequency::OnEvents(ref triggers) = a.frequency {
                     for trigger in triggers.iter() {
-                        // In Solana, EventTriggerConfig.source is the program name
-                        // and .event is the decoded event name.
-                        let key = (trigger.source.clone(), trigger.event.clone());
-                        map.entry(key).or_default().push(a.account_type.clone());
+                        let key = (trigger.source.clone(), extract_event_name(&trigger.event));
+                        map.entry(key).or_default().push(OnEventAccountReadTarget {
+                            owner_program: owner_program.clone(),
+                            account_type: a.account_type.clone(),
+                        });
                     }
                 }
             }
@@ -724,12 +748,58 @@ fn build_on_events_lookup(programs: &SolanaPrograms) -> HashMap<(String, String)
     map
 }
 
+fn collect_on_event_account_read_triggers(
+    slot: u64,
+    block_time: Option<i64>,
+    trigger_source_name: &str,
+    events: &[DiscoveryEventData],
+    on_events_lookup: &OnEventsLookup,
+    discovery_manager: &DiscoveryManager,
+    already_enqueued_targets: &mut HashSet<OnEventAccountReadTarget>,
+) -> Vec<AccountReadTrigger> {
+    let mut triggers = Vec::new();
+
+    for event in events {
+        let key = (trigger_source_name.to_string(), event.event_name.clone());
+        let Some(targets) = on_events_lookup.get(&key) else {
+            continue;
+        };
+
+        for target in targets {
+            let known_addresses =
+                discovery_manager.known_addresses(&target.owner_program, &target.account_type);
+            if known_addresses.is_empty() {
+                continue;
+            }
+            if !already_enqueued_targets.insert(target.clone()) {
+                continue;
+            }
+
+            triggers.push(AccountReadTrigger {
+                slot,
+                block_time,
+                source_name: target.owner_program.clone(),
+                addresses: known_addresses
+                    .into_iter()
+                    .map(|address| address.to_bytes())
+                    .collect(),
+                await_completion_barrier: true,
+                mark_complete_only: false,
+            });
+        }
+    }
+
+    triggers
+}
+
 /// In live mode, defer slot-level account completion through the discovery loop
 /// whenever decoded events can enqueue account reads after the collector's
 /// per-slot trigger. This covers both newly discovered addresses and OnEvents
 /// reads.
 fn should_defer_live_account_completion(features: &SolanaChainFeatures) -> bool {
-    features.has_account_reads && features.has_discovery && features.has_events
+    features.has_account_reads
+        && features.has_events
+        && (features.has_discovery || features.has_on_events_account_reads)
 }
 
 fn decoded_events_block_time(
@@ -738,6 +808,40 @@ fn decoded_events_block_time(
     events
         .first()
         .and_then(|event| i64::try_from(event.block_timestamp).ok())
+}
+
+fn build_live_decoder_destinations(
+    has_discovery: bool,
+    transform_events_tx: Option<mpsc::Sender<DecodedEventsMessage>>,
+    discovery_events_tx: Option<mpsc::Sender<DecodedEventsMessage>>,
+) -> (
+    Option<mpsc::Sender<DecodedEventsMessage>>,
+    Option<mpsc::Sender<DecodedEventsMessage>>,
+) {
+    let event_decoder_dest = if has_discovery {
+        discovery_events_tx
+    } else {
+        transform_events_tx.clone()
+    };
+    let instruction_decoder_dest = transform_events_tx;
+
+    (event_decoder_dest, instruction_decoder_dest)
+}
+
+fn build_startup_once_account_read_trigger(
+    slot: u64,
+    block_time: Option<i64>,
+    source_name: String,
+    addresses: Vec<[u8; 32]>,
+) -> AccountReadTrigger {
+    AccountReadTrigger {
+        slot,
+        block_time,
+        source_name,
+        addresses,
+        await_completion_barrier: false,
+        mark_complete_only: false,
+    }
 }
 
 async fn resolve_startup_once_trigger_metadata(
@@ -908,6 +1012,21 @@ async fn run_solana_live_mode(
         }
     }
 
+    // Reload handler progress from persisted status files so that compaction
+    // can recognize slots that completed transformation before the last crash.
+    if let Some(ref tracker) = runtime.progress_tracker {
+        let mut guard = tracker.lock().await;
+        for slot in live_storage.list_statuses().unwrap_or_default() {
+            if let Ok(status) = live_storage.read_status(slot) {
+                guard.restore_completed(slot, status.completed_handlers);
+            }
+        }
+        tracing::info!(
+            chain = chain.name.as_str(),
+            "Reloaded handler progress from persisted status files",
+        );
+    }
+
     let expected_start_slot =
         compute_live_expected_start_slot(live_storage.max_slot_number()?, &deleted_slots);
 
@@ -915,8 +1034,10 @@ async fn run_solana_live_mode(
     // while slot 200 survives). The collector backfills these before the WS loop.
     let startup_gaps = live_storage.find_gaps()?;
 
-    // Load discovery state
-    let discovery_manager = if runtime.features.has_discovery {
+    // Load known-account state whenever account reads are configured so
+    // persisted addresses remain available even without discovery rules.
+    let discovery_manager = if runtime.features.has_discovery || runtime.features.has_account_reads
+    {
         let mut manager = DiscoveryManager::load_persisted(&chain.name, &chain.solana_programs);
         tracing::info!(
             chain = chain.name.as_str(),
@@ -1042,7 +1163,10 @@ async fn run_solana_live_mode(
 
     // Discovery channels — the bridge task (spawned below) taps decoded events
     // and forwards DiscoveryMessages to this channel.
-    let (discovery_tx, discovery_rx) = if runtime.features.has_discovery {
+    let needs_event_driven_account_reads =
+        runtime.features.has_discovery || runtime.features.has_on_events_account_reads;
+
+    let (discovery_tx, discovery_rx) = if needs_event_driven_account_reads {
         let (tx, rx) = mpsc::channel(channel_capacity);
         (Some(tx), Some(rx))
     } else {
@@ -1109,30 +1233,37 @@ async fn run_solana_live_mode(
                 .await
                 .map_err(|e| anyhow::anyhow!("Solana live collector error: {}", e))
         });
+        // Drop the original sender so the engine's reorg input closes when
+        // the collector (holding the clone) exits.
+        drop(transform_reorg_tx);
     }
 
     // When discovery is active, decoders write to an intermediate channel.
     // A bridge task forwards to both the transform engine and the discovery
     // manager. When discovery is inactive, decoders write to transform_events_tx
     // directly.
-    let (decoder_events_tx, decoder_events_rx) = if runtime.features.has_discovery {
+    let (decoder_events_tx, decoder_events_rx) = if needs_event_driven_account_reads {
         let (tx, rx) = mpsc::channel(channel_capacity);
         (Some(tx), Some(rx))
     } else {
         (None, None)
     };
 
-    // Decide where decoder sends events: bridge channel if discovery, engine directly otherwise.
-    let events_dest_tx = decoder_events_tx
-        .clone()
-        .or_else(|| transform_events_tx.clone());
+    // Discovery is event-only. When enabled, decoded events flow through the
+    // bridge so discovery/account reads can inspect them before the engine.
+    // Decoded instructions always go directly to the engine.
+    let (event_decoder_dest_tx, instruction_decoder_dest_tx) = build_live_decoder_destinations(
+        needs_event_driven_account_reads,
+        transform_events_tx.clone(),
+        decoder_events_tx.clone(),
+    );
 
     // Event decoder task (live mode)
     let defer_live_account_completion = should_defer_live_account_completion(&runtime.features);
     if let Some(event_rx) = event_decoder_rx {
         let event_decoder = Arc::new(SolanaEventDecoder::new(runtime.decoders.clone()));
         let program_names = runtime.program_names.clone();
-        let tx = events_dest_tx.clone();
+        let tx = event_decoder_dest_tx.clone();
         let complete = transform_complete_tx.clone();
         let chain_name = runtime.chain.name.clone();
         let storage_for_decoder = live_storage.clone();
@@ -1160,7 +1291,7 @@ async fn run_solana_live_mode(
     if let Some(instr_rx) = instr_decoder_rx {
         let instr_decoder = Arc::new(SolanaInstructionDecoder::new(runtime.decoders.clone()));
         let program_names = runtime.program_names.clone();
-        let tx = events_dest_tx.clone();
+        let tx = instruction_decoder_dest_tx.clone();
         let complete = transform_complete_tx.clone();
         let chain_name = runtime.chain.name.clone();
         let storage_for_decoder = live_storage.clone();
@@ -1182,7 +1313,8 @@ async fn run_solana_live_mode(
         });
     }
     drop(instr_decoder_tx);
-    drop(events_dest_tx);
+    drop(event_decoder_dest_tx);
+    drop(instruction_decoder_dest_tx);
     drop(decoder_events_tx);
     // Save a clone for the account reader before dropping the original
     let account_reader_complete_tx = transform_complete_tx.clone();
@@ -1278,6 +1410,8 @@ async fn run_solana_live_mode(
         let per_slot_types_for_discovery = per_slot_account_types.clone();
         let on_events_for_discovery = on_events_lookup.clone();
         let defer_live_account_completion = defer_live_account_completion;
+        let mut seen_on_event_targets_by_slot: HashMap<u64, HashSet<OnEventAccountReadTarget>> =
+            HashMap::new();
 
         tasks.spawn(async move {
             use crate::solana::discovery::DiscoveryMessage;
@@ -1319,6 +1453,7 @@ async fn run_solana_live_mode(
                                             block_time,
                                             source_name: addrs.program_name.clone(),
                                             addresses,
+                                            await_completion_barrier: true,
                                             mark_complete_only: false,
                                         })
                                         .await;
@@ -1330,42 +1465,27 @@ async fn run_solana_live_mode(
                         //    an OnEvents trigger, read all known addresses for the
                         //    matching account types.
                         if !on_events_for_discovery.is_empty() {
-                            for event in &events {
-                                let key =
-                                    (source_name.clone(), event.event_name.clone());
-                                if let Some(account_types) =
-                                    on_events_for_discovery.get(&key)
-                                {
-                                    for acct_type in account_types {
-                                        let addrs = manager_instance
-                                            .known_addresses(&source_name, acct_type);
-                                        if addrs.is_empty() {
-                                            continue;
-                                        }
-                                        if let Some(ref tx) = account_tx {
-                                            let addresses: Vec<[u8; 32]> = addrs
-                                                .iter()
-                                                .map(|pk| pk.to_bytes())
-                                                .collect();
-                                            let _ = tx
-                                                .send(AccountReadTrigger {
-                                                    slot: range_start,
-                                                    block_time,
-                                                    source_name: source_name.clone(),
-                                                    addresses,
-                                                    mark_complete_only: false,
-                                                })
-                                                .await;
-                                        }
-                                    }
+                            if let Some(ref tx) = account_tx {
+                                let seen_targets =
+                                    seen_on_event_targets_by_slot.entry(range_start).or_default();
+                                for trigger in collect_on_event_account_read_triggers(
+                                    range_start,
+                                    block_time,
+                                    &source_name,
+                                    &events,
+                                    &on_events_for_discovery,
+                                    &manager_instance,
+                                    seen_targets,
+                                ) {
+                                    let _ = tx.send(trigger).await;
                                 }
                             }
-
                         }
                     }
                     DiscoveryMessage::RangeComplete {
                         range_start, ..
                     } => {
+                        seen_on_event_targets_by_slot.remove(&range_start);
                         // All events for this slot have been decoded and
                         // forwarded through this loop. Any discovery-triggered
                         // reads for this slot have already been enqueued on
@@ -1379,6 +1499,7 @@ async fn run_solana_live_mode(
                                         block_time: None,
                                         source_name: String::new(),
                                         addresses: Vec::new(),
+                                        await_completion_barrier: false,
                                         mark_complete_only: true,
                                     })
                                     .await;
@@ -1458,13 +1579,12 @@ async fn run_solana_live_mode(
                     "Sending initial Once read for startup-known accounts",
                 );
                 let _ = tx
-                    .send(AccountReadTrigger {
-                        slot: startup_slot,
-                        block_time: startup_block_time,
-                        source_name: program_name.clone(),
-                        addresses: addresses.clone(),
-                        mark_complete_only: false,
-                    })
+                    .send(build_startup_once_account_read_trigger(
+                        startup_slot,
+                        startup_block_time,
+                        program_name.clone(),
+                        addresses.clone(),
+                    ))
                     .await;
             }
         }
@@ -1558,6 +1678,9 @@ async fn run_solana_live_mode(
                 .await
                 .map_err(|e| anyhow::anyhow!("Transformation engine error: {}", e))
         });
+        // No other task holds this sender (retry is disabled for Solana live);
+        // drop it so the engine's retry input closes immediately.
+        drop(transform_retry_tx);
     }
 
     // --- Run until shutdown ---
@@ -1943,10 +2066,13 @@ async fn feed_raw_instructions_to_decoder(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::solana::discovery::{DiscoveryEventData, DiscoveryFieldValue};
     use crate::solana::live::catchup::{SlotCollectionResumeRequest, SlotCollectionResumeStage};
+    use crate::types::config::eth_call::{EventTriggerConfig, EventTriggerConfigs, Frequency};
     use crate::types::config::solana::{
         SolanaAccountReadConfig, SolanaDiscoveryConfig, SolanaEventConfig, SolanaProgramConfig,
     };
+    use tokio::sync::mpsc;
 
     fn make_programs(configs: Vec<(&str, SolanaProgramConfig)>) -> SolanaPrograms {
         configs
@@ -2078,6 +2204,26 @@ mod tests {
     }
 
     #[test]
+    fn features_on_events_account_reads_detected_without_discovery() {
+        let mut prog = idl_program("11111111111111111111111111111111");
+        prog.accounts = Some(vec![SolanaAccountReadConfig {
+            name: "pool_state".to_string(),
+            account_type: "Pool".to_string(),
+            frequency: Frequency::OnEvents(EventTriggerConfigs::single(EventTriggerConfig {
+                source: "emitter".to_string(),
+                event: "PoolInitialized(address,address)".to_string(),
+            })),
+        }]);
+
+        let programs = make_programs(vec![("test", prog)]);
+        let features = SolanaChainFeatures::detect(&programs);
+
+        assert!(features.has_account_reads);
+        assert!(features.has_on_events_account_reads);
+        assert!(!features.has_discovery);
+    }
+
+    #[test]
     fn live_account_completion_defers_for_discovery_once_reads_without_on_events() {
         let mut prog = idl_program("11111111111111111111111111111111");
         prog.discovery = Some(vec![SolanaDiscoveryConfig {
@@ -2096,6 +2242,230 @@ mod tests {
 
         assert!(build_on_events_lookup(&programs).is_empty());
         assert!(should_defer_live_account_completion(&features));
+    }
+
+    #[tokio::test]
+    async fn live_account_completion_defers_for_on_events_without_discovery() {
+        let mut prog = idl_program("11111111111111111111111111111111");
+        prog.accounts = Some(vec![SolanaAccountReadConfig {
+            name: "pool_state".to_string(),
+            account_type: "Pool".to_string(),
+            frequency: Frequency::OnEvents(EventTriggerConfigs::single(EventTriggerConfig {
+                source: "emitter".to_string(),
+                event: "PoolInitialized(address,address)".to_string(),
+            })),
+        }]);
+
+        let programs = make_programs(vec![("test", prog)]);
+        let features = SolanaChainFeatures::detect(&programs);
+
+        assert!(features.has_on_events_account_reads);
+        assert!(should_defer_live_account_completion(&features));
+    }
+
+    #[tokio::test]
+    async fn live_decoder_destinations_keep_instructions_out_of_discovery_bridge() {
+        let (transform_tx, mut transform_rx) = mpsc::channel(1);
+        let (bridge_tx, mut bridge_rx) = mpsc::channel(1);
+
+        let (event_tx, instruction_tx) =
+            build_live_decoder_destinations(true, Some(transform_tx), Some(bridge_tx));
+
+        event_tx
+            .unwrap()
+            .send(DecodedEventsMessage {
+                range_start: 1,
+                range_end: 2,
+                source_name: "program".to_string(),
+                event_name: "Swap".to_string(),
+                events: Vec::new(),
+            })
+            .await
+            .unwrap();
+        instruction_tx
+            .unwrap()
+            .send(DecodedEventsMessage {
+                range_start: 1,
+                range_end: 2,
+                source_name: "program".to_string(),
+                event_name: "Transfer".to_string(),
+                events: Vec::new(),
+            })
+            .await
+            .unwrap();
+
+        let bridged = bridge_rx.recv().await.unwrap();
+        let transformed = transform_rx.recv().await.unwrap();
+
+        assert_eq!(bridged.event_name, "Swap");
+        assert_eq!(transformed.event_name, "Transfer");
+        assert!(bridge_rx.try_recv().is_err());
+        assert!(transform_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn on_events_lookup_normalizes_event_signatures_to_decoded_names() {
+        let mut prog = idl_program("11111111111111111111111111111111");
+        prog.accounts = Some(vec![SolanaAccountReadConfig {
+            name: "pool_state".to_string(),
+            account_type: "Pool".to_string(),
+            frequency: Frequency::OnEvents(EventTriggerConfigs::single(EventTriggerConfig {
+                source: "emitter".to_string(),
+                event: "PoolInitialized(address,address)".to_string(),
+            })),
+        }]);
+
+        let programs = make_programs(vec![("owner_program", prog)]);
+        let lookup = build_on_events_lookup(&programs);
+
+        assert_eq!(
+            lookup.get(&("emitter".to_string(), "PoolInitialized".to_string())),
+            Some(&vec![OnEventAccountReadTarget {
+                owner_program: "owner_program".to_string(),
+                account_type: "Pool".to_string(),
+            }]),
+        );
+        assert!(!lookup.contains_key(&(
+            "emitter".to_string(),
+            "PoolInitialized(address,address)".to_string(),
+        )));
+    }
+
+    #[test]
+    fn on_event_account_triggers_use_owning_program_addresses() {
+        let mut owner_prog = idl_program("11111111111111111111111111111111");
+        owner_prog.discovery = Some(vec![SolanaDiscoveryConfig {
+            event_name: "PoolInitialized".to_string(),
+            address_field: "pool".to_string(),
+            account_type: Some("Pool".to_string()),
+        }]);
+        owner_prog.accounts = Some(vec![SolanaAccountReadConfig {
+            name: "pool_state".to_string(),
+            account_type: "Pool".to_string(),
+            frequency: Frequency::OnEvents(EventTriggerConfigs::single(EventTriggerConfig {
+                source: "program_b".to_string(),
+                event: "PoolInitialized(address,address)".to_string(),
+            })),
+        }]);
+
+        let emitter_prog = idl_program("Sysvar1111111111111111111111111111111111111");
+        let programs = make_programs(vec![("program_a", owner_prog), ("program_b", emitter_prog)]);
+        let lookup = build_on_events_lookup(&programs);
+
+        let mut manager = DiscoveryManager::new(&programs);
+        let known_address = [0xAB; 32];
+        manager.process_events(
+            "program_a",
+            &[DiscoveryEventData {
+                event_name: "PoolInitialized".to_string(),
+                fields: HashMap::from([(
+                    "pool".to_string(),
+                    DiscoveryFieldValue::Pubkey(known_address),
+                )]),
+            }],
+        );
+
+        let triggers = collect_on_event_account_read_triggers(
+            42,
+            Some(1_700_000_123),
+            "program_b",
+            &[DiscoveryEventData {
+                event_name: "PoolInitialized".to_string(),
+                fields: HashMap::new(),
+            }],
+            &lookup,
+            &manager,
+            &mut HashSet::new(),
+        );
+
+        assert_eq!(triggers.len(), 1);
+        assert_eq!(triggers[0].slot, 42);
+        assert_eq!(triggers[0].block_time, Some(1_700_000_123));
+        assert_eq!(triggers[0].source_name, "program_a");
+        assert_eq!(triggers[0].addresses, vec![known_address]);
+        assert!(triggers[0].await_completion_barrier);
+        assert!(!triggers[0].mark_complete_only);
+    }
+
+    #[test]
+    fn startup_once_account_triggers_bypass_deferred_completion_barrier() {
+        let trigger = build_startup_once_account_read_trigger(
+            42,
+            Some(1_700_000_123),
+            "program_a".to_string(),
+            vec![[0xEF; 32]],
+        );
+
+        assert_eq!(trigger.slot, 42);
+        assert_eq!(trigger.block_time, Some(1_700_000_123));
+        assert_eq!(trigger.source_name, "program_a");
+        assert_eq!(trigger.addresses, vec![[0xEF; 32]]);
+        assert!(!trigger.await_completion_barrier);
+        assert!(!trigger.mark_complete_only);
+    }
+
+    #[test]
+    fn on_event_account_triggers_dedupe_per_slot() {
+        let mut owner_prog = idl_program("11111111111111111111111111111111");
+        owner_prog.discovery = Some(vec![SolanaDiscoveryConfig {
+            event_name: "PoolInitialized".to_string(),
+            address_field: "pool".to_string(),
+            account_type: Some("Pool".to_string()),
+        }]);
+        owner_prog.accounts = Some(vec![SolanaAccountReadConfig {
+            name: "pool_state".to_string(),
+            account_type: "Pool".to_string(),
+            frequency: Frequency::OnEvents(EventTriggerConfigs::single(EventTriggerConfig {
+                source: "program_b".to_string(),
+                event: "PoolInitialized(address,address)".to_string(),
+            })),
+        }]);
+
+        let emitter_prog = idl_program("Sysvar1111111111111111111111111111111111111");
+        let programs = make_programs(vec![("program_a", owner_prog), ("program_b", emitter_prog)]);
+        let lookup = build_on_events_lookup(&programs);
+
+        let mut manager = DiscoveryManager::new(&programs);
+        let known_address = [0xCD; 32];
+        manager.process_events(
+            "program_a",
+            &[DiscoveryEventData {
+                event_name: "PoolInitialized".to_string(),
+                fields: HashMap::from([(
+                    "pool".to_string(),
+                    DiscoveryFieldValue::Pubkey(known_address),
+                )]),
+            }],
+        );
+
+        let mut seen_targets = HashSet::new();
+        let first = collect_on_event_account_read_triggers(
+            42,
+            Some(1_700_000_123),
+            "program_b",
+            &[DiscoveryEventData {
+                event_name: "PoolInitialized".to_string(),
+                fields: HashMap::new(),
+            }],
+            &lookup,
+            &manager,
+            &mut seen_targets,
+        );
+        let second = collect_on_event_account_read_triggers(
+            42,
+            Some(1_700_000_123),
+            "program_b",
+            &[DiscoveryEventData {
+                event_name: "PoolInitialized".to_string(),
+                fields: HashMap::new(),
+            }],
+            &lookup,
+            &manager,
+            &mut seen_targets,
+        );
+
+        assert_eq!(first.len(), 1);
+        assert_eq!(second.len(), 0);
     }
 
     #[test]

--- a/src/solana/raw_data/catchup.rs
+++ b/src/solana/raw_data/catchup.rs
@@ -59,7 +59,10 @@ pub async fn signature_driven_backfill(
     repair_scope: Option<&RepairScope>,
 ) -> Result<(), SolanaCollectionError> {
     if programs.is_empty() {
-        tracing::info!(chain = chain_name, "No Solana programs configured, nothing to backfill");
+        tracing::info!(
+            chain = chain_name,
+            "No Solana programs configured, nothing to backfill"
+        );
         return Ok(());
     }
 
@@ -236,11 +239,7 @@ pub async fn signature_driven_backfill(
 
     // During repair, pass the target slots so collect_slots_selective can
     // merge fresh data with existing records instead of overwriting.
-    let merge_slots = if is_repair {
-        Some(&target_slots)
-    } else {
-        None
-    };
+    let merge_slots = if is_repair { Some(&target_slots) } else { None };
 
     // When repair scopes to specific sources, also scope the program IDs
     // used for event/instruction extraction so unrelated programs in the
@@ -466,8 +465,7 @@ pub fn find_resume_slot(chain_name: &str) -> Option<u64> {
             for (start, end_inclusive, _path) in ranges {
                 let rk = crate::storage::skipped_slots::range_key(start, end_inclusive);
                 if crate::storage::skipped_slots::is_range_complete(&skipped_index, &rk) {
-                    max_slot =
-                        Some(max_slot.map_or(end_inclusive, |m: u64| m.max(end_inclusive)));
+                    max_slot = Some(max_slot.map_or(end_inclusive, |m: u64| m.max(end_inclusive)));
                 }
             }
         }

--- a/src/solana/raw_data/events.rs
+++ b/src/solana/raw_data/events.rs
@@ -132,8 +132,7 @@ impl ProgramLogParser {
         if depth == 1 {
             // New top-level instruction.
             if self.has_started {
-                self.top_level_instruction_index =
-                    self.top_level_instruction_index.wrapping_add(1);
+                self.top_level_instruction_index = self.top_level_instruction_index.wrapping_add(1);
             }
             self.has_started = true;
             self.inner_instruction_count = 0;
@@ -149,13 +148,7 @@ impl ProgramLogParser {
         self.program_stack.pop();
     }
 
-    fn handle_data(
-        &mut self,
-        b64: &str,
-        slot: u64,
-        block_time: Option<i64>,
-        tx_sig: &[u8; 64],
-    ) {
+    fn handle_data(&mut self, b64: &str, slot: u64, block_time: Option<i64>, tx_sig: &[u8; 64]) {
         let Ok(decoded) = base64::engine::general_purpose::STANDARD.decode(b64.trim()) else {
             return;
         };
@@ -275,9 +268,7 @@ mod tests {
         let event_bytes: Vec<u8> = vec![1, 2, 3, 4, 5, 6, 7, 8, 0xDE, 0xAD, 0xBE, 0xEF];
 
         let logs = vec![
-            format!(
-                "Program 11111111111111111111111111111111 invoke [1]"
-            ),
+            format!("Program 11111111111111111111111111111111 invoke [1]"),
             format!("Program data: {}", b64(&event_bytes)),
             "Program 11111111111111111111111111111111 success".to_string(),
         ];

--- a/src/solana/raw_data/extraction.rs
+++ b/src/solana/raw_data/extraction.rs
@@ -56,13 +56,8 @@ pub fn extract_events_and_instructions(
         let log_messages: Option<&Vec<String>> = meta.log_messages.as_ref().into();
         if let Some(logs) = log_messages {
             if let Some(sig) = extract_signature_from_tx(&encoded_tx.transaction) {
-                let events = extract_events_from_logs(
-                    logs,
-                    slot,
-                    block_time,
-                    &sig,
-                    configured_programs,
-                );
+                let events =
+                    extract_events_from_logs(logs, slot, block_time, &sig, configured_programs);
                 all_events.extend(events);
             }
         }
@@ -160,8 +155,7 @@ mod tests {
             block_height: None,
         };
 
-        let (events, instructions) =
-            extract_events_and_instructions(&block, 100, &HashSet::new());
+        let (events, instructions) = extract_events_and_instructions(&block, 100, &HashSet::new());
         assert!(events.is_empty());
         assert!(instructions.is_empty());
     }
@@ -180,8 +174,7 @@ mod tests {
             block_height: Some(200_000_000),
         };
 
-        let (events, instructions) =
-            extract_events_and_instructions(&block, 200, &HashSet::new());
+        let (events, instructions) = extract_events_and_instructions(&block, 200, &HashSet::new());
         assert!(events.is_empty());
         assert!(instructions.is_empty());
     }
@@ -213,8 +206,7 @@ mod tests {
             block_height: None,
         };
 
-        let (events, instructions) =
-            extract_events_and_instructions(&block, 300, &HashSet::new());
+        let (events, instructions) = extract_events_and_instructions(&block, 300, &HashSet::new());
         assert!(events.is_empty());
         assert!(instructions.is_empty());
     }
@@ -242,8 +234,7 @@ mod tests {
             block_height: None,
         };
 
-        let (events, instructions) =
-            extract_events_and_instructions(&block, 400, &HashSet::new());
+        let (events, instructions) = extract_events_and_instructions(&block, 400, &HashSet::new());
         assert!(events.is_empty());
         assert!(instructions.is_empty());
     }
@@ -274,17 +265,12 @@ mod tests {
         let tx = Transaction::new(&[&payer], msg, Hash::new_unique());
 
         let tx_bytes = bincode::serialize(&tx).unwrap();
-        let b64 = base64::Engine::encode(
-            &base64::engine::general_purpose::STANDARD,
-            &tx_bytes,
-        );
+        let b64 = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &tx_bytes);
 
         // Build log messages with an event from program_id.
         let event_bytes: Vec<u8> = vec![10, 20, 30, 40, 50, 60, 70, 80, 0xAA, 0xBB];
-        let event_b64 = base64::Engine::encode(
-            &base64::engine::general_purpose::STANDARD,
-            &event_bytes,
-        );
+        let event_b64 =
+            base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &event_bytes);
 
         let logs = vec![
             format!("Program {} invoke [1]", program_id),
@@ -316,8 +302,7 @@ mod tests {
         let mut configured = HashSet::new();
         configured.insert(program_id.to_bytes());
 
-        let (events, instructions) =
-            extract_events_and_instructions(&block, 500, &configured);
+        let (events, instructions) = extract_events_and_instructions(&block, 500, &configured);
 
         // Should have 1 event and 1 instruction.
         assert_eq!(events.len(), 1);
@@ -327,7 +312,10 @@ mod tests {
         assert_eq!(events[0].slot, 500);
         assert_eq!(events[0].block_time, Some(1_700_000_000));
         assert_eq!(events[0].program_id, program_id.to_bytes());
-        assert_eq!(events[0].event_discriminator, [10, 20, 30, 40, 50, 60, 70, 80]);
+        assert_eq!(
+            events[0].event_discriminator,
+            [10, 20, 30, 40, 50, 60, 70, 80]
+        );
         assert_eq!(events[0].event_data, vec![0xAA, 0xBB]);
 
         // Verify instruction.

--- a/src/solana/raw_data/instructions.rs
+++ b/src/solana/raw_data/instructions.rs
@@ -50,7 +50,13 @@ pub fn extract_instructions_from_transaction(
         Some(tx) => tx,
         None => {
             // JSON-encoded transactions: fall back to UiMessage parsing.
-            return extract_from_json_transaction(encoded_tx, meta, slot, block_time, configured_programs);
+            return extract_from_json_transaction(
+                encoded_tx,
+                meta,
+                slot,
+                block_time,
+                configured_programs,
+            );
         }
     };
 
@@ -64,10 +70,7 @@ pub fn extract_instructions_from_transaction(
     };
 
     // Build the full account key list: static keys + loaded addresses (ALT).
-    let mut account_keys: Vec<Pubkey> = versioned_tx
-        .message
-        .static_account_keys()
-        .to_vec();
+    let mut account_keys: Vec<Pubkey> = versioned_tx.message.static_account_keys().to_vec();
     append_loaded_addresses(&mut account_keys, meta);
 
     let mut records = Vec::new();
@@ -343,12 +346,7 @@ mod tests {
             version: None,
         };
 
-        let result = extract_instructions_from_transaction(
-            &encoded_tx,
-            100,
-            None,
-            &HashSet::new(),
-        );
+        let result = extract_instructions_from_transaction(&encoded_tx, 100, None, &HashSet::new());
         assert!(result.is_empty());
     }
 
@@ -366,12 +364,7 @@ mod tests {
             version: None,
         };
 
-        let result = extract_instructions_from_transaction(
-            &encoded_tx,
-            100,
-            None,
-            &HashSet::new(),
-        );
+        let result = extract_instructions_from_transaction(&encoded_tx, 100, None, &HashSet::new());
         assert!(result.is_empty());
     }
 
@@ -388,12 +381,7 @@ mod tests {
             version: None,
         };
 
-        let result = extract_instructions_from_transaction(
-            &encoded_tx,
-            100,
-            None,
-            &HashSet::new(),
-        );
+        let result = extract_instructions_from_transaction(&encoded_tx, 100, None, &HashSet::new());
         // The decode() call returns None, then we try JSON path which also
         // returns empty since it's not JSON.
         assert!(result.is_empty());
@@ -459,10 +447,7 @@ mod tests {
 
         // Serialize and base64-encode.
         let tx_bytes = bincode::serialize(&tx).unwrap();
-        let b64 = base64::Engine::encode(
-            &base64::engine::general_purpose::STANDARD,
-            &tx_bytes,
-        );
+        let b64 = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &tx_bytes);
 
         let meta = test_meta(None);
         let encoded_tx = EncodedTransactionWithStatusMeta {
@@ -472,24 +457,15 @@ mod tests {
         };
 
         // Without the program configured, no instructions extracted.
-        let result = extract_instructions_from_transaction(
-            &encoded_tx,
-            42,
-            Some(999),
-            &HashSet::new(),
-        );
+        let result =
+            extract_instructions_from_transaction(&encoded_tx, 42, Some(999), &HashSet::new());
         assert!(result.is_empty());
 
         // With the program configured, we get the instruction.
         let mut configured = HashSet::new();
         configured.insert(program_id.to_bytes());
 
-        let result = extract_instructions_from_transaction(
-            &encoded_tx,
-            42,
-            Some(999),
-            &configured,
-        );
+        let result = extract_instructions_from_transaction(&encoded_tx, 42, Some(999), &configured);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].slot, 42);
         assert_eq!(result[0].block_time, Some(999));
@@ -529,10 +505,7 @@ mod tests {
         let tx = Transaction::new(&[&payer], msg, recent_blockhash);
 
         let tx_bytes = bincode::serialize(&tx).unwrap();
-        let b64 = base64::Engine::encode(
-            &base64::engine::general_purpose::STANDARD,
-            &tx_bytes,
-        );
+        let b64 = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &tx_bytes);
 
         // Figure out inner_program's index in the account keys.
         // The transaction's account keys are: [payer, account1, outer_program].
@@ -548,9 +521,7 @@ mod tests {
 
         let inner_group = solana_transaction_status::UiInnerInstructions {
             index: 0, // parent instruction index
-            instructions: vec![solana_transaction_status::UiInstruction::Compiled(
-                inner_ix,
-            )],
+            instructions: vec![solana_transaction_status::UiInstruction::Compiled(inner_ix)],
         };
 
         let loaded = solana_transaction_status::UiLoadedAddresses {
@@ -573,12 +544,7 @@ mod tests {
         configured.insert(outer_program.to_bytes());
         configured.insert(inner_program.to_bytes());
 
-        let result = extract_instructions_from_transaction(
-            &encoded_tx,
-            100,
-            None,
-            &configured,
-        );
+        let result = extract_instructions_from_transaction(&encoded_tx, 100, None, &configured);
 
         assert_eq!(result.len(), 2);
 
@@ -625,10 +591,7 @@ mod tests {
         let tx = Transaction::new(&[&payer], msg, recent_blockhash);
 
         let tx_bytes = bincode::serialize(&tx).unwrap();
-        let b64 = base64::Engine::encode(
-            &base64::engine::general_purpose::STANDARD,
-            &tx_bytes,
-        );
+        let b64 = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &tx_bytes);
 
         let meta = test_meta(None);
         let encoded_tx = EncodedTransactionWithStatusMeta {
@@ -641,12 +604,7 @@ mod tests {
         let mut configured = HashSet::new();
         configured.insert(program_b.to_bytes());
 
-        let result = extract_instructions_from_transaction(
-            &encoded_tx,
-            500,
-            None,
-            &configured,
-        );
+        let result = extract_instructions_from_transaction(&encoded_tx, 500, None, &configured);
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].program_id, program_b.to_bytes());

--- a/src/solana/raw_data/mod.rs
+++ b/src/solana/raw_data/mod.rs
@@ -1,7 +1,7 @@
-pub mod types;
-pub mod parquet;
-pub mod events;
-pub mod instructions;
-pub mod extraction;
-pub mod slots;
 pub mod catchup;
+pub mod events;
+pub mod extraction;
+pub mod instructions;
+pub mod parquet;
+pub mod slots;
+pub mod types;

--- a/src/solana/raw_data/parquet.rs
+++ b/src/solana/raw_data/parquet.rs
@@ -31,7 +31,11 @@ pub fn build_slot_schema() -> Arc<Schema> {
         Field::new("transaction_count", DataType::UInt32, false),
         Field::new(
             "transaction_signatures",
-            DataType::List(Arc::new(Field::new("item", DataType::FixedSizeBinary(64), true))),
+            DataType::List(Arc::new(Field::new(
+                "item",
+                DataType::FixedSizeBinary(64),
+                true,
+            ))),
             false,
         ),
     ]))
@@ -229,7 +233,11 @@ pub fn build_instruction_schema() -> Arc<Schema> {
         Field::new("data", DataType::Binary, false),
         Field::new(
             "accounts",
-            DataType::List(Arc::new(Field::new("item", DataType::FixedSizeBinary(32), true))),
+            DataType::List(Arc::new(Field::new(
+                "item",
+                DataType::FixedSizeBinary(32),
+                true,
+            ))),
             false,
         ),
         Field::new("instruction_index", DataType::UInt16, false),
@@ -272,10 +280,7 @@ pub fn write_instructions_to_parquet(
     arrays.push(Arc::new(arr));
 
     // data (Binary)
-    let arr: BinaryArray = records
-        .iter()
-        .map(|r| Some(r.data.as_slice()))
-        .collect();
+    let arr: BinaryArray = records.iter().map(|r| Some(r.data.as_slice())).collect();
     arrays.push(Arc::new(arr));
 
     // accounts (List(FixedSizeBinary(32)))
@@ -319,7 +324,9 @@ pub async fn write_instructions_to_parquet_async(
 // ---------------------------------------------------------------------------
 
 /// Read `SolanaEventRecord`s from a parquet file.
-pub fn read_events_from_parquet(path: &Path) -> Result<Vec<SolanaEventRecord>, SolanaCollectionError> {
+pub fn read_events_from_parquet(
+    path: &Path,
+) -> Result<Vec<SolanaEventRecord>, SolanaCollectionError> {
     let file = std::fs::File::open(path)?;
     let builder = ParquetRecordBatchReaderBuilder::try_new(file)
         .map_err(|e| SolanaCollectionError::ParquetWrite(e.to_string()))?;
@@ -432,7 +439,9 @@ pub fn read_events_from_parquet(path: &Path) -> Result<Vec<SolanaEventRecord>, S
 }
 
 /// Read `SolanaSlotRecord`s from a parquet file.
-pub fn read_slots_from_parquet(path: &Path) -> Result<Vec<SolanaSlotRecord>, SolanaCollectionError> {
+pub fn read_slots_from_parquet(
+    path: &Path,
+) -> Result<Vec<SolanaSlotRecord>, SolanaCollectionError> {
     let file = std::fs::File::open(path)?;
     let builder = ParquetRecordBatchReaderBuilder::try_new(file)
         .map_err(|e| SolanaCollectionError::ParquetWrite(e.to_string()))?;
@@ -603,8 +612,7 @@ pub fn read_instructions_from_parquet(
         let accounts_col = batch
             .column_by_name("accounts")
             .expect("missing accounts column");
-        let accounts_list = accounts_col
-            .as_list::<i32>();
+        let accounts_list = accounts_col.as_list::<i32>();
 
         let ix_arr = batch
             .column_by_name("instruction_index")
@@ -1002,7 +1010,10 @@ mod tests {
         );
         assert_eq!(read_back[0].event_data, original[0].event_data);
         assert_eq!(read_back[0].log_index, original[0].log_index);
-        assert_eq!(read_back[0].instruction_index, original[0].instruction_index);
+        assert_eq!(
+            read_back[0].instruction_index,
+            original[0].instruction_index
+        );
         assert_eq!(
             read_back[0].inner_instruction_index,
             original[0].inner_instruction_index
@@ -1050,7 +1061,10 @@ mod tests {
         assert_eq!(read_back[0].accounts.len(), 2);
         assert_eq!(read_back[0].accounts[0], original[0].accounts[0]);
         assert_eq!(read_back[0].accounts[1], original[0].accounts[1]);
-        assert_eq!(read_back[0].instruction_index, original[0].instruction_index);
+        assert_eq!(
+            read_back[0].instruction_index,
+            original[0].instruction_index
+        );
         assert!(read_back[0].inner_instruction_index.is_none());
 
         // Second record
@@ -1093,11 +1107,23 @@ mod tests {
         assert_eq!(read_back[0].block_height, original[0].block_height);
         assert_eq!(read_back[0].parent_slot, original[0].parent_slot);
         assert_eq!(read_back[0].blockhash, original[0].blockhash);
-        assert_eq!(read_back[0].previous_blockhash, original[0].previous_blockhash);
-        assert_eq!(read_back[0].transaction_count, original[0].transaction_count);
+        assert_eq!(
+            read_back[0].previous_blockhash,
+            original[0].previous_blockhash
+        );
+        assert_eq!(
+            read_back[0].transaction_count,
+            original[0].transaction_count
+        );
         assert_eq!(read_back[0].transaction_signatures.len(), 2);
-        assert_eq!(read_back[0].transaction_signatures[0], original[0].transaction_signatures[0]);
-        assert_eq!(read_back[0].transaction_signatures[1], original[0].transaction_signatures[1]);
+        assert_eq!(
+            read_back[0].transaction_signatures[0],
+            original[0].transaction_signatures[0]
+        );
+        assert_eq!(
+            read_back[0].transaction_signatures[1],
+            original[0].transaction_signatures[1]
+        );
 
         // Second record (optional fields are None, empty signatures)
         assert_eq!(read_back[1].slot, original[1].slot);
@@ -1105,7 +1131,10 @@ mod tests {
         assert!(read_back[1].block_height.is_none());
         assert_eq!(read_back[1].parent_slot, original[1].parent_slot);
         assert_eq!(read_back[1].blockhash, original[1].blockhash);
-        assert_eq!(read_back[1].previous_blockhash, original[1].previous_blockhash);
+        assert_eq!(
+            read_back[1].previous_blockhash,
+            original[1].previous_blockhash
+        );
         assert_eq!(read_back[1].transaction_count, 0);
         assert!(read_back[1].transaction_signatures.is_empty());
     }

--- a/src/solana/raw_data/slots.rs
+++ b/src/solana/raw_data/slots.rs
@@ -73,12 +73,7 @@ pub async fn collect_solana_raw_data(
     let mut skipped_index = skipped_slots::read_skipped_slots_index(&events_dir);
 
     // Compute ranges to fetch
-    let ranges = compute_slot_ranges_to_fetch(
-        start_slot,
-        end_slot,
-        range_size,
-        &skipped_index,
-    );
+    let ranges = compute_slot_ranges_to_fetch(start_slot, end_slot, range_size, &skipped_index);
 
     if ranges.is_empty() {
         tracing::info!(chain = chain_name, "No slot ranges to collect");
@@ -158,11 +153,11 @@ pub async fn collect_solana_raw_data(
                 events: all_events,
                 live_mode: false,
             };
-            tx.send(msg)
-                .await
-                .map_err(|e: tokio::sync::mpsc::error::SendError<DecoderMessage>| {
+            tx.send(msg).await.map_err(
+                |e: tokio::sync::mpsc::error::SendError<DecoderMessage>| {
                     SolanaCollectionError::ChannelSend(e.to_string())
-                })?;
+                },
+            )?;
         }
 
         if let Some(tx) = instr_decoder_tx {
@@ -172,11 +167,11 @@ pub async fn collect_solana_raw_data(
                 instructions: all_instructions,
                 live_mode: false,
             };
-            tx.send(msg)
-                .await
-                .map_err(|e: tokio::sync::mpsc::error::SendError<DecoderMessage>| {
+            tx.send(msg).await.map_err(
+                |e: tokio::sync::mpsc::error::SendError<DecoderMessage>| {
                     SolanaCollectionError::ChannelSend(e.to_string())
-                })?;
+                },
+            )?;
         }
 
         tracing::info!(
@@ -481,7 +476,12 @@ pub async fn collect_slots_selective(
     write_events_to_parquet_async(all_events.clone(), event_schema, events_path).await?;
 
     let instructions_path = instructions_dir.join(range.file_name("instructions"));
-    write_instructions_to_parquet_async(all_instructions.clone(), instruction_schema, instructions_path).await?;
+    write_instructions_to_parquet_async(
+        all_instructions.clone(),
+        instruction_schema,
+        instructions_path,
+    )
+    .await?;
 
     // Update skipped slots index
     let mut skipped_index = skipped_slots::read_skipped_slots_index(&events_dir);
@@ -489,10 +489,7 @@ pub async fn collect_slots_selective(
     if let Some(repaired) = repair_slots {
         // Merge: keep existing skipped slots for non-repaired slots,
         // add new skipped slots from repaired slots
-        let mut merged = skipped_index
-            .get(&rk)
-            .cloned()
-            .unwrap_or_default();
+        let mut merged = skipped_index.get(&rk).cloned().unwrap_or_default();
         // Remove skipped entries for slots being repaired (they may no longer be skipped)
         merged.retain(|s| !repaired.contains(s));
         // Add newly discovered skipped slots
@@ -714,10 +711,7 @@ mod tests {
         let expected_sig = tx.signatures[0];
 
         let tx_bytes = bincode::serialize(&tx).unwrap();
-        let b64 = base64::Engine::encode(
-            &base64::engine::general_purpose::STANDARD,
-            &tx_bytes,
-        );
+        let b64 = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &tx_bytes);
 
         let encoded_tx = EncodedTransactionWithStatusMeta {
             transaction: EncodedTransaction::Binary(b64, TransactionBinaryEncoding::Base64),

--- a/src/solana/rpc.rs
+++ b/src/solana/rpc.rs
@@ -5,9 +5,7 @@ use std::time::Duration;
 use solana_client::client_error::ClientError as SolanaClientError;
 use solana_client::nonblocking::rpc_client::RpcClient as SolanaRpcClientInner;
 use solana_client::rpc_client::GetConfirmedSignaturesForAddress2Config;
-use solana_client::rpc_config::{
-    RpcBlockConfig, RpcProgramAccountsConfig, RpcTransactionConfig,
-};
+use solana_client::rpc_config::{RpcBlockConfig, RpcProgramAccountsConfig, RpcTransactionConfig};
 use solana_client::rpc_filter::RpcFilterType;
 use solana_client::rpc_response::RpcConfirmedTransactionStatusWithSignature;
 use solana_sdk::account::Account;
@@ -176,14 +174,11 @@ impl SolanaRpcClient {
         requests_per_second: Option<u32>,
         concurrency: Option<usize>,
     ) -> Result<Self, SolanaRpcError> {
-        let _ = url::Url::parse(rpc_url)
-            .map_err(|e| SolanaRpcError::InvalidUrl(e.to_string()))?;
+        let _ = url::Url::parse(rpc_url).map_err(|e| SolanaRpcError::InvalidUrl(e.to_string()))?;
 
         let commitment_config = commitment_config_from(commitment);
-        let inner = SolanaRpcClientInner::new_with_commitment(
-            rpc_url.to_string(),
-            commitment_config,
-        );
+        let inner =
+            SolanaRpcClientInner::new_with_commitment(rpc_url.to_string(), commitment_config);
 
         let rps = requests_per_second.unwrap_or(defaults::REQUESTS_PER_SECOND);
         let conc = concurrency.unwrap_or(defaults::CONCURRENCY);
@@ -205,14 +200,11 @@ impl SolanaRpcClient {
         shared_limiter: Arc<SlidingWindowRateLimiter>,
         concurrency: Option<usize>,
     ) -> Result<Self, SolanaRpcError> {
-        let _ = url::Url::parse(rpc_url)
-            .map_err(|e| SolanaRpcError::InvalidUrl(e.to_string()))?;
+        let _ = url::Url::parse(rpc_url).map_err(|e| SolanaRpcError::InvalidUrl(e.to_string()))?;
 
         let commitment_config = commitment_config_from(commitment);
-        let inner = SolanaRpcClientInner::new_with_commitment(
-            rpc_url.to_string(),
-            commitment_config,
-        );
+        let inner =
+            SolanaRpcClientInner::new_with_commitment(rpc_url.to_string(), commitment_config);
         let conc = concurrency.unwrap_or(defaults::CONCURRENCY);
 
         Ok(Self {
@@ -282,10 +274,7 @@ impl SolanaRpcClient {
     /// Get a full block with transactions for a given slot.
     ///
     /// Returns `None` if the slot was skipped (no block produced).
-    pub async fn get_block(
-        &self,
-        slot: u64,
-    ) -> Result<Option<UiConfirmedBlock>, SolanaRpcError> {
+    pub async fn get_block(&self, slot: u64) -> Result<Option<UiConfirmedBlock>, SolanaRpcError> {
         let inner = self.inner.clone();
         let commitment = self.commitment;
         let config = RpcBlockConfig {
@@ -370,9 +359,8 @@ impl SolanaRpcClient {
 
         let mut results = Vec::with_capacity(slots.len());
         while let Some(join_result) = join_set.join_next().await {
-            let (slot, block) = join_result.map_err(|e| {
-                SolanaRpcError::Transport(format!("Task join error: {e}"))
-            })??;
+            let (slot, block) = join_result
+                .map_err(|e| SolanaRpcError::Transport(format!("Task join error: {e}")))??;
             results.push((slot, block));
         }
 
@@ -570,12 +558,8 @@ mod tests {
 
     #[test]
     fn test_constructor_invalid_url() {
-        let result = SolanaRpcClient::new(
-            "not a valid url",
-            SolanaCommitment::Confirmed,
-            None,
-            None,
-        );
+        let result =
+            SolanaRpcClient::new("not a valid url", SolanaCommitment::Confirmed, None, None);
         assert!(result.is_err());
         assert!(matches!(result.unwrap_err(), SolanaRpcError::InvalidUrl(_)));
     }
@@ -622,15 +606,14 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
         let cc = call_count.clone();
 
-        let result: Result<(), SolanaRpcError> =
-            with_solana_retry(&config, "test", || {
-                let cc = cc.clone();
-                async move {
-                    cc.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-                    Err(SolanaRpcError::InvalidUrl("permanent".into()))
-                }
-            })
-            .await;
+        let result: Result<(), SolanaRpcError> = with_solana_retry(&config, "test", || {
+            let cc = cc.clone();
+            async move {
+                cc.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Err(SolanaRpcError::InvalidUrl("permanent".into()))
+            }
+        })
+        .await;
 
         assert!(result.is_err());
         assert_eq!(call_count.load(std::sync::atomic::Ordering::SeqCst), 1);
@@ -642,19 +625,18 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
         let cc = call_count.clone();
 
-        let result: Result<u32, SolanaRpcError> =
-            with_solana_retry(&config, "test", || {
-                let cc = cc.clone();
-                async move {
-                    let count = cc.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-                    if count < 2 {
-                        Err(SolanaRpcError::Transport("timeout".into()))
-                    } else {
-                        Ok(42)
-                    }
+        let result: Result<u32, SolanaRpcError> = with_solana_retry(&config, "test", || {
+            let cc = cc.clone();
+            async move {
+                let count = cc.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                if count < 2 {
+                    Err(SolanaRpcError::Transport("timeout".into()))
+                } else {
+                    Ok(42)
                 }
-            })
-            .await;
+            }
+        })
+        .await;
 
         assert_eq!(result.unwrap(), 42);
         assert_eq!(call_count.load(std::sync::atomic::Ordering::SeqCst), 3);

--- a/src/solana/ws.rs
+++ b/src/solana/ws.rs
@@ -72,10 +72,7 @@ impl SolanaWsClient {
         }
     }
 
-    pub fn with_default_config(
-        ws_url: &str,
-        rpc_client: Arc<SolanaRpcClient>,
-    ) -> Self {
+    pub fn with_default_config(ws_url: &str, rpc_client: Arc<SolanaRpcClient>) -> Self {
         Self::new(ws_url, rpc_client, ReconnectConfig::default())
     }
 
@@ -102,10 +99,7 @@ impl SolanaWsClient {
         let mut reconnect_attempt = 0u32;
 
         loop {
-            match self
-                .connect_and_listen(&event_tx, &mut last_slot)
-                .await
-            {
+            match self.connect_and_listen(&event_tx, &mut last_slot).await {
                 Ok(()) => {
                     tracing::info!("Solana WebSocket subscription ended cleanly");
                     return Ok(());
@@ -130,8 +124,7 @@ impl SolanaWsClient {
                         return Err(e);
                     }
 
-                    let delay =
-                        self.reconnect_config.delay_for_attempt(reconnect_attempt);
+                    let delay = self.reconnect_config.delay_for_attempt(reconnect_attempt);
                     tracing::info!(
                         "Solana WS reconnecting in {delay:?} (attempt {})",
                         reconnect_attempt + 1,
@@ -183,9 +176,7 @@ impl SolanaWsClient {
                     }
                 }
                 Err(e) => {
-                    tracing::warn!(
-                        "Failed to get current slot for gap detection: {e}"
-                    );
+                    tracing::warn!("Failed to get current slot for gap detection: {e}");
                 }
             }
         }
@@ -270,10 +261,8 @@ mod tests {
             .unwrap(),
         );
 
-        let ws = SolanaWsClient::with_default_config(
-            "wss://api.mainnet-beta.solana.com",
-            rpc_client,
-        );
+        let ws =
+            SolanaWsClient::with_default_config("wss://api.mainnet-beta.solana.com", rpc_client);
 
         assert_eq!(ws.ws_url, "wss://api.mainnet-beta.solana.com");
         let _ = format!("{ws:?}");

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -32,8 +32,6 @@
 mod cached;
 pub mod contract_index;
 mod data_loader;
-#[cfg(feature = "solana")]
-pub mod skipped_slots;
 pub mod decoded_index;
 mod error;
 pub mod factory_data;
@@ -45,6 +43,8 @@ pub mod parquet_writer;
 pub mod paths;
 mod retry;
 mod s3;
+#[cfg(feature = "solana")]
+pub mod skipped_slots;
 mod upload;
 
 pub use cached::CachedBackend;

--- a/src/transformations/context.rs
+++ b/src/transformations/context.rs
@@ -439,11 +439,11 @@ pub struct TransformationContext {
     // ===== Services =====
     /// Historical data reader for querying parquet files
     pub(crate) historical: Arc<HistoricalDataReader>,
-    /// RPC client for ad-hoc eth_calls
-    pub(crate) rpc: Arc<UnifiedRpcClient>,
+    /// RPC client for ad-hoc eth_calls (None for non-EVM chains)
+    pub(crate) rpc: Option<Arc<UnifiedRpcClient>>,
 
     // ===== Contract Configuration =====
-    /// Contract configurations for the chain
+    /// Contract configurations for the chain (empty for non-EVM chains like Solana)
     pub(crate) contracts: Arc<Contracts>,
 }
 
@@ -460,8 +460,8 @@ impl TransformationContext {
         account_states: Arc<Vec<DecodedAccountState>>,
         tx_addresses: HashMap<TxId, TransactionAddresses>,
         historical: Arc<HistoricalDataReader>,
-        rpc: Arc<UnifiedRpcClient>,
-        contracts: Arc<Contracts>,
+        rpc: Option<Arc<UnifiedRpcClient>>,
+        contracts: Option<Arc<Contracts>>,
     ) -> Self {
         Self {
             chain_name,
@@ -474,7 +474,7 @@ impl TransformationContext {
             tx_addresses,
             historical,
             rpc,
-            contracts,
+            contracts: contracts.unwrap_or_else(|| Arc::new(Contracts::new())),
         }
     }
 
@@ -482,6 +482,7 @@ impl TransformationContext {
 
     /// Get events of a specific type from the current block range.
     /// Filters out events before the contract's start_block if configured.
+    /// When contracts config is unavailable (non-EVM chains), no start_block filtering is applied.
     pub fn events_of_type(
         &self,
         source: &str,
@@ -627,6 +628,12 @@ impl TransformationContext {
     }
 
     // ===== Contract Configuration Helpers =====
+
+    /// Returns a reference to the contracts config.
+    /// Returns an empty map for non-EVM chains (e.g. Solana).
+    pub fn contracts_ref(&self) -> &Contracts {
+        &self.contracts
+    }
 
     /// Get the start_block for a contract or collection by name.
     pub fn get_contract_start_block(&self, name: &str) -> Option<u64> {
@@ -776,8 +783,10 @@ impl TransformationContext {
         let calldata = encode_calldata(&selector, &params)?;
 
         // Build call
-        let result = self
-            .rpc
+        let rpc = self.rpc.as_ref().ok_or_else(|| {
+            TransformationError::RpcError("RPC client not available (non-EVM chain)".to_string())
+        })?;
+        let result = rpc
             .eth_call(
                 Address::from(contract_address),
                 Bytes::from(calldata),
@@ -804,8 +813,10 @@ impl TransformationContext {
         topic0: B256,
     ) -> Result<[u8; 20], TransformationError> {
         let tx_hash = B256::from(transaction_hash);
-        let receipt = self
-            .rpc
+        let rpc = self.rpc.as_ref().ok_or_else(|| {
+            TransformationError::RpcError("RPC client not available (non-EVM chain)".to_string())
+        })?;
+        let receipt = rpc
             .get_transaction_receipt(tx_hash)
             .await
             .map_err(|e| TransformationError::RpcError(e.to_string()))?

--- a/src/transformations/engine.rs
+++ b/src/transformations/engine.rs
@@ -37,7 +37,9 @@ use super::scheduler::loader::{
 };
 use super::scheduler::tracker::CompletionTracker;
 use crate::db::DbPool;
-use crate::live::{LiveProgressTracker, LiveStorage, StorageError, TransformRetryRequest};
+use crate::live::{
+    LiveProgressTracker, LiveStorage, ProgressStatusStorage, StorageError, TransformRetryRequest,
+};
 use crate::rpc::UnifiedRpcClient;
 use crate::storage::contract_index::{
     build_expected_factory_contracts_for_range, get_missing_contracts, range_key,
@@ -182,7 +184,7 @@ pub struct TransformationEngine {
     decoded_calls_dir: PathBuf,
     raw_eth_calls_dir: PathBuf,
     raw_receipts_dir: PathBuf,
-    contracts: Arc<Contracts>,
+    contracts: Option<Arc<Contracts>>,
     handler_concurrency: usize,
     // Sub-components
     executor: Arc<HandlerExecutor>,
@@ -191,6 +193,11 @@ pub struct TransformationEngine {
     live_state: Mutex<LiveProcessingState>,
     /// Live mode progress tracker for marking block completion.
     progress_tracker: Option<Arc<Mutex<LiveProgressTracker>>>,
+    /// Status-file storage backend. Matches the backend used by the
+    /// `progress_tracker` (when present) so all writes target the same
+    /// on-disk status format (EVM `LiveBlockStatus` or Solana
+    /// `LiveSlotStatus`).
+    status_storage: Arc<dyn ProgressStatusStorage>,
 }
 
 impl TransformationEngine {
@@ -198,7 +205,7 @@ impl TransformationEngine {
     pub async fn new(
         registry: Arc<TransformationRegistry>,
         db_pool: Arc<DbPool>,
-        rpc_client: Arc<UnifiedRpcClient>,
+        rpc_client: Option<Arc<UnifiedRpcClient>>,
         config: TransformationEngineConfig,
         progress_tracker: Option<Arc<Mutex<LiveProgressTracker>>>,
     ) -> Result<Self, TransformationError> {
@@ -213,8 +220,16 @@ impl TransformationEngine {
         let raw_eth_calls_dir = crate::storage::paths::raw_eth_calls_dir(&chain_name);
         let raw_receipts_dir = crate::storage::paths::raw_receipts_dir(&chain_name);
 
-        let contracts = Arc::new(config.contracts);
-        let factory_collections = Arc::new(config.factory_collections);
+        let contracts = if config.contracts.is_empty() {
+            None
+        } else {
+            Some(Arc::new(config.contracts))
+        };
+        let factory_collections = if config.factory_collections.is_empty() {
+            None
+        } else {
+            Some(Arc::new(config.factory_collections))
+        };
 
         let executor = Arc::new(HandlerExecutor {
             db_pool: db_pool.clone(),
@@ -226,12 +241,24 @@ impl TransformationEngine {
             handler_concurrency,
         });
 
+        // Derive status-file storage from the progress tracker when present
+        // so the engine, finalizer, and retry processor all write to the
+        // same on-disk format (EVM LiveBlockStatus or Solana LiveSlotStatus).
+        // Falls back to EVM LiveStorage when no tracker is supplied.
+        let status_storage: Arc<dyn ProgressStatusStorage> =
+            if let Some(ref tracker) = progress_tracker {
+                tracker.lock().await.status_storage()
+            } else {
+                Arc::new(LiveStorage::new(&chain_name))
+            };
+
         let finalizer = Arc::new(RangeFinalizer {
             registry: registry.clone(),
             db_pool: db_pool.clone(),
             chain_name: chain_name.clone(),
             chain_id,
             progress_tracker: progress_tracker.clone(),
+            status_storage: status_storage.clone(),
             expect_log_completion: config.expect_log_completion,
             expect_eth_call_completion: config.expect_eth_call_completion,
             expect_account_state_completion: config.expect_account_state_completion,
@@ -244,11 +271,12 @@ impl TransformationEngine {
             rpc_client: rpc_client.clone(),
             historical_reader: historical_reader.clone(),
             contracts: contracts.clone(),
-            factory_collections: factory_collections.clone(),
+            factory_collections,
             chain_name: chain_name.clone(),
             chain_id,
             handler_concurrency,
             progress_tracker: progress_tracker.clone(),
+            status_storage: status_storage.clone(),
         };
 
         Ok(Self {
@@ -269,6 +297,7 @@ impl TransformationEngine {
             retry_processor,
             live_state: Mutex::new(LiveProcessingState::default()),
             progress_tracker,
+            status_storage,
         })
     }
 
@@ -397,7 +426,10 @@ impl TransformationEngine {
         let function_name = function_name.to_string();
         let decoded_base = self.decoded_calls_dir.join(&source).join(&function_name);
         let raw_base = self.raw_eth_calls_dir.join(&source).join(&function_name);
-        let contracts = self.contracts.clone();
+        let contracts = self
+            .contracts
+            .clone()
+            .unwrap_or_else(|| Arc::new(Contracts::new()));
 
         tokio::task::spawn_blocking(move || -> std::io::Result<HashSet<(u64, u64)>> {
             fn scan_recursive(
@@ -523,8 +555,9 @@ impl TransformationEngine {
         range_key: (u64, u64),
         decoded_file_path: &Path,
     ) -> bool {
-        let expected =
-            build_expected_factory_contracts_for_range(self.contracts.as_ref(), range_key.1);
+        let empty_contracts = Contracts::new();
+        let contracts_ref = self.contracts.as_deref().unwrap_or(&empty_contracts);
+        let expected = build_expected_factory_contracts_for_range(contracts_ref, range_key.1);
         let raw_index_dir =
             self.raw_call_dependency_index_dir(source, function_name, decoded_file_path);
 
@@ -1443,7 +1476,8 @@ impl TransformationEngine {
             );
         }
 
-        let filtered_events = filter_events_by_start_block(&self.contracts, msg.events.clone());
+        let filtered_events =
+            filter_events_by_start_block(self.contracts.as_deref(), msg.events.clone());
 
         if !filtered_events.is_empty() {
             counter!(
@@ -1561,8 +1595,11 @@ impl TransformationEngine {
                         let calls: Vec<_> = calls
                             .into_iter()
                             .filter(|c| {
-                                let start_block =
-                                    self.contracts.get(&c.source_name).and_then(|ct| {
+                                let start_block = self
+                                    .contracts
+                                    .as_ref()
+                                    .and_then(|contracts| contracts.get(&c.source_name))
+                                    .and_then(|ct| {
                                         ct.start_block.map(|u| u.try_into().unwrap_or(u64::MAX))
                                     });
                                 start_block.is_none_or(|sb| c.block_number >= sb)
@@ -1634,14 +1671,16 @@ impl TransformationEngine {
                             .map(|k| k.to_string())
                     })
                     .collect();
-                let storage = LiveStorage::new(&self.chain_name);
-                if let Err(e) = storage.update_status_atomic(range_key.0, |status| {
-                    status.failed_handlers.extend(failed_keys.iter().cloned());
-                    for k in &failed_keys {
-                        status.completed_handlers.remove(k);
-                    }
-                    status.transformed = false;
-                }) {
+                if let Err(e) = self.status_storage.update_handler_sets_atomic(
+                    range_key.0,
+                    &mut |completed, failed, transformed| {
+                        failed.extend(failed_keys.iter().cloned());
+                        for k in &failed_keys {
+                            completed.remove(k);
+                        }
+                        *transformed = false;
+                    },
+                ) {
                     if !matches!(e, StorageError::NotFound(_)) {
                         tracing::warn!(
                             "Failed to persist dep-failed handlers for block {}: {}",
@@ -1807,14 +1846,16 @@ impl TransformationEngine {
         let failed_keys: HashSet<String> =
             submitted_keys.difference(succeeded_keys).cloned().collect();
         if !failed_keys.is_empty() {
-            let storage = LiveStorage::new(&self.chain_name);
-            if let Err(e) = storage.update_status_atomic(block_number, |status| {
-                status.failed_handlers.extend(failed_keys.iter().cloned());
-                for h in &failed_keys {
-                    status.completed_handlers.remove(h);
-                }
-                status.transformed = false;
-            }) {
+            if let Err(e) = self.status_storage.update_handler_sets_atomic(
+                block_number,
+                &mut |completed, failed, transformed| {
+                    failed.extend(failed_keys.iter().cloned());
+                    for h in &failed_keys {
+                        completed.remove(h);
+                    }
+                    *transformed = false;
+                },
+            ) {
                 if !matches!(e, StorageError::NotFound(_)) {
                     tracing::warn!(
                         "Failed to persist failed handlers for block {}: {}",
@@ -1922,7 +1963,7 @@ impl TransformationEngine {
                 .extend(msg.calls.clone());
         }
 
-        let filtered_calls = filter_calls_by_start_block(&self.contracts, msg.calls);
+        let filtered_calls = filter_calls_by_start_block(self.contracts.as_deref(), msg.calls);
 
         if !filtered_calls.is_empty() {
             counter!(
@@ -2197,7 +2238,10 @@ impl TransformationEngine {
             let calls = {
                 let state = self.live_state.lock().await;
                 let calls = state.get_buffered_calls(range_key);
-                Arc::new(filter_calls_by_start_block(&self.contracts, calls))
+                Arc::new(filter_calls_by_start_block(
+                    self.contracts.as_deref(),
+                    calls,
+                ))
             };
 
             // Build HandlerTasks and use executor
@@ -2450,16 +2494,16 @@ impl TransformationEngine {
         // Persist cascaded failures to status file for single-block (live) ranges.
         if range_key.1 - range_key.0 == 1 {
             let cascaded_key_set: HashSet<String> = cascaded_keys.into_iter().collect();
-            let storage = LiveStorage::new(&self.chain_name);
-            if let Err(e) = storage.update_status_atomic(range_key.0, |status| {
-                status
-                    .failed_handlers
-                    .extend(cascaded_key_set.iter().cloned());
-                for k in &cascaded_key_set {
-                    status.completed_handlers.remove(k);
-                }
-                status.transformed = false;
-            }) {
+            if let Err(e) = self.status_storage.update_handler_sets_atomic(
+                range_key.0,
+                &mut |completed, failed, transformed| {
+                    failed.extend(cascaded_key_set.iter().cloned());
+                    for k in &cascaded_key_set {
+                        completed.remove(k);
+                    }
+                    *transformed = false;
+                },
+            ) {
                 if !matches!(e, StorageError::NotFound(_)) {
                     tracing::warn!(
                         "Failed to persist cascaded failures for block {}: {}",

--- a/src/transformations/eth_call/price.rs
+++ b/src/transformations/eth_call/price.rs
@@ -107,8 +107,8 @@ impl TransformationHandler for PriceHandler {
         let mut ops = Vec::new();
 
         for config in POOL_CONFIGS {
-            let token_address = resolve_address(&ctx.contracts, config.token)?;
-            let quote_token_address = resolve_address(&ctx.contracts, config.quote_token)?;
+            let token_address = resolve_address(ctx.contracts_ref(), config.token)?;
+            let quote_token_address = resolve_address(ctx.contracts_ref(), config.quote_token)?;
 
             for call in ctx.calls_of_type(config.source, config.function_name) {
                 let sqrt_price_x96 = call.extract_uint256("sqrtPriceX96")?;

--- a/src/transformations/event/decay_multicurve/metrics.rs
+++ b/src/transformations/event/decay_multicurve/metrics.rs
@@ -58,7 +58,8 @@ impl TransformationHandler for DecayMulticurveSwapMetricsHandler {
         ctx: &TransformationContext,
     ) -> Result<Vec<DbOperation>, TransformationError> {
         self.decimals_init.call_once(|| {
-            self.metadata_cache.resolve_quote_decimals(&ctx.contracts);
+            self.metadata_cache
+                .resolve_quote_decimals(ctx.contracts_ref());
         });
 
         let swaps = extract_v4_hook_swaps(ctx, SOURCE, SOURCE)?;
@@ -68,7 +69,7 @@ impl TransformationHandler for DecayMulticurveSwapMetricsHandler {
             &self.metadata_cache,
             &self.db_pool,
             self.chain_id,
-            &ctx.contracts,
+            ctx.contracts_ref(),
             self.name(),
             SOURCE,
         )

--- a/src/transformations/event/dhook/metrics.rs
+++ b/src/transformations/event/dhook/metrics.rs
@@ -58,7 +58,8 @@ impl TransformationHandler for DhookSwapMetricsHandler {
         ctx: &TransformationContext,
     ) -> Result<Vec<DbOperation>, TransformationError> {
         self.decimals_init.call_once(|| {
-            self.metadata_cache.resolve_quote_decimals(&ctx.contracts);
+            self.metadata_cache
+                .resolve_quote_decimals(ctx.contracts_ref());
         });
 
         let swaps = extract_v4_hook_swaps(ctx, SOURCE, SOURCE)?;
@@ -68,7 +69,7 @@ impl TransformationHandler for DhookSwapMetricsHandler {
             &self.metadata_cache,
             &self.db_pool,
             self.chain_id,
-            &ctx.contracts,
+            ctx.contracts_ref(),
             self.name(),
             SOURCE,
         )

--- a/src/transformations/event/metrics/swap_data.rs
+++ b/src/transformations/event/metrics/swap_data.rs
@@ -268,11 +268,7 @@ pub async fn refresh_cache_if_needed(
         .collect();
 
     if !still_missing.is_empty() {
-        let sample: Vec<String> = still_missing
-            .iter()
-            .take(10)
-            .map(hex::encode)
-            .collect();
+        let sample: Vec<String> = still_missing.iter().take(10).map(hex::encode).collect();
         tracing::warn!(
             handler = handler_name,
             source = source_name,

--- a/src/transformations/event/metrics/v4_hook_extract.rs
+++ b/src/transformations/event/metrics/v4_hook_extract.rs
@@ -181,8 +181,8 @@ mod tests {
             Arc::new(Vec::new()),
             HashMap::new(),
             historical,
-            rpc,
-            Arc::new(HashMap::new()),
+            Some(rpc),
+            Some(Arc::new(HashMap::new())),
         )
     }
 
@@ -242,7 +242,9 @@ mod tests {
             contract_address: ChainAddress::Evm([0u8; 20]),
             source_name: SOURCE.to_string(),
             function_name: "getSlot0".to_string(),
-            trigger_position: Some(LogPosition::Evm { log_index: trigger_log_index }),
+            trigger_position: Some(LogPosition::Evm {
+                log_index: trigger_log_index,
+            }),
             result,
             is_reverted,
             revert_reason: None,

--- a/src/transformations/event/migration_pool/metrics.rs
+++ b/src/transformations/event/migration_pool/metrics.rs
@@ -116,7 +116,8 @@ impl TransformationHandler for MigrationPoolSwapMetricsHandler {
         ctx: &TransformationContext,
     ) -> Result<Vec<DbOperation>, TransformationError> {
         self.decimals_init.call_once(|| {
-            self.metadata_cache.resolve_quote_decimals(&ctx.contracts);
+            self.metadata_cache
+                .resolve_quote_decimals(ctx.contracts_ref());
         });
 
         // Refresh the migration pool ID set from DB to pick up any pools
@@ -159,7 +160,7 @@ impl TransformationHandler for MigrationPoolSwapMetricsHandler {
             &self.metadata_cache,
             &self.db_pool,
             self.chain_id,
-            &ctx.contracts,
+            ctx.contracts_ref(),
             self.name(),
             POOL_MANAGER_SOURCE,
         )

--- a/src/transformations/event/multicurve/metrics.rs
+++ b/src/transformations/event/multicurve/metrics.rs
@@ -58,7 +58,8 @@ impl TransformationHandler for MulticurveSwapMetricsHandler {
         ctx: &TransformationContext,
     ) -> Result<Vec<DbOperation>, TransformationError> {
         self.decimals_init.call_once(|| {
-            self.metadata_cache.resolve_quote_decimals(&ctx.contracts);
+            self.metadata_cache
+                .resolve_quote_decimals(ctx.contracts_ref());
         });
 
         let swaps = extract_v4_hook_swaps(ctx, SOURCE, SOURCE)?;
@@ -68,7 +69,7 @@ impl TransformationHandler for MulticurveSwapMetricsHandler {
             &self.metadata_cache,
             &self.db_pool,
             self.chain_id,
-            &ctx.contracts,
+            ctx.contracts_ref(),
             self.name(),
             SOURCE,
         )

--- a/src/transformations/event/scheduled_multicurve/metrics.rs
+++ b/src/transformations/event/scheduled_multicurve/metrics.rs
@@ -58,7 +58,8 @@ impl TransformationHandler for ScheduledMulticurveSwapMetricsHandler {
         ctx: &TransformationContext,
     ) -> Result<Vec<DbOperation>, TransformationError> {
         self.decimals_init.call_once(|| {
-            self.metadata_cache.resolve_quote_decimals(&ctx.contracts);
+            self.metadata_cache
+                .resolve_quote_decimals(ctx.contracts_ref());
         });
 
         let swaps = extract_v4_hook_swaps(ctx, SOURCE, SOURCE)?;
@@ -68,7 +69,7 @@ impl TransformationHandler for ScheduledMulticurveSwapMetricsHandler {
             &self.metadata_cache,
             &self.db_pool,
             self.chain_id,
-            &ctx.contracts,
+            ctx.contracts_ref(),
             self.name(),
             SOURCE,
         )

--- a/src/transformations/event/v3/create.rs
+++ b/src/transformations/event/v3/create.rs
@@ -400,8 +400,8 @@ mod tests {
             Arc::new(Vec::new()),
             HashMap::new(),
             historical,
-            rpc,
-            Arc::new(HashMap::new()),
+            Some(rpc),
+            Some(Arc::new(HashMap::new())),
         )
     }
 

--- a/src/transformations/event/v3/metrics.rs
+++ b/src/transformations/event/v3/metrics.rs
@@ -133,7 +133,8 @@ impl TransformationHandler for V3SwapMetricsHandler {
         ctx: &TransformationContext,
     ) -> Result<Vec<DbOperation>, TransformationError> {
         self.decimals_init.call_once(|| {
-            self.metadata_cache.resolve_quote_decimals(&ctx.contracts);
+            self.metadata_cache
+                .resolve_quote_decimals(ctx.contracts_ref());
         });
 
         let swaps = extract_v3_swaps(ctx, "DopplerV3Pool")?;
@@ -143,7 +144,7 @@ impl TransformationHandler for V3SwapMetricsHandler {
             &self.metadata_cache,
             &self.db_pool,
             self.chain_id,
-            &ctx.contracts,
+            ctx.contracts_ref(),
             self.name(),
             "DopplerV3Pool",
         )
@@ -268,7 +269,8 @@ impl TransformationHandler for LockableV3SwapMetricsHandler {
         ctx: &TransformationContext,
     ) -> Result<Vec<DbOperation>, TransformationError> {
         self.decimals_init.call_once(|| {
-            self.metadata_cache.resolve_quote_decimals(&ctx.contracts);
+            self.metadata_cache
+                .resolve_quote_decimals(ctx.contracts_ref());
         });
 
         let swaps = extract_v3_swaps(ctx, "DopplerLockableV3Pool")?;
@@ -278,7 +280,7 @@ impl TransformationHandler for LockableV3SwapMetricsHandler {
             &self.metadata_cache,
             &self.db_pool,
             self.chain_id,
-            &ctx.contracts,
+            ctx.contracts_ref(),
             self.name(),
             "DopplerLockableV3Pool",
         )
@@ -425,8 +427,8 @@ mod tests {
             Arc::new(Vec::new()),
             HashMap::new(),
             historical,
-            rpc,
-            Arc::new(HashMap::new()),
+            Some(rpc),
+            Some(Arc::new(HashMap::new())),
         )
     }
 

--- a/src/transformations/event/v4/metrics.rs
+++ b/src/transformations/event/v4/metrics.rs
@@ -120,7 +120,8 @@ impl TransformationHandler for V4BaseMetricsHandler {
         }
 
         self.decimals_init.call_once(|| {
-            self.metadata_cache.resolve_quote_decimals(&ctx.contracts);
+            self.metadata_cache
+                .resolve_quote_decimals(ctx.contracts_ref());
         });
 
         let events: Vec<&DecodedEvent> = ctx.events_of_type(SOURCE, "Swap").collect();
@@ -154,7 +155,7 @@ impl TransformationHandler for V4BaseMetricsHandler {
             &self.metadata_cache,
             &self.db_pool,
             self.chain_id,
-            &ctx.contracts,
+            ctx.contracts_ref(),
             self.name(),
             SOURCE,
         )
@@ -1187,8 +1188,8 @@ mod tests {
             Arc::new(Vec::new()),
             StdHashMap::new(),
             historical,
-            rpc,
-            Arc::new(StdHashMap::new()),
+            Some(rpc),
+            Some(Arc::new(StdHashMap::new())),
         )
     }
 

--- a/src/transformations/executor.rs
+++ b/src/transformations/executor.rs
@@ -70,8 +70,8 @@ pub(crate) struct ProcessRangePayload {
 pub(crate) struct HandlerExecutor {
     pub db_pool: Arc<DbPool>,
     pub historical_reader: Arc<HistoricalDataReader>,
-    pub rpc_client: Arc<UnifiedRpcClient>,
-    pub contracts: Arc<Contracts>,
+    pub rpc_client: Option<Arc<UnifiedRpcClient>>,
+    pub contracts: Option<Arc<Contracts>>,
     pub chain_name: String,
     pub chain_id: u64,
     pub handler_concurrency: usize,
@@ -193,8 +193,8 @@ pub(crate) async fn run_handler_task(
     range_start: u64,
     range_end: u64,
     historical: Arc<HistoricalDataReader>,
-    rpc: Arc<UnifiedRpcClient>,
-    contracts: Arc<Contracts>,
+    rpc: Option<Arc<UnifiedRpcClient>>,
+    contracts: Option<Arc<Contracts>>,
     db_pool: Arc<DbPool>,
     db_exec_mode: &DbExecMode,
 ) -> Result<HandlerOutcome, TransformationError> {

--- a/src/transformations/finalizer.rs
+++ b/src/transformations/finalizer.rs
@@ -16,7 +16,9 @@ use super::error::TransformationError;
 use super::live_state::{LiveProcessingState, TimedOutPendingHandler};
 use super::registry::TransformationRegistry;
 use crate::db::{DbOperation, DbPool, DbValue, WhereClause};
-use crate::live::{LiveProgressTracker, LiveStorage, LiveUpsertSnapshot, StorageError};
+use crate::live::{
+    LiveProgressTracker, LiveStorage, LiveUpsertSnapshot, ProgressStatusStorage, StorageError,
+};
 
 /// Handles range finalization, reorg cleanup, and progress tracking.
 pub(crate) struct RangeFinalizer {
@@ -25,6 +27,10 @@ pub(crate) struct RangeFinalizer {
     pub chain_name: String,
     pub chain_id: u64,
     pub progress_tracker: Option<Arc<Mutex<LiveProgressTracker>>>,
+    /// Status-file storage backend (EVM `LiveStorage` or `SolanaLiveStorage`).
+    /// Used for reading/updating `completed_handlers`, `failed_handlers`,
+    /// and the `transformed` flag regardless of the chain family.
+    pub status_storage: Arc<dyn ProgressStatusStorage>,
     pub expect_log_completion: bool,
     pub expect_eth_call_completion: bool,
     pub expect_account_state_completion: bool,
@@ -144,18 +150,16 @@ impl RangeFinalizer {
             // Persist timed-out handlers as failures so they remain retryable
             let is_single_block = range_key.1 - range_key.0 == 1;
             if is_single_block {
-                let storage = LiveStorage::new(&self.chain_name);
-                if let Err(e) = storage.update_status_atomic(range_key.0, |status| {
-                    for timed_out_handler in &timed_out_handlers {
-                        status
-                            .failed_handlers
-                            .insert(timed_out_handler.handler_key.clone());
-                        status
-                            .completed_handlers
-                            .remove(&timed_out_handler.handler_key);
-                    }
-                    status.transformed = false;
-                }) {
+                if let Err(e) = self.status_storage.update_handler_sets_atomic(
+                    range_key.0,
+                    &mut |completed, failed, transformed| {
+                        for timed_out_handler in &timed_out_handlers {
+                            failed.insert(timed_out_handler.handler_key.clone());
+                            completed.remove(&timed_out_handler.handler_key);
+                        }
+                        *transformed = false;
+                    },
+                ) {
                     if !matches!(e, StorageError::NotFound(_)) {
                         tracing::warn!(
                             "Failed to persist timed-out handlers for block {}: {}",
@@ -221,9 +225,8 @@ impl RangeFinalizer {
 
         // Read failed/completed handlers from status file (single-block only)
         let (failed_handlers, completed_handlers) = if is_single_block {
-            let storage = LiveStorage::new(&self.chain_name);
-            match storage.read_status(range_start) {
-                Ok(status) => (status.failed_handlers, status.completed_handlers),
+            match self.status_storage.read_handler_sets(range_start) {
+                Ok(sets) => sets,
                 Err(StorageError::NotFound(_)) => (HashSet::new(), HashSet::new()),
                 Err(e) => {
                     tracing::warn!(
@@ -297,14 +300,15 @@ impl RangeFinalizer {
 
         // Only set transformed=true if no failed handlers remain
         if is_single_block {
-            let storage = LiveStorage::new(&self.chain_name);
             let registered_keys: HashSet<String> = self
                 .registry
                 .all_handlers()
                 .iter()
                 .map(|h| h.handler_key())
                 .collect();
-            if let Err(e) = update_finalization_status(&storage, range_start, &registered_keys) {
+            if let Err(e) =
+                update_finalization_status(&*self.status_storage, range_start, &registered_keys)
+            {
                 if !matches!(e, StorageError::NotFound(_)) {
                     tracing::warn!(
                         "Failed to update status for block {} during finalization: {}",
@@ -896,18 +900,16 @@ mod tests {
 /// half of the two-phase protocol — retry records handler outcomes, finalization
 /// gates the `transformed` flag.
 pub(crate) fn update_finalization_status(
-    storage: &LiveStorage,
+    storage: &dyn ProgressStatusStorage,
     block_number: u64,
     registered_keys: &HashSet<String>,
 ) -> Result<(), StorageError> {
-    storage.update_status_atomic(block_number, |status| {
+    storage.update_handler_sets_atomic(block_number, &mut |_completed, failed, transformed| {
         // Filter stale keys: only keep failed handlers that are still registered
-        status
-            .failed_handlers
-            .retain(|k| registered_keys.contains(k));
+        failed.retain(|k| registered_keys.contains(k));
 
-        if status.failed_handlers.is_empty() {
-            status.transformed = true;
+        if failed.is_empty() {
+            *transformed = true;
         }
     })
 }

--- a/src/transformations/live_state.rs
+++ b/src/transformations/live_state.rs
@@ -145,8 +145,12 @@ impl LiveProcessingState {
         expect_instructions: bool,
     ) -> (bool, Vec<TimedOutPendingHandler>) {
         let completion = self.completion.get(&range_key).copied().unwrap_or_default();
-        let streams_ready =
-            completion.is_ready(expect_logs, expect_eth_calls, expect_account_states, expect_instructions);
+        let streams_ready = completion.is_ready(
+            expect_logs,
+            expect_eth_calls,
+            expect_account_states,
+            expect_instructions,
+        );
 
         // Check for timed-out pending events
         let timeout = Duration::from_secs(PENDING_EVENT_TIMEOUT_SECS);
@@ -234,7 +238,12 @@ impl LiveProcessingState {
         }
 
         let ready = !has_pending
-            && completion.is_ready(expect_logs, expect_eth_calls, expect_account_states, expect_instructions);
+            && completion.is_ready(
+                expect_logs,
+                expect_eth_calls,
+                expect_account_states,
+                expect_instructions,
+            );
         (ready, timed_out.into_values().collect())
     }
 
@@ -316,7 +325,12 @@ impl RangeCompletionState {
         expect_account_states: bool,
         expect_instructions: bool,
     ) -> bool {
-        self.has_required_completions(expect_logs, expect_eth_calls, expect_account_states, expect_instructions)
+        self.has_required_completions(
+            expect_logs,
+            expect_eth_calls,
+            expect_account_states,
+            expect_instructions,
+        )
     }
 }
 
@@ -624,7 +638,8 @@ mod tests {
             .or_default()
             .mark(RangeCompleteKind::Logs);
 
-        let (ready, timed_out) = state.check_finalization_readiness(range_key, true, true, false, false);
+        let (ready, timed_out) =
+            state.check_finalization_readiness(range_key, true, true, false, false);
         assert!(!ready);
         assert!(
             timed_out.is_empty(),
@@ -636,7 +651,8 @@ mod tests {
             .entry(range_key)
             .or_default()
             .mark(RangeCompleteKind::EthCalls);
-        let (_, timed_out) = state.check_finalization_readiness(range_key, true, true, false, false);
+        let (_, timed_out) =
+            state.check_finalization_readiness(range_key, true, true, false, false);
         assert_eq!(timed_out.len(), 1);
         assert_eq!(timed_out[0].handler_key, "handler_v1");
     }

--- a/src/transformations/retry.rs
+++ b/src/transformations/retry.rs
@@ -25,7 +25,9 @@ use crate::decoding::eth_calls::{
 };
 use crate::decoding::event_parsing::ParsedEvent;
 use crate::decoding::logs::build_event_matchers;
-use crate::live::{LiveProgressTracker, LiveStorage, StorageError, TransformRetryRequest};
+use crate::live::{
+    LiveProgressTracker, LiveStorage, ProgressStatusStorage, StorageError, TransformRetryRequest,
+};
 use crate::rpc::UnifiedRpcClient;
 use crate::types::chain::{ChainAddress, LogPosition, TxId};
 use crate::types::config::contract::{Contracts, FactoryCollections};
@@ -121,14 +123,18 @@ pub(crate) fn classify_live_retry_call_artifact(
 pub(crate) struct RetryProcessor {
     pub registry: Arc<TransformationRegistry>,
     pub db_pool: Arc<DbPool>,
-    pub rpc_client: Arc<UnifiedRpcClient>,
+    pub rpc_client: Option<Arc<UnifiedRpcClient>>,
     pub historical_reader: Arc<HistoricalDataReader>,
-    pub contracts: Arc<Contracts>,
-    pub factory_collections: Arc<FactoryCollections>,
+    pub contracts: Option<Arc<Contracts>>,
+    pub factory_collections: Option<Arc<FactoryCollections>>,
     pub chain_name: String,
     pub chain_id: u64,
     pub handler_concurrency: usize,
     pub progress_tracker: Option<Arc<Mutex<LiveProgressTracker>>>,
+    /// Status-file storage backend (EVM `LiveStorage` or `SolanaLiveStorage`).
+    /// Used for reading/updating `completed_handlers`, `failed_handlers`,
+    /// and the `transformed` flag regardless of the chain family.
+    pub status_storage: Arc<dyn ProgressStatusStorage>,
 }
 
 use crate::db::DbPool;
@@ -169,13 +175,9 @@ impl RetryProcessor {
 
         // Union in persisted failed_handlers so stale tracker state can't hide
         // known failures. This must happen BEFORE the empty check.
-        let storage = LiveStorage::new(&self.chain_name);
-        if let Ok(status) = storage.read_status(block_number) {
-            if !status.failed_handlers.is_empty() {
-                missing_handlers = missing_handlers
-                    .union(&status.failed_handlers)
-                    .cloned()
-                    .collect();
+        if let Ok((failed, _completed)) = self.status_storage.read_handler_sets(block_number) {
+            if !failed.is_empty() {
+                missing_handlers = missing_handlers.union(&failed).cloned().collect();
             }
         }
 
@@ -186,8 +188,8 @@ impl RetryProcessor {
         }
 
         let (events, calls) = self.read_live_retry_data(block_number).await?;
-        let events = filter_events_by_start_block(&self.contracts, events);
-        let calls = filter_calls_by_start_block(&self.contracts, calls);
+        let events = filter_events_by_start_block(self.contracts.as_deref(), events);
+        let calls = filter_calls_by_start_block(self.contracts.as_deref(), calls);
 
         let blocked_handlers = self
             .execute_live_retry_handlers(block_number, events, calls, &missing_handlers)
@@ -215,8 +217,15 @@ impl RetryProcessor {
         let mut events = Vec::new();
         let mut calls = Vec::new();
 
-        let (regular_matchers, factory_matchers) =
-            build_event_matchers(&self.contracts, &self.factory_collections).map_err(|e| {
+        let empty_contracts = Contracts::new();
+        let empty_factory_collections = FactoryCollections::new();
+        let contracts_ref = self.contracts.as_deref().unwrap_or(&empty_contracts);
+        let factory_ref = self
+            .factory_collections
+            .as_deref()
+            .unwrap_or(&empty_factory_collections);
+        let (regular_matchers, factory_matchers) = build_event_matchers(contracts_ref, factory_ref)
+            .map_err(|e| {
                 TransformationError::DecodeError(format!(
                     "failed to build live retry event matchers: {}",
                     e
@@ -259,7 +268,7 @@ impl RetryProcessor {
             }
         }
 
-        let (regular_configs, once_configs, event_configs) = build_decode_configs(&self.contracts);
+        let (regular_configs, once_configs, event_configs) = build_decode_configs(contracts_ref);
         let regular_map: HashMap<(String, String), CallDecodeConfig> = regular_configs
             .into_iter()
             .map(|config| {
@@ -342,8 +351,8 @@ impl RetryProcessor {
             }
         }
 
-        let mut once_sources: HashSet<String> = self.contracts.keys().cloned().collect();
-        for contract in self.contracts.values() {
+        let mut once_sources: HashSet<String> = contracts_ref.keys().cloned().collect();
+        for contract in contracts_ref.values() {
             if let Some(factories) = &contract.factories {
                 once_sources.extend(factories.iter().map(|factory| factory.collection.clone()));
             }
@@ -715,9 +724,8 @@ impl RetryProcessor {
             .collect();
 
         // Update status file: mark succeeded handlers, track failed ones.
-        let storage = LiveStorage::new(&self.chain_name);
         if let Err(e) = update_retry_status(
-            &storage,
+            &*self.status_storage,
             block_number,
             &attempted_keys,
             &succeeded_keys,
@@ -906,7 +914,7 @@ impl RetryProcessor {
 /// that is `finalize_range()`'s responsibility after all `_handler_progress`
 /// rows are recorded.
 pub(crate) fn update_retry_status(
-    storage: &LiveStorage,
+    storage: &dyn ProgressStatusStorage,
     block_number: u64,
     attempted_keys: &HashSet<String>,
     succeeded_keys: &HashSet<String>,
@@ -918,17 +926,17 @@ pub(crate) fn update_retry_status(
         .cloned()
         .collect();
 
-    storage.update_status_atomic(block_number, |status| {
+    storage.update_handler_sets_atomic(block_number, &mut |completed, failed, transformed| {
         for key in succeeded_keys {
-            status.failed_handlers.remove(key);
-            status.completed_handlers.insert(key.clone());
+            failed.remove(key);
+            completed.insert(key.clone());
         }
         for key in &failed_keys {
-            status.failed_handlers.insert(key.clone());
-            status.completed_handlers.remove(key);
+            failed.insert(key.clone());
+            completed.remove(key);
         }
         if !failed_keys.is_empty() {
-            status.transformed = false;
+            *transformed = false;
         }
         // Don't set transformed=true here — finalize_range() handles that
         // after recording _handler_progress for all handlers.
@@ -1042,9 +1050,12 @@ fn read_live_receipt_addresses(
 // ─── Start block filtering helpers ───────────────────────────────────
 
 pub(crate) fn filter_events_by_start_block(
-    contracts: &Contracts,
+    contracts: Option<&Contracts>,
     events: Vec<DecodedEvent>,
 ) -> Vec<DecodedEvent> {
+    let Some(contracts) = contracts else {
+        return events;
+    };
     events
         .into_iter()
         .filter(|e| {
@@ -1057,9 +1068,12 @@ pub(crate) fn filter_events_by_start_block(
 }
 
 pub(crate) fn filter_calls_by_start_block(
-    contracts: &Contracts,
+    contracts: Option<&Contracts>,
     calls: Vec<DecodedCall>,
 ) -> Vec<DecodedCall> {
+    let Some(contracts) = contracts else {
+        return calls;
+    };
     calls
         .into_iter()
         .filter(|c| {

--- a/src/transformations/scheduler/loader.rs
+++ b/src/transformations/scheduler/loader.rs
@@ -288,8 +288,8 @@ pub(crate) struct CatchupLoader {
     pub decoded_calls_dir: PathBuf,
     pub raw_receipts_dir: PathBuf,
     pub historical_reader: Arc<HistoricalDataReader>,
-    pub rpc_client: Arc<UnifiedRpcClient>,
-    pub contracts: Arc<Contracts>,
+    pub rpc_client: Option<Arc<UnifiedRpcClient>>,
+    pub contracts: Option<Arc<Contracts>>,
     pub chain_name: String,
     pub chain_id: u64,
     pub db_pool: Arc<DbPool>,
@@ -314,13 +314,13 @@ impl CatchupLoader {
                 let evts = self
                     .load_events(range_start, range_end, &payload.triggers)
                     .await?;
-                let evts = filter_events_by_start_block(&self.contracts, evts);
+                let evts = filter_events_by_start_block(self.contracts.as_deref(), evts);
 
                 let calls = if !evts.is_empty() && !payload.call_deps.is_empty() {
                     let raw_calls = self
                         .load_calls(range_start, range_end, &payload.call_deps)
                         .await?;
-                    filter_calls_by_start_block(&self.contracts, raw_calls)
+                    filter_calls_by_start_block(self.contracts.as_deref(), raw_calls)
                 } else {
                     Vec::new()
                 };
@@ -331,7 +331,7 @@ impl CatchupLoader {
                 let raw_calls = self
                     .load_calls(range_start, range_end, &payload.triggers)
                     .await?;
-                let calls = filter_calls_by_start_block(&self.contracts, raw_calls);
+                let calls = filter_calls_by_start_block(self.contracts.as_deref(), raw_calls);
                 (Vec::new(), calls)
             }
         };
@@ -450,7 +450,7 @@ use crate::transformations::scheduler::tracker::CompletionTracker;
 pub(crate) struct CallDepScanner {
     decoded_calls_dir: PathBuf,
     raw_eth_calls_dir: PathBuf,
-    contracts: Arc<Contracts>,
+    contracts: Option<Arc<Contracts>>,
     /// Unique `(source, function)` pairs to scan for.
     call_dep_pairs: Vec<(String, String)>,
 }
@@ -459,7 +459,7 @@ impl CallDepScanner {
     pub(crate) fn new(
         decoded_calls_dir: PathBuf,
         raw_eth_calls_dir: PathBuf,
-        contracts: Arc<Contracts>,
+        contracts: Option<Arc<Contracts>>,
         call_dep_pairs: Vec<(String, String)>,
     ) -> Self {
         Self {
@@ -501,7 +501,10 @@ impl CallDepScanner {
         let function_name = function_name.to_string();
         let decoded_base = self.decoded_calls_dir.join(&source).join(&function_name);
         let raw_base = self.raw_eth_calls_dir.join(&source).join(&function_name);
-        let contracts = self.contracts.clone();
+        let contracts = self
+            .contracts
+            .clone()
+            .unwrap_or_else(|| Arc::new(Contracts::new()));
 
         tokio::task::spawn_blocking(move || {
             fn scan_recursive(

--- a/src/types/chain.rs
+++ b/src/types/chain.rs
@@ -409,10 +409,7 @@ mod tests {
             instruction_index: 3,
             inner_instruction_index: None,
         };
-        assert_eq!(
-            pos.packed_ordinal_i64(),
-            3 * SOLANA_PACKED_ORDINAL_STRIDE
-        );
+        assert_eq!(pos.packed_ordinal_i64(), 3 * SOLANA_PACKED_ORDINAL_STRIDE);
     }
 
     #[test]

--- a/src/types/config/solana.rs
+++ b/src/types/config/solana.rs
@@ -157,7 +157,10 @@ mod tests {
     fn solana_program_config_minimal_deserializes() {
         let json = r#"{ "program_id": "whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc" }"#;
         let cfg: SolanaProgramConfig = serde_json::from_str(json).unwrap();
-        assert_eq!(cfg.program_id, "whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc");
+        assert_eq!(
+            cfg.program_id,
+            "whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc"
+        );
         assert!(cfg.idl_path.is_none());
         assert!(cfg.events.is_none());
         assert!(cfg.accounts.is_none());


### PR DESCRIPTION
## Summary

- Adds full Solana live mode pipeline under `src/solana/live/` — accounts, catchup, collector, compaction, reorg, storage, and types modules
- Generalizes live progress tracking for non-EVM chains (`src/live/progress.rs`)
- Wires Solana live pipeline into `src/solana/pipeline.rs` alongside historical path
- Adds bincode I/O support (`src/live/bincode_io.rs`) for Solana block storage
- Fixes: OnEvents cross-program reads, decoder routing, progress restore on startup, slots parquet during compaction, transaction signature extraction, `await_completion_barrier` on AccountReadTrigger, reorg prune with `retention_depth=0` in finalized mode

## Notes

This branch diverges from `feat/solana-support` at the generalize-live-progress commit and will conflict with any concurrent changes to `src/live/`, `src/solana/pipeline.rs`, and `src/transformations/`.