### PR TITLE
fix: fall back to abi_decode for single dynamic struct returns

### DIFF
--- a/src/decoding/eth_calls/decode.rs
+++ b/src/decoding/eth_calls/decode.rs
@@ -49,16 +49,29 @@ fn evm_type_to_dyn_sol_type(output_type: &EvmType) -> DynSolType {
     }
 }
 
-/// Decode a raw value using the specified type
+/// Decode a raw value using the specified type.
+///
+/// Solidity encodes a function returning a single dynamic struct (e.g.
+/// `returns (PoolCoin)`) as `abi.encode(s)` — a 1-tuple wrapping the struct,
+/// which prepends an outer `0x20` offset. `abi_decode_params` on a
+/// `DynSolType::Tuple` assumes the flat multi-return layout and misreads that
+/// offset. When the params-style decode fails on a tuple type, retry with
+/// `abi_decode`, which expects the single-wrapped-struct layout.
 pub fn decode_value(
     raw: &[u8],
     output_type: &EvmType,
 ) -> Result<DecodedValue, EthCallDecodingError> {
     let sol_type = evm_type_to_dyn_sol_type(output_type);
 
-    let decoded = sol_type
-        .abi_decode_params(raw)
-        .map_err(|e| EthCallDecodingError::Decode(e.to_string()))?;
+    let decoded = match sol_type.abi_decode_params(raw) {
+        Ok(v) => v,
+        Err(primary) => match &sol_type {
+            DynSolType::Tuple(_) => sol_type
+                .abi_decode(raw)
+                .map_err(|_| EthCallDecodingError::Decode(primary.to_string()))?,
+            _ => return Err(EthCallDecodingError::Decode(primary.to_string())),
+        },
+    };
 
     convert_dyn_sol_value(&decoded, output_type)
 }
@@ -285,5 +298,71 @@ mod tests {
         let val = DynSolValue::Int(I256::ZERO, 8);
         let result = convert_dyn_sol_value(&val, &EvmType::Int8).unwrap();
         assert!(matches!(result, DecodedValue::Int8(0)));
+    }
+
+    #[test]
+    fn test_decode_single_dynamic_struct_return() {
+        // Mirrors Zora `getPoolCoin` returning a single dynamic struct
+        // `(address coin, (int24,int24,uint128)[] positions)`. Solidity encodes
+        // this as `abi.encode(poolCoin)` with a leading 0x20 offset, which the
+        // flat-params decoder can't handle.
+        let output_type = EvmType::NamedTuple(vec![
+            ("coin".to_string(), Box::new(EvmType::Address)),
+            (
+                "positions".to_string(),
+                Box::new(EvmType::Array(Box::new(EvmType::NamedTuple(vec![
+                    ("tickLower".to_string(), Box::new(EvmType::Int24)),
+                    ("tickUpper".to_string(), Box::new(EvmType::Int24)),
+                    ("liquidity".to_string(), Box::new(EvmType::Uint128)),
+                ])))),
+            ),
+        ]);
+
+        let value = DynSolValue::Tuple(vec![
+            DynSolValue::Address(
+                "0x1111111111111111111111111111111111111111"
+                    .parse()
+                    .unwrap(),
+            ),
+            DynSolValue::Array(vec![DynSolValue::Tuple(vec![
+                DynSolValue::Int(I256::try_from(-100).unwrap(), 24),
+                DynSolValue::Int(I256::try_from(100).unwrap(), 24),
+                DynSolValue::Uint(U256::from(999u64), 128),
+            ])]),
+        ]);
+        // Solidity's `returns (PoolCoin)` encoding: equivalent to abi.encode(s).
+        let raw = value.abi_encode();
+        assert_eq!(
+            &raw[..32],
+            &[0u8; 31].iter().chain([0x20u8].iter()).copied().collect::<Vec<_>>()[..],
+            "expected leading 0x20 offset for single dynamic struct return"
+        );
+
+        let decoded = decode_value(&raw, &output_type).expect("decode should succeed");
+        match decoded {
+            DecodedValue::NamedTuple(fields) => {
+                assert_eq!(fields.len(), 2);
+                assert_eq!(&*fields[0].0, "coin");
+                assert!(matches!(&fields[1].1, DecodedValue::Array(a) if a.len() == 1));
+            }
+            other => panic!("expected NamedTuple, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_decode_flat_multi_return_still_works() {
+        // Flat params encoding must still decode — this is the normal case for
+        // functions with multiple returns (e.g. `returns (uint160, int24, ...)`).
+        let output_type = EvmType::NamedTuple(vec![
+            ("sqrtPriceX96".to_string(), Box::new(EvmType::Uint160)),
+            ("tick".to_string(), Box::new(EvmType::Int24)),
+        ]);
+        let value = DynSolValue::Tuple(vec![
+            DynSolValue::Uint(U256::from(42u64), 160),
+            DynSolValue::Int(I256::try_from(7i64).unwrap(), 24),
+        ]);
+        let raw = value.abi_encode_params();
+        let decoded = decode_value(&raw, &output_type).expect("flat decode should succeed");
+        assert!(matches!(decoded, DecodedValue::NamedTuple(_)));
     }
 }


### PR DESCRIPTION
## Summary

`decode_value` called `sol_type.abi_decode_params(raw)` for every eth_call result. For a `DynSolType::Tuple`, that routes to `abi_decode_sequence`, which expects the flat multi-return layout.

Solidity's `returns (S)` where `S` is a dynamic struct (e.g. Zora `getPoolCoin` → `PoolCoin { address coin; LpPosition[] positions; }`) is encoded as `abi.encode(s)` — a 1-tuple wrapping the struct — and the payload starts with a leading `0x20` offset. The params-style decoder reads that offset as the first field (a garbage `address`), then misinterprets subsequent bytes as an array offset and fails.

Observed in production as:
```
All 3036 decode attempts failed for ZoraContentCoinHook.getPoolCoin
(output_type: NamedTuple([("coin", Address),
 ("positions", Array(NamedTuple([("tickLower", Int24), ("tickUpper", Int24), ("liquidity", Uint128)])))]))
in blocks 34730000-34739999
```

The same shape affects any `output_type` that's a single dynamic struct (e.g. dhook `getState` with its `bytes graduationDopplerHookCalldata`).

## Fix

On an `abi_decode_params` failure where `sol_type` is a `Tuple`, retry with `abi_decode`, which expects the single-wrapped-struct layout. The original error is preserved if the fallback also fails. Static tuples and flat multi-return calls are unchanged (params succeeds on the first attempt).

## Tests

- `test_decode_single_dynamic_struct_return` — builds the `PoolCoin` payload via `abi_encode` (Solidity's single-struct encoding), asserts the leading `0x20`, and verifies decode succeeds.
- `test_decode_flat_multi_return_still_works` — guards the original multi-return path.