### PR TITLE
feat: ZoraMigrateHandler + backfill for LiquidityMigrated events

### DIFF
--- a/src/bin/backfill_zora_migrations.rs
+++ b/src/bin/backfill_zora_migrations.rs
@@ -1,0 +1,257 @@
+//! One-shot backfill for Zora creator coin pool migrations.
+//!
+//! Reads all ZoraCreatorCoinV4:LiquidityMigrated events from the historical
+//! decoded parquet files and, for each migration:
+//!   1. Looks up the original pool by fromPoolKeyHash in the pools table.
+//!   2. Inserts a new pool row keyed on toPoolKeyHash (source="ZoraMigrateHandler").
+//!   3. Updates the original pool to record migration_pool/migrated_at/migration_type.
+//!
+//! Safe to re-run: inserts use ON CONFLICT DO NOTHING.
+//!
+//! Usage:
+//!   DATABASE_URL=postgresql://... cargo run --bin backfill_zora_migrations [-- <data_dir>]
+//!
+//! Defaults to `data/base/historical/decoded/logs/ZoraCreatorCoinV4/LiquidityMigrated`.
+
+use std::fs::File;
+use std::path::{Path, PathBuf};
+
+use arrow::array::{Array, FixedSizeBinaryArray, Int64Array, UInt64Array};
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use tokio_postgres::NoTls;
+
+const CHAIN_ID: i64 = 8453;
+const ZORA_CREATE_SOURCE: &str = "ZoraCreateHandler";
+const ZORA_CREATE_VERSION: i32 = 1;
+const ZORA_MIGRATE_SOURCE: &str = "ZoraMigrateHandler";
+const ZORA_MIGRATE_VERSION: i32 = 1;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let data_dir = std::env::args().nth(1).unwrap_or_else(|| {
+        "data/base/historical/decoded/logs/ZoraCreatorCoinV4/LiquidityMigrated".to_string()
+    });
+
+    let db_url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgresql://doppler:doppler@localhost/doppler".to_string());
+
+    let (client, connection) = tokio_postgres::connect(&db_url, NoTls).await?;
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            eprintln!("connection error: {}", e);
+        }
+    });
+
+    let mut files: Vec<PathBuf> = std::fs::read_dir(&data_dir)?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().map(|e| e == "parquet").unwrap_or(false))
+        .collect();
+    files.sort();
+
+    eprintln!("found {} parquet files in {}", files.len(), data_dir);
+
+    let mut total_rows = 0u64;
+    let mut inserted = 0u64;
+    let mut updated = 0u64;
+    let mut skipped = 0u64;
+
+    for file in &files {
+        process_file(
+            file,
+            &client,
+            &mut total_rows,
+            &mut inserted,
+            &mut updated,
+            &mut skipped,
+        )
+        .await?;
+    }
+
+    eprintln!(
+        "done: total_rows={} inserted={} updated={} skipped={}",
+        total_rows, inserted, updated, skipped
+    );
+    Ok(())
+}
+
+async fn process_file(
+    path: &Path,
+    client: &tokio_postgres::Client,
+    total_rows: &mut u64,
+    inserted: &mut u64,
+    updated: &mut u64,
+    skipped: &mut u64,
+) -> anyhow::Result<()> {
+    let file = File::open(path)?;
+    let builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
+    let mut reader = builder.build()?;
+
+    while let Some(batch) = reader.next() {
+        let batch = batch?;
+        let num_rows = batch.num_rows();
+        *total_rows += num_rows as u64;
+
+        let from_hashes = col_binary(&batch, "fromPoolKeyHash");
+        let to_hashes = col_binary(&batch, "toPoolKeyHash");
+        let to_currency0 = col_binary(&batch, "toPoolKey.currency0");
+        let to_currency1 = col_binary(&batch, "toPoolKey.currency1");
+        let to_fee = col_u64(&batch, "toPoolKey.fee");
+        let to_tick_spacing = col_i64(&batch, "toPoolKey.tickSpacing");
+        let to_hooks = col_binary(&batch, "toPoolKey.hooks");
+        let block_numbers = col_u64(&batch, "block_number");
+        let block_timestamps = col_u64(&batch, "block_timestamp");
+
+        for i in 0..num_rows {
+            let from_hash = from_hashes.value(i);
+            let to_hash = to_hashes.value(i);
+            let block_number = block_numbers.value(i) as i64;
+            let block_timestamp = block_timestamps.value(i) as f64;
+
+            // Look up the original pool.
+            let rows = client
+                .query(
+                    "SELECT base_token, quote_token, is_token_0, fee, integrator, initializer \
+                     FROM pools \
+                     WHERE chain_id = $1 AND address = $2 AND source = $3 AND source_version = $4 \
+                     LIMIT 1",
+                    &[
+                        &CHAIN_ID,
+                        &from_hash,
+                        &ZORA_CREATE_SOURCE,
+                        &ZORA_CREATE_VERSION,
+                    ],
+                )
+                .await?;
+
+            let Some(row) = rows.first() else {
+                eprintln!(
+                    "  skip: no pool for from_hash={}",
+                    hex::encode(from_hash)
+                );
+                *skipped += 1;
+                continue;
+            };
+
+            let base_token: Vec<u8> = row.get("base_token");
+            let quote_token: Vec<u8> = row.get("quote_token");
+            let is_token_0: bool = row.get("is_token_0");
+            let fee: i32 = row.get("fee");
+            let integrator: Vec<u8> = row.get("integrator");
+            let initializer: Vec<u8> = row.get("initializer");
+
+            // Build pool_key JSON.
+            let pool_key_json = serde_json::json!({
+                "currency0": format!("0x{}", hex::encode(to_currency0.value(i))),
+                "currency1": format!("0x{}", hex::encode(to_currency1.value(i))),
+                "fee": to_fee.value(i) as u32,
+                "tick_spacing": to_tick_spacing.value(i) as i32,
+                "hooks": format!("0x{}", hex::encode(to_hooks.value(i))),
+            });
+
+            // Insert new migrated pool (ON CONFLICT DO NOTHING → idempotent).
+            let n = client
+                .execute(
+                    "INSERT INTO pools (
+                        chain_id, block_number, created_at, address,
+                        base_token, quote_token, is_token_0, type,
+                        integrator, initializer, fee,
+                        min_threshold, max_threshold,
+                        migrator, migrated_at, migration_pool, migration_type,
+                        lock_duration, beneficiaries, pool_key,
+                        starting_time, ending_time,
+                        source, source_version
+                     ) VALUES (
+                        $1, $2, to_timestamp($3), $4,
+                        $5, $6, $7, 'zora_creator_coin',
+                        $8, $9, $10,
+                        0, 0,
+                        '\\x0000000000000000000000000000000000000000', NULL,
+                        '\\x0000000000000000000000000000000000000000000000000000000000000000',
+                        'unknown',
+                        NULL, NULL, $11::jsonb,
+                        to_timestamp(0), to_timestamp(0),
+                        $12, $13
+                     )
+                     ON CONFLICT (chain_id, address, source, source_version) DO NOTHING",
+                    &[
+                        &CHAIN_ID,
+                        &block_number,
+                        &block_timestamp,
+                        &to_hash,
+                        &base_token,
+                        &quote_token,
+                        &is_token_0,
+                        &integrator,
+                        &initializer,
+                        &fee,
+                        &pool_key_json,
+                        &ZORA_MIGRATE_SOURCE,
+                        &ZORA_MIGRATE_VERSION,
+                    ],
+                )
+                .await?;
+            *inserted += n;
+
+            // Update original pool with migration metadata.
+            let n = client
+                .execute(
+                    "UPDATE pools \
+                     SET migration_pool = $1, migrated_at = to_timestamp($2), migration_type = 'zora' \
+                     WHERE chain_id = $3 AND address = $4 AND source = $5 AND source_version = $6",
+                    &[
+                        &to_hash,
+                        &block_timestamp,
+                        &CHAIN_ID,
+                        &from_hash,
+                        &ZORA_CREATE_SOURCE,
+                        &ZORA_CREATE_VERSION,
+                    ],
+                )
+                .await?;
+            *updated += n;
+        }
+    }
+
+    Ok(())
+}
+
+fn col_binary<'a>(
+    batch: &'a arrow::record_batch::RecordBatch,
+    name: &str,
+) -> &'a FixedSizeBinaryArray {
+    let idx = batch.schema().index_of(name).unwrap_or_else(|_| {
+        panic!("column '{}' not found in parquet schema", name)
+    });
+    let col = batch.column(idx);
+    col.as_any()
+        .downcast_ref::<FixedSizeBinaryArray>()
+        .unwrap_or_else(|| panic!("column '{}' is not FixedSizeBinaryArray (type={:?})", name, col.data_type()))
+}
+
+fn col_u64<'a>(
+    batch: &'a arrow::record_batch::RecordBatch,
+    name: &str,
+) -> &'a UInt64Array {
+    let idx = batch.schema().index_of(name).unwrap_or_else(|_| {
+        panic!("column '{}' not found in parquet schema", name)
+    });
+    let col = batch.column(idx);
+    // ubigint in DuckDB parquet maps to UInt64 in arrow.
+    col.as_any()
+        .downcast_ref::<UInt64Array>()
+        .unwrap_or_else(|| panic!("column '{}' is not UInt64Array (type={:?})", name, col.data_type()))
+}
+
+fn col_i64<'a>(
+    batch: &'a arrow::record_batch::RecordBatch,
+    name: &str,
+) -> &'a Int64Array {
+    let idx = batch.schema().index_of(name).unwrap_or_else(|_| {
+        panic!("column '{}' not found in parquet schema", name)
+    });
+    let col = batch.column(idx);
+    col.as_any()
+        .downcast_ref::<Int64Array>()
+        .unwrap_or_else(|| panic!("column '{}' is not Int64Array (type={:?})", name, col.data_type()))
+}

--- a/src/transformations/event/mod.rs
+++ b/src/transformations/event/mod.rs
@@ -46,6 +46,7 @@ fn register_handlers_inner(
     //decay_multicurve::create::register_handlers(registry);
     //dhook::create::register_handlers(registry);
     zora::create::register_handlers(registry);
+    zora::migrate::register_handlers(registry);
     //zora::transfer::register_handlers(registry);
 
     // Shared oracle price cache across all swap metrics handlers.
@@ -110,6 +111,7 @@ fn register_handlers_inner(
 
     let zora_cache = Arc::new(PoolMetadataCache::with_shared_scopes(vec![
         zora::create::ZORA_CREATE_HANDLER_SCOPE,
+        zora::migrate::ZORA_MIGRATE_HANDLER_SCOPE,
     ]));
     zora::metrics::register_handlers(registry, chain_id, zora_cache, Arc::clone(&oracle_cache));
 

--- a/src/transformations/event/zora/migrate.rs
+++ b/src/transformations/event/zora/migrate.rs
@@ -1,0 +1,210 @@
+use std::sync::OnceLock;
+
+use alloy_primitives::U256;
+use async_trait::async_trait;
+use deadpool_postgres::Pool;
+
+use crate::db::{DbOperation, DbPool, DbValue};
+use crate::transformations::context::{FieldExtractor, TransformationContext};
+use crate::transformations::error::TransformationError;
+use crate::transformations::registry::TransformationRegistry;
+use crate::transformations::traits::{
+    dep, EventHandler, EventTrigger, HandlerDependencySpec, TransformationHandler,
+};
+use crate::transformations::util::db::pool::{insert_pool, PoolData};
+use crate::transformations::util::pool_metadata::VersionedSource;
+use crate::types::uniswap::v4::{PoolAddressOrPoolId, PoolKey};
+
+use super::create::{ZORA_CREATE_HANDLER_NAME, ZORA_CREATE_HANDLER_VERSION};
+
+const CREATOR_COIN_SOURCE: &str = "ZoraCreatorCoinV4";
+const ZERO_ADDRESS: [u8; 20] = [0u8; 20];
+
+pub const ZORA_MIGRATE_HANDLER_NAME: &str = "ZoraMigrateHandler";
+pub const ZORA_MIGRATE_HANDLER_VERSION: u32 = 1;
+pub const ZORA_MIGRATE_HANDLER_SCOPE: VersionedSource =
+    VersionedSource::new(ZORA_MIGRATE_HANDLER_NAME, ZORA_MIGRATE_HANDLER_VERSION);
+
+pub struct ZoraMigrateHandler {
+    db_pool: OnceLock<Pool>,
+}
+
+#[async_trait]
+impl TransformationHandler for ZoraMigrateHandler {
+    fn name(&self) -> &'static str {
+        ZORA_MIGRATE_HANDLER_NAME
+    }
+
+    fn version(&self) -> u32 {
+        ZORA_MIGRATE_HANDLER_VERSION
+    }
+
+    fn migration_paths(&self) -> Vec<&'static str> {
+        vec!["migrations/tables/pools.sql"]
+    }
+
+    fn reorg_tables(&self) -> Vec<&'static str> {
+        vec!["pools"]
+    }
+
+    fn requires_sequential(&self) -> bool {
+        false
+    }
+
+    async fn handle(
+        &self,
+        ctx: &TransformationContext,
+    ) -> Result<Vec<DbOperation>, TransformationError> {
+        let mut ops = Vec::new();
+
+        for event in ctx.events_of_type(CREATOR_COIN_SOURCE, "LiquidityMigrated") {
+            let from_pool_key_hash = event.extract_bytes32("fromPoolKeyHash")?;
+            let to_pool_key_hash = event.extract_bytes32("toPoolKeyHash")?;
+
+            let to_pool_key = PoolKey {
+                currency0: event.extract_address("toPoolKey.currency0")?.into(),
+                currency1: event.extract_address("toPoolKey.currency1")?.into(),
+                fee: event.extract_u32("toPoolKey.fee")?,
+                tick_spacing: event.extract_i32_flexible("toPoolKey.tickSpacing")?,
+                hooks: event.extract_address("toPoolKey.hooks")?.into(),
+            };
+
+            let client = self
+                .db_pool
+                .get()
+                .expect("db_pool must be set before handle()")
+                .get()
+                .await?;
+
+            let rows = client
+                .query(
+                    "SELECT base_token, quote_token, is_token_0, fee, integrator, initializer \
+                     FROM pools \
+                     WHERE chain_id = $1 AND address = $2 AND source = $3 AND source_version = $4 \
+                     LIMIT 1",
+                    &[
+                        &(ctx.chain_id as i64),
+                        &from_pool_key_hash.to_vec(),
+                        &ZORA_CREATE_HANDLER_NAME,
+                        &(ZORA_CREATE_HANDLER_VERSION as i32),
+                    ],
+                )
+                .await?;
+
+            let Some(row) = rows.first() else {
+                tracing::warn!(
+                    from_pool = hex::encode(from_pool_key_hash),
+                    to_pool = hex::encode(to_pool_key_hash),
+                    block = event.block_number,
+                    "no ZoraCreateHandler pool found for LiquidityMigrated; skipping"
+                );
+                continue;
+            };
+
+            let base_token_bytes: Vec<u8> = row.get("base_token");
+            let quote_token_bytes: Vec<u8> = row.get("quote_token");
+            let integrator_bytes: Vec<u8> = row.get("integrator");
+            let initializer_bytes: Vec<u8> = row.get("initializer");
+
+            if base_token_bytes.len() != 20
+                || quote_token_bytes.len() != 20
+                || integrator_bytes.len() != 20
+                || initializer_bytes.len() != 20
+            {
+                tracing::warn!(
+                    from_pool = hex::encode(from_pool_key_hash),
+                    block = event.block_number,
+                    "malformed address bytes in original pool row; skipping"
+                );
+                continue;
+            }
+
+            let mut base_token = [0u8; 20];
+            let mut quote_token = [0u8; 20];
+            let mut integrator = [0u8; 20];
+            let mut initializer = [0u8; 20];
+            base_token.copy_from_slice(&base_token_bytes);
+            quote_token.copy_from_slice(&quote_token_bytes);
+            integrator.copy_from_slice(&integrator_bytes);
+            initializer.copy_from_slice(&initializer_bytes);
+
+            let is_token_0: bool = row.get("is_token_0");
+            let fee: i32 = row.get("fee");
+
+            // Insert the migrated pool. inject_source_version adds
+            // source="ZoraMigrateHandler", source_version=1 automatically.
+            ops.push(insert_pool(
+                &PoolData {
+                    block_number: event.block_number,
+                    block_timestamp: event.block_timestamp,
+                    address: PoolAddressOrPoolId::PoolId(to_pool_key_hash),
+                    base_token,
+                    quote_token,
+                    is_token_0,
+                    pool_type: "zora_creator_coin".to_string(),
+                    integrator,
+                    initializer,
+                    fee: fee as u32,
+                    min_threshold: U256::ZERO,
+                    max_threshold: U256::ZERO,
+                    migrator: ZERO_ADDRESS,
+                    migrated_at: None,
+                    migration_pool: PoolAddressOrPoolId::Address(ZERO_ADDRESS),
+                    migration_type: "unknown".to_string(),
+                    lock_duration: None,
+                    beneficiaries: None,
+                    pool_key: Some(to_pool_key),
+                    starting_time: 0,
+                    ending_time: 0,
+                },
+                ctx,
+            ));
+
+            // Mark the original pool as migrated. RawSql bypasses inject_source_version
+            // so the WHERE clause targets the ZoraCreateHandler-owned row directly.
+            ops.push(DbOperation::RawSql {
+                query: "UPDATE pools \
+                    SET migration_pool = $1, migrated_at = to_timestamp($2), migration_type = $3 \
+                    WHERE chain_id = $4 AND address = $5 AND source = $6 AND source_version = $7"
+                    .to_string(),
+                params: vec![
+                    DbValue::Bytes32(to_pool_key_hash),
+                    DbValue::Timestamp(event.block_timestamp as i64),
+                    DbValue::VarChar("zora".to_string()),
+                    DbValue::Int64(ctx.chain_id as i64),
+                    DbValue::Bytes(from_pool_key_hash.to_vec()),
+                    DbValue::VarChar(ZORA_CREATE_HANDLER_NAME.to_string()),
+                    DbValue::Int32(ZORA_CREATE_HANDLER_VERSION as i32),
+                ],
+                snapshot: None,
+            });
+        }
+
+        Ok(ops)
+    }
+
+    async fn initialize(&self, db_pool: &DbPool) -> Result<(), TransformationError> {
+        self.db_pool.set(db_pool.inner().clone()).ok();
+        tracing::info!("ZoraMigrateHandler initialized");
+        Ok(())
+    }
+}
+
+impl EventHandler for ZoraMigrateHandler {
+    fn triggers(&self) -> Vec<EventTrigger> {
+        vec![EventTrigger::new(
+            CREATOR_COIN_SOURCE,
+            "LiquidityMigrated((address,address,uint24,int24,address),bytes32,(address,address,uint24,int24,address),bytes32)",
+        )]
+    }
+
+    fn contiguous_handler_dependency_specs(&self) -> Vec<HandlerDependencySpec> {
+        vec![dep("ZoraCreateHandler")]
+    }
+}
+
+pub fn register_handlers(registry: &mut TransformationRegistry) {
+    registry.register_event_handler(ZoraMigrateHandler {
+        db_pool: OnceLock::new(),
+    });
+}

--- a/src/transformations/event/zora/mod.rs
+++ b/src/transformations/event/zora/mod.rs
@@ -1,3 +1,4 @@
 pub mod create;
 pub mod metrics;
+pub mod migrate;
 pub mod transfer;


### PR DESCRIPTION
## Summary

- `ZoraCreatorCoinV4:LiquidityMigrated` moves a creator coin pool from `fromPoolKeyHash` → `toPoolKeyHash`. Without handling this event, post-migration pool IDs never land in `pools`, causing `ZoraSwapMetricsHandler` to silently drop swap metrics for all migrated pools (2173 historical, blocks 31,962,983–43,110,686).
- New `ZoraMigrateHandler` in `zora/migrate.rs` triggers on `LiquidityMigrated`, looks up the original pool, inserts a new `pools` row for `toPoolKeyHash` (`source=ZoraMigrateHandler`), and marks the original with `migration_pool`/`migrated_at`/`migration_type=zora`. The update uses `RawSql` to bypass `inject_source_version` (which would otherwise target the wrong source).
- `ZORA_MIGRATE_HANDLER_SCOPE` added to the shared Zora metadata cache in `mod.rs` so `ZoraSwapMetricsHandler`'s `refresh_cache_if_needed` finds migrated pools without any changes to the metrics handler itself.
- `src/bin/backfill_zora_migrations.rs`: one-shot binary that reads the historical decoded parquet files and inserts all 2173 missing migration records. Idempotent via `ON CONFLICT DO NOTHING`. Run with `DATABASE_URL=... cargo run --bin backfill_zora_migrations`.