### PR TITLE
perf: optimize catchup pipeline throughput

### DIFF
--- a/src/transformations/engine.rs
+++ b/src/transformations/engine.rs
@@ -36,7 +36,7 @@ use super::scheduler::loader::{
     read_receipt_addresses, run_call_dep_scanner_loop, CallDepScanner, CatchupLoader,
     CatchupPayload,
 };
-use super::scheduler::tracker::CompletionTracker;
+use super::scheduler::tracker::{CompletionTracker, TrackerSnapshot};
 use crate::db::DbPool;
 use crate::live::{LiveProgressTracker, LiveStorage, StorageError, TransformRetryRequest};
 use crate::metrics::record_chain_head_block;
@@ -883,6 +883,9 @@ impl TransformationEngine {
             db_pool: self.db_pool.clone(),
             finalizer: self.finalizer.clone(),
             receipt_cache: tokio::sync::RwLock::new(HashMap::new()),
+            parquet_io_semaphore: Arc::new(tokio::sync::Semaphore::new(
+                (self.handler_concurrency * 2).max(16).min(64),
+            )),
         });
 
         let scheduler = DagScheduler::new(tracker.clone(), self.handler_concurrency);
@@ -897,15 +900,15 @@ impl TransformationEngine {
         let mut acc = CatchupOutcomeAccumulator::new(handler_name_to_key);
 
         loop {
+            let snapshot = tracker.snapshot_for_item_building().await;
             let (items, per_handler_submitted) = self
                 .build_catchup_work_items(
                     &handlers,
                     &available,
                     &trigger_range_sets,
-                    &tracker,
+                    &snapshot,
                     chunk_size,
-                )
-                .await;
+                );
 
             if items.is_empty() {
                 if !acc.has_outcomes {
@@ -939,10 +942,11 @@ impl TransformationEngine {
 
             acc.ingest(outcomes, kind_label);
 
-            // Release receipt data cached during this chunk and prune
-            // completed entries the tracker no longer needs.
-            loader.clear_receipt_cache().await;
-            tracker.compact(&handler_names).await;
+            // Prune completed entries the tracker no longer needs, and evict
+            // receipt data for ranges at or below the new watermark.
+            if let Some(watermark) = tracker.compact(&handler_names).await {
+                loader.evict_receipts_below(watermark).await;
+            }
         }
 
         histogram!(
@@ -1099,12 +1103,12 @@ impl TransformationEngine {
     /// Skips ranges already completed or failed in the tracker. Stops after
     /// `chunk_size` items to bound peak allocation. The tracker persists across
     /// chunks, so dependency state from earlier chunks is naturally available.
-    async fn build_catchup_work_items(
+    fn build_catchup_work_items(
         &self,
         handlers: &[CatchupHandler],
         available: &[(u64, u64)],
         trigger_range_sets: &HashMap<String, HashSet<(u64, u64)>>,
-        tracker: &Arc<CompletionTracker>,
+        snapshot: &TrackerSnapshot,
         chunk_size: usize,
     ) -> (Vec<WorkItem>, HashMap<String, usize>) {
         let mut items: Vec<WorkItem> = Vec::new();
@@ -1118,15 +1122,15 @@ impl TransformationEngine {
                     return (items, per_handler_submitted);
                 }
 
-                // Skip if already completed in the tracker (DB-seeded + runtime).
-                if tracker.is_completed(&name, range_start).await {
+                // Skip if already completed in the snapshot (DB-seeded + runtime).
+                if snapshot.is_completed(&name, range_start) {
                     continue;
                 }
 
                 // Skip if any handler dep already failed.
                 let mut dep_failed = false;
                 for dep in ch.handler_deps.iter() {
-                    if tracker.is_failed(dep, range_start).await {
+                    if snapshot.is_failed(dep, range_start) {
                         dep_failed = true;
                         break;
                     }

--- a/src/transformations/scheduler/loader.rs
+++ b/src/transformations/scheduler/loader.rs
@@ -40,6 +40,7 @@ pub(crate) async fn read_decoded_parquet<T>(
         + Send
         + Sync
         + 'static,
+    io_semaphore: &Arc<tokio::sync::Semaphore>,
 ) -> Result<Vec<T>, TransformationError>
 where
     T: Send + 'static,
@@ -59,8 +60,14 @@ where
             let src = source_name.clone();
             let name = secondary_name.clone();
             let read_fn = read_fn.clone();
+            let permit = io_semaphore
+                .clone()
+                .acquire_owned()
+                .await
+                .expect("parquet IO semaphore never closed");
 
             read_tasks.spawn_blocking(move || {
+                let _permit = permit; // held for duration, dropped on return
                 tracing::debug!("Reading decoded data from {}", file_path.display());
                 match read_fn(reader, &file_path, &src, &name) {
                     Ok(items) => {
@@ -312,15 +319,17 @@ pub(crate) struct CatchupLoader {
     /// Cache of receipt address maps keyed by (range_start, range_end).
     /// Multiple event handlers processing the same range share one Arc'd HashMap.
     pub receipt_cache: ReceiptCache,
+    /// Limits the number of concurrent parquet `spawn_blocking` I/O tasks.
+    pub parquet_io_semaphore: Arc<tokio::sync::Semaphore>,
 }
 
 impl CatchupLoader {
-    /// Drop all cached receipt address maps.
+    /// Evict cached receipt address maps whose range starts at or below `watermark`.
     ///
-    /// Called between scheduler chunks so that ranges processed in earlier chunks
-    /// do not pin their receipt data for the remainder of catchup.
-    pub(crate) async fn clear_receipt_cache(&self) {
-        self.receipt_cache.write().await.clear();
+    /// Ranges above the watermark stay cached for cross-chunk reuse.
+    pub(crate) async fn evict_receipts_below(&self, watermark: u64) {
+        let mut cache = self.receipt_cache.write().await;
+        cache.retain(|(range_start, _), _| *range_start > watermark);
     }
 
     /// Load data, invoke handler, execute DB ops, and record progress for one [`WorkItem`].
@@ -452,6 +461,7 @@ impl CatchupLoader {
             triggers,
             move |source, event| vec![logs_dir.join(source).join(event).join(&file_name)],
             |reader, path, src, evt| reader.read_events_from_file(path, src, evt),
+            &self.parquet_io_semaphore,
         )
         .await
     }
@@ -484,6 +494,7 @@ impl CatchupLoader {
                 .collect()
             },
             |reader, path, src, func| reader.read_calls_from_file(path, src, func),
+            &self.parquet_io_semaphore,
         )
         .await
     }

--- a/src/transformations/scheduler/tracker.rs
+++ b/src/transformations/scheduler/tracker.rs
@@ -585,9 +585,9 @@ impl CompletionTracker {
     ///
     /// [`is_pruned`]: Self::is_pruned
     /// [`with_available_starts`]: Self::with_available_starts
-    pub(crate) async fn compact(&self, handler_names: &[&str]) {
+    pub(crate) async fn compact(&self, handler_names: &[&str]) -> Option<u64> {
         if self.available_starts.is_empty() || handler_names.is_empty() {
-            return;
+            return None;
         }
 
         // Collect each handler's contiguous watermark. `Vec<Option<u64>>`
@@ -602,14 +602,14 @@ impl CompletionTracker {
         drop(contiguous);
 
         let Some(min_wm) = watermarks.and_then(|ws| ws.into_iter().min()) else {
-            return;
+            return None;
         };
 
         // Only advance the pruned watermark, never regress.
         {
             let current = *self.pruned_up_to.read().unwrap();
             if current.is_some_and(|c| c >= min_wm) {
-                return;
+                return None;
             }
         }
 
@@ -626,6 +626,8 @@ impl CompletionTracker {
             "CompletionTracker compacted: pruned completed entries at or below range_start {}",
             min_wm
         );
+
+        Some(min_wm)
     }
 
     // ─── Extended wait (handler deps + contiguous deps + call deps) ─────
@@ -809,6 +811,56 @@ impl CompletionTracker {
             result.entry(name.clone()).or_default().2 = ranges.len();
         }
         result
+    }
+
+    /// Create a read-only snapshot of completed/failed state for batch queries.
+    ///
+    /// Takes one read lock on `state` and one read on `pruned_up_to`, then
+    /// returns a [`TrackerSnapshot`] that can answer `is_completed` /
+    /// `is_failed` without further locking.
+    pub(crate) async fn snapshot_for_item_building(&self) -> TrackerSnapshot {
+        let state = self.state.read().await;
+        let completed = state.completed.clone();
+        let failed = state.failed.clone();
+        drop(state);
+        let pruned_up_to = *self.pruned_up_to.read().unwrap();
+        TrackerSnapshot {
+            completed,
+            failed,
+            pruned_up_to,
+        }
+    }
+}
+
+/// Read-only snapshot of completed/failed state for batch queries.
+///
+/// Avoids repeated async lock acquisitions in tight loops like
+/// `build_catchup_work_items` by capturing the state once.
+pub(crate) struct TrackerSnapshot {
+    pub(crate) completed: HashMap<String, HashSet<u64>>,
+    pub(crate) failed: HashMap<String, HashSet<u64>>,
+    pub(crate) pruned_up_to: Option<u64>,
+}
+
+impl TrackerSnapshot {
+    /// Check whether `(handler_name, range_start)` is completed in this snapshot.
+    ///
+    /// Returns true if the range was pruned (at or below `pruned_up_to`) or
+    /// is present in the handler's completed set.
+    pub(crate) fn is_completed(&self, handler_name: &str, range_start: u64) -> bool {
+        if self.pruned_up_to.is_some_and(|wm| range_start <= wm) {
+            return true;
+        }
+        self.completed
+            .get(handler_name)
+            .is_some_and(|ranges| ranges.contains(&range_start))
+    }
+
+    /// Check whether `(handler_name, range_start)` is failed in this snapshot.
+    pub(crate) fn is_failed(&self, handler_name: &str, range_start: u64) -> bool {
+        self.failed
+            .get(handler_name)
+            .is_some_and(|ranges| ranges.contains(&range_start))
     }
 }
 
@@ -1446,5 +1498,62 @@ mod tests {
         // And A's entries remain in memory.
         let state = tracker.state.read().await;
         assert!(state.completed.get("A").unwrap().contains(&100));
+    }
+
+    // ─── TrackerSnapshot tests ─────────────────────────────────────────
+
+    #[test]
+    fn snapshot_is_completed_basic() {
+        let snapshot = TrackerSnapshot {
+            completed: HashMap::from([("A".to_string(), HashSet::from([100, 200]))]),
+            failed: HashMap::new(),
+            pruned_up_to: None,
+        };
+        assert!(snapshot.is_completed("A", 100));
+        assert!(snapshot.is_completed("A", 200));
+        assert!(!snapshot.is_completed("A", 300));
+        assert!(!snapshot.is_completed("B", 100));
+    }
+
+    #[test]
+    fn snapshot_is_completed_with_pruning() {
+        let snapshot = TrackerSnapshot {
+            completed: HashMap::from([("A".to_string(), HashSet::from([300]))]),
+            failed: HashMap::new(),
+            pruned_up_to: Some(200),
+        };
+        assert!(snapshot.is_completed("A", 100)); // pruned
+        assert!(snapshot.is_completed("A", 200)); // pruned (at boundary)
+        assert!(snapshot.is_completed("A", 300)); // in completed set
+        assert!(!snapshot.is_completed("A", 400)); // neither
+        // Pruned ranges are completed for ALL handlers
+        assert!(snapshot.is_completed("B", 100));
+    }
+
+    #[test]
+    fn snapshot_is_failed() {
+        let snapshot = TrackerSnapshot {
+            completed: HashMap::new(),
+            failed: HashMap::from([("A".to_string(), HashSet::from([100]))]),
+            pruned_up_to: None,
+        };
+        assert!(snapshot.is_failed("A", 100));
+        assert!(!snapshot.is_failed("A", 200));
+        assert!(!snapshot.is_failed("B", 100));
+    }
+
+    #[tokio::test]
+    async fn snapshot_for_item_building_captures_state() {
+        let tracker = CompletionTracker::new();
+        tracker.mark_completed("A", 100).await;
+        tracker.mark_completed("A", 200).await;
+        tracker.mark_failed("B", 300).await;
+
+        let snapshot = tracker.snapshot_for_item_building().await;
+        assert!(snapshot.is_completed("A", 100));
+        assert!(snapshot.is_completed("A", 200));
+        assert!(!snapshot.is_completed("A", 300));
+        assert!(snapshot.is_failed("B", 300));
+        assert!(!snapshot.is_failed("B", 100));
     }
 }


### PR DESCRIPTION
## Summary

Three independent optimizations targeting historical catchup performance:

- **TrackerSnapshot for batch queries**: `build_catchup_work_items` previously called `tracker.is_completed()` and `tracker.is_failed()` per handler per range, each acquiring an async `RwLock`. With many handlers and large range sets this meant millions of lock round-trips between chunks. Now a single snapshot is taken at chunk start and queried synchronously — one lock acquisition replaces N×M.

- **Watermark-based receipt cache eviction**: The receipt cache was fully cleared after every chunk via `clear_receipt_cache()`, forcing redundant parquet I/O when adjacent chunks share ranges. Now `compact()` returns its pruned watermark and only entries at or below it are evicted. Ranges still in progress survive across chunks for reuse.

- **Parquet IO semaphore**: `read_decoded_parquet` spawned one `spawn_blocking` task per trigger file with no concurrency limit. Under high handler concurrency this saturated tokio's blocking thread pool. A shared semaphore (capacity = `handler_concurrency * 2`, clamped 16–64) now bounds concurrent parquet I/O.