### PR TITLE
fix: explicit provider config, group concurrency, and jitter in rate limiter

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,7 @@ use storage::{InitialSyncService, LocalBackend, RetryQueue, S3Backend, StorageMa
 use transformations::{
     ExecutionMode, ReorgMessage, TransformationEngine, TransformationEngineConfig,
 };
-use types::config::chain::ChainConfig;
+use types::config::chain::{ChainConfig, ProviderType};
 use types::config::defaults::{raw_data as raw_data_defaults, rpc as rpc_defaults};
 use types::config::indexer::IndexerConfig;
 use types::config::raw_data::RawDataCollectionConfig;
@@ -66,6 +66,23 @@ fn optional_channel<T>(
     } else {
         (None, None)
     }
+}
+
+/// Resolve the effective provider type for a chain, consulting the rate_limit_group
+/// config when the chain belongs to one (group provider supersedes chain-level provider).
+fn resolve_provider(config: &IndexerConfig, chain: &ChainConfig) -> ProviderType {
+    if let Some(ref group_name) = chain.rpc.rate_limit_group {
+        if let Some(group) = config
+            .rpc_rate_limits
+            .as_ref()
+            .and_then(|groups| groups.get(group_name))
+        {
+            if let Some(ref p) = group.provider {
+                return p.clone();
+            }
+        }
+    }
+    chain.rpc.provider.clone().unwrap_or_default()
 }
 
 fn collect_flag_values(args: &[String], flag: &str) -> anyhow::Result<Vec<String>> {
@@ -920,7 +937,9 @@ async fn transformation_only_chain(
         .batch_size
         .or(config.raw_data_collection.rpc_batch_size)
         .unwrap_or(types::config::defaults::rpc::MAX_BATCH_SIZE) as usize;
-    let (_rate_limiter, rpc_client) = build_rpc_client(&rpc_url, &chain.rpc, rpc_batch_size)?;
+    let use_alchemy = resolve_provider(config, chain) == ProviderType::Alchemy;
+    let (_rate_limiter, rpc_client) =
+        build_rpc_client(&rpc_url, &chain.rpc, rpc_batch_size, use_alchemy)?;
 
     // Validate call dependencies
     transformations::registry::validate_call_dependencies(
@@ -1014,12 +1033,18 @@ async fn repair_only_chain(
         .batch_size
         .or(config.raw_data_collection.rpc_batch_size)
         .unwrap_or(rpc_defaults::MAX_BATCH_SIZE) as usize;
+    let use_alchemy = resolve_provider(config, chain) == ProviderType::Alchemy;
     let (_rate_limiter, client) = if let Some(limiter) = shared_rate_limiter {
-        let client =
-            build_rpc_client_with_limiter(&rpc_url, &chain.rpc, rpc_batch_size, limiter.clone())?;
+        let client = build_rpc_client_with_limiter(
+            &rpc_url,
+            &chain.rpc,
+            rpc_batch_size,
+            limiter.clone(),
+            use_alchemy,
+        )?;
         (limiter, Arc::new(client))
     } else {
-        build_rpc_client(&rpc_url, &chain.rpc, rpc_batch_size)?
+        build_rpc_client(&rpc_url, &chain.rpc, rpc_batch_size, use_alchemy)?
     };
 
     let s3_manifest = storage_manager.manifest_for(&chain.name);

--- a/src/rpc/alchemy.rs
+++ b/src/rpc/alchemy.rs
@@ -4,6 +4,8 @@ use std::num::NonZeroU32;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use rand::Rng as _;
+
 use alloy::primitives::{Address, BlockNumber, Bytes, B256, U256};
 use alloy::providers::Provider;
 use alloy::rpc::types::{
@@ -147,10 +149,13 @@ impl SlidingWindowRateLimiter {
                     }
                 }
 
-                // Add a small buffer to ensure the entry has expired
+                // Add a small buffer plus jitter to prevent thundering-herd wakeups
+                // when many tasks wake simultaneously after the window resets.
+                let jitter_ms = rand::rng().random_range(0u64..50);
                 wait_until
                     .saturating_duration_since(now)
                     .saturating_add(Duration::from_millis(1))
+                    .saturating_add(Duration::from_millis(jitter_ms))
             };
 
             // Wait outside the lock

--- a/src/rpc/unified.rs
+++ b/src/rpc/unified.rs
@@ -50,6 +50,31 @@ impl UnifiedRpcClient {
         }
     }
 
+    /// Convenience wrapper that infers the provider from the URL string.
+    ///
+    /// Prefer `from_url_with_options` with an explicit `use_alchemy` flag derived
+    /// from the `provider` field in config.  This method is kept for contexts where
+    /// only a URL is available (e.g. tests, one-off tooling).
+    pub fn from_url_with_options_inferred(
+        url: &str,
+        compute_units_per_second: u32,
+        rpc_concurrency: usize,
+        max_batch_size: usize,
+        shared_limiter: Option<Arc<SlidingWindowRateLimiter>>,
+        force_http2: bool,
+    ) -> Result<Self, RpcError> {
+        let use_alchemy = url.contains("alchemy");
+        Self::from_url_with_options(
+            url,
+            compute_units_per_second,
+            rpc_concurrency,
+            max_batch_size,
+            shared_limiter,
+            force_http2,
+            use_alchemy,
+        )
+    }
+
     /// Create a client with custom options for Alchemy rate limiting.
     ///
     /// # Arguments
@@ -61,6 +86,10 @@ impl UnifiedRpcClient {
     /// * `force_http2` - When true, build the HTTP transport with HTTP/2 prior knowledge
     ///   (no HTTP/1.1 fallback) and H2 tuning (adaptive window, keep-alive). Applies to
     ///   both Standard and Alchemy clients.
+    /// * `use_alchemy` - When true, use `AlchemyClient` with per-method CU costs and a
+    ///   sliding-window rate limiter. When false, use the standard `RpcClient`.
+    ///   Caller should set this based on the explicit `provider` field in config rather
+    ///   than inferring from the URL.
     pub fn from_url_with_options(
         url: &str,
         compute_units_per_second: u32,
@@ -68,8 +97,9 @@ impl UnifiedRpcClient {
         max_batch_size: usize,
         shared_limiter: Option<Arc<SlidingWindowRateLimiter>>,
         force_http2: bool,
+        use_alchemy: bool,
     ) -> Result<Self, RpcError> {
-        if url.contains("alchemy") {
+        if use_alchemy {
             Ok(Self::Alchemy(AlchemyClient::from_url_with_options(
                 url,
                 compute_units_per_second,
@@ -371,13 +401,14 @@ mod tests {
             100,
             None,
             true,
+            false,
         )
         .expect("should build standard HTTP/2 client");
         assert!(matches!(client, UnifiedRpcClient::Standard(_)));
     }
 
-    /// Building an Alchemy client with force_http2=true should succeed and
-    /// select the Alchemy variant.
+    /// Building an Alchemy client via explicit use_alchemy=true should succeed and
+    /// select the Alchemy variant regardless of the URL string.
     #[test]
     fn from_url_with_options_alchemy_http2() {
         let client = UnifiedRpcClient::from_url_with_options(
@@ -387,8 +418,25 @@ mod tests {
             100,
             None,
             true,
+            true,
         )
         .expect("should build Alchemy HTTP/2 client");
+        assert!(matches!(client, UnifiedRpcClient::Alchemy(_)));
+    }
+
+    /// Explicit use_alchemy=true works with non-alchemy-domain URLs (proxy case).
+    #[test]
+    fn from_url_with_options_alchemy_proxied_url() {
+        let client = UnifiedRpcClient::from_url_with_options(
+            "https://my-proxy.example.com/rpc",
+            7500,
+            100,
+            100,
+            None,
+            false,
+            true,
+        )
+        .expect("should build Alchemy client via explicit provider flag");
         assert!(matches!(client, UnifiedRpcClient::Alchemy(_)));
     }
 
@@ -401,6 +449,7 @@ mod tests {
             100,
             100,
             None,
+            false,
             false,
         )
         .expect("should build standard client with default transport");

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -18,7 +18,7 @@ use crate::transformations::{
     build_registry_for_chain, DecodedCallsMessage, DecodedEventsMessage, RangeCompleteMessage,
     ReorgMessage,
 };
-use crate::types::config::chain::{ChainConfig, RpcConfig};
+use crate::types::config::chain::{ChainConfig, ProviderType, RpcConfig};
 use crate::types::config::defaults::{raw_data as raw_data_defaults, rpc as rpc_defaults};
 use crate::types::config::eth_call::Frequency;
 use crate::types::config::indexer::IndexerConfig;
@@ -129,6 +129,7 @@ pub fn build_rpc_client(
     rpc_url: &str,
     rpc_config: &RpcConfig,
     batch_size: usize,
+    use_alchemy: bool,
 ) -> anyhow::Result<(Arc<SlidingWindowRateLimiter>, Arc<UnifiedRpcClient>)> {
     let concurrency = rpc_config.concurrency.unwrap_or(rpc_defaults::CONCURRENCY);
     let units_per_second = rpc_config
@@ -145,14 +146,16 @@ pub fn build_rpc_client(
         batch_size,
         Some(rate_limiter.clone()),
         http2,
+        use_alchemy,
     )?;
 
     tracing::info!(
-        "RPC config: concurrency={}, units_per_second={}, batch_size={}, http2={}",
+        "RPC config: concurrency={}, units_per_second={}, batch_size={}, http2={}, alchemy={}",
         concurrency,
         units_per_second,
         batch_size,
-        http2
+        http2,
+        use_alchemy,
     );
 
     Ok((rate_limiter, Arc::new(client)))
@@ -164,6 +167,7 @@ pub fn build_rpc_client_with_limiter(
     rpc_config: &RpcConfig,
     batch_size: usize,
     shared_limiter: Arc<SlidingWindowRateLimiter>,
+    use_alchemy: bool,
 ) -> anyhow::Result<UnifiedRpcClient> {
     let concurrency = rpc_config.concurrency.unwrap_or(rpc_defaults::CONCURRENCY);
     let units_per_second = rpc_config
@@ -177,6 +181,7 @@ pub fn build_rpc_client_with_limiter(
         batch_size,
         Some(shared_limiter),
         rpc_config.http2_enabled(),
+        use_alchemy,
     )
     .map_err(Into::into)
 }
@@ -297,6 +302,9 @@ pub struct ChainRuntime {
     pub progress_tracker: Option<Arc<Mutex<LiveProgressTracker>>>,
     pub transformations_enabled: bool,
     pub chain: Arc<ChainConfig>,
+    /// Whether the chain uses the Alchemy provider. Stored so `build_additional_client`
+    /// can create matching client instances without re-resolving config.
+    pub use_alchemy: bool,
 }
 
 impl ChainRuntime {
@@ -331,8 +339,27 @@ impl ChainRuntime {
             .or(config.raw_data_collection.rpc_batch_size)
             .unwrap_or(rpc_defaults::MAX_BATCH_SIZE) as usize;
 
-        // Resolve RPC parameters before building client
-        let concurrency = chain.rpc.concurrency.unwrap_or(rpc_defaults::CONCURRENCY);
+        // Resolve provider type and concurrency, with group config taking precedence.
+        let (concurrency, use_alchemy) =
+            if let Some(ref group_name) = chain.rpc.rate_limit_group {
+                let group = config
+                    .rpc_rate_limits
+                    .as_ref()
+                    .and_then(|groups| groups.get(group_name));
+                let group_concurrency = group
+                    .and_then(|g| g.concurrency)
+                    .unwrap_or(rpc_defaults::CONCURRENCY);
+                let provider = group
+                    .and_then(|g| g.provider.clone())
+                    .or_else(|| chain.rpc.provider.clone())
+                    .unwrap_or_default();
+                (group_concurrency, provider == ProviderType::Alchemy)
+            } else {
+                let concurrency = chain.rpc.concurrency.unwrap_or(rpc_defaults::CONCURRENCY);
+                let use_alchemy = chain.rpc.effective_provider() == ProviderType::Alchemy;
+                (concurrency, use_alchemy)
+            };
+
         let units_per_second = chain
             .rpc
             .units_per_second()
@@ -347,10 +374,11 @@ impl ChainRuntime {
                 rpc_batch_size,
                 Some(limiter.clone()),
                 chain.rpc.http2_enabled(),
+                use_alchemy,
             )?;
             (limiter, Arc::new(client))
         } else {
-            build_rpc_client(&rpc_url, &chain.rpc, rpc_batch_size)?
+            build_rpc_client(&rpc_url, &chain.rpc, rpc_batch_size, use_alchemy)?
         };
 
         // Build transformation registry filtered to this chain's contracts
@@ -439,6 +467,7 @@ impl ChainRuntime {
             progress_tracker,
             transformations_enabled,
             chain: Arc::new(chain.clone()),
+            use_alchemy,
         })
     }
 
@@ -449,6 +478,7 @@ impl ChainRuntime {
             &self.chain.rpc,
             self.rpc_batch_size,
             self.rate_limiter.clone(),
+            self.use_alchemy,
         )
     }
 

--- a/src/types/config/chain.rs
+++ b/src/types/config/chain.rs
@@ -3,6 +3,19 @@ use std::path::Path;
 use alloy_primitives::U256;
 use serde::{Deserialize, Serialize};
 
+/// Selects the RPC provider implementation for a chain or rate limit group.
+///
+/// `Alchemy` enables the `AlchemyClient` with per-method compute-unit costs and a
+/// sliding-window rate limiter.  All other values (or the absence of the field)
+/// select the standard `RpcClient`.
+#[derive(Debug, Clone, Deserialize, Serialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ProviderType {
+    Alchemy,
+    #[default]
+    Standard,
+}
+
 use crate::types::config::contract::{
     load_contracts_from_path, load_factory_collections_from_path, Contracts, FactoryCollections,
 };
@@ -35,9 +48,17 @@ impl BlockReceiptsMethod {
 /// Configuration for a shared RPC rate limit group.
 ///
 /// Multiple chains can reference the same group to share a single rate limit budget.
+/// Concurrency set here supersedes per-chain `rpc.concurrency`; chains in this group
+/// must not set `rpc.concurrency`.
 #[derive(Debug, Clone, Deserialize)]
 pub struct RpcRateLimitGroup {
     pub units_per_second: u32,
+    /// Max concurrent in-flight RPC requests for all chains in this group combined.
+    /// Supersedes per-chain rpc.concurrency. Required when chains belong to this group.
+    pub concurrency: Option<usize>,
+    /// Provider implementation to use for all chains in this group.
+    /// Chains may not override this.
+    pub provider: Option<ProviderType>,
 }
 
 /// RPC client configuration for a chain.
@@ -70,6 +91,9 @@ pub struct RpcConfig {
     /// allows HTTP/1.1 fallback.
     #[serde(default)]
     pub http2: Option<bool>,
+    /// Provider implementation to use for this chain's RPC client.
+    /// When the chain belongs to a rate_limit_group, the group's provider takes precedence.
+    pub provider: Option<ProviderType>,
 }
 
 impl RpcConfig {
@@ -84,6 +108,13 @@ impl RpcConfig {
     /// Returns the resolved HTTP/2 opt-in flag. Defaults to false when unset.
     pub fn http2_enabled(&self) -> bool {
         self.http2.unwrap_or(false)
+    }
+
+    /// Returns the chain-level provider type. Defaults to `Standard` when unset.
+    /// When the chain belongs to a rate_limit_group, the group's provider takes precedence —
+    /// callers should resolve the effective provider via `IndexerConfig` before using this.
+    pub fn effective_provider(&self) -> ProviderType {
+        self.provider.clone().unwrap_or_default()
     }
 }
 
@@ -296,6 +327,7 @@ mod tests {
             batch_size: None,
             rate_limit_group: None,
             http2: None,
+            provider: None,
         };
 
         assert_eq!(rpc.units_per_second(), Some(25));

--- a/src/types/config/indexer.rs
+++ b/src/types/config/indexer.rs
@@ -82,6 +82,12 @@ impl IndexerConfig {
                     chain.name
                 );
             }
+            if chain.rpc.rate_limit_group.is_some() && chain.rpc.concurrency.is_some() {
+                anyhow::bail!(
+                    "Chain '{}' is in a rate_limit_group and must not set rpc.concurrency; set concurrency on the group instead",
+                    chain.name
+                );
+            }
         }
 
         Ok(IndexerConfig {
@@ -179,5 +185,66 @@ mod tests {
         fs::write(&path, config_json).unwrap();
         let result = IndexerConfig::load(&path);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_chain_in_group_with_concurrency_returns_err() {
+        let dir = TempDir::new().unwrap();
+        let config_json = format!(
+            r#"{{
+                "chains": [
+                    {{
+                        "name": "test",
+                        "chain_id": 1,
+                        "rpc_url_env_var": "RPC_URL",
+                        "contracts": {{}},
+                        "rpc": {{
+                            "rate_limit_group": "shared",
+                            "concurrency": 50
+                        }}
+                    }}
+                ],
+                "rpc_rate_limits": {{
+                    "shared": {{ "units_per_second": 7500, "concurrency": 25 }}
+                }},
+                "raw_data_collection": {}
+            }}"#,
+            raw_data_collection_json()
+        );
+        let path = dir.path().join("config.json");
+        fs::write(&path, config_json).unwrap();
+        let result = IndexerConfig::load(&path);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("must not set rpc.concurrency"));
+    }
+
+    #[test]
+    fn test_chain_in_group_with_group_provider_returns_ok() {
+        let dir = TempDir::new().unwrap();
+        let config_json = format!(
+            r#"{{
+                "chains": [
+                    {{
+                        "name": "test",
+                        "chain_id": 1,
+                        "rpc_url_env_var": "RPC_URL",
+                        "contracts": {{}},
+                        "rpc": {{
+                            "rate_limit_group": "shared"
+                        }}
+                    }}
+                ],
+                "rpc_rate_limits": {{
+                    "shared": {{ "units_per_second": 7500, "concurrency": 25, "provider": "alchemy" }}
+                }},
+                "raw_data_collection": {}
+            }}"#,
+            raw_data_collection_json()
+        );
+        let path = dir.path().join("config.json");
+        fs::write(&path, config_json).unwrap();
+        let result = IndexerConfig::load(&path);
+        assert!(result.is_ok());
     }
 }


### PR DESCRIPTION
## Summary

- **Bug 3 (URL-based detection)**: Adds a `ProviderType` enum (`alchemy` | `standard`) to both `RpcConfig` and `RpcRateLimitGroup`. The new `use_alchemy` flag flows explicitly through `from_url_with_options`, `build_rpc_client`, `build_rpc_client_with_limiter`, and `ChainRuntime::build`. Provider selection no longer depends on a string check against the URL, so proxied Alchemy endpoints work correctly.

- **Bug 2 (group concurrency)**: `RpcRateLimitGroup` gains a `concurrency` field. Validation in `IndexerConfig::load` rejects chains that set `rpc.concurrency` while also belonging to a `rate_limit_group`. `ChainRuntime::build` resolves concurrency from the group when the chain is in one, ignoring the chain-level default of 100.

- **Bug 1 (thundering herd)**: `SlidingWindowRateLimiter::acquire` now adds 0–49 ms of random jitter to the computed sleep duration, so tasks that all computed the same `wait_until` wake up spread across ~50 ms rather than all at once.

## Config example

```json
{
  "rpc_rate_limits": {
    "alchemy": {
      "units_per_second": 7500,
      "concurrency": 25,
      "provider": "alchemy"
    }
  },
  "chains": [
    {
      "name": "mainnet",
      "rpc": { "rate_limit_group": "alchemy" }
    }
  ]
}
```

## Compatibility

- `from_url_with_options` gains a `use_alchemy: bool` parameter; existing callers in `runtime.rs` and `main.rs` are updated. A `from_url_with_options_inferred` shim preserves URL-based detection for test and one-off tooling contexts.
- The pre-existing `from_url` / `from_url_with_alchemy_cu` methods still use URL inference and are unchanged.