### PR TITLE
fix: include empty ranges when loading factory addresses from parquet

### DIFF
--- a/src/raw_data/historical/factories.rs
+++ b/src/raw_data/historical/factories.rs
@@ -843,13 +843,16 @@ pub(crate) fn load_factory_addresses_from_parquet(
                 }
             }
 
-            if !addresses_by_block.is_empty() {
-                results.push(FactoryAddressData {
-                    range_start,
-                    range_end,
-                    addresses_by_block,
-                });
-            }
+            // Include empty ranges too: callers (repair-only factory-once
+            // fallback, Phase C event-trigger filtering) must see every range
+            // that was collected, including ones with zero addresses, so
+            // empty `once` output parquets get written as readiness markers
+            // rather than leaving a hole that stalls transformation catchup.
+            results.push(FactoryAddressData {
+                range_start,
+                range_end,
+                addresses_by_block,
+            });
         }
     }
 


### PR DESCRIPTION
## What

`load_factory_addresses_from_parquet` silently drops any factory parquet whose rows are empty. Callers that rely on iterating every collected range — notably the `--repair-only` factory-once fallback in `catchup/eth_calls.rs:1221` — therefore see fewer ranges than exist on disk and skip writing empty `once` output parquets for them.

## Why it matters

During normal (streaming) catchup, `FactoryMessage::RangeComplete` fires for every range regardless of whether any addresses were discovered, and `process_factory_once_catchup_range` writes an empty `once/{range}.parquet` as a readiness marker. The parquet-fallback path used by repair-only skipped those ranges entirely, so any range where the factory found zero addresses had no `once` marker written.

Transformation handlers with `call_dependencies` on factory-once files gate on the file's presence for each range. A missing marker parks the work item in `wait_ready_extended` indefinitely, freezing the handler's contiguous watermark at the first hole and stalling every downstream handler that depends on it.

Observed on monad (chain 143) at range 43740000: the factory parquet was an empty 638-byte schema-only file, the fallback skipped it, no `DERC20/once` / `DopplerV4Hook/once` / `DopplerLockableV3Pool/once` marker got written, and seven handlers' watermarks froze — cascading into V2MigrationPoolCreate (0/1114) and its downstream metrics stalling indefinitely.

## Change

Remove the `if !addresses_by_block.is_empty()` guard in `load_factory_addresses_from_parquet` so every parquet that was collected — even empty ones — produces a `FactoryAddressData` entry. The three callers:

- `catchup/factories.rs:175` streams entries into factory channels; streaming already handles empty `RangeComplete` ranges so this mirrors the live-mode behavior.
- `catchup/eth_calls.rs:1230` — the repair-only factory-once fallback this patch targets.
- `catchup/eth_calls.rs:1310` — Phase C event-trigger address flattening; empty entries contribute zero addresses (no-op).

After the fix, running `--repair-only --from-block X --to-block Y` on a chain with an empty-factory hole correctly writes the missing empty `once` parquet and unblocks downstream transformation catchup.