### PR TITLE
fix: exclude cross-collection triggers from skipped factory warning

### DIFF
--- a/src/raw_data/historical/eth_calls/event_triggers.rs
+++ b/src/raw_data/historical/eth_calls/event_triggers.rs
@@ -681,29 +681,46 @@ async fn process_trigger_chunk<'a>(
                     addr
                 } else {
                     let emitter = Address::from(trigger.emitter_address);
+                    let is_cross_collection = config.contract_name != trigger.source_name;
                     match factory_addresses.get(&config.contract_name) {
                         Some(known_addresses) => {
                             if !known_addresses.contains(&emitter) {
-                                skipped.push(SkippedFactoryTrigger {
-                                    trigger: trigger.clone(),
-                                });
-                                tracing::debug!(
-                                    "Buffering event trigger: emitter {:?} not yet in known addresses for {}",
-                                    emitter,
-                                    config.contract_name
-                                );
+                                if is_cross_collection {
+                                    tracing::trace!(
+                                        "Skipping cross-collection event trigger: emitter {:?} from {} not in {}",
+                                        emitter,
+                                        trigger.source_name,
+                                        config.contract_name
+                                    );
+                                } else {
+                                    skipped.push(SkippedFactoryTrigger {
+                                        trigger: trigger.clone(),
+                                    });
+                                    tracing::debug!(
+                                        "Buffering event trigger: emitter {:?} not yet in known addresses for {}",
+                                        emitter,
+                                        config.contract_name
+                                    );
+                                }
                                 continue;
                             }
                             emitter
                         }
                         None => {
-                            skipped.push(SkippedFactoryTrigger {
-                                trigger: trigger.clone(),
-                            });
-                            tracing::debug!(
-                                "Buffering event trigger for {}: no factory addresses loaded yet",
-                                config.contract_name
-                            );
+                            if is_cross_collection {
+                                tracing::trace!(
+                                    "Skipping cross-collection event trigger for {}: no factory addresses loaded yet",
+                                    config.contract_name
+                                );
+                            } else {
+                                skipped.push(SkippedFactoryTrigger {
+                                    trigger: trigger.clone(),
+                                });
+                                tracing::debug!(
+                                    "Buffering event trigger for {}: no factory addresses loaded yet",
+                                    config.contract_name
+                                );
+                            }
                             continue;
                         }
                     }
@@ -1162,29 +1179,46 @@ async fn process_trigger_chunk_multicall<'a>(
                     addr
                 } else {
                     let emitter = Address::from(trigger.emitter_address);
+                    let is_cross_collection = config.contract_name != trigger.source_name;
                     match factory_addresses.get(&config.contract_name) {
                         Some(known_addresses) => {
                             if !known_addresses.contains(&emitter) {
-                                skipped.push(SkippedFactoryTrigger {
-                                    trigger: trigger.clone(),
-                                });
-                                tracing::debug!(
-                                    "Buffering event trigger: emitter {:?} not yet in known addresses for {}",
-                                    emitter,
-                                    config.contract_name
-                                );
+                                if is_cross_collection {
+                                    tracing::trace!(
+                                        "Skipping cross-collection event trigger: emitter {:?} from {} not in {}",
+                                        emitter,
+                                        trigger.source_name,
+                                        config.contract_name
+                                    );
+                                } else {
+                                    skipped.push(SkippedFactoryTrigger {
+                                        trigger: trigger.clone(),
+                                    });
+                                    tracing::debug!(
+                                        "Buffering event trigger: emitter {:?} not yet in known addresses for {}",
+                                        emitter,
+                                        config.contract_name
+                                    );
+                                }
                                 continue;
                             }
                             emitter
                         }
                         None => {
-                            skipped.push(SkippedFactoryTrigger {
-                                trigger: trigger.clone(),
-                            });
-                            tracing::debug!(
-                                "Buffering event trigger for {}: no factory addresses loaded yet",
-                                config.contract_name
-                            );
+                            if is_cross_collection {
+                                tracing::trace!(
+                                    "Skipping cross-collection event trigger for {}: no factory addresses loaded yet",
+                                    config.contract_name
+                                );
+                            } else {
+                                skipped.push(SkippedFactoryTrigger {
+                                    trigger: trigger.clone(),
+                                });
+                                tracing::debug!(
+                                    "Buffering event trigger for {}: no factory addresses loaded yet",
+                                    config.contract_name
+                                );
+                            }
                             continue;
                         }
                     }


### PR DESCRIPTION
## Summary

- The previous fix (PR #159) correctly made `ready_factory_sources_for_range` non-empty in repair mode, but the warning still fires because `filter_ready_factory_event_triggers` filters by `trigger.source_name` while `process_trigger_chunk` checks `factory_addresses[config.contract_name]`. For cross-collection triggers (where `source != collection`), the emitter belongs to the source collection's address set, never the target's — so the skip is always expected.
- Both `process_trigger_chunk` and `process_trigger_chunk_multicall` now distinguish cross-collection mismatches (silently skipped at trace level) from same-collection misses (added to `skipped` vec, trigger the warning).