### PR TITLE
fix: add chain filters to DhookMigration and DecayMulticurve dep specs

### DIFF
--- a/src/transformations/event/decay_multicurve/metrics.rs
+++ b/src/transformations/event/decay_multicurve/metrics.rs
@@ -19,7 +19,9 @@ use crate::transformations::event::metrics::v4_hook_extract::{
     extract_tuple_modify_liquidity, extract_v4_hook_swaps, extract_v4_hook_tvl_targets,
 };
 use crate::transformations::registry::TransformationRegistry;
-use crate::transformations::traits::{EventHandler, EventTrigger, TransformationHandler};
+use crate::transformations::traits::{
+    dep, EventHandler, EventTrigger, HandlerDependencySpec, TransformationHandler,
+};
 use crate::transformations::util::pool_metadata::PoolMetadataCache;
 use crate::transformations::util::usd_price::{
     build_usd_price_context_with_paths, chainlink_latest_answer_dependency, OraclePriceCache,
@@ -131,8 +133,8 @@ impl EventHandler for DecayMulticurveSwapMetricsHandler {
         ]
     }
 
-    fn contiguous_handler_dependencies(&self) -> Vec<&'static str> {
-        vec!["V4DecayMulticurveCreateHandler"]
+    fn contiguous_handler_dependency_specs(&self) -> Vec<HandlerDependencySpec> {
+        vec![dep("V4DecayMulticurveCreateHandler").only([8453, 84532, 11155111])]
     }
 }
 
@@ -177,8 +179,8 @@ impl EventHandler for DecayMulticurveLiquidityMetricsHandler {
         )]
     }
 
-    fn contiguous_handler_dependencies(&self) -> Vec<&'static str> {
-        vec!["V4DecayMulticurveCreateHandler"]
+    fn contiguous_handler_dependency_specs(&self) -> Vec<HandlerDependencySpec> {
+        vec![dep("V4DecayMulticurveCreateHandler").only([8453, 84532, 11155111])]
     }
 }
 
@@ -288,10 +290,10 @@ impl EventHandler for DecayMulticurveTvlMetricsHandler {
         ]
     }
 
-    fn contiguous_handler_dependencies(&self) -> Vec<&'static str> {
+    fn contiguous_handler_dependency_specs(&self) -> Vec<HandlerDependencySpec> {
         vec![
-            "V4DecayMulticurveCreateHandler",
-            "DecayMulticurveLiquidityMetricsHandler",
+            dep("V4DecayMulticurveCreateHandler").only([8453, 84532, 11155111]),
+            dep("DecayMulticurveLiquidityMetricsHandler").only([8453, 84532, 11155111]),
         ]
     }
 }

--- a/src/transformations/event/dhook/migrate.rs
+++ b/src/transformations/event/dhook/migrate.rs
@@ -187,7 +187,7 @@ impl EventHandler for DhookMigrationPoolCreateHandler {
     }
 
     fn contiguous_handler_dependency_specs(&self) -> Vec<HandlerDependencySpec> {
-        vec![dep("DopplerHookCreateHandler")]
+        vec![dep("DopplerHookCreateHandler").except([130, 57073])]
     }
 }
 


### PR DESCRIPTION
## Summary

- `DhookMigrationPoolCreateHandler`: added `.except([130, 57073])` to the `DopplerHookCreateHandler` dep — unichain and ink have no `DopplerHookMigrator` so this handler is never registered there, but the unfiltered dep caused a panic when `validate_and_sort_handler_dependencies` ran on those chains
- `DecayMulticurve{Swap,Liquidity,Tvl}MetricsHandlers`: migrated from `contiguous_handler_dependencies()` (no chain filter) to `contiguous_handler_dependency_specs()` with `.only([8453, 84532, 11155111])` — `V4DecayMulticurveCreateHandler` only exists on chains that have `decay_multicurve.json` contracts; the unfiltered deps caused panics on all other chains