### PR TITLE
fix: silence spurious skipped factory triggers in repair-only mode

### DIFF
--- a/src/raw_data/historical/catchup/eth_calls.rs
+++ b/src/raw_data/historical/catchup/eth_calls.rs
@@ -116,17 +116,27 @@ pub(crate) async fn process_event_triggered_catchup_range(
     let range_start = log_range.start;
     let inclusive_end = log_range.end - 1;
     let factory_range_key = range_key(range_start, inclusive_end);
-    let ready_factory_sources_for_range: HashSet<String> = ctx
-        .factory_collections
-        .iter()
-        .filter(|collection_name| {
-            ctx.factory_contract_indexes
-                .get(*collection_name)
-                .is_some_and(|index| index.contains_key(&factory_range_key))
-                && ctx.factory_addresses.contains_key(*collection_name)
-        })
-        .cloned()
-        .collect();
+    // In repair mode factory_contract_indexes is always empty (no factory stream), so we
+    // consider any collection with loaded addresses as "ready" for all ranges — the parquet
+    // load already merged addresses from every historical range.
+    let ready_factory_sources_for_range: HashSet<String> = if ctx.repair {
+        ctx.factory_collections
+            .iter()
+            .filter(|c| ctx.factory_addresses.contains_key(*c))
+            .cloned()
+            .collect()
+    } else {
+        ctx.factory_collections
+            .iter()
+            .filter(|collection_name| {
+                ctx.factory_contract_indexes
+                    .get(*collection_name)
+                    .is_some_and(|index| index.contains_key(&factory_range_key))
+                    && ctx.factory_addresses.contains_key(*collection_name)
+            })
+            .cloned()
+            .collect()
+    };
 
     // === Skip check (non-repair only) ===
     if !ctx.repair {


### PR DESCRIPTION
## Summary

- `ZoraCreatorCoinHook` and `ZoraContentCoinHook` share the same `Swapped` event signature. Each `Swapped` log generates two triggers — one per factory collection — because both matchers use `is_factory: true` with no address filter.
- In normal mode, `filter_ready_factory_event_triggers` pre-filters cross-collection triggers (e.g. a ZoraCreatorCoinHook emitter matched by the ZoraContentCoinHook matcher) using `ready_factory_sources_for_range`, which is computed from the in-memory `factory_contract_indexes` populated by the factory stream.
- In repair-only mode, `factory_contract_indexes` is never populated (no factory stream), so `ready_factory_sources_for_range` was always empty. `filter_ready_factory_event_triggers` short-circuits on empty and returns all triggers unfiltered. Cross-collection triggers then hit the address check in `process_event_triggers` and the "Unexpected skipped factory triggers" warning fires for every range.
- Fix: in repair mode, factory addresses are loaded from all historical parquet files (merged across all ranges), so any collection with loaded addresses is treated as ready for all ranges. This lets `filter_ready_factory_event_triggers` correctly pre-filter cross-collection noise without needing `factory_contract_indexes`.