### PR TITLE
feat: Solana program event handlers

### DIFF
--- a/migrations/tables/sol_cpmm_migrator.sql
+++ b/migrations/tables/sol_cpmm_migrator.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS sol_cpmm_migrator (
+    id BIGSERIAL PRIMARY KEY,
+    chain_id BIGINT NOT NULL,
+    block_height BIGINT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL,
+    launch BYTEA NOT NULL,
+    state BYTEA,
+    cpmm_config BYTEA,
+    min_raise_quote BIGINT,
+    pool BYTEA,
+    quote_for_liquidity BIGINT,
+    base_for_liquidity BIGINT,
+    migrated BOOLEAN NOT NULL DEFAULT false,
+    source VARCHAR(255) NOT NULL,
+    source_version INT NOT NULL,
+    UNIQUE (chain_id, launch, source, source_version)
+);

--- a/migrations/tables/sol_cpmm_positions.sql
+++ b/migrations/tables/sol_cpmm_positions.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS sol_cpmm_positions (
+    id BIGSERIAL PRIMARY KEY,
+    chain_id BIGINT NOT NULL,
+    block_height BIGINT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL,
+    closed_at TIMESTAMPTZ,
+    position BYTEA NOT NULL,
+    pool BYTEA NOT NULL,
+    owner BYTEA NOT NULL,
+    position_id BIGINT NOT NULL,
+    source VARCHAR(255) NOT NULL,
+    source_version INT NOT NULL,
+    UNIQUE (chain_id, position, source, source_version)
+);

--- a/migrations/tables/sol_prediction_claims.sql
+++ b/migrations/tables/sol_prediction_claims.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS sol_prediction_claims (
+    id BIGSERIAL PRIMARY KEY,
+    chain_id BIGINT NOT NULL,
+    block_height BIGINT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL,
+    tx_id BYTEA NOT NULL,
+    log_position BIGINT NOT NULL,
+    market BYTEA NOT NULL,
+    claimer BYTEA NOT NULL,
+    burned_amount BIGINT NOT NULL,
+    reward_amount BIGINT NOT NULL,
+    total_burned BIGINT NOT NULL,
+    source VARCHAR(255) NOT NULL,
+    source_version INT NOT NULL,
+    UNIQUE (chain_id, tx_id, log_position, source, source_version)
+);

--- a/migrations/tables/sol_prediction_entries.sql
+++ b/migrations/tables/sol_prediction_entries.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS sol_prediction_entries (
+    id BIGSERIAL PRIMARY KEY,
+    chain_id BIGINT NOT NULL,
+    block_height BIGINT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL,
+    market BYTEA NOT NULL,
+    oracle BYTEA NOT NULL,
+    entry_id BYTEA NOT NULL,
+    base_mint BYTEA NOT NULL,
+    contribution BIGINT,
+    is_winner BOOLEAN,
+    source VARCHAR(255) NOT NULL,
+    source_version INT NOT NULL,
+    UNIQUE (chain_id, market, entry_id, source, source_version)
+);

--- a/migrations/tables/sol_prediction_markets.sql
+++ b/migrations/tables/sol_prediction_markets.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS sol_prediction_markets (
+    id BIGSERIAL PRIMARY KEY,
+    chain_id BIGINT NOT NULL,
+    block_height BIGINT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL,
+    resolved_at TIMESTAMPTZ,
+    market BYTEA NOT NULL,
+    oracle BYTEA NOT NULL,
+    quote_mint BYTEA NOT NULL,
+    winner_mint BYTEA,
+    claimable_supply BIGINT,
+    total_pot BIGINT,
+    source VARCHAR(255) NOT NULL,
+    source_version INT NOT NULL,
+    UNIQUE (chain_id, market, source, source_version)
+);

--- a/src/bin/backfill_zora_migrations.rs
+++ b/src/bin/backfill_zora_migrations.rs
@@ -85,9 +85,9 @@ async fn process_file(
 ) -> anyhow::Result<()> {
     let file = File::open(path)?;
     let builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
-    let mut reader = builder.build()?;
+    let reader = builder.build()?;
 
-    while let Some(batch) = reader.next() {
+    for batch in reader {
         let batch = batch?;
         let num_rows = batch.num_rows();
         *total_rows += num_rows as u64;

--- a/src/bin/backfill_zora_migrations.rs
+++ b/src/bin/backfill_zora_migrations.rs
@@ -125,10 +125,7 @@ async fn process_file(
                 .await?;
 
             let Some(row) = rows.first() else {
-                eprintln!(
-                    "  skip: no pool for from_hash={}",
-                    hex::encode(from_hash)
-                );
+                eprintln!("  skip: no pool for from_hash={}", hex::encode(from_hash));
                 *skipped += 1;
                 continue;
             };
@@ -220,38 +217,53 @@ fn col_binary<'a>(
     batch: &'a arrow::record_batch::RecordBatch,
     name: &str,
 ) -> &'a FixedSizeBinaryArray {
-    let idx = batch.schema().index_of(name).unwrap_or_else(|_| {
-        panic!("column '{}' not found in parquet schema", name)
-    });
+    let idx = batch
+        .schema()
+        .index_of(name)
+        .unwrap_or_else(|_| panic!("column '{}' not found in parquet schema", name));
     let col = batch.column(idx);
     col.as_any()
         .downcast_ref::<FixedSizeBinaryArray>()
-        .unwrap_or_else(|| panic!("column '{}' is not FixedSizeBinaryArray (type={:?})", name, col.data_type()))
+        .unwrap_or_else(|| {
+            panic!(
+                "column '{}' is not FixedSizeBinaryArray (type={:?})",
+                name,
+                col.data_type()
+            )
+        })
 }
 
-fn col_u64<'a>(
-    batch: &'a arrow::record_batch::RecordBatch,
-    name: &str,
-) -> &'a UInt64Array {
-    let idx = batch.schema().index_of(name).unwrap_or_else(|_| {
-        panic!("column '{}' not found in parquet schema", name)
-    });
+fn col_u64<'a>(batch: &'a arrow::record_batch::RecordBatch, name: &str) -> &'a UInt64Array {
+    let idx = batch
+        .schema()
+        .index_of(name)
+        .unwrap_or_else(|_| panic!("column '{}' not found in parquet schema", name));
     let col = batch.column(idx);
     // ubigint in DuckDB parquet maps to UInt64 in arrow.
     col.as_any()
         .downcast_ref::<UInt64Array>()
-        .unwrap_or_else(|| panic!("column '{}' is not UInt64Array (type={:?})", name, col.data_type()))
+        .unwrap_or_else(|| {
+            panic!(
+                "column '{}' is not UInt64Array (type={:?})",
+                name,
+                col.data_type()
+            )
+        })
 }
 
-fn col_i64<'a>(
-    batch: &'a arrow::record_batch::RecordBatch,
-    name: &str,
-) -> &'a Int64Array {
-    let idx = batch.schema().index_of(name).unwrap_or_else(|_| {
-        panic!("column '{}' not found in parquet schema", name)
-    });
+fn col_i64<'a>(batch: &'a arrow::record_batch::RecordBatch, name: &str) -> &'a Int64Array {
+    let idx = batch
+        .schema()
+        .index_of(name)
+        .unwrap_or_else(|_| panic!("column '{}' not found in parquet schema", name));
     let col = batch.column(idx);
     col.as_any()
         .downcast_ref::<Int64Array>()
-        .unwrap_or_else(|| panic!("column '{}' is not Int64Array (type={:?})", name, col.data_type()))
+        .unwrap_or_else(|| {
+            panic!(
+                "column '{}' is not Int64Array (type={:?})",
+                name,
+                col.data_type()
+            )
+        })
 }

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -343,9 +343,9 @@ impl DbPool {
 }
 
 fn build_tls_connector() -> Result<MakeTlsConnector, DbError> {
-    let tls_connector = TlsConnector::builder()
-        .build()
-        .map_err(|e| DbError::ConfigError(format!("failed to build database TLS connector: {e}")))?;
+    let tls_connector = TlsConnector::builder().build().map_err(|e| {
+        DbError::ConfigError(format!("failed to build database TLS connector: {e}"))
+    })?;
 
     Ok(MakeTlsConnector::new(tls_connector))
 }

--- a/src/live/progress.rs
+++ b/src/live/progress.rs
@@ -4,6 +4,8 @@
 //! enabling the compaction service to know when ranges are ready.
 
 use std::collections::{HashMap, HashSet};
+
+type HandlerSetsFn<'a> = &'a mut dyn FnMut(&mut HashSet<String>, &mut HashSet<String>, &mut bool);
 use std::sync::Arc;
 
 use tokio_postgres::types::ToSql;
@@ -48,7 +50,7 @@ pub trait ProgressStatusStorage: Send + Sync {
     fn update_handler_sets_atomic(
         &self,
         number: u64,
-        update_fn: &mut dyn FnMut(&mut HashSet<String>, &mut HashSet<String>, &mut bool),
+        update_fn: HandlerSetsFn<'_>,
     ) -> Result<(), StorageError>;
 }
 
@@ -85,7 +87,7 @@ impl ProgressStatusStorage for LiveStorage {
     fn update_handler_sets_atomic(
         &self,
         number: u64,
-        update_fn: &mut dyn FnMut(&mut HashSet<String>, &mut HashSet<String>, &mut bool),
+        update_fn: HandlerSetsFn<'_>,
     ) -> Result<(), StorageError> {
         self.update_status_atomic(number, |status| {
             update_fn(

--- a/src/raw_data/historical/catchup/eth_calls.rs
+++ b/src/raw_data/historical/catchup/eth_calls.rs
@@ -39,7 +39,6 @@ use crate::types::config::defaults;
 use crate::types::config::raw_data::RawDataCollectionConfig;
 use crate::types::shared::repair::RepairScope;
 use alloy::primitives::Address;
-use tokio::sync::oneshot;
 
 type EthCallJoinSet =
     tokio::task::JoinSet<Result<Option<(u64, u64, bool)>, EthCallCollectionError>>;

--- a/src/raw_data/historical/eth_calls/once_calls.rs
+++ b/src/raw_data/historical/eth_calls/once_calls.rs
@@ -2232,7 +2232,7 @@ mod tests {
         // Step 4: a subsequent read_parquet_column_names returns full schema,
         // so the missing-column check would now pass — no infinite loop.
         let final_cols = read_parquet_column_names(&path);
-        let all_fn_names = vec!["getA".to_string(), "getB".to_string()];
+        let all_fn_names = ["getA".to_string(), "getB".to_string()];
         let missing: Vec<&String> = all_fn_names
             .iter()
             .filter(|f| !final_cols.contains(*f))

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -4,6 +4,6 @@ mod unified;
 mod websocket;
 
 pub use alchemy::SlidingWindowRateLimiter;
-pub use provider::{RetryConfig, RpcError};
+pub use provider::RpcError;
 pub use unified::UnifiedRpcClient;
-pub use websocket::{ReconnectConfig, WsClient, WsEvent};
+pub use websocket::{WsClient, WsEvent};

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -4,6 +4,6 @@ mod unified;
 mod websocket;
 
 pub use alchemy::SlidingWindowRateLimiter;
-pub use provider::RpcError;
+pub use provider::{RetryConfig, RpcError};
 pub use unified::UnifiedRpcClient;
-pub use websocket::{WsClient, WsEvent};
+pub use websocket::{ReconnectConfig, WsClient, WsEvent};

--- a/src/transformations/event/metrics/swap_data.rs
+++ b/src/transformations/event/metrics/swap_data.rs
@@ -361,6 +361,7 @@ pub fn process_liquidity_deltas(deltas: &[LiquidityInput], chain_id: u64) -> Vec
 /// Returns `Err` only if the DB refresh itself fails. Pools that remain absent
 /// after the refresh are logged and silently skipped — `process_swaps` already
 /// handles missing metadata gracefully by skipping the affected pools.
+#[allow(clippy::too_many_arguments)]
 pub async fn refresh_cache_if_needed(
     pool_ids: impl Iterator<Item = &Vec<u8>>,
     cache: &PoolMetadataCache,

--- a/src/transformations/event/mod.rs
+++ b/src/transformations/event/mod.rs
@@ -9,6 +9,8 @@ pub mod metrics;
 pub mod migration_pool;
 pub mod multicurve;
 pub mod scheduled_multicurve;
+#[cfg(feature = "solana")]
+pub mod solana;
 pub mod v3;
 pub mod v4;
 pub mod zora;

--- a/src/transformations/event/solana/cpmm/metrics.rs
+++ b/src/transformations/event/solana/cpmm/metrics.rs
@@ -188,11 +188,7 @@ impl TransformationHandler for CpmmMetricsHandler {
                     DbValue::Numeric(acc.volume1.to_string()),
                     DbValue::Int32(acc.swap_count),
                 ],
-                conflict_columns: vec![
-                    "chain_id".into(),
-                    "pool_id".into(),
-                    "block_height".into(),
-                ],
+                conflict_columns: vec!["chain_id".into(), "pool_id".into(), "block_height".into()],
                 update_columns: vec![
                     "price_open".into(),
                     "price_close".into(),

--- a/src/transformations/event/solana/cpmm/metrics.rs
+++ b/src/transformations/event/solana/cpmm/metrics.rs
@@ -1,0 +1,226 @@
+use std::collections::HashMap;
+
+use alloy_primitives::U256;
+use async_trait::async_trait;
+use bigdecimal::BigDecimal;
+
+use crate::db::{DbOperation, DbValue};
+use crate::transformations::context::{FieldExtractor, TransformationContext};
+use crate::transformations::error::TransformationError;
+use crate::transformations::registry::TransformationRegistry;
+use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
+use crate::types::chain::ChainType;
+
+pub struct CpmmMetricsHandler;
+
+#[derive(Default)]
+struct SlotAccumulator {
+    price_open: Option<BigDecimal>,
+    price_close: Option<BigDecimal>,
+    price_high: Option<BigDecimal>,
+    price_low: Option<BigDecimal>,
+    volume0: u64,
+    volume1: u64,
+    swap_count: i32,
+    liquidity_added: U256,
+    liquidity_removed: U256,
+    block_timestamp: u64,
+}
+
+#[async_trait]
+impl TransformationHandler for CpmmMetricsHandler {
+    fn name(&self) -> &'static str {
+        "CpmmMetricsHandler"
+    }
+
+    fn version(&self) -> u32 {
+        1
+    }
+
+    fn chain_type(&self) -> ChainType {
+        ChainType::Solana
+    }
+
+    fn migration_paths(&self) -> Vec<&'static str> {
+        vec![
+            "migrations/tables/pool_snapshots.sql",
+            "migrations/tables/pool_snapshots_add_tvl.sql",
+            "migrations/tables/pool_snapshots_add_volume_usd.sql",
+        ]
+    }
+
+    fn reorg_tables(&self) -> Vec<&'static str> {
+        vec!["pool_snapshots"]
+    }
+
+    fn requires_sequential(&self) -> bool {
+        true
+    }
+
+    async fn handle(
+        &self,
+        ctx: &TransformationContext,
+    ) -> Result<Vec<DbOperation>, TransformationError> {
+        // Key: (pool_pubkey, slot)
+        let mut accumulators: HashMap<([u8; 32], u64), SlotAccumulator> = HashMap::new();
+
+        for event in ctx.events_of_type("DopplerCPMM", "Swap") {
+            let pool = event.extract_pubkey("pool")?;
+            let direction = event.extract_u8("direction")?;
+            let amount_in = event.extract_u64("amount_in")?;
+            let amount_out = event.extract_u64("amount_out")?;
+            let slot = event.block_number;
+
+            if amount_in == 0 || amount_out == 0 {
+                continue;
+            }
+
+            // Express price as token1 per token0.
+            // direction=0: user pays token1 (amount_in), receives token0 (amount_out)
+            // direction=1: user pays token0 (amount_in), receives token1 (amount_out)
+            let price = if direction == 0 {
+                BigDecimal::from(amount_in) / BigDecimal::from(amount_out)
+            } else {
+                BigDecimal::from(amount_out) / BigDecimal::from(amount_in)
+            };
+
+            let (vol0, vol1) = if direction == 0 {
+                (amount_out, amount_in)
+            } else {
+                (amount_in, amount_out)
+            };
+
+            let acc = accumulators
+                .entry((pool, slot))
+                .or_insert_with(|| SlotAccumulator {
+                    block_timestamp: event.block_timestamp,
+                    ..Default::default()
+                });
+
+            if acc.price_open.is_none() {
+                acc.price_open = Some(price.clone());
+            }
+            acc.price_close = Some(price.clone());
+            acc.price_high = Some(match acc.price_high.take() {
+                Some(h) => h.max(price.clone()),
+                None => price.clone(),
+            });
+            acc.price_low = Some(match acc.price_low.take() {
+                Some(l) => l.min(price),
+                None => price,
+            });
+            acc.volume0 = acc.volume0.saturating_add(vol0);
+            acc.volume1 = acc.volume1.saturating_add(vol1);
+            acc.swap_count += 1;
+        }
+
+        for event in ctx.events_of_type("DopplerCPMM", "AddLiquidity") {
+            let pool = event.extract_pubkey("pool")?;
+            let shares_out = event.extract_uint256("shares_out")?;
+            let slot = event.block_number;
+
+            let acc = accumulators
+                .entry((pool, slot))
+                .or_insert_with(|| SlotAccumulator {
+                    block_timestamp: event.block_timestamp,
+                    ..Default::default()
+                });
+            acc.liquidity_added = acc.liquidity_added.saturating_add(shares_out);
+        }
+
+        for event in ctx.events_of_type("DopplerCPMM", "RemoveLiquidity") {
+            let pool = event.extract_pubkey("pool")?;
+            let shares_in = event.extract_uint256("shares_in")?;
+            let slot = event.block_number;
+
+            let acc = accumulators
+                .entry((pool, slot))
+                .or_insert_with(|| SlotAccumulator {
+                    block_timestamp: event.block_timestamp,
+                    ..Default::default()
+                });
+            acc.liquidity_removed = acc.liquidity_removed.saturating_add(shares_in);
+        }
+
+        let mut ops = Vec::new();
+        let zero = BigDecimal::from(0u64);
+
+        for ((pool, slot), acc) in accumulators {
+            let price_open = acc.price_open.unwrap_or_else(|| zero.clone());
+            let price_close = acc.price_close.unwrap_or_else(|| price_open.clone());
+            let price_high = acc.price_high.unwrap_or_else(|| price_open.clone());
+            let price_low = acc.price_low.unwrap_or_else(|| price_open.clone());
+
+            // Net liquidity share delta for this slot (can be negative).
+            let liquidity_delta = if acc.liquidity_added >= acc.liquidity_removed {
+                (acc.liquidity_added - acc.liquidity_removed).to_string()
+            } else {
+                format!("-{}", acc.liquidity_removed - acc.liquidity_added)
+            };
+
+            ops.push(DbOperation::Upsert {
+                table: "pool_snapshots".to_string(),
+                columns: vec![
+                    "chain_id".into(),
+                    "pool_id".into(),
+                    "block_height".into(),
+                    "block_timestamp".into(),
+                    "price_open".into(),
+                    "price_close".into(),
+                    "price_high".into(),
+                    "price_low".into(),
+                    "active_liquidity".into(),
+                    "volume0".into(),
+                    "volume1".into(),
+                    "swap_count".into(),
+                ],
+                values: vec![
+                    DbValue::Int64(ctx.chain_id as i64),
+                    DbValue::Pubkey(pool),
+                    DbValue::Int64(slot as i64),
+                    DbValue::Int64(acc.block_timestamp as i64),
+                    DbValue::Numeric(price_open.to_string()),
+                    DbValue::Numeric(price_close.to_string()),
+                    DbValue::Numeric(price_high.to_string()),
+                    DbValue::Numeric(price_low.to_string()),
+                    DbValue::Numeric(liquidity_delta),
+                    DbValue::Numeric(acc.volume0.to_string()),
+                    DbValue::Numeric(acc.volume1.to_string()),
+                    DbValue::Int32(acc.swap_count),
+                ],
+                conflict_columns: vec![
+                    "chain_id".into(),
+                    "pool_id".into(),
+                    "block_height".into(),
+                ],
+                update_columns: vec![
+                    "price_open".into(),
+                    "price_close".into(),
+                    "price_high".into(),
+                    "price_low".into(),
+                    "active_liquidity".into(),
+                    "volume0".into(),
+                    "volume1".into(),
+                    "swap_count".into(),
+                ],
+                update_condition: None,
+            });
+        }
+
+        Ok(ops)
+    }
+}
+
+impl EventHandler for CpmmMetricsHandler {
+    fn triggers(&self) -> Vec<EventTrigger> {
+        vec![
+            EventTrigger::new("DopplerCPMM", "Swap"),
+            EventTrigger::new("DopplerCPMM", "AddLiquidity"),
+            EventTrigger::new("DopplerCPMM", "RemoveLiquidity"),
+        ]
+    }
+}
+
+pub fn register_handlers(registry: &mut TransformationRegistry) {
+    registry.register_event_handler(CpmmMetricsHandler);
+}

--- a/src/transformations/event/solana/cpmm/mod.rs
+++ b/src/transformations/event/solana/cpmm/mod.rs
@@ -1,0 +1,13 @@
+pub mod metrics;
+pub mod pool_create;
+pub mod positions;
+pub mod swap;
+
+use crate::transformations::registry::TransformationRegistry;
+
+pub fn register_handlers(registry: &mut TransformationRegistry) {
+    pool_create::register_handlers(registry);
+    swap::register_handlers(registry);
+    metrics::register_handlers(registry);
+    positions::register_handlers(registry);
+}

--- a/src/transformations/event/solana/cpmm/pool_create.rs
+++ b/src/transformations/event/solana/cpmm/pool_create.rs
@@ -1,0 +1,126 @@
+use async_trait::async_trait;
+use serde_json::json;
+
+use crate::db::{DbOperation, DbValue};
+use crate::transformations::context::{FieldExtractor, TransformationContext};
+use crate::transformations::error::TransformationError;
+use crate::transformations::registry::TransformationRegistry;
+use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
+use crate::types::chain::ChainType;
+
+pub struct CpmmPoolCreateHandler;
+
+#[async_trait]
+impl TransformationHandler for CpmmPoolCreateHandler {
+    fn name(&self) -> &'static str {
+        "CpmmPoolCreateHandler"
+    }
+
+    fn version(&self) -> u32 {
+        1
+    }
+
+    fn chain_type(&self) -> ChainType {
+        ChainType::Solana
+    }
+
+    fn migration_paths(&self) -> Vec<&'static str> {
+        vec![
+            "migrations/tables/pools.sql",
+            "migrations/tables/pools_solana_nullable.sql",
+        ]
+    }
+
+    fn reorg_tables(&self) -> Vec<&'static str> {
+        vec!["pools"]
+    }
+
+    async fn handle(
+        &self,
+        ctx: &TransformationContext,
+    ) -> Result<Vec<DbOperation>, TransformationError> {
+        let mut ops = Vec::new();
+
+        for event in ctx.events_of_type("DopplerCPMM", "PoolInitialized") {
+            let pool = event.extract_pubkey("pool")?;
+            let token0_mint = event.extract_pubkey("token0_mint")?;
+            let token1_mint = event.extract_pubkey("token1_mint")?;
+            let vault0 = event.extract_pubkey("vault0")?;
+            let vault1 = event.extract_pubkey("vault1")?;
+
+            let pool_key = json!({
+                "vault0": bs58::encode(&vault0).into_string(),
+                "vault1": bs58::encode(&vault1).into_string(),
+            });
+
+            ops.push(DbOperation::Upsert {
+                table: "pools".to_string(),
+                columns: vec![
+                    "chain_id".into(),
+                    "block_height".into(),
+                    "created_at".into(),
+                    "address".into(),
+                    "base_token".into(),
+                    "quote_token".into(),
+                    "is_token_0".into(),
+                    "type".into(),
+                    "integrator".into(),
+                    "initializer".into(),
+                    "fee".into(),
+                    "min_threshold".into(),
+                    "max_threshold".into(),
+                    "migrator".into(),
+                    "migrated_at".into(),
+                    "migration_pool".into(),
+                    "migrated_from".into(),
+                    "migration_type".into(),
+                    "lock_duration".into(),
+                    "beneficiaries".into(),
+                    "pool_key".into(),
+                    "starting_time".into(),
+                    "ending_time".into(),
+                ],
+                values: vec![
+                    DbValue::Int64(ctx.chain_id as i64),
+                    DbValue::Int64(event.block_number as i64),
+                    DbValue::Timestamp(event.block_timestamp as i64),
+                    DbValue::Pubkey(pool),
+                    DbValue::Pubkey(token0_mint),
+                    DbValue::Pubkey(token1_mint),
+                    DbValue::Bool(true),
+                    DbValue::VarChar("cpmm".into()),
+                    DbValue::Null,
+                    DbValue::Null,
+                    DbValue::Null,
+                    DbValue::Null,
+                    DbValue::Null,
+                    DbValue::Null,
+                    DbValue::Null,
+                    DbValue::Null,
+                    DbValue::Null,
+                    DbValue::Null,
+                    DbValue::Null,
+                    DbValue::Null,
+                    DbValue::JsonB(pool_key),
+                    DbValue::Null,
+                    DbValue::Null,
+                ],
+                conflict_columns: vec!["chain_id".into(), "address".into()],
+                update_columns: vec![],
+                update_condition: None,
+            });
+        }
+
+        Ok(ops)
+    }
+}
+
+impl EventHandler for CpmmPoolCreateHandler {
+    fn triggers(&self) -> Vec<EventTrigger> {
+        vec![EventTrigger::new("DopplerCPMM", "PoolInitialized")]
+    }
+}
+
+pub fn register_handlers(registry: &mut TransformationRegistry) {
+    registry.register_event_handler(CpmmPoolCreateHandler);
+}

--- a/src/transformations/event/solana/cpmm/positions.rs
+++ b/src/transformations/event/solana/cpmm/positions.rs
@@ -1,0 +1,122 @@
+use async_trait::async_trait;
+
+use crate::db::{DbOperation, DbValue};
+use crate::transformations::context::{FieldExtractor, TransformationContext};
+use crate::transformations::error::TransformationError;
+use crate::transformations::registry::TransformationRegistry;
+use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
+use crate::types::chain::ChainType;
+
+pub struct CpmmPositionHandler;
+
+#[async_trait]
+impl TransformationHandler for CpmmPositionHandler {
+    fn name(&self) -> &'static str {
+        "CpmmPositionHandler"
+    }
+
+    fn version(&self) -> u32 {
+        1
+    }
+
+    fn chain_type(&self) -> ChainType {
+        ChainType::Solana
+    }
+
+    fn migration_paths(&self) -> Vec<&'static str> {
+        vec!["migrations/tables/sol_cpmm_positions.sql"]
+    }
+
+    fn reorg_tables(&self) -> Vec<&'static str> {
+        vec!["sol_cpmm_positions"]
+    }
+
+    async fn handle(
+        &self,
+        ctx: &TransformationContext,
+    ) -> Result<Vec<DbOperation>, TransformationError> {
+        let mut ops = Vec::new();
+
+        for event in ctx.events_of_type("DopplerCPMM", "PositionCreated") {
+            let pool = event.extract_pubkey("pool")?;
+            let owner = event.extract_pubkey("owner")?;
+            let position = event.extract_pubkey("position")?;
+            let position_id = event.extract_u64("position_id")?;
+
+            ops.push(DbOperation::Upsert {
+                table: "sol_cpmm_positions".to_string(),
+                columns: vec![
+                    "chain_id".into(),
+                    "block_height".into(),
+                    "created_at".into(),
+                    "closed_at".into(),
+                    "position".into(),
+                    "pool".into(),
+                    "owner".into(),
+                    "position_id".into(),
+                ],
+                values: vec![
+                    DbValue::Int64(ctx.chain_id as i64),
+                    DbValue::Int64(event.block_number as i64),
+                    DbValue::Timestamp(event.block_timestamp as i64),
+                    DbValue::Null,
+                    DbValue::Pubkey(position),
+                    DbValue::Pubkey(pool),
+                    DbValue::Pubkey(owner),
+                    DbValue::Int64(position_id as i64),
+                ],
+                conflict_columns: vec!["chain_id".into(), "position".into()],
+                update_columns: vec![],
+                update_condition: None,
+            });
+        }
+
+        for event in ctx.events_of_type("DopplerCPMM", "PositionClosed") {
+            let pool = event.extract_pubkey("pool")?;
+            let owner = event.extract_pubkey("owner")?;
+            let position = event.extract_pubkey("position")?;
+
+            ops.push(DbOperation::Upsert {
+                table: "sol_cpmm_positions".to_string(),
+                columns: vec![
+                    "chain_id".into(),
+                    "block_height".into(),
+                    "created_at".into(),
+                    "closed_at".into(),
+                    "position".into(),
+                    "pool".into(),
+                    "owner".into(),
+                    "position_id".into(),
+                ],
+                values: vec![
+                    DbValue::Int64(ctx.chain_id as i64),
+                    DbValue::Int64(event.block_number as i64),
+                    DbValue::Timestamp(event.block_timestamp as i64),
+                    DbValue::Timestamp(event.block_timestamp as i64),
+                    DbValue::Pubkey(position),
+                    DbValue::Pubkey(pool),
+                    DbValue::Pubkey(owner),
+                    DbValue::Int64(0i64), // unknown at close time; preserved from create on conflict
+                ],
+                conflict_columns: vec!["chain_id".into(), "position".into()],
+                update_columns: vec!["closed_at".into()],
+                update_condition: None,
+            });
+        }
+
+        Ok(ops)
+    }
+}
+
+impl EventHandler for CpmmPositionHandler {
+    fn triggers(&self) -> Vec<EventTrigger> {
+        vec![
+            EventTrigger::new("DopplerCPMM", "PositionCreated"),
+            EventTrigger::new("DopplerCPMM", "PositionClosed"),
+        ]
+    }
+}
+
+pub fn register_handlers(registry: &mut TransformationRegistry) {
+    registry.register_event_handler(CpmmPositionHandler);
+}

--- a/src/transformations/event/solana/cpmm/swap.rs
+++ b/src/transformations/event/solana/cpmm/swap.rs
@@ -1,0 +1,124 @@
+use async_trait::async_trait;
+
+use crate::db::{DbOperation, DbValue};
+use crate::transformations::context::{FieldExtractor, TransformationContext};
+use crate::transformations::error::TransformationError;
+use crate::transformations::registry::TransformationRegistry;
+use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
+use crate::types::chain::ChainType;
+
+pub struct CpmmSwapHandler;
+
+#[async_trait]
+impl TransformationHandler for CpmmSwapHandler {
+    fn name(&self) -> &'static str {
+        "CpmmSwapHandler"
+    }
+
+    fn version(&self) -> u32 {
+        1
+    }
+
+    fn chain_type(&self) -> ChainType {
+        ChainType::Solana
+    }
+
+    fn migration_paths(&self) -> Vec<&'static str> {
+        vec![
+            "migrations/tables/swaps.sql",
+            "migrations/tables/swaps_solana_nullable.sql",
+        ]
+    }
+
+    fn reorg_tables(&self) -> Vec<&'static str> {
+        vec!["swaps"]
+    }
+
+    async fn handle(
+        &self,
+        ctx: &TransformationContext,
+    ) -> Result<Vec<DbOperation>, TransformationError> {
+        let mut ops = Vec::new();
+
+        for event in ctx.events_of_type("DopplerCPMM", "Swap") {
+            let pool = event.extract_pubkey("pool")?;
+            let direction = event.extract_u8("direction")?;
+            let amount_in = event.extract_u64("amount_in")?;
+            let amount_out = event.extract_u64("amount_out")?;
+            let fee_total = event.extract_u64("fee_total")?;
+            let fee_dist = event.extract_u64("fee_dist")?;
+            let tx_sig = event
+                .transaction_id
+                .as_solana()
+                .expect("Solana event has Solana tx id");
+            let log_position = event.position.packed_ordinal_i64();
+
+            ops.push(DbOperation::Upsert {
+                table: "swaps".to_string(),
+                columns: vec![
+                    "chain_id".into(),
+                    "tx_id".into(),
+                    "block_height".into(),
+                    "timestamp".into(),
+                    "pool".into(),
+                    "asset".into(),
+                    "amountin".into(),
+                    "amountout".into(),
+                    "is_buy".into(),
+                    "current_tick".into(),
+                    "graduation_tick".into(),
+                    "fee0_delta".into(),
+                    "fee1_delta".into(),
+                    "tokens_sold_delta".into(),
+                    "graduation_balance_delta".into(),
+                    "max_threshold_delta".into(),
+                    "market_cap_usd_delta".into(),
+                    "liquidity_usd_delta".into(),
+                    "value_usd".into(),
+                    "log_position".into(),
+                ],
+                values: vec![
+                    DbValue::Int64(ctx.chain_id as i64),
+                    DbValue::Bytes(tx_sig.to_vec()),
+                    DbValue::Int64(event.block_number as i64),
+                    DbValue::Timestamp(event.block_timestamp as i64),
+                    DbValue::Pubkey(pool),
+                    DbValue::Null,
+                    DbValue::Uint64(amount_in),
+                    DbValue::Uint64(amount_out),
+                    DbValue::Bool(direction == 0),
+                    DbValue::Null,
+                    DbValue::Null,
+                    DbValue::Uint64(fee_total),
+                    DbValue::Uint64(fee_dist),
+                    DbValue::Null,
+                    DbValue::Null,
+                    DbValue::Null,
+                    DbValue::Null,
+                    DbValue::Null,
+                    DbValue::Null,
+                    DbValue::Int64(log_position),
+                ],
+                conflict_columns: vec![
+                    "chain_id".into(),
+                    "tx_id".into(),
+                    "log_position".into(),
+                ],
+                update_columns: vec![],
+                update_condition: None,
+            });
+        }
+
+        Ok(ops)
+    }
+}
+
+impl EventHandler for CpmmSwapHandler {
+    fn triggers(&self) -> Vec<EventTrigger> {
+        vec![EventTrigger::new("DopplerCPMM", "Swap")]
+    }
+}
+
+pub fn register_handlers(registry: &mut TransformationRegistry) {
+    registry.register_event_handler(CpmmSwapHandler);
+}

--- a/src/transformations/event/solana/cpmm/swap.rs
+++ b/src/transformations/event/solana/cpmm/swap.rs
@@ -99,11 +99,7 @@ impl TransformationHandler for CpmmSwapHandler {
                     DbValue::Null,
                     DbValue::Int64(log_position),
                 ],
-                conflict_columns: vec![
-                    "chain_id".into(),
-                    "tx_id".into(),
-                    "log_position".into(),
-                ],
+                conflict_columns: vec!["chain_id".into(), "tx_id".into(), "log_position".into()],
                 update_columns: vec![],
                 update_condition: None,
             });

--- a/src/transformations/event/solana/cpmm_migrator/handlers.rs
+++ b/src/transformations/event/solana/cpmm_migrator/handlers.rs
@@ -1,0 +1,162 @@
+use async_trait::async_trait;
+
+use crate::db::{DbOperation, DbValue};
+use crate::transformations::context::{FieldExtractor, TransformationContext};
+use crate::transformations::error::TransformationError;
+use crate::transformations::registry::TransformationRegistry;
+use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
+use crate::types::chain::ChainType;
+
+pub struct CpmmMigratorHandler;
+
+#[async_trait]
+impl TransformationHandler for CpmmMigratorHandler {
+    fn name(&self) -> &'static str {
+        "CpmmMigratorHandler"
+    }
+
+    fn version(&self) -> u32 {
+        1
+    }
+
+    fn chain_type(&self) -> ChainType {
+        ChainType::Solana
+    }
+
+    fn migration_paths(&self) -> Vec<&'static str> {
+        vec![
+            "migrations/tables/pools.sql",
+            "migrations/tables/pools_solana_nullable.sql",
+            "migrations/tables/sol_cpmm_migrator.sql",
+        ]
+    }
+
+    fn reorg_tables(&self) -> Vec<&'static str> {
+        vec!["sol_cpmm_migrator"]
+    }
+
+    async fn handle(
+        &self,
+        ctx: &TransformationContext,
+    ) -> Result<Vec<DbOperation>, TransformationError> {
+        let mut ops = Vec::new();
+
+        for event in ctx.events_of_type("DopplerCpmmMigrator", "LaunchRegistered") {
+            let launch = event.extract_pubkey("launch")?;
+            let state = event.extract_pubkey("state")?;
+            let cpmm_config = event.extract_pubkey("cpmm_config")?;
+            let min_raise_quote = event.extract_u64("min_raise_quote")?;
+
+            ops.push(DbOperation::Upsert {
+                table: "sol_cpmm_migrator".to_string(),
+                columns: vec![
+                    "chain_id".into(),
+                    "block_height".into(),
+                    "created_at".into(),
+                    "launch".into(),
+                    "state".into(),
+                    "cpmm_config".into(),
+                    "min_raise_quote".into(),
+                    "pool".into(),
+                    "quote_for_liquidity".into(),
+                    "base_for_liquidity".into(),
+                    "migrated".into(),
+                ],
+                values: vec![
+                    DbValue::Int64(ctx.chain_id as i64),
+                    DbValue::Int64(event.block_number as i64),
+                    DbValue::Timestamp(event.block_timestamp as i64),
+                    DbValue::Pubkey(launch),
+                    DbValue::Pubkey(state),
+                    DbValue::Pubkey(cpmm_config),
+                    DbValue::Uint64(min_raise_quote),
+                    DbValue::Null,
+                    DbValue::Null,
+                    DbValue::Null,
+                    DbValue::Bool(false),
+                ],
+                conflict_columns: vec!["chain_id".into(), "launch".into()],
+                update_columns: vec![],
+                update_condition: None,
+            });
+        }
+
+        for event in ctx.events_of_type("DopplerCpmmMigrator", "LaunchMigrated") {
+            let launch = event.extract_pubkey("launch")?;
+            let pool = event.extract_pubkey("pool")?;
+            let quote_for_liquidity = event.extract_u64("quote_for_liquidity")?;
+            let base_for_liquidity = event.extract_u64("base_for_liquidity")?;
+
+            ops.push(DbOperation::Upsert {
+                table: "sol_cpmm_migrator".to_string(),
+                columns: vec![
+                    "chain_id".into(),
+                    "block_height".into(),
+                    "created_at".into(),
+                    "launch".into(),
+                    "state".into(),
+                    "cpmm_config".into(),
+                    "min_raise_quote".into(),
+                    "pool".into(),
+                    "quote_for_liquidity".into(),
+                    "base_for_liquidity".into(),
+                    "migrated".into(),
+                ],
+                values: vec![
+                    DbValue::Int64(ctx.chain_id as i64),
+                    DbValue::Int64(event.block_number as i64),
+                    DbValue::Timestamp(event.block_timestamp as i64),
+                    DbValue::Pubkey(launch),
+                    DbValue::Null,
+                    DbValue::Null,
+                    DbValue::Null,
+                    DbValue::Pubkey(pool),
+                    DbValue::Uint64(quote_for_liquidity),
+                    DbValue::Uint64(base_for_liquidity),
+                    DbValue::Bool(true),
+                ],
+                conflict_columns: vec!["chain_id".into(), "launch".into()],
+                update_columns: vec![
+                    "pool".into(),
+                    "quote_for_liquidity".into(),
+                    "base_for_liquidity".into(),
+                    "migrated".into(),
+                ],
+                update_condition: None,
+            });
+
+            // Update the originating pools row with the final CPMM pool address.
+            // RawSql targets the LaunchCreateHandler-owned row explicitly.
+            ops.push(DbOperation::RawSql {
+                query: "UPDATE pools \
+                    SET migration_pool = $1, migrated_at = to_timestamp($2) \
+                    WHERE chain_id = $3 AND address = $4 AND source = $5 AND source_version = $6"
+                    .to_string(),
+                params: vec![
+                    DbValue::Pubkey(pool),
+                    DbValue::Timestamp(event.block_timestamp as i64),
+                    DbValue::Int64(ctx.chain_id as i64),
+                    DbValue::Pubkey(launch),
+                    DbValue::Text("LaunchCreateHandler".to_string()),
+                    DbValue::Int32(1),
+                ],
+                snapshot: None,
+            });
+        }
+
+        Ok(ops)
+    }
+}
+
+impl EventHandler for CpmmMigratorHandler {
+    fn triggers(&self) -> Vec<EventTrigger> {
+        vec![
+            EventTrigger::new("DopplerCpmmMigrator", "LaunchRegistered"),
+            EventTrigger::new("DopplerCpmmMigrator", "LaunchMigrated"),
+        ]
+    }
+}
+
+pub fn register_handlers(registry: &mut TransformationRegistry) {
+    registry.register_event_handler(CpmmMigratorHandler);
+}

--- a/src/transformations/event/solana/cpmm_migrator/mod.rs
+++ b/src/transformations/event/solana/cpmm_migrator/mod.rs
@@ -1,0 +1,7 @@
+pub mod handlers;
+
+use crate::transformations::registry::TransformationRegistry;
+
+pub fn register_handlers(registry: &mut TransformationRegistry) {
+    handlers::register_handlers(registry);
+}

--- a/src/transformations/event/solana/initializer/curve_swap.rs
+++ b/src/transformations/event/solana/initializer/curve_swap.rs
@@ -98,11 +98,7 @@ impl TransformationHandler for CurveSwapHandler {
                     DbValue::Null,
                     DbValue::Int64(log_position),
                 ],
-                conflict_columns: vec![
-                    "chain_id".into(),
-                    "tx_id".into(),
-                    "log_position".into(),
-                ],
+                conflict_columns: vec!["chain_id".into(), "tx_id".into(), "log_position".into()],
                 update_columns: vec![],
                 update_condition: None,
             });

--- a/src/transformations/event/solana/initializer/curve_swap.rs
+++ b/src/transformations/event/solana/initializer/curve_swap.rs
@@ -1,0 +1,123 @@
+use async_trait::async_trait;
+
+use crate::db::{DbOperation, DbValue};
+use crate::transformations::context::{FieldExtractor, TransformationContext};
+use crate::transformations::error::TransformationError;
+use crate::transformations::registry::TransformationRegistry;
+use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
+use crate::types::chain::ChainType;
+
+pub struct CurveSwapHandler;
+
+#[async_trait]
+impl TransformationHandler for CurveSwapHandler {
+    fn name(&self) -> &'static str {
+        "CurveSwapHandler"
+    }
+
+    fn version(&self) -> u32 {
+        1
+    }
+
+    fn chain_type(&self) -> ChainType {
+        ChainType::Solana
+    }
+
+    fn migration_paths(&self) -> Vec<&'static str> {
+        vec![
+            "migrations/tables/swaps.sql",
+            "migrations/tables/swaps_solana_nullable.sql",
+        ]
+    }
+
+    fn reorg_tables(&self) -> Vec<&'static str> {
+        vec!["swaps"]
+    }
+
+    async fn handle(
+        &self,
+        ctx: &TransformationContext,
+    ) -> Result<Vec<DbOperation>, TransformationError> {
+        let mut ops = Vec::new();
+
+        for event in ctx.events_of_type("DopplerInitializer", "CurveSwap") {
+            let launch = event.extract_pubkey("launch")?;
+            let direction = event.extract_u8("direction")?;
+            let amount_in = event.extract_u64("amount_in")?;
+            let amount_out = event.extract_u64("amount_out")?;
+            let fee_paid = event.extract_u64("fee_paid")?;
+            let tx_sig = event
+                .transaction_id
+                .as_solana()
+                .expect("Solana event has Solana tx id");
+            let log_position = event.position.packed_ordinal_i64();
+
+            ops.push(DbOperation::Upsert {
+                table: "swaps".to_string(),
+                columns: vec![
+                    "chain_id".into(),
+                    "tx_id".into(),
+                    "block_height".into(),
+                    "timestamp".into(),
+                    "pool".into(),
+                    "asset".into(),
+                    "amountin".into(),
+                    "amountout".into(),
+                    "is_buy".into(),
+                    "current_tick".into(),
+                    "graduation_tick".into(),
+                    "fee0_delta".into(),
+                    "fee1_delta".into(),
+                    "tokens_sold_delta".into(),
+                    "graduation_balance_delta".into(),
+                    "max_threshold_delta".into(),
+                    "market_cap_usd_delta".into(),
+                    "liquidity_usd_delta".into(),
+                    "value_usd".into(),
+                    "log_position".into(),
+                ],
+                values: vec![
+                    DbValue::Int64(ctx.chain_id as i64),
+                    DbValue::Bytes(tx_sig.to_vec()),
+                    DbValue::Int64(event.block_number as i64),
+                    DbValue::Timestamp(event.block_timestamp as i64),
+                    DbValue::Pubkey(launch),
+                    DbValue::Null,
+                    DbValue::Uint64(amount_in),
+                    DbValue::Uint64(amount_out),
+                    DbValue::Bool(direction == 0),
+                    DbValue::Null,
+                    DbValue::Null,
+                    DbValue::Uint64(fee_paid),
+                    DbValue::Null,
+                    DbValue::Null,
+                    DbValue::Null,
+                    DbValue::Null,
+                    DbValue::Null,
+                    DbValue::Null,
+                    DbValue::Null,
+                    DbValue::Int64(log_position),
+                ],
+                conflict_columns: vec![
+                    "chain_id".into(),
+                    "tx_id".into(),
+                    "log_position".into(),
+                ],
+                update_columns: vec![],
+                update_condition: None,
+            });
+        }
+
+        Ok(ops)
+    }
+}
+
+impl EventHandler for CurveSwapHandler {
+    fn triggers(&self) -> Vec<EventTrigger> {
+        vec![EventTrigger::new("DopplerInitializer", "CurveSwap")]
+    }
+}
+
+pub fn register_handlers(registry: &mut TransformationRegistry) {
+    registry.register_event_handler(CurveSwapHandler);
+}

--- a/src/transformations/event/solana/initializer/launch_create.rs
+++ b/src/transformations/event/solana/initializer/launch_create.rs
@@ -1,0 +1,133 @@
+use async_trait::async_trait;
+use serde_json::json;
+
+use crate::db::{DbOperation, DbValue};
+use crate::transformations::context::{FieldExtractor, TransformationContext};
+use crate::transformations::error::TransformationError;
+use crate::transformations::registry::TransformationRegistry;
+use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
+use crate::types::chain::ChainType;
+
+pub struct LaunchCreateHandler;
+
+#[async_trait]
+impl TransformationHandler for LaunchCreateHandler {
+    fn name(&self) -> &'static str {
+        "LaunchCreateHandler"
+    }
+
+    fn version(&self) -> u32 {
+        1
+    }
+
+    fn chain_type(&self) -> ChainType {
+        ChainType::Solana
+    }
+
+    fn migration_paths(&self) -> Vec<&'static str> {
+        vec![
+            "migrations/tables/pools.sql",
+            "migrations/tables/pools_solana_nullable.sql",
+        ]
+    }
+
+    fn reorg_tables(&self) -> Vec<&'static str> {
+        vec!["pools"]
+    }
+
+    async fn handle(
+        &self,
+        ctx: &TransformationContext,
+    ) -> Result<Vec<DbOperation>, TransformationError> {
+        let mut ops = Vec::new();
+
+        for event in ctx.events_of_type("DopplerInitializer", "LaunchInitialized") {
+            let launch = event.extract_pubkey("launch")?;
+            let namespace = event.extract_pubkey("namespace")?;
+            let launch_id = event.extract_bytes32("launch_id")?;
+            let base_mint = event.extract_pubkey("base_mint")?;
+            let quote_mint = event.extract_pubkey("quote_mint")?;
+            let base_total_supply = event.extract_u64("base_total_supply")?;
+            let curve_kind = event.extract_u8("curve_kind")?;
+            let migrator_program = event.extract_pubkey("migrator_program")?;
+            let sentinel_program = event.extract_pubkey("sentinel_program")?;
+
+            let pool_key = json!({
+                "namespace": bs58::encode(&namespace).into_string(),
+                "launch_id": hex::encode(&launch_id),
+                "base_total_supply": base_total_supply,
+                "curve_kind": curve_kind,
+                "sentinel_program": bs58::encode(&sentinel_program).into_string(),
+            });
+
+            ops.push(DbOperation::Upsert {
+                table: "pools".to_string(),
+                columns: vec![
+                    "chain_id".into(),
+                    "block_height".into(),
+                    "created_at".into(),
+                    "address".into(),
+                    "base_token".into(),
+                    "quote_token".into(),
+                    "is_token_0".into(),
+                    "type".into(),
+                    "integrator".into(),
+                    "initializer".into(),
+                    "fee".into(),
+                    "min_threshold".into(),
+                    "max_threshold".into(),
+                    "migrator".into(),
+                    "migrated_at".into(),
+                    "migration_pool".into(),
+                    "migrated_from".into(),
+                    "migration_type".into(),
+                    "lock_duration".into(),
+                    "beneficiaries".into(),
+                    "pool_key".into(),
+                    "starting_time".into(),
+                    "ending_time".into(),
+                ],
+                values: vec![
+                    DbValue::Int64(ctx.chain_id as i64),
+                    DbValue::Int64(event.block_number as i64),
+                    DbValue::Timestamp(event.block_timestamp as i64),
+                    DbValue::Pubkey(launch),
+                    DbValue::Pubkey(base_mint),
+                    DbValue::Pubkey(quote_mint),
+                    DbValue::Bool(true),
+                    DbValue::VarChar(format!("curve_{}", curve_kind)),
+                    DbValue::Null,
+                    DbValue::Null,
+                    DbValue::Null,
+                    DbValue::Null,
+                    DbValue::Null,
+                    DbValue::Pubkey(migrator_program),
+                    DbValue::Null,
+                    DbValue::Null,
+                    DbValue::Null,
+                    DbValue::Null,
+                    DbValue::Null,
+                    DbValue::Null,
+                    DbValue::JsonB(pool_key),
+                    DbValue::Null,
+                    DbValue::Null,
+                ],
+                conflict_columns: vec!["chain_id".into(), "address".into()],
+                update_columns: vec![],
+                update_condition: None,
+            });
+        }
+
+        Ok(ops)
+    }
+}
+
+impl EventHandler for LaunchCreateHandler {
+    fn triggers(&self) -> Vec<EventTrigger> {
+        vec![EventTrigger::new("DopplerInitializer", "LaunchInitialized")]
+    }
+}
+
+pub fn register_handlers(registry: &mut TransformationRegistry) {
+    registry.register_event_handler(LaunchCreateHandler);
+}

--- a/src/transformations/event/solana/initializer/launch_migrate.rs
+++ b/src/transformations/event/solana/initializer/launch_migrate.rs
@@ -1,0 +1,80 @@
+use async_trait::async_trait;
+
+use crate::db::{DbOperation, DbValue};
+use crate::transformations::context::{FieldExtractor, TransformationContext};
+use crate::transformations::error::TransformationError;
+use crate::transformations::registry::TransformationRegistry;
+use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
+use crate::types::chain::ChainType;
+
+pub struct LaunchMigrateHandler;
+
+#[async_trait]
+impl TransformationHandler for LaunchMigrateHandler {
+    fn name(&self) -> &'static str {
+        "LaunchMigrateHandler"
+    }
+
+    fn version(&self) -> u32 {
+        1
+    }
+
+    fn chain_type(&self) -> ChainType {
+        ChainType::Solana
+    }
+
+    fn migration_paths(&self) -> Vec<&'static str> {
+        vec![
+            "migrations/tables/pools.sql",
+            "migrations/tables/pools_solana_nullable.sql",
+        ]
+    }
+
+    fn reorg_tables(&self) -> Vec<&'static str> {
+        vec![]
+    }
+
+    async fn handle(
+        &self,
+        ctx: &TransformationContext,
+    ) -> Result<Vec<DbOperation>, TransformationError> {
+        let mut ops = Vec::new();
+
+        for event in ctx.events_of_type("DopplerInitializer", "LaunchMigrated") {
+            let launch = event.extract_pubkey("launch")?;
+
+            // Target the pools row created by LaunchCreateHandler.
+            // RawSql is used to explicitly scope the update to the originating handler's source.
+            ops.push(DbOperation::RawSql {
+                query: "UPDATE pools \
+                    SET migrated_at = to_timestamp($1) \
+                    WHERE chain_id = $2 AND address = $3 AND source = $4 AND source_version = $5"
+                    .to_string(),
+                params: vec![
+                    DbValue::Timestamp(event.block_timestamp as i64),
+                    DbValue::Int64(ctx.chain_id as i64),
+                    DbValue::Pubkey(launch),
+                    DbValue::Text("LaunchCreateHandler".to_string()),
+                    DbValue::Int32(1),
+                ],
+                snapshot: None,
+            });
+        }
+
+        Ok(ops)
+    }
+}
+
+impl EventHandler for LaunchMigrateHandler {
+    fn triggers(&self) -> Vec<EventTrigger> {
+        vec![EventTrigger::new("DopplerInitializer", "LaunchMigrated")]
+    }
+
+    fn contiguous_handler_dependencies(&self) -> Vec<&'static str> {
+        vec!["LaunchCreateHandler"]
+    }
+}
+
+pub fn register_handlers(registry: &mut TransformationRegistry) {
+    registry.register_event_handler(LaunchMigrateHandler);
+}

--- a/src/transformations/event/solana/initializer/mod.rs
+++ b/src/transformations/event/solana/initializer/mod.rs
@@ -1,0 +1,11 @@
+pub mod curve_swap;
+pub mod launch_create;
+pub mod launch_migrate;
+
+use crate::transformations::registry::TransformationRegistry;
+
+pub fn register_handlers(registry: &mut TransformationRegistry) {
+    launch_create::register_handlers(registry);
+    curve_swap::register_handlers(registry);
+    launch_migrate::register_handlers(registry);
+}

--- a/src/transformations/event/solana/mod.rs
+++ b/src/transformations/event/solana/mod.rs
@@ -1,0 +1,4 @@
+pub mod cpmm;
+pub mod cpmm_migrator;
+pub mod initializer;
+pub mod prediction;

--- a/src/transformations/event/solana/prediction/claims.rs
+++ b/src/transformations/event/solana/prediction/claims.rs
@@ -1,0 +1,100 @@
+use async_trait::async_trait;
+
+use crate::db::{DbOperation, DbValue};
+use crate::transformations::context::{FieldExtractor, TransformationContext};
+use crate::transformations::error::TransformationError;
+use crate::transformations::registry::TransformationRegistry;
+use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
+use crate::types::chain::ChainType;
+
+pub struct PredictionClaimHandler;
+
+#[async_trait]
+impl TransformationHandler for PredictionClaimHandler {
+    fn name(&self) -> &'static str {
+        "PredictionClaimHandler"
+    }
+
+    fn version(&self) -> u32 {
+        1
+    }
+
+    fn chain_type(&self) -> ChainType {
+        ChainType::Solana
+    }
+
+    fn migration_paths(&self) -> Vec<&'static str> {
+        vec!["migrations/tables/sol_prediction_claims.sql"]
+    }
+
+    fn reorg_tables(&self) -> Vec<&'static str> {
+        vec!["sol_prediction_claims"]
+    }
+
+    async fn handle(
+        &self,
+        ctx: &TransformationContext,
+    ) -> Result<Vec<DbOperation>, TransformationError> {
+        let mut ops = Vec::new();
+
+        for event in ctx.events_of_type("DopplerPredictionMigrator", "RewardsClaimed") {
+            let market = event.extract_pubkey("market")?;
+            let claimer = event.extract_pubkey("claimer")?;
+            let burned_amount = event.extract_u64("burned_amount")?;
+            let reward_amount = event.extract_u64("reward_amount")?;
+            let total_burned = event.extract_u64("total_burned")?;
+            let tx_sig = event
+                .transaction_id
+                .as_solana()
+                .expect("Solana event has Solana tx id");
+            let log_position = event.position.packed_ordinal_i64();
+
+            ops.push(DbOperation::Upsert {
+                table: "sol_prediction_claims".to_string(),
+                columns: vec![
+                    "chain_id".into(),
+                    "block_height".into(),
+                    "created_at".into(),
+                    "tx_id".into(),
+                    "log_position".into(),
+                    "market".into(),
+                    "claimer".into(),
+                    "burned_amount".into(),
+                    "reward_amount".into(),
+                    "total_burned".into(),
+                ],
+                values: vec![
+                    DbValue::Int64(ctx.chain_id as i64),
+                    DbValue::Int64(event.block_number as i64),
+                    DbValue::Timestamp(event.block_timestamp as i64),
+                    DbValue::Bytes(tx_sig.to_vec()),
+                    DbValue::Int64(log_position),
+                    DbValue::Pubkey(market),
+                    DbValue::Pubkey(claimer),
+                    DbValue::Uint64(burned_amount),
+                    DbValue::Uint64(reward_amount),
+                    DbValue::Uint64(total_burned),
+                ],
+                conflict_columns: vec![
+                    "chain_id".into(),
+                    "tx_id".into(),
+                    "log_position".into(),
+                ],
+                update_columns: vec![],
+                update_condition: None,
+            });
+        }
+
+        Ok(ops)
+    }
+}
+
+impl EventHandler for PredictionClaimHandler {
+    fn triggers(&self) -> Vec<EventTrigger> {
+        vec![EventTrigger::new("DopplerPredictionMigrator", "RewardsClaimed")]
+    }
+}
+
+pub fn register_handlers(registry: &mut TransformationRegistry) {
+    registry.register_event_handler(PredictionClaimHandler);
+}

--- a/src/transformations/event/solana/prediction/claims.rs
+++ b/src/transformations/event/solana/prediction/claims.rs
@@ -75,11 +75,7 @@ impl TransformationHandler for PredictionClaimHandler {
                     DbValue::Uint64(reward_amount),
                     DbValue::Uint64(total_burned),
                 ],
-                conflict_columns: vec![
-                    "chain_id".into(),
-                    "tx_id".into(),
-                    "log_position".into(),
-                ],
+                conflict_columns: vec!["chain_id".into(), "tx_id".into(), "log_position".into()],
                 update_columns: vec![],
                 update_condition: None,
             });
@@ -91,7 +87,10 @@ impl TransformationHandler for PredictionClaimHandler {
 
 impl EventHandler for PredictionClaimHandler {
     fn triggers(&self) -> Vec<EventTrigger> {
-        vec![EventTrigger::new("DopplerPredictionMigrator", "RewardsClaimed")]
+        vec![EventTrigger::new(
+            "DopplerPredictionMigrator",
+            "RewardsClaimed",
+        )]
     }
 }
 

--- a/src/transformations/event/solana/prediction/entries.rs
+++ b/src/transformations/event/solana/prediction/entries.rs
@@ -67,11 +67,7 @@ impl TransformationHandler for PredictionEntryHandler {
                     DbValue::Null,
                     DbValue::Null,
                 ],
-                conflict_columns: vec![
-                    "chain_id".into(),
-                    "market".into(),
-                    "entry_id".into(),
-                ],
+                conflict_columns: vec!["chain_id".into(), "market".into(), "entry_id".into()],
                 update_columns: vec![],
                 update_condition: None,
             });
@@ -109,11 +105,7 @@ impl TransformationHandler for PredictionEntryHandler {
                     DbValue::Uint64(contribution),
                     DbValue::Bool(is_winner),
                 ],
-                conflict_columns: vec![
-                    "chain_id".into(),
-                    "market".into(),
-                    "entry_id".into(),
-                ],
+                conflict_columns: vec!["chain_id".into(), "market".into(), "entry_id".into()],
                 update_columns: vec!["contribution".into(), "is_winner".into()],
                 update_condition: None,
             });

--- a/src/transformations/event/solana/prediction/entries.rs
+++ b/src/transformations/event/solana/prediction/entries.rs
@@ -1,0 +1,137 @@
+use async_trait::async_trait;
+
+use crate::db::{DbOperation, DbValue};
+use crate::transformations::context::{FieldExtractor, TransformationContext};
+use crate::transformations::error::TransformationError;
+use crate::transformations::registry::TransformationRegistry;
+use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
+use crate::types::chain::ChainType;
+
+pub struct PredictionEntryHandler;
+
+#[async_trait]
+impl TransformationHandler for PredictionEntryHandler {
+    fn name(&self) -> &'static str {
+        "PredictionEntryHandler"
+    }
+
+    fn version(&self) -> u32 {
+        1
+    }
+
+    fn chain_type(&self) -> ChainType {
+        ChainType::Solana
+    }
+
+    fn migration_paths(&self) -> Vec<&'static str> {
+        vec!["migrations/tables/sol_prediction_entries.sql"]
+    }
+
+    fn reorg_tables(&self) -> Vec<&'static str> {
+        vec!["sol_prediction_entries"]
+    }
+
+    async fn handle(
+        &self,
+        ctx: &TransformationContext,
+    ) -> Result<Vec<DbOperation>, TransformationError> {
+        let mut ops = Vec::new();
+
+        for event in ctx.events_of_type("DopplerPredictionMigrator", "EntryRegistered") {
+            let market = event.extract_pubkey("market")?;
+            let oracle = event.extract_pubkey("oracle")?;
+            let entry_id = event.extract_bytes32("entry_id")?;
+            let base_mint = event.extract_pubkey("base_mint")?;
+
+            ops.push(DbOperation::Upsert {
+                table: "sol_prediction_entries".to_string(),
+                columns: vec![
+                    "chain_id".into(),
+                    "block_height".into(),
+                    "created_at".into(),
+                    "market".into(),
+                    "oracle".into(),
+                    "entry_id".into(),
+                    "base_mint".into(),
+                    "contribution".into(),
+                    "is_winner".into(),
+                ],
+                values: vec![
+                    DbValue::Int64(ctx.chain_id as i64),
+                    DbValue::Int64(event.block_number as i64),
+                    DbValue::Timestamp(event.block_timestamp as i64),
+                    DbValue::Pubkey(market),
+                    DbValue::Pubkey(oracle),
+                    DbValue::Bytes32(entry_id),
+                    DbValue::Pubkey(base_mint),
+                    DbValue::Null,
+                    DbValue::Null,
+                ],
+                conflict_columns: vec![
+                    "chain_id".into(),
+                    "market".into(),
+                    "entry_id".into(),
+                ],
+                update_columns: vec![],
+                update_condition: None,
+            });
+        }
+
+        for event in ctx.events_of_type("DopplerPredictionMigrator", "EntryMigrated") {
+            let market = event.extract_pubkey("market")?;
+            let oracle = event.extract_pubkey("oracle")?;
+            let entry_id = event.extract_bytes32("entry_id")?;
+            let base_mint = event.extract_pubkey("base_mint")?;
+            let contribution = event.extract_u64("contribution")?;
+            let is_winner = event.extract_bool("is_winner")?;
+
+            ops.push(DbOperation::Upsert {
+                table: "sol_prediction_entries".to_string(),
+                columns: vec![
+                    "chain_id".into(),
+                    "block_height".into(),
+                    "created_at".into(),
+                    "market".into(),
+                    "oracle".into(),
+                    "entry_id".into(),
+                    "base_mint".into(),
+                    "contribution".into(),
+                    "is_winner".into(),
+                ],
+                values: vec![
+                    DbValue::Int64(ctx.chain_id as i64),
+                    DbValue::Int64(event.block_number as i64),
+                    DbValue::Timestamp(event.block_timestamp as i64),
+                    DbValue::Pubkey(market),
+                    DbValue::Pubkey(oracle),
+                    DbValue::Bytes32(entry_id),
+                    DbValue::Pubkey(base_mint),
+                    DbValue::Uint64(contribution),
+                    DbValue::Bool(is_winner),
+                ],
+                conflict_columns: vec![
+                    "chain_id".into(),
+                    "market".into(),
+                    "entry_id".into(),
+                ],
+                update_columns: vec!["contribution".into(), "is_winner".into()],
+                update_condition: None,
+            });
+        }
+
+        Ok(ops)
+    }
+}
+
+impl EventHandler for PredictionEntryHandler {
+    fn triggers(&self) -> Vec<EventTrigger> {
+        vec![
+            EventTrigger::new("DopplerPredictionMigrator", "EntryRegistered"),
+            EventTrigger::new("DopplerPredictionMigrator", "EntryMigrated"),
+        ]
+    }
+}
+
+pub fn register_handlers(registry: &mut TransformationRegistry) {
+    registry.register_event_handler(PredictionEntryHandler);
+}

--- a/src/transformations/event/solana/prediction/market.rs
+++ b/src/transformations/event/solana/prediction/market.rs
@@ -1,0 +1,136 @@
+use async_trait::async_trait;
+
+use crate::db::{DbOperation, DbValue};
+use crate::transformations::context::{FieldExtractor, TransformationContext};
+use crate::transformations::error::TransformationError;
+use crate::transformations::registry::TransformationRegistry;
+use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
+use crate::types::chain::ChainType;
+
+pub struct PredictionMarketHandler;
+
+#[async_trait]
+impl TransformationHandler for PredictionMarketHandler {
+    fn name(&self) -> &'static str {
+        "PredictionMarketHandler"
+    }
+
+    fn version(&self) -> u32 {
+        1
+    }
+
+    fn chain_type(&self) -> ChainType {
+        ChainType::Solana
+    }
+
+    fn migration_paths(&self) -> Vec<&'static str> {
+        vec!["migrations/tables/sol_prediction_markets.sql"]
+    }
+
+    fn reorg_tables(&self) -> Vec<&'static str> {
+        vec!["sol_prediction_markets"]
+    }
+
+    async fn handle(
+        &self,
+        ctx: &TransformationContext,
+    ) -> Result<Vec<DbOperation>, TransformationError> {
+        let mut ops = Vec::new();
+
+        for event in ctx.events_of_type("DopplerPredictionMigrator", "MarketCreated") {
+            let market = event.extract_pubkey("market")?;
+            let oracle = event.extract_pubkey("oracle")?;
+            let quote_mint = event.extract_pubkey("quote_mint")?;
+
+            ops.push(DbOperation::Upsert {
+                table: "sol_prediction_markets".to_string(),
+                columns: vec![
+                    "chain_id".into(),
+                    "block_height".into(),
+                    "created_at".into(),
+                    "resolved_at".into(),
+                    "market".into(),
+                    "oracle".into(),
+                    "quote_mint".into(),
+                    "winner_mint".into(),
+                    "claimable_supply".into(),
+                    "total_pot".into(),
+                ],
+                values: vec![
+                    DbValue::Int64(ctx.chain_id as i64),
+                    DbValue::Int64(event.block_number as i64),
+                    DbValue::Timestamp(event.block_timestamp as i64),
+                    DbValue::Null,
+                    DbValue::Pubkey(market),
+                    DbValue::Pubkey(oracle),
+                    DbValue::Pubkey(quote_mint),
+                    DbValue::Null,
+                    DbValue::Null,
+                    DbValue::Null,
+                ],
+                conflict_columns: vec!["chain_id".into(), "market".into()],
+                update_columns: vec![],
+                update_condition: None,
+            });
+        }
+
+        for event in ctx.events_of_type("DopplerPredictionMigrator", "MarketResolved") {
+            let market = event.extract_pubkey("market")?;
+            let oracle = event.extract_pubkey("oracle")?;
+            let winner_mint = event.extract_pubkey("winner_mint")?;
+            let claimable_supply = event.extract_u64("claimable_supply")?;
+            let total_pot = event.extract_u64("total_pot")?;
+
+            ops.push(DbOperation::Upsert {
+                table: "sol_prediction_markets".to_string(),
+                columns: vec![
+                    "chain_id".into(),
+                    "block_height".into(),
+                    "created_at".into(),
+                    "resolved_at".into(),
+                    "market".into(),
+                    "oracle".into(),
+                    "quote_mint".into(),
+                    "winner_mint".into(),
+                    "claimable_supply".into(),
+                    "total_pot".into(),
+                ],
+                values: vec![
+                    DbValue::Int64(ctx.chain_id as i64),
+                    DbValue::Int64(event.block_number as i64),
+                    DbValue::Timestamp(event.block_timestamp as i64),
+                    DbValue::Timestamp(event.block_timestamp as i64),
+                    DbValue::Pubkey(market),
+                    DbValue::Pubkey(oracle),
+                    DbValue::Null, // quote_mint unknown at resolve; preserved from create on conflict
+                    DbValue::Pubkey(winner_mint),
+                    DbValue::Uint64(claimable_supply),
+                    DbValue::Uint64(total_pot),
+                ],
+                conflict_columns: vec!["chain_id".into(), "market".into()],
+                update_columns: vec![
+                    "winner_mint".into(),
+                    "claimable_supply".into(),
+                    "total_pot".into(),
+                    "resolved_at".into(),
+                ],
+                update_condition: None,
+            });
+        }
+
+        Ok(ops)
+    }
+}
+
+impl EventHandler for PredictionMarketHandler {
+    fn triggers(&self) -> Vec<EventTrigger> {
+        vec![
+            EventTrigger::new("DopplerPredictionMigrator", "MarketCreated"),
+            EventTrigger::new("DopplerPredictionMigrator", "MarketResolved"),
+        ]
+    }
+}
+
+pub fn register_handlers(registry: &mut TransformationRegistry) {
+    registry.register_event_handler(PredictionMarketHandler);
+}

--- a/src/transformations/event/solana/prediction/mod.rs
+++ b/src/transformations/event/solana/prediction/mod.rs
@@ -1,0 +1,11 @@
+pub mod claims;
+pub mod entries;
+pub mod market;
+
+use crate::transformations::registry::TransformationRegistry;
+
+pub fn register_handlers(registry: &mut TransformationRegistry) {
+    market::register_handlers(registry);
+    entries::register_handlers(registry);
+    claims::register_handlers(registry);
+}

--- a/src/transformations/event/zora/create.rs
+++ b/src/transformations/event/zora/create.rs
@@ -160,7 +160,9 @@ impl ZoraCreateHandler {
                     block_timestamp: event.block_timestamp,
                     tx_id: event.evm_tx_hash_ref(),
                     creator_address: Some(payout_recipient.as_slice()),
-                    integrator: non_zero_address(platform_referrer).as_ref().map(|a| a.as_slice()),
+                    integrator: non_zero_address(platform_referrer)
+                        .as_ref()
+                        .map(|a| a.as_slice()),
                     token_address: &coin,
                     pool: Some(&PoolAddressOrPoolId::PoolId(pool_id)),
                     name: name.as_ref(),

--- a/src/transformations/finalizer.rs
+++ b/src/transformations/finalizer.rs
@@ -703,6 +703,25 @@ pub(crate) fn compute_fallback_deletes(
     result
 }
 
+/// Update the status file during finalization: prune stale failed handler keys,
+/// then set `transformed=true` only when no failures remain. This is the second
+/// half of the two-phase protocol — retry records handler outcomes, finalization
+/// gates the `transformed` flag.
+pub(crate) fn update_finalization_status(
+    storage: &dyn ProgressStatusStorage,
+    block_number: u64,
+    registered_keys: &HashSet<String>,
+) -> Result<(), StorageError> {
+    storage.update_handler_sets_atomic(block_number, &mut |_completed, failed, transformed| {
+        // Filter stale keys: only keep failed handlers that are still registered
+        failed.retain(|k| registered_keys.contains(k));
+
+        if failed.is_empty() {
+            *transformed = true;
+        }
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -898,23 +917,4 @@ mod tests {
         let (_, blocks) = &fallbacks[0];
         assert_eq!(*blocks, vec![100u64, 101u64, 102u64]);
     }
-}
-
-/// Update the status file during finalization: prune stale failed handler keys,
-/// then set `transformed=true` only when no failures remain. This is the second
-/// half of the two-phase protocol — retry records handler outcomes, finalization
-/// gates the `transformed` flag.
-pub(crate) fn update_finalization_status(
-    storage: &dyn ProgressStatusStorage,
-    block_number: u64,
-    registered_keys: &HashSet<String>,
-) -> Result<(), StorageError> {
-    storage.update_handler_sets_atomic(block_number, &mut |_completed, failed, transformed| {
-        // Filter stale keys: only keep failed handlers that are still registered
-        failed.retain(|k| registered_keys.contains(k));
-
-        if failed.is_empty() {
-            *transformed = true;
-        }
-    })
 }

--- a/src/transformations/registry.rs
+++ b/src/transformations/registry.rs
@@ -1673,7 +1673,7 @@ mod tests {
     fn single_trigger_handler_is_not_multi_trigger() {
         let mut registry = TransformationRegistry::new();
         registry.register_event_handler(mock_handler("A", vec![]));
-        assert!(!registry.is_multi_trigger(&"A_v1".to_string()));
+        assert!(!registry.is_multi_trigger("A_v1"));
     }
 
     #[test]

--- a/src/transformations/registry.rs
+++ b/src/transformations/registry.rs
@@ -1064,8 +1064,10 @@ pub fn build_registry_for_solana_chain(
     let mut registry =
         TransformationRegistry::with_source_and_chain_filter(available, ChainType::Solana);
 
-    // Solana transformation handlers will be registered here as they're implemented.
-    // For now, the registry is empty but properly source-filtered and chain-type-filtered.
+    crate::transformations::event::solana::cpmm::register_handlers(&mut registry);
+    crate::transformations::event::solana::initializer::register_handlers(&mut registry);
+    crate::transformations::event::solana::cpmm_migrator::register_handlers(&mut registry);
+    crate::transformations::event::solana::prediction::register_handlers(&mut registry);
 
     registry.validate_and_sort_handler_dependencies();
 

--- a/src/transformations/util/price_path.rs
+++ b/src/transformations/util/price_path.rs
@@ -660,7 +660,7 @@ mod tests {
 
         // Future entry: resolved_at_block >= current_block  →  should NOT pass the guard
         assert!(
-            !(cached_resolved_at < current_block),
+            (cached_resolved_at >= current_block),
             "A path resolved at block {} should be rejected when current_block is {}",
             cached_resolved_at,
             current_block
@@ -669,7 +669,7 @@ mod tests {
         // Equal blocks: also rejected (resolved_at_block is NOT strictly less than current_block)
         let cached_resolved_at_equal = 100_u64;
         assert!(
-            !(cached_resolved_at_equal < current_block),
+            (cached_resolved_at_equal >= current_block),
             "A path resolved at the same block should also be rejected"
         );
 

--- a/src/types/chain.rs
+++ b/src/types/chain.rs
@@ -41,7 +41,7 @@ impl ChainAddress {
         false
     }
 
-    pub fn to_hex(&self) -> String {
+    pub fn to_hex(self) -> String {
         match self {
             Self::Evm(address) => format!("0x{}", hex::encode(address)),
             Self::Solana(pubkey) => hex::encode(pubkey),
@@ -69,7 +69,7 @@ impl ChainAddress {
         }
     }
 
-    pub fn to_vec(&self) -> Vec<u8> {
+    pub fn to_vec(self) -> Vec<u8> {
         self.as_bytes().to_vec()
     }
 }
@@ -221,16 +221,13 @@ impl LogPosition {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
+#[derive(Default)]
 pub enum ChainType {
+    #[default]
     Evm,
     Solana,
 }
 
-impl Default for ChainType {
-    fn default() -> Self {
-        Self::Evm
-    }
-}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary

- Adds transformation handlers for all four Doppler Solana programs: CPMM, Initializer, CPMM Migrator, and Prediction Migrator
- Introduces five new Solana-specific SQL tables (`sol_cpmm_positions`, `sol_cpmm_migrator`, `sol_prediction_markets`, `sol_prediction_entries`, `sol_prediction_claims`)
- Handlers write to shared `pools`, `swaps`, and `pool_snapshots` tables (using pre-existing nullable-column migrations)
- All handlers are feature-gated behind `--features solana` and registered in `build_registry_for_solana_chain()`

## Handler groups

| Program | Handlers | Tables |
|---|---|---|
| `DopplerCPMM` | pool create, swap, OHLC metrics, positions | `pools`, `swaps`, `pool_snapshots`, `sol_cpmm_positions` |
| `DopplerInitializer` | launch create, curve swap, launch migrate | `pools`, `swaps` |
| `DopplerCpmmMigrator` | registration + migration | `sol_cpmm_migrator`, `pools` (update) |
| `DopplerPredictionMigrator` | market, entries, claims | `sol_prediction_markets`, `sol_prediction_entries`, `sol_prediction_claims` |

## Notes

- `LaunchMigrateHandler` and `CpmmMigratorHandler` use `RawSql` (not `DbOperation::Update`) to update `pools` rows owned by `LaunchCreateHandler` — same pattern as `zora/migrate.rs`
- `CpmmMetricsHandler` sets `requires_sequential: true` and accumulates OHLC + share-delta per `(pool, slot)` within each `handle()` call
- `amountin`/`amountout` stored lowercase to match PostgreSQL's identifier normalization of the unquoted DDL in `swaps.sql`