### PR TITLE
feat: track dhook/rehype and V2 migration pools

### DIFF
--- a/config/contracts/base/dhook.json
+++ b/config/contracts/base/dhook.json
@@ -97,7 +97,15 @@
             "0x1e40b0875dda35f41e15cfb475403859b8c860c4",
             "0x65b6737c7a897029afe54dbb61bc4a84b232e0c4"
         ],
-        "start_block": 30822164
+        "start_block": 30822164,
+        "events": [
+            {
+                "signature": "Migrate(address indexed asset, (address currency0, address currency1, uint24 fee, int24 tickSpacing, address hooks) poolKey)"
+            },
+            {
+                "signature": "ModifyLiquidity((address currency0, address currency1, uint24 fee, int24 tickSpacing, address hooks) key, (int24 tickLower, int24 tickUpper, int256 liquidityDelta, bytes32 salt) params)"
+            }
+        ]
     },
     "RehypeDopplerHookMigrator": {
         "address": [

--- a/config/contracts/baseSepolia/dhook.json
+++ b/config/contracts/baseSepolia/dhook.json
@@ -102,7 +102,15 @@
             "0xf848fea3329185529b50228bcb36f3b5a60960c4",
             "0x8bbbe586f9a902c15a759fc134a99a2d28bc20c4"
         ],
-        "start_block": 26638492
+        "start_block": 26638492,
+        "events": [
+            {
+                "signature": "Migrate(address indexed asset, (address currency0, address currency1, uint24 fee, int24 tickSpacing, address hooks) poolKey)"
+            },
+            {
+                "signature": "ModifyLiquidity((address currency0, address currency1, uint24 fee, int24 tickSpacing, address hooks) key, (int24 tickLower, int24 tickUpper, int256 liquidityDelta, bytes32 salt) params)"
+            }
+        ]
     },
     "RehypeDopplerHookMigrator": {
         "address": [

--- a/config/contracts/mainnet/dhook.json
+++ b/config/contracts/mainnet/dhook.json
@@ -97,7 +97,15 @@
             "0x1e40b0875dda35f41e15cfb475403859b8c860c4",
             "0x65b6737c7a897029afe54dbb61bc4a84b232e0c4"
         ],
-        "start_block": 24326115
+        "start_block": 24326115,
+        "events": [
+            {
+                "signature": "Migrate(address indexed asset, (address currency0, address currency1, uint24 fee, int24 tickSpacing, address hooks) poolKey)"
+            },
+            {
+                "signature": "ModifyLiquidity((address currency0, address currency1, uint24 fee, int24 tickSpacing, address hooks) key, (int24 tickLower, int24 tickUpper, int256 liquidityDelta, bytes32 salt) params)"
+            }
+        ]
     },
     "RehypeDopplerHookMigrator": {
         "address": [

--- a/config/contracts/monad/dhook.json
+++ b/config/contracts/monad/dhook.json
@@ -91,7 +91,15 @@
             "0x1e40b0875dda35f41e15cfb475403859b8c860c4",
             "0x65b6737c7a897029afe54dbb61bc4a84b232e0c4"
         ],
-        "start_block": 34746371
+        "start_block": 34746371,
+        "events": [
+            {
+                "signature": "Migrate(address indexed asset, (address currency0, address currency1, uint24 fee, int24 tickSpacing, address hooks) poolKey)"
+            },
+            {
+                "signature": "ModifyLiquidity((address currency0, address currency1, uint24 fee, int24 tickSpacing, address hooks) key, (int24 tickLower, int24 tickUpper, int256 liquidityDelta, bytes32 salt) params)"
+            }
+        ]
     },
     "RehypeDopplerHookMigrator": {
         "address": "0xd199e7836e91654c0475a90e0c1d0e402bb84372",

--- a/config/contracts/sepolia/dhook.json
+++ b/config/contracts/sepolia/dhook.json
@@ -97,7 +97,15 @@
             "0x1e40b0875dda35f41e15cfb475403859b8c860c4",
             "0x65b6737c7a897029afe54dbb61bc4a84b232e0c4"
         ],
-        "start_block": 10134362
+        "start_block": 10134362,
+        "events": [
+            {
+                "signature": "Migrate(address indexed asset, (address currency0, address currency1, uint24 fee, int24 tickSpacing, address hooks) poolKey)"
+            },
+            {
+                "signature": "ModifyLiquidity((address currency0, address currency1, uint24 fee, int24 tickSpacing, address hooks) key, (int24 tickLower, int24 tickUpper, int256 liquidityDelta, bytes32 salt) params)"
+            }
+        ]
     },
     "RehypeDopplerHookMigrator": {
         "address": [

--- a/src/transformations/event/dhook/migrate.rs
+++ b/src/transformations/event/dhook/migrate.rs
@@ -1,0 +1,198 @@
+//! Dhook migration pool create handler.
+//!
+//! Inserts a `pools` row for each dhook/rehype pool that graduates to a
+//! standard UniswapV4 pool via `DopplerHookMigrator.Migrate`. The new row
+//! carries `migrated_from` pointing to the original dhook pool's bytes32
+//! address, enabling `MigrationPoolSwapMetricsHandler` to discover the pool.
+
+use std::sync::OnceLock;
+
+use async_trait::async_trait;
+use deadpool_postgres::Pool;
+
+use crate::db::{DbOperation, DbPool};
+use crate::transformations::context::{FieldExtractor, TransformationContext};
+use crate::transformations::error::TransformationError;
+use crate::transformations::event::dhook::create::{
+    DOPPLER_HOOK_CREATE_HANDLER_NAME, DOPPLER_HOOK_CREATE_HANDLER_VERSION,
+};
+use crate::transformations::registry::TransformationRegistry;
+use crate::transformations::traits::{
+    dep, EventHandler, EventTrigger, HandlerDependencySpec, TransformationHandler,
+};
+use crate::transformations::util::db::pool::{insert_migration_pool, MigrationPoolData};
+use crate::transformations::util::pool_metadata::VersionedSource;
+use crate::types::uniswap::v4::PoolKey;
+
+const SOURCE: &str = "DopplerHookMigrator";
+pub const DHOOK_MIGRATION_POOL_CREATE_HANDLER_NAME: &str = "DhookMigrationPoolCreateHandler";
+pub const DHOOK_MIGRATION_POOL_CREATE_HANDLER_VERSION: u32 = 1;
+pub const DHOOK_MIGRATION_POOL_CREATE_HANDLER_SCOPE: VersionedSource = VersionedSource::new(
+    DHOOK_MIGRATION_POOL_CREATE_HANDLER_NAME,
+    DHOOK_MIGRATION_POOL_CREATE_HANDLER_VERSION,
+);
+
+pub struct DhookMigrationPoolCreateHandler {
+    db_pool: OnceLock<Pool>,
+}
+
+#[async_trait]
+impl TransformationHandler for DhookMigrationPoolCreateHandler {
+    fn name(&self) -> &'static str {
+        DHOOK_MIGRATION_POOL_CREATE_HANDLER_NAME
+    }
+
+    fn version(&self) -> u32 {
+        DHOOK_MIGRATION_POOL_CREATE_HANDLER_VERSION
+    }
+
+    fn migration_paths(&self) -> Vec<&'static str> {
+        vec!["migrations/tables/pools.sql"]
+    }
+
+    fn reorg_tables(&self) -> Vec<&'static str> {
+        vec!["pools"]
+    }
+
+    fn requires_sequential(&self) -> bool {
+        false
+    }
+
+    async fn handle(
+        &self,
+        ctx: &TransformationContext,
+    ) -> Result<Vec<DbOperation>, TransformationError> {
+        let mut ops = Vec::new();
+
+        for event in ctx.events_of_type(SOURCE, "Migrate") {
+            let asset = event.extract_address("asset")?;
+
+            let pool_key = PoolKey {
+                currency0: event.extract_address("poolKey.currency0")?.into(),
+                currency1: event.extract_address("poolKey.currency1")?.into(),
+                fee: event.extract_u32("poolKey.fee")?,
+                tick_spacing: event.extract_i32_flexible("poolKey.tickSpacing")?,
+                hooks: event.extract_address("poolKey.hooks")?.into(),
+            };
+            let pool_id = pool_key.pool_id();
+
+            let client = self
+                .db_pool
+                .get()
+                .expect("db_pool must be set before handle()")
+                .get()
+                .await?;
+
+            let rows = client
+                .query(
+                    "SELECT p.address, p.base_token, p.quote_token, p.is_token_0, p.fee, \
+                            p.integrator, p.initializer, p.type \
+                     FROM pools p \
+                     WHERE p.chain_id = $1 \
+                       AND p.base_token = $2 \
+                       AND p.source = $3 \
+                       AND p.source_version = $4 \
+                     LIMIT 1",
+                    &[
+                        &(ctx.chain_id as i64),
+                        &asset.to_vec(),
+                        &DOPPLER_HOOK_CREATE_HANDLER_NAME,
+                        &(DOPPLER_HOOK_CREATE_HANDLER_VERSION as i32),
+                    ],
+                )
+                .await?;
+
+            let Some(row) = rows.first() else {
+                tracing::warn!(
+                    asset = hex::encode(asset),
+                    block = event.block_number,
+                    "no dhook pool found for DopplerHookMigrator.Migrate asset; skipping"
+                );
+                continue;
+            };
+
+            let base_token_bytes: Vec<u8> = row.get("base_token");
+            let quote_token_bytes: Vec<u8> = row.get("quote_token");
+            let integrator_bytes: Vec<u8> = row.get("integrator");
+            let initializer_bytes: Vec<u8> = row.get("initializer");
+            let original_address: Vec<u8> = row.get("address");
+            let original_type: String = row.get("type");
+
+            if base_token_bytes.len() != 20
+                || quote_token_bytes.len() != 20
+                || integrator_bytes.len() != 20
+                || initializer_bytes.len() != 20
+            {
+                tracing::warn!(
+                    asset = hex::encode(asset),
+                    block = event.block_number,
+                    "malformed address bytes in dhook pool row; skipping"
+                );
+                continue;
+            }
+
+            let mut base_token = [0u8; 20];
+            let mut quote_token = [0u8; 20];
+            let mut integrator = [0u8; 20];
+            let mut initializer = [0u8; 20];
+            base_token.copy_from_slice(&base_token_bytes);
+            quote_token.copy_from_slice(&quote_token_bytes);
+            integrator.copy_from_slice(&integrator_bytes);
+            initializer.copy_from_slice(&initializer_bytes);
+
+            let is_token_0: bool = row.get("is_token_0");
+            let fee: i32 = row.get("fee");
+
+            let (pool_type, migration_type) = if original_type == "rehype" {
+                ("migration_rehype", "rehype")
+            } else {
+                ("migration_dhook", "dhook")
+            };
+
+            ops.push(insert_migration_pool(
+                &MigrationPoolData {
+                    block_number: event.block_number,
+                    block_timestamp: event.block_timestamp,
+                    pool_id: &pool_id.0,
+                    base_token,
+                    quote_token,
+                    is_token_0,
+                    integrator,
+                    initializer,
+                    fee: fee as u32,
+                    migrated_from: &original_address,
+                    pool_type,
+                    migration_type,
+                },
+                ctx,
+            ));
+        }
+
+        Ok(ops)
+    }
+
+    async fn initialize(&self, db_pool: &DbPool) -> Result<(), TransformationError> {
+        self.db_pool.set(db_pool.inner().clone()).ok();
+        tracing::info!("DhookMigrationPoolCreateHandler initialized");
+        Ok(())
+    }
+}
+
+impl EventHandler for DhookMigrationPoolCreateHandler {
+    fn triggers(&self) -> Vec<EventTrigger> {
+        vec![EventTrigger::new(
+            SOURCE,
+            "Migrate(address,(address,address,uint24,int24,address))",
+        )]
+    }
+
+    fn contiguous_handler_dependency_specs(&self) -> Vec<HandlerDependencySpec> {
+        vec![dep("DopplerHookCreateHandler")]
+    }
+}
+
+pub fn register_handlers(registry: &mut TransformationRegistry) {
+    registry.register_event_handler(DhookMigrationPoolCreateHandler {
+        db_pool: OnceLock::new(),
+    });
+}

--- a/src/transformations/event/dhook/mod.rs
+++ b/src/transformations/event/dhook/mod.rs
@@ -1,2 +1,3 @@
 pub mod create;
 pub mod metrics;
+pub mod migrate;

--- a/src/transformations/event/metrics/swap_data.rs
+++ b/src/transformations/event/metrics/swap_data.rs
@@ -7,6 +7,7 @@ use std::collections::{BTreeMap, HashSet};
 use std::sync::{Arc, OnceLock};
 
 use alloy_primitives::{I256, U256};
+use bigdecimal::{BigDecimal, Zero};
 use deadpool_postgres::Pool;
 
 use crate::db::{DbOperation, DbSnapshot, DbValue};
@@ -16,7 +17,7 @@ use crate::transformations::util::db::pool_metrics::{
     PoolStateData, SnapshotData,
 };
 use crate::transformations::util::pool_metadata::{PoolMetadata, PoolMetadataCache};
-use crate::transformations::util::price::sqrt_price_x96_to_price;
+use crate::transformations::util::price::{apply_decimal_exp, sqrt_price_x96_to_price};
 use crate::transformations::util::usd_price::UsdPriceContext;
 
 use super::accumulator::BlockAccumulator;
@@ -336,6 +337,232 @@ WHERE pool_state.chain_id = :chain_id
             ],
         }),
     }
+}
+
+/// Normalized V2 swap input (Uniswap V2 Swap event fields).
+#[derive(Debug, Clone)]
+pub struct V2SwapInput {
+    pub pool_id: Vec<u8>,
+    pub transaction_hash: [u8; 32],
+    pub block_number: u64,
+    pub block_timestamp: u64,
+    pub log_index: u32,
+    pub amount0_in: U256,
+    pub amount1_in: U256,
+    pub amount0_out: U256,
+    pub amount1_out: U256,
+}
+
+/// Compute execution price (quote per base) from V2 swap amounts.
+///
+/// Returns None when both input amounts for a direction are zero (invalid event).
+fn v2_execution_price(
+    amount0_in: U256,
+    amount1_in: U256,
+    amount0_out: U256,
+    amount1_out: U256,
+    base_decimals: u8,
+    quote_decimals: u8,
+    is_token_0: bool,
+) -> Option<BigDecimal> {
+    // Pick quote_raw and base_raw depending on trade direction.
+    // is_token_0=true: base=token0, quote=token1
+    // is_token_0=false: base=token1, quote=token0
+    let (quote_raw, base_raw) = if is_token_0 {
+        if !amount0_in.is_zero() {
+            (amount1_out, amount0_in)
+        } else {
+            (amount1_in, amount0_out)
+        }
+    } else {
+        if !amount1_in.is_zero() {
+            (amount0_out, amount1_in)
+        } else {
+            (amount0_in, amount1_out)
+        }
+    };
+
+    if base_raw.is_zero() || quote_raw.is_zero() {
+        return None;
+    }
+
+    let quote_bd: BigDecimal = quote_raw.to_string().parse().ok()?;
+    let base_bd: BigDecimal = base_raw.to_string().parse().ok()?;
+
+    // price = (quote_raw / 10^quote_dec) / (base_raw / 10^base_dec)
+    //       = (quote_raw / base_raw) * 10^(base_dec - quote_dec)
+    let raw_ratio = &quote_bd / &base_bd;
+    let price = apply_decimal_exp(raw_ratio, base_decimals as i32 - quote_decimals as i32);
+
+    if price.is_zero() {
+        None
+    } else {
+        Some(price)
+    }
+}
+
+/// Process a batch of V2 swap inputs into pool_snapshots + pool_state DbOperations.
+///
+/// Computes execution price from token amounts (bypassing sqrtPriceX96).
+/// tick and liquidity are stored as 0/zero since V2 has no on-chain equivalent.
+pub fn process_v2_swaps(
+    swaps: &[V2SwapInput],
+    metadata_cache: &PoolMetadataCache,
+    chain_id: u64,
+    handler_name: &str,
+    source_name: &str,
+    usd_ctx: Option<&UsdPriceContext>,
+    source_version: u32,
+) -> Vec<DbOperation> {
+    if swaps.is_empty() {
+        return Vec::new();
+    }
+
+    let mut grouped: BTreeMap<(Vec<u8>, u64), Vec<&V2SwapInput>> = BTreeMap::new();
+    for swap in swaps {
+        grouped
+            .entry((swap.pool_id.clone(), swap.block_number))
+            .or_default()
+            .push(swap);
+    }
+
+    let mut ops = Vec::new();
+    let mut latest_per_pool: BTreeMap<Vec<u8>, (u64, BlockAccumulator)> = BTreeMap::new();
+
+    let mut skipped_swap_count = 0u64;
+    let mut skipped_pool_count = 0u64;
+    let mut skipped_samples: Vec<(String, u64, String)> = Vec::new();
+
+    for ((pool_id, block_number), swap_group) in &grouped {
+        let meta = match metadata_cache.get(pool_id) {
+            Some(m) => m,
+            None => {
+                skipped_swap_count += swap_group.len() as u64;
+                skipped_pool_count += 1;
+                if skipped_samples.len() < 5 {
+                    let tx = swap_group
+                        .first()
+                        .map(|s| hex::encode(s.transaction_hash))
+                        .unwrap_or_default();
+                    skipped_samples.push((hex::encode(pool_id), *block_number, tx));
+                }
+                continue;
+            }
+        };
+
+        let block_timestamp = swap_group[0].block_timestamp;
+        let mut acc = BlockAccumulator::new(block_timestamp);
+
+        let mut sorted: Vec<&&V2SwapInput> = swap_group.iter().collect();
+        sorted.sort_by_key(|s| s.log_index);
+
+        for swap in sorted {
+            let Some(price) = v2_execution_price(
+                swap.amount0_in,
+                swap.amount1_in,
+                swap.amount0_out,
+                swap.amount1_out,
+                meta.base_decimals,
+                meta.quote_decimals,
+                meta.is_token_0,
+            ) else {
+                continue;
+            };
+
+            let amount0 = I256::try_from(swap.amount0_in)
+                .unwrap_or(I256::MAX)
+                .saturating_sub(
+                    I256::try_from(swap.amount0_out).unwrap_or(I256::MAX),
+                );
+            let amount1 = I256::try_from(swap.amount1_in)
+                .unwrap_or(I256::MAX)
+                .saturating_sub(
+                    I256::try_from(swap.amount1_out).unwrap_or(I256::MAX),
+                );
+
+            acc.record_swap(price, amount0, amount1, 0, U256::ZERO, U256::ZERO);
+        }
+
+        if acc.swap_count == 0 {
+            continue;
+        }
+
+        let price_open = acc.price_open.as_ref().unwrap().to_string();
+        let price_close = acc.price_close.as_ref().unwrap().to_string();
+        let price_high = acc.price_high.as_ref().unwrap().to_string();
+        let price_low = acc.price_low.as_ref().unwrap().to_string();
+
+        let volume_usd = usd_ctx.and_then(|ctx| {
+            let quote_volume = if meta.is_token_0 {
+                &acc.volume1
+            } else {
+                &acc.volume0
+            };
+            ctx.quote_volume_to_usd(quote_volume, &meta.quote_token, meta.quote_decimals)
+        });
+
+        ops.push(insert_pool_snapshot(&SnapshotData {
+            chain_id,
+            pool_id: pool_id.clone(),
+            block_number: *block_number,
+            block_timestamp: acc.block_timestamp,
+            price_open,
+            price_close,
+            price_high,
+            price_low,
+            active_liquidity: "0".to_string(),
+            volume0: acc.volume0.to_string(),
+            volume1: acc.volume1.to_string(),
+            swap_count: i32::try_from(acc.swap_count).unwrap_or(i32::MAX),
+            volume_usd: volume_usd.map(|v| v.to_string()),
+        }));
+
+        latest_per_pool.insert(pool_id.clone(), (*block_number, acc));
+    }
+
+    if skipped_swap_count > 0 {
+        let samples_str: Vec<String> = skipped_samples
+            .iter()
+            .map(|(pool, block, tx)| format!("pool={} block={} tx={}", pool, block, tx))
+            .collect();
+        tracing::warn!(
+            handler = handler_name,
+            source = source_name,
+            "Skipped {} V2 swap(s) across {} pool(s) due to missing metadata. Samples: [{}]",
+            skipped_swap_count,
+            skipped_pool_count,
+            samples_str.join("; "),
+        );
+    }
+
+    for (pool_id, (block_number, acc)) in &latest_per_pool {
+        let price_close = acc.price_close.as_ref().unwrap().to_string();
+
+        ops.push(upsert_pool_state(&PoolStateData {
+            chain_id,
+            pool_id: pool_id.clone(),
+            block_number: *block_number,
+            block_timestamp: acc.block_timestamp,
+            tick: 0,
+            sqrt_price_x96: "0".to_string(),
+            price: price_close.clone(),
+            active_liquidity: "0".to_string(),
+        }));
+
+        if usd_ctx.is_some() {
+            ops.push(build_rolling_metrics_update(
+                chain_id,
+                pool_id,
+                &price_close,
+                *block_number,
+                acc.block_timestamp,
+                handler_name,
+                source_version,
+            ));
+        }
+    }
+
+    ops
 }
 
 /// Process a batch of liquidity inputs into liquidity_deltas INSERT operations.

--- a/src/transformations/event/migration_pool/create.rs
+++ b/src/transformations/event/migration_pool/create.rs
@@ -164,6 +164,8 @@ impl TransformationHandler for MigrationPoolCreateHandler {
                     initializer,
                     fee: fee as u32,
                     migrated_from: &original_address,
+                    pool_type: "migration_v4",
+                    migration_type: "v4",
                 },
                 ctx,
             ));

--- a/src/transformations/event/migration_pool/metrics.rs
+++ b/src/transformations/event/migration_pool/metrics.rs
@@ -32,9 +32,6 @@ use crate::transformations::event::metrics::swap_data::{
 };
 use crate::transformations::event::metrics::tvl::{process_tvl, TvlHandlerConfig, TvlTarget};
 use crate::transformations::event::metrics::v4_hook_extract::extract_tuple_modify_liquidity;
-use crate::transformations::event::migration_pool::create::{
-    MIGRATION_POOL_CREATE_HANDLER_NAME, MIGRATION_POOL_CREATE_HANDLER_VERSION,
-};
 use crate::transformations::registry::TransformationRegistry;
 use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
 use crate::transformations::util::pool_metadata::PoolMetadataCache;
@@ -73,14 +70,8 @@ impl MigrationPoolSwapMetricsHandler {
                 "SELECT p.address \
                  FROM pools p \
                  WHERE p.chain_id = $1 \
-                   AND p.migrated_from IS NOT NULL \
-                   AND p.source = $2 \
-                   AND p.source_version = $3",
-                &[
-                    &(self.chain_id as i64),
-                    &MIGRATION_POOL_CREATE_HANDLER_NAME,
-                    &(MIGRATION_POOL_CREATE_HANDLER_VERSION as i32),
-                ],
+                   AND p.migrated_from IS NOT NULL",
+                &[&(self.chain_id as i64)],
             )
             .await?;
 
@@ -217,14 +208,8 @@ impl TransformationHandler for MigrationPoolSwapMetricsHandler {
                 "SELECT p.address \
                  FROM pools p \
                  WHERE p.chain_id = $1 \
-                   AND p.migrated_from IS NOT NULL \
-                   AND p.source = $2 \
-                   AND p.source_version = $3",
-                &[
-                    &(self.chain_id as i64),
-                    &MIGRATION_POOL_CREATE_HANDLER_NAME,
-                    &(MIGRATION_POOL_CREATE_HANDLER_VERSION as i32),
-                ],
+                   AND p.migrated_from IS NOT NULL",
+                &[&(self.chain_id as i64)],
             )
             .await?;
 
@@ -252,7 +237,7 @@ impl EventHandler for MigrationPoolSwapMetricsHandler {
     }
 
     fn contiguous_handler_dependencies(&self) -> Vec<&'static str> {
-        vec!["MigrationPoolCreateHandler"]
+        vec!["MigrationPoolCreateHandler", "DhookMigrationPoolCreateHandler"]
     }
 
     fn call_dependencies(&self) -> Vec<(String, String)> {
@@ -288,21 +273,28 @@ impl TransformationHandler for MigrationPoolLiquidityMetricsHandler {
         &self,
         ctx: &TransformationContext,
     ) -> Result<Vec<DbOperation>, TransformationError> {
-        let deltas = extract_tuple_modify_liquidity(ctx, MIGRATOR_HOOK_SOURCE)?;
+        let mut deltas = extract_tuple_modify_liquidity(ctx, MIGRATOR_HOOK_SOURCE)?;
+        deltas.extend(extract_tuple_modify_liquidity(ctx, "DopplerHookMigrator")?);
         Ok(process_liquidity_deltas(&deltas, self.chain_id))
     }
 }
 
 impl EventHandler for MigrationPoolLiquidityMetricsHandler {
     fn triggers(&self) -> Vec<EventTrigger> {
-        vec![EventTrigger::new(
-            MIGRATOR_HOOK_SOURCE,
-            "ModifyLiquidity((address,address,uint24,int24,address),(int24,int24,int256,bytes32))",
-        )]
+        vec![
+            EventTrigger::new(
+                MIGRATOR_HOOK_SOURCE,
+                "ModifyLiquidity((address,address,uint24,int24,address),(int24,int24,int256,bytes32))",
+            ),
+            EventTrigger::new(
+                "DopplerHookMigrator",
+                "ModifyLiquidity((address,address,uint24,int24,address),(int24,int24,int256,bytes32))",
+            ),
+        ]
     }
 
     fn contiguous_handler_dependencies(&self) -> Vec<&'static str> {
-        vec!["MigrationPoolCreateHandler"]
+        vec!["MigrationPoolCreateHandler", "DhookMigrationPoolCreateHandler"]
     }
 }
 
@@ -329,14 +321,8 @@ impl MigrationPoolTvlMetricsHandler {
                 "SELECT p.address \
                  FROM pools p \
                  WHERE p.chain_id = $1 \
-                   AND p.migrated_from IS NOT NULL \
-                   AND p.source = $2 \
-                   AND p.source_version = $3",
-                &[
-                    &(self.chain_id as i64),
-                    &MIGRATION_POOL_CREATE_HANDLER_NAME,
-                    &(MIGRATION_POOL_CREATE_HANDLER_VERSION as i32),
-                ],
+                   AND p.migrated_from IS NOT NULL",
+                &[&(self.chain_id as i64)],
             )
             .await?;
 
@@ -473,14 +459,8 @@ impl TransformationHandler for MigrationPoolTvlMetricsHandler {
                 "SELECT p.address \
                  FROM pools p \
                  WHERE p.chain_id = $1 \
-                   AND p.migrated_from IS NOT NULL \
-                   AND p.source = $2 \
-                   AND p.source_version = $3",
-                &[
-                    &(self.chain_id as i64),
-                    &MIGRATION_POOL_CREATE_HANDLER_NAME,
-                    &(MIGRATION_POOL_CREATE_HANDLER_VERSION as i32),
-                ],
+                   AND p.migrated_from IS NOT NULL",
+                &[&(self.chain_id as i64)],
             )
             .await?;
 
@@ -510,6 +490,7 @@ impl EventHandler for MigrationPoolTvlMetricsHandler {
     fn contiguous_handler_dependencies(&self) -> Vec<&'static str> {
         vec![
             "MigrationPoolCreateHandler",
+            "DhookMigrationPoolCreateHandler",
             "MigrationPoolLiquidityMetricsHandler",
         ]
     }

--- a/src/transformations/event/migration_pool/mod.rs
+++ b/src/transformations/event/migration_pool/mod.rs
@@ -1,2 +1,4 @@
 pub mod create;
 pub mod metrics;
+pub mod v2_create;
+pub mod v2_metrics;

--- a/src/transformations/event/migration_pool/v2_create.rs
+++ b/src/transformations/event/migration_pool/v2_create.rs
@@ -1,0 +1,177 @@
+//! V2 migration pool create handler.
+//!
+//! Inserts a `pools` row for each Doppler pool that graduates to a UniswapV2
+//! pair via `Airlock.Migrate`. The new row carries `migrated_from` pointing to
+//! the original Doppler pool's address, enabling `V2MigrationSwapMetricsHandler`
+//! to discover the pair address set at initialization.
+
+use std::sync::OnceLock;
+
+use async_trait::async_trait;
+use deadpool_postgres::Pool;
+
+use crate::db::{DbOperation, DbPool};
+use crate::transformations::context::{FieldExtractor, TransformationContext};
+use crate::transformations::error::TransformationError;
+use crate::transformations::registry::TransformationRegistry;
+use crate::transformations::traits::{
+    dep, EventHandler, EventTrigger, HandlerDependencySpec, TransformationHandler,
+};
+use crate::transformations::util::db::pool::{insert_v2_migration_pool, MigrationV2PoolData};
+use crate::transformations::util::pool_metadata::VersionedSource;
+
+const SOURCE: &str = "Airlock";
+pub const V2_MIGRATION_POOL_CREATE_HANDLER_NAME: &str = "V2MigrationPoolCreateHandler";
+pub const V2_MIGRATION_POOL_CREATE_HANDLER_VERSION: u32 = 1;
+pub const V2_MIGRATION_POOL_CREATE_HANDLER_SCOPE: VersionedSource = VersionedSource::new(
+    V2_MIGRATION_POOL_CREATE_HANDLER_NAME,
+    V2_MIGRATION_POOL_CREATE_HANDLER_VERSION,
+);
+
+pub struct V2MigrationPoolCreateHandler {
+    db_pool: OnceLock<Pool>,
+}
+
+#[async_trait]
+impl TransformationHandler for V2MigrationPoolCreateHandler {
+    fn name(&self) -> &'static str {
+        V2_MIGRATION_POOL_CREATE_HANDLER_NAME
+    }
+
+    fn version(&self) -> u32 {
+        V2_MIGRATION_POOL_CREATE_HANDLER_VERSION
+    }
+
+    fn migration_paths(&self) -> Vec<&'static str> {
+        vec!["migrations/tables/pools.sql"]
+    }
+
+    fn reorg_tables(&self) -> Vec<&'static str> {
+        vec!["pools"]
+    }
+
+    fn requires_sequential(&self) -> bool {
+        false
+    }
+
+    async fn handle(
+        &self,
+        ctx: &TransformationContext,
+    ) -> Result<Vec<DbOperation>, TransformationError> {
+        let mut ops = Vec::new();
+
+        for event in ctx.events_of_type(SOURCE, "Migrate") {
+            let pair_address = event.extract_address("pool")?;
+
+            // V4/dhook migrations have pool == address(0); skip them.
+            if pair_address == [0u8; 20] {
+                continue;
+            }
+
+            let client = self
+                .db_pool
+                .get()
+                .expect("db_pool must be set before handle()")
+                .get()
+                .await?;
+
+            let rows = client
+                .query(
+                    "SELECT p.address, p.base_token, p.quote_token, p.is_token_0, p.fee, \
+                            p.integrator, p.initializer \
+                     FROM pools p \
+                     WHERE p.chain_id = $1 \
+                       AND p.migration_pool = $2 \
+                       AND p.migration_type = 'v2' \
+                     LIMIT 1",
+                    &[&(ctx.chain_id as i64), &pair_address.to_vec()],
+                )
+                .await?;
+
+            let Some(row) = rows.first() else {
+                // Not a V2 migration (could be V3/V4 with same Airlock.Migrate event).
+                continue;
+            };
+
+            let base_token_bytes: Vec<u8> = row.get("base_token");
+            let quote_token_bytes: Vec<u8> = row.get("quote_token");
+            let integrator_bytes: Vec<u8> = row.get("integrator");
+            let initializer_bytes: Vec<u8> = row.get("initializer");
+            let original_address: Vec<u8> = row.get("address");
+
+            if base_token_bytes.len() != 20
+                || quote_token_bytes.len() != 20
+                || integrator_bytes.len() != 20
+                || initializer_bytes.len() != 20
+            {
+                tracing::warn!(
+                    pair = hex::encode(pair_address),
+                    block = event.block_number,
+                    "malformed address bytes in original V2 pool row; skipping"
+                );
+                continue;
+            }
+
+            let mut base_token = [0u8; 20];
+            let mut quote_token = [0u8; 20];
+            let mut integrator = [0u8; 20];
+            let mut initializer = [0u8; 20];
+            base_token.copy_from_slice(&base_token_bytes);
+            quote_token.copy_from_slice(&quote_token_bytes);
+            integrator.copy_from_slice(&integrator_bytes);
+            initializer.copy_from_slice(&initializer_bytes);
+
+            let is_token_0: bool = row.get("is_token_0");
+            let fee: i32 = row.get("fee");
+
+            ops.push(insert_v2_migration_pool(
+                &MigrationV2PoolData {
+                    block_number: event.block_number,
+                    block_timestamp: event.block_timestamp,
+                    pair_address: &pair_address,
+                    base_token,
+                    quote_token,
+                    is_token_0,
+                    integrator,
+                    initializer,
+                    fee: fee as u32,
+                    migrated_from: &original_address,
+                },
+                ctx,
+            ));
+        }
+
+        Ok(ops)
+    }
+
+    async fn initialize(&self, db_pool: &DbPool) -> Result<(), TransformationError> {
+        self.db_pool.set(db_pool.inner().clone()).ok();
+        tracing::info!("V2MigrationPoolCreateHandler initialized");
+        Ok(())
+    }
+}
+
+impl EventHandler for V2MigrationPoolCreateHandler {
+    fn triggers(&self) -> Vec<EventTrigger> {
+        vec![EventTrigger::new(
+            SOURCE,
+            "Migrate(address,address)",
+        )]
+    }
+
+    fn contiguous_handler_dependency_specs(&self) -> Vec<HandlerDependencySpec> {
+        vec![
+            dep("V4CreateHandler"),
+            dep("V4MulticurveCreateHandler").only([8453, 84532]),
+            dep("V4ScheduledMulticurveCreateHandler").except([130, 57073]),
+            dep("V4DecayMulticurveCreateHandler").only([8453, 11155111, 84532]),
+            dep("DopplerHookCreateHandler").except([130, 57073]),
+        ]
+    }
+}
+
+pub fn register_handlers(registry: &mut TransformationRegistry) {
+    registry.register_event_handler(V2MigrationPoolCreateHandler {
+        db_pool: OnceLock::new(),
+    });
+}

--- a/src/transformations/event/migration_pool/v2_metrics.rs
+++ b/src/transformations/event/migration_pool/v2_metrics.rs
@@ -1,0 +1,244 @@
+//! V2 migration pool swap metrics handler.
+//!
+//! Processes UniswapV2 Swap events emitted by graduated V2 migration pair
+//! contracts. The `MigrationPool` factory collection in shared.json already
+//! spawns per-pair Swap listeners from Airlock.Migrate events, so these events
+//! arrive in the context with source="MigrationPool".
+//!
+//! Price is computed from execution amounts rather than sqrtPriceX96 (which V2
+//! does not have). tick and liquidity are stored as 0 in the DB.
+
+use std::collections::HashSet;
+use std::sync::{Arc, Once, OnceLock, RwLock};
+
+use async_trait::async_trait;
+use deadpool_postgres::Pool;
+
+use crate::db::{DbOperation, DbPool};
+use crate::transformations::context::{FieldExtractor, TransformationContext};
+use crate::transformations::error::TransformationError;
+use crate::transformations::event::metrics::swap_data::{
+    process_v2_swaps, refresh_cache_if_needed, V2SwapInput,
+};
+use crate::transformations::registry::TransformationRegistry;
+use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
+use crate::transformations::util::pool_metadata::PoolMetadataCache;
+use crate::transformations::util::usd_price::{
+    build_usd_price_context_with_paths, chainlink_latest_answer_dependency, OraclePriceCache,
+};
+
+const MIGRATION_POOL_SOURCE: &str = "MigrationPool";
+
+pub struct V2MigrationSwapMetricsHandler {
+    metadata_cache: Arc<PoolMetadataCache>,
+    oracle_cache: Arc<OraclePriceCache>,
+    decimals_init: Once,
+    chain_id: u64,
+    db_pool: OnceLock<Pool>,
+    /// 20-byte pair addresses of known V2 migration pools.
+    /// Seeded at init and refreshed per handle() to pick up newly graduated pools.
+    v2_pair_addresses: RwLock<HashSet<Vec<u8>>>,
+}
+
+impl V2MigrationSwapMetricsHandler {
+    async fn refresh_v2_pair_addresses(&self) -> Result<(), TransformationError> {
+        let Some(pool) = self.db_pool.get() else {
+            return Ok(());
+        };
+        let client = pool.get().await?;
+        let rows = client
+            .query(
+                "SELECT p.address \
+                 FROM pools p \
+                 WHERE p.chain_id = $1 \
+                   AND p.migration_type = 'v2' \
+                   AND p.migrated_from IS NOT NULL",
+                &[&(self.chain_id as i64)],
+            )
+            .await?;
+
+        let mut addrs = self.v2_pair_addresses.write().unwrap();
+        let before = addrs.len();
+        for row in &rows {
+            let address: Vec<u8> = row.get("address");
+            addrs.insert(address);
+        }
+        let added = addrs.len() - before;
+        if added > 0 {
+            tracing::info!(
+                added,
+                total = addrs.len(),
+                chain_id = self.chain_id,
+                "V2MigrationSwapMetricsHandler refreshed pair address set"
+            );
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl TransformationHandler for V2MigrationSwapMetricsHandler {
+    fn name(&self) -> &'static str {
+        "V2MigrationSwapMetricsHandler"
+    }
+
+    fn version(&self) -> u32 {
+        1
+    }
+
+    fn migration_paths(&self) -> Vec<&'static str> {
+        vec![
+            "migrations/tables/pool_state.sql",
+            "migrations/tables/pool_state_add_tvl.sql",
+            "migrations/tables/pool_snapshots.sql",
+            "migrations/tables/pool_snapshots_add_tvl.sql",
+            "migrations/tables/pool_snapshots_add_volume_usd.sql",
+        ]
+    }
+
+    fn reorg_tables(&self) -> Vec<&'static str> {
+        vec!["pool_state", "pool_snapshots"]
+    }
+
+    async fn handle(
+        &self,
+        ctx: &TransformationContext,
+    ) -> Result<Vec<DbOperation>, TransformationError> {
+        self.decimals_init.call_once(|| {
+            self.metadata_cache.resolve_quote_decimals(&ctx.contracts);
+        });
+
+        self.refresh_v2_pair_addresses().await?;
+
+        let mut swaps: Vec<V2SwapInput> = Vec::new();
+        for event in ctx.events_of_type(
+            MIGRATION_POOL_SOURCE,
+            "Swap(address,uint256,uint256,uint256,uint256,address)",
+        ) {
+            let pair_address = event.contract_address;
+
+            let known = {
+                let addrs = self.v2_pair_addresses.read().unwrap();
+                addrs.contains(pair_address.as_slice())
+            };
+            if !known {
+                continue;
+            }
+
+            swaps.push(V2SwapInput {
+                pool_id: pair_address.to_vec(),
+                transaction_hash: event.transaction_hash,
+                block_number: event.block_number,
+                block_timestamp: event.block_timestamp,
+                log_index: event.log_index,
+                amount0_in: event.extract_uint256("amount0In")?,
+                amount1_in: event.extract_uint256("amount1In")?,
+                amount0_out: event.extract_uint256("amount0Out")?,
+                amount1_out: event.extract_uint256("amount1Out")?,
+            });
+        }
+
+        if swaps.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        refresh_cache_if_needed(
+            swaps.iter().map(|s| &s.pool_id),
+            &self.metadata_cache,
+            &self.db_pool,
+            self.chain_id,
+            &ctx.contracts,
+            self.name(),
+            MIGRATION_POOL_SOURCE,
+            Some((ctx.blockrange_start, ctx.blockrange_end)),
+        )
+        .await?;
+
+        let (usd_ctx, price_ops) = build_usd_price_context_with_paths(
+            ctx,
+            &self.oracle_cache,
+            &self.db_pool,
+            self.chain_id,
+            &ctx.contracts,
+            &self.metadata_cache,
+        )
+        .await;
+
+        let mut ops = process_v2_swaps(
+            &swaps,
+            &self.metadata_cache,
+            ctx.chain_id,
+            self.name(),
+            MIGRATION_POOL_SOURCE,
+            Some(&usd_ctx),
+            self.version(),
+        );
+        ops.extend(price_ops);
+        Ok(ops)
+    }
+
+    async fn initialize(&self, db_pool: &DbPool) -> Result<(), TransformationError> {
+        self.db_pool.set(db_pool.inner().clone()).ok();
+        self.oracle_cache
+            .load_from_db_once(db_pool.inner(), self.chain_id)
+            .await?;
+
+        let client = db_pool.inner().get().await?;
+        let rows = client
+            .query(
+                "SELECT p.address \
+                 FROM pools p \
+                 WHERE p.chain_id = $1 \
+                   AND p.migration_type = 'v2' \
+                   AND p.migrated_from IS NOT NULL",
+                &[&(self.chain_id as i64)],
+            )
+            .await?;
+
+        let mut addrs = self.v2_pair_addresses.write().unwrap();
+        for row in &rows {
+            let address: Vec<u8> = row.get("address");
+            addrs.insert(address);
+        }
+
+        tracing::info!(
+            count = addrs.len(),
+            chain_id = self.chain_id,
+            "V2MigrationSwapMetricsHandler initialized"
+        );
+        Ok(())
+    }
+}
+
+impl EventHandler for V2MigrationSwapMetricsHandler {
+    fn triggers(&self) -> Vec<EventTrigger> {
+        vec![EventTrigger::new(
+            MIGRATION_POOL_SOURCE,
+            "Swap(address,uint256,uint256,uint256,uint256,address)",
+        )]
+    }
+
+    fn contiguous_handler_dependencies(&self) -> Vec<&'static str> {
+        vec!["V2MigrationPoolCreateHandler"]
+    }
+
+    fn call_dependencies(&self) -> Vec<(String, String)> {
+        vec![chainlink_latest_answer_dependency()]
+    }
+}
+
+pub fn register_handlers(
+    registry: &mut TransformationRegistry,
+    chain_id: u64,
+    cache: Arc<PoolMetadataCache>,
+    oracle_cache: Arc<OraclePriceCache>,
+) {
+    registry.register_event_handler(V2MigrationSwapMetricsHandler {
+        metadata_cache: cache,
+        oracle_cache,
+        decimals_init: Once::new(),
+        chain_id,
+        db_pool: OnceLock::new(),
+        v2_pair_addresses: RwLock::new(HashSet::new()),
+    });
+}

--- a/src/transformations/event/mod.rs
+++ b/src/transformations/event/mod.rs
@@ -115,17 +115,28 @@ fn register_handlers_inner(
     ]));
     zora::metrics::register_handlers(registry, chain_id, zora_cache, Arc::clone(&oracle_cache));
 
-    // Register migration pool handlers as a group only on chains with a V4
-    // migrator. The swap handler depends on MigrationPoolCreateHandler, so
-    // letting source filtering split them apart can leave a dangling dependency
+    // Register migration pool handlers as a group on chains with a V4 migrator
+    // or a dhook migrator. The swap handler depends on MigrationPoolCreateHandler,
+    // so letting source filtering split them apart can leave a dangling dependency
     // on PoolManager-only chains.
     let register_migration_pool_handlers = contracts
-        .map(|contracts| contracts.contains_key("UniswapV4Migrator"))
+        .map(|c| c.contains_key("UniswapV4Migrator") || c.contains_key("DopplerHookMigrator"))
         .unwrap_or(true);
     if register_migration_pool_handlers {
         migration_pool::create::register_handlers(registry);
+
+        let register_dhook_migration = contracts
+            .map(|c| c.contains_key("DopplerHookMigrator"))
+            .unwrap_or(true);
+        if register_dhook_migration {
+            dhook::migrate::register_handlers(registry);
+        }
+
         let migration_pool_cache = Arc::new(PoolMetadataCache::with_scopes(
-            vec![migration_pool::create::MIGRATION_POOL_CREATE_HANDLER_SCOPE],
+            vec![
+                migration_pool::create::MIGRATION_POOL_CREATE_HANDLER_SCOPE,
+                dhook::migrate::DHOOK_MIGRATION_POOL_CREATE_HANDLER_SCOPE,
+            ],
             vec![
                 v3::create::V3_CREATE_HANDLER_SCOPE,
                 v3::create::LOCKABLE_V3_CREATE_HANDLER_SCOPE,
@@ -140,6 +151,32 @@ fn register_handlers_inner(
             registry,
             chain_id,
             migration_pool_cache,
+            Arc::clone(&oracle_cache),
+        );
+    }
+
+    // Register V2 migration pool handlers on chains with a V2 migrator.
+    let register_v2_migration_handlers = contracts
+        .map(|c| {
+            c.contains_key("UniswapV2Migrator") || c.contains_key("NimCustomV2Migrator")
+        })
+        .unwrap_or(true);
+    if register_v2_migration_handlers {
+        migration_pool::v2_create::register_handlers(registry);
+        let v2_migration_cache = Arc::new(PoolMetadataCache::with_scopes(
+            vec![migration_pool::v2_create::V2_MIGRATION_POOL_CREATE_HANDLER_SCOPE],
+            vec![
+                v4::create::V4_CREATE_HANDLER_SCOPE,
+                multicurve::create::V4_MULTICURVE_CREATE_HANDLER_SCOPE,
+                decay_multicurve::create::V4_DECAY_MULTICURVE_CREATE_HANDLER_SCOPE,
+                scheduled_multicurve::create::V4_SCHEDULED_MULTICURVE_CREATE_HANDLER_SCOPE,
+                dhook::create::DOPPLER_HOOK_CREATE_HANDLER_SCOPE,
+            ],
+        ));
+        migration_pool::v2_metrics::register_handlers(
+            registry,
+            chain_id,
+            v2_migration_cache,
             Arc::clone(&oracle_cache),
         );
     }

--- a/src/transformations/util/db/pool.rs
+++ b/src/transformations/util/db/pool.rs
@@ -149,6 +149,28 @@ pub struct MigrationPoolData<'a> {
     pub fee: u32,
     /// The original Doppler V4 pool's bytes32 address stored in `pools.address`.
     pub migrated_from: &'a [u8],
+    /// Value for the `type` column, e.g. `"migration_v4"`, `"migration_dhook"`.
+    pub pool_type: &'static str,
+    /// Value for the `migration_type` column, e.g. `"v4"`, `"dhook"`.
+    pub migration_type: &'static str,
+}
+
+/// Domain data for inserting a V2 migration pool record into the database.
+///
+/// V2 migration pools use a 20-byte pair address as their identifier.
+pub struct MigrationV2PoolData<'a> {
+    pub block_number: u64,
+    pub block_timestamp: u64,
+    /// The V2 pair contract address (20 bytes).
+    pub pair_address: &'a [u8; 20],
+    pub base_token: [u8; 20],
+    pub quote_token: [u8; 20],
+    pub is_token_0: bool,
+    pub integrator: [u8; 20],
+    pub initializer: [u8; 20],
+    pub fee: u32,
+    /// The original Doppler pool's bytes stored in `pools.address`.
+    pub migrated_from: &'a [u8],
 }
 
 /// Insert a migration pool row into the `pools` table.
@@ -196,7 +218,7 @@ pub fn insert_migration_pool(
             DbValue::Address(data.base_token),
             DbValue::Address(data.quote_token),
             DbValue::Bool(data.is_token_0),
-            DbValue::VarChar("migration_v4".to_string()),
+            DbValue::VarChar(data.pool_type.to_string()),
             DbValue::Address(data.integrator),
             DbValue::Address(data.initializer),
             DbValue::Int32(data.fee as i32),
@@ -206,12 +228,78 @@ pub fn insert_migration_pool(
             DbValue::Null, // migrated_at
             DbValue::Null, // migration_pool
             DbValue::Bytes(data.migrated_from.to_vec()),
-            DbValue::VarChar("v4".to_string()), // migration_type
+            DbValue::VarChar(data.migration_type.to_string()),
             DbValue::Null,                      // lock_duration
             DbValue::Null,                      // beneficiaries
             DbValue::Null,                      // pool_key
             DbValue::Timestamp(data.block_timestamp as i64), // starting_time = migration time
             DbValue::Timestamp(data.block_timestamp as i64), // ending_time = migration time
+        ],
+    }
+}
+
+/// Insert a V2 migration pool row into the `pools` table.
+///
+/// V2 migration pools use a 20-byte pair address as their identifier.
+/// Uses ON CONFLICT DO NOTHING so reprocessing is idempotent.
+pub fn insert_v2_migration_pool(
+    data: &MigrationV2PoolData<'_>,
+    ctx: &crate::transformations::TransformationContext,
+) -> DbOperation {
+    DbOperation::Upsert {
+        table: "pools".to_string(),
+        conflict_columns: vec!["chain_id".to_string(), "address".to_string()],
+        update_columns: vec![],
+        update_condition: None,
+        columns: vec![
+            "chain_id".to_string(),
+            "block_number".to_string(),
+            "created_at".to_string(),
+            "address".to_string(),
+            "base_token".to_string(),
+            "quote_token".to_string(),
+            "is_token_0".to_string(),
+            "type".to_string(),
+            "integrator".to_string(),
+            "initializer".to_string(),
+            "fee".to_string(),
+            "min_threshold".to_string(),
+            "max_threshold".to_string(),
+            "migrator".to_string(),
+            "migrated_at".to_string(),
+            "migration_pool".to_string(),
+            "migrated_from".to_string(),
+            "migration_type".to_string(),
+            "lock_duration".to_string(),
+            "beneficiaries".to_string(),
+            "pool_key".to_string(),
+            "starting_time".to_string(),
+            "ending_time".to_string(),
+        ],
+        values: vec![
+            DbValue::Int64(ctx.chain_id as i64),
+            DbValue::Uint64(data.block_number),
+            DbValue::Timestamp(data.block_timestamp as i64),
+            DbValue::Address(*data.pair_address),
+            DbValue::Address(data.base_token),
+            DbValue::Address(data.quote_token),
+            DbValue::Bool(data.is_token_0),
+            DbValue::VarChar("migration_v2".to_string()),
+            DbValue::Address(data.integrator),
+            DbValue::Address(data.initializer),
+            DbValue::Int32(data.fee as i32),
+            DbValue::Null, // min_threshold
+            DbValue::Null, // max_threshold
+            DbValue::Null, // migrator
+            DbValue::Null, // migrated_at
+            DbValue::Null, // migration_pool
+            DbValue::Bytes(data.migrated_from.to_vec()),
+            DbValue::VarChar("v2".to_string()),
+            DbValue::Null, // lock_duration
+            DbValue::Null, // beneficiaries
+            DbValue::Null, // pool_key
+            DbValue::Timestamp(data.block_timestamp as i64),
+            DbValue::Timestamp(data.block_timestamp as i64),
         ],
     }
 }

--- a/src/transformations/util/price.rs
+++ b/src/transformations/util/price.rs
@@ -76,7 +76,7 @@ pub fn sqrt_price_x96_to_price(
 }
 
 /// Multiply a BigDecimal by 10^exp (positive or negative).
-fn apply_decimal_exp(value: BigDecimal, exp: i32) -> BigDecimal {
+pub(crate) fn apply_decimal_exp(value: BigDecimal, exp: i32) -> BigDecimal {
     if exp == 0 {
         return value;
     }


### PR DESCRIPTION
## Summary

- **Dhook/rehype migrations**: `DopplerHookMigrator.Migrate` events were never captured, so post-graduation V4 pools were invisible to `MigrationPoolSwapMetricsHandler`. New `DhookMigrationPoolCreateHandler` inserts a `pools` row on each `Migrate` event, deriving `pool_id` from the emitted `PoolKey` via keccak256 and inheriting metadata from the original dhook pool row.
- **V2 migrations**: `Airlock.Migrate` (with non-zero pool address) now creates a `pools` row via `V2MigrationPoolCreateHandler`. `V2MigrationSwapMetricsHandler` processes the V2 `Swap` events already decoded by the `MigrationPool` factory collection, computing execution price directly from token amounts instead of `sqrtPriceX96`.
- **Config**: Added `Migrate` and `ModifyLiquidity` events to `DopplerHookMigrator` in all five chain `dhook.json` files.
- **Shared infrastructure**: `MigrationPoolData` type now parameterizes `pool_type`/`migration_type` instead of hardcoding `"migration_v4"`/`"v4"`. Migration pool ID queries in swap/TVL handlers now use `WHERE migrated_from IS NOT NULL` (no source filter) so dhook and V2 pools are automatically included. `process_v2_swaps` added to `swap_data.rs` alongside `process_swaps`.
- **Gating**: Migration pool metrics are now registered on chains with either `UniswapV4Migrator` or `DopplerHookMigrator`. V2 handlers are gated on `UniswapV2Migrator` or `NimCustomV2Migrator`.